### PR TITLE
GEOT-4221 add quotation marks around the "${java.library.path}"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1206,7 +1206,7 @@
             <exclude>${stress.skip.pattern}</exclude>
             <exclude>${test.exclude.pattern}</exclude>
           </excludes>
-          <argLine>-Xmx${test.maxHeapSize} ${jvm.opts} -Dorg.geotools.test.extensive=${extensive.tests} -Dorg.geotools.test.interactive=${interactive.tests} -Dorg.geotools.image.test.enabled=${image.tests} -Dorg.geotools.image.test.interactive=${interactive.image} -Djava.awt.headless=${java.awt.headless} -Djava.io.tmpdir=${java.io.tmpdir} -Djava.library.path=${java.library.path}</argLine>
+          <argLine>-Xmx${test.maxHeapSize} ${jvm.opts} -Dorg.geotools.test.extensive=${extensive.tests} -Dorg.geotools.test.interactive=${interactive.tests} -Dorg.geotools.image.test.enabled=${image.tests} -Dorg.geotools.image.test.interactive=${interactive.image} -Djava.awt.headless=${java.awt.headless} -Djava.io.tmpdir="${java.io.tmpdir}" -Djava.library.path="${java.library.path}"</argLine>
           <!-- Ignores test failure only if we are generating a       -->
           <!-- report for publication on the web site. See the        -->
           <!-- profiles section at the begining of this pom.xml file. -->


### PR DESCRIPTION
- GEOT-4221: add quotation marks around the "${java.library.path}" in the top level pom, as described in https://jira.codehaus.org/browse/GEOT-4221 . I'm not sure how this works out on other OS than Windows, so you will need to check this.
- clean up the Geometries module pom: it overrides the toplevel surefire version (which is a bad idea) and has two surefire elements in the build section (which is strange), it also overrides the top level compiler.
