### PR TITLE
Fix regular expression so negative timezone offsets work, too.

### DIFF
--- a/modules/library/cql/src/main/java/org/geotools/filter/text/commons/AbstractFilterBuilder.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/commons/AbstractFilterBuilder.java
@@ -458,7 +458,7 @@ public abstract class AbstractFilterBuilder {
 		assert dateTime.length >= 2 : "date and time is required by the sintax rule";
 		
 		// splits the time and time zone 
-		String[] time = dateTime[1].split("[+|-|Z]");
+		String[] time = dateTime[1].split("[-+Z]");
 		
 		return time[0]; // the time
 	}

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/CQLTemporalPredicateTest.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/CQLTemporalPredicateTest.java
@@ -243,7 +243,24 @@ public class CQLTemporalPredicateTest {
 		Date actualDate =  (Date) literalDate.getValue();
         
         Assert.assertEquals(expectedDate, actualDate);
+
+        expectedTime = "2008-09-09T17:00:00-01:00";
+
+        resultFilter = CompilerUtil.parseFilter(this.language, "ZONE_VALID_FROM BEFORE " + expectedTime);
+
+        comparation = (Before) resultFilter;
+
+        // date test 
+        expr2 = comparation.getExpression2();
+        literalDate = (Literal)expr2;
+        
+		expectedDate = dateFormatter.parse("2008-09-09T17:00:00-0100");
+
+		actualDate =  (Date) literalDate.getValue();
+        
+        Assert.assertEquals(expectedDate, actualDate);
     }
+
     /**
      * before with compound attribute
      * 


### PR DESCRIPTION
I decided to extend an existing unit test that already checked positive offsets.
