### PR TITLE
Release connection correctly after borrowing it for handleVisitor implem...

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -1668,12 +1668,12 @@ public final class JDBCDataStore extends ContentDataStore
     }
     
     /**
-     * Releases an existing connection.
+     * Releases an existing connection (paying special attention to {@link Transaction#AUTO_COMMIT}.
+     * <p>
+     * If the state is based off the AUTO_COMMIT transaction - close using {@link #closeSafe(Connection)}.
+     * Otherwise wait until the transaction itself is closed to close the connection.
      */
     protected final void releaseConnection( Connection cx, JDBCState state ) {
-        //if the state is based off the AUTO_COMMIT transaction, close the 
-        // connection, otherwise wait until the transaction itself is closed to 
-        // close the connection
         if ( state.getTransaction() == Transaction.AUTO_COMMIT ) {
             closeSafe( cx );
         }

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureSource.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureSource.java
@@ -655,14 +655,15 @@ public class JDBCFeatureSource extends ContentFeatureSource {
 
     @Override
     protected boolean handleVisitor(Query query, FeatureVisitor visitor) throws IOException {
-        //grab connection
+        // grab connection using the current transaction
         Connection cx = getDataStore().getConnection(getState());
         try {
             Object result = getDataStore().getAggregateValue(visitor, getSchema(), query, cx);
             return result != null;
         }
         finally {
-            getDataStore().closeSafe( cx );
+        	// release the connection - behaviour depends on Transaction.AUTO_COMMIT
+        	getDataStore().releaseConnection(cx, getState());
         }
     }
     


### PR DESCRIPTION
Fix for https://jira.codehaus.org/browse/GEOT-4193

JDBC implementation of FeatureCollection.accepts( visitor, progress ) method has the side effect of closing the current JDBC connection. This causes the next use of the featureSource to fail.
