### PR TITLE
FunctionName conflict between FilterFunction_numPoints and Filter_Function_numInteriorRing

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numPoints.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numPoints.java
@@ -33,7 +33,7 @@ import com.vividsolutions.jts.geom.Geometry;
  */
 public class FilterFunction_numPoints extends FunctionExpressionImpl {
     
-    public static FunctionName NAME = new FunctionNameImpl("numInteriorRing", Integer.class,
+    public static FunctionName NAME = new FunctionNameImpl("numPoints", Integer.class,
             parameter("geometry", Geometry.class));
 
     public FilterFunction_numPoints() {


### PR DESCRIPTION
As per https://jira.codehaus.org/browse/GEOT-4213

When starting a GeoTools application the FunctionFactory system detects (and logs) the following FunctionName conflict:

Jul 30, 2012 11:56:49 AM org.geotools.filter.function.DefaultFunctionFactory loadFunctions
WARNING: Function numinteriorring clash between FilterFunction_numPoints and FilterFunction_numInteriorRing
