### PR TITLE
Blank spaces in process parameter names

### DIFF
--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/feature/gs/InclusionFeatureCollection.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/feature/gs/InclusionFeatureCollection.java
@@ -49,8 +49,8 @@ import com.vividsolutions.jts.geom.Geometry;
 public class InclusionFeatureCollection implements GSProcess {
     @DescribeResult(description = "Output feature collection")
     public SimpleFeatureCollection execute(
-            @DescribeParameter(name = "first feature collection", description = "First feature collection") SimpleFeatureCollection firstFeatures,
-            @DescribeParameter(name = "second feature collection", description = "Second feature collection") SimpleFeatureCollection secondFeatures) {
+            @DescribeParameter(name = "first_feature_collection", description = "First feature collection") SimpleFeatureCollection firstFeatures,
+            @DescribeParameter(name = "second_feature_collection", description = "Second feature collection") SimpleFeatureCollection secondFeatures) {
         return new IncludedFeatureCollection(firstFeatures, secondFeatures);
     }
 

--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/feature/gs/UnionFeatureCollection.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/feature/gs/UnionFeatureCollection.java
@@ -52,8 +52,8 @@ public class UnionFeatureCollection implements GSProcess {
 
     @DescribeResult(name = "result", description = "Output feature collection")
     public SimpleFeatureCollection execute(
-            @DescribeParameter(name = "first feature collection", description = "First input feature collection") SimpleFeatureCollection firstFeatures,
-            @DescribeParameter(name = "second feature collection", description = "Second feature collection") SimpleFeatureCollection secondFeatures)
+            @DescribeParameter(name = "first_feature_collection", description = "First input feature collection") SimpleFeatureCollection firstFeatures,
+            @DescribeParameter(name = "second_feature_collection", description = "Second feature collection") SimpleFeatureCollection secondFeatures)
             throws ClassNotFoundException {
         if (!(firstFeatures.features().next().getDefaultGeometry().getClass().equals(secondFeatures
                 .features().next().getDefaultGeometry().getClass()))) {

--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/feature/gs/UniqueProcess.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/feature/gs/UniqueProcess.java
@@ -42,10 +42,6 @@ import org.opengis.util.ProgressListener;
  */
 @DescribeProcess(title = "Unique", description = "Returns the unique values of a given attribute in a feature collection.")
 public class UniqueProcess implements GSProcess {
-    // the functions this process can handle
-    public enum AggregationFunction {
-        Average, Max, Median, Min, StdDev, Sum;
-    }
 
     @DescribeResult(name = "result", description = "Feature collection with an attribute containing the unique values")
     public SimpleFeatureCollection execute(


### PR DESCRIPTION
This patch changes process parameter names in InclusionFeatureCollection and UnionFeatureCollection, which included blank spaces. This is not a good idea, as it makes it harder to reuse them at an upper level to call processes (for instance, when using them as an argument name)

I also Removed AggregationFunction enum at UniqueProcess (probably left there unintentionally)
