### PR TITLE
cleanup build section of Geometries module

### DIFF
--- a/modules/unsupported/geometry/pom.xml
+++ b/modules/unsupported/geometry/pom.xml
@@ -88,24 +88,6 @@
   <!-- ======================================================= -->
   <build>
     <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.3</version>
-          <!-- Current version is 2.3, but it seems to be rough with
-               class loaders; JAI is not found anymore, and we have
-               some additional test failures. -->
-        </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.5</source>  <!-- The -source argument for the Java compiler. -->
-          <target>1.5</target>  <!-- The -target argument for the Java compiler. -->
-          <debug>true</debug>   <!-- Whether to include debugging information.   -->
-          <encoding>UTF-8</encoding> <!-- The -encoding argument for the Java compiler. -->
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
The build section specifies the surefire plugin twice, one of them overriding the top level version. 
It also specifies the compiler plugin overriding the top level config (bad idea)

(this was split out of #7 )
