### PR TITLE
Removing spaces from process input identifiers.

### DIFF
--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/feature/gs/IntersectionFeatureCollection.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/feature/gs/IntersectionFeatureCollection.java
@@ -79,10 +79,10 @@ public class IntersectionFeatureCollection implements GSProcess {
 
     @DescribeResult(description = "Output feature collection")
     public SimpleFeatureCollection execute(
-            @DescribeParameter(name = "first feature collection", description = "First feature collection") SimpleFeatureCollection firstFeatures,
-            @DescribeParameter(name = "second feature collection", description = "Second feature collection") SimpleFeatureCollection secondFeatures,
-            @DescribeParameter(name = "first attributes to retain", collectionType = String.class, min = 0, description = "First feature collection attribute to include") List<String> firstAttributes,
-            @DescribeParameter(name = "second attributes to retain", collectionType = String.class, min = 0, description = "Second feature collection attribute to include") List<String> sndAttributes,
+            @DescribeParameter(name = "firstFeatures", description = "First feature collection") SimpleFeatureCollection firstFeatures,
+            @DescribeParameter(name = "secondFeatures", description = "Second feature collection") SimpleFeatureCollection secondFeatures,
+            @DescribeParameter(name = "firstAttrs", collectionType = String.class, min = 0, description = "First feature collection attribute to include") List<String> firstAttributes,
+            @DescribeParameter(name = "secondAttrs", collectionType = String.class, min = 0, description = "Second feature collection attribute to include") List<String> sndAttributes,
             @DescribeParameter(name = "intersectionMode", min = 0, description = "Specifies geometry computed for intersecting features.  INTERSECTION (default) computes the spatial intersection of the inputs. FIRST copies geometry A.  SECOND copies geometry B.") IntersectionMode intersectionMode,
             @DescribeParameter(name = "percentagesEnabled", min = 0, description = "Indicates whether to output feature area percentages (attributes percentageA and percentageB)") Boolean percentagesEnabled,
             @DescribeParameter(name = "areasEnabled", min = 0, description = "Indicates whether to output feature areas (attributes areaA and areaB)") Boolean areasEnabled) {

--- a/modules/unsupported/process-geometry/src/main/java/org/geotools/process/jts/GeometryFunctions.java
+++ b/modules/unsupported/process-geometry/src/main/java/org/geotools/process/jts/GeometryFunctions.java
@@ -203,7 +203,7 @@ public class GeometryFunctions {
     @DescribeResult(description = "True if the inputs have the given relationship")
     static public boolean relatePattern(@DescribeParameter(name = "a", description = "First input geometry") Geometry a,
             @DescribeParameter(name = "b", description = "First input geometry") Geometry b,
-            @DescribeParameter(name = "Relate pattern", description = "Intersection matrix pattern") String pattern) {
+            @DescribeParameter(name = "pattern", description = "Intersection matrix pattern") String pattern) {
         return a.relate(b, pattern);
     }
 


### PR DESCRIPTION
Having seen Martin's earlier changes improving process metadata (but only title/description), I assumed input/output names were left untouched for backwards compatibility.  With 3f286a027062b0eaa86fb48784f3552f7dadecc6, it looks like that is not the case.  There are a couple other places where spaces in input identifiers remain:
- gs:IntersectionFeatureCollection 
  - input: first feature collection
  - input: second feature collection
  - input: first attributes to retain
  - input: second attributes to retain
- JTS:relatePattern
  - input: Relate pattern

GeoTools tests still pass with this change.  I haven't seen if there are GeoServer tests that use these process input names.
