### PR TITLE
Avoid silently swallowing exceptions in ImageMosaic CatalogBuilder

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalogbuilder/CatalogBuilder.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalogbuilder/CatalogBuilder.java
@@ -693,14 +693,8 @@ public class CatalogBuilder implements Runnable {
                         } finally {
                             transaction.close();
                             
-                            try{
-                                indexingPostamble(!canceled);
-                            } catch (Exception e) {
-                                // eat me
-                            }
+                            indexingPostamble(!canceled);
                         }
-                        
-			
 		}
 
 		public int getNumberOfProcessedFiles() {


### PR DESCRIPTION
After spending several hours tracking down a GeoServer build failure to a configuration error on my machine, I suggest that we not silently swallow exceptions in the CatalogBuilderDirectoryWalker constructor.
