### PR TITLE
Typo in illegal argument exception message

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/type/PropertyDescriptorImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/type/PropertyDescriptorImpl.java
@@ -60,7 +60,7 @@ public class PropertyDescriptorImpl implements PropertyDescriptor {
         }
         
         if (max > 0 && (max < min) ) {
-            throw new IllegalArgumentException("max must be -1, or < min");
+            throw new IllegalArgumentException("max must be -1, or >= min");
         }
     }
     


### PR DESCRIPTION
This corrects a typo in exception messages for improperly configured property descriptors.
