### PR TITLE
WMS 1.3.0 Axis order GetCapabilities fix for GEOT-375

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/data/ows/Layer.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/ows/Layer.java
@@ -313,7 +313,7 @@ public class Layer implements Comparable<Layer> {
      * The Extents contributed by this Layer.
      * <p>
      * Please note that for the complete list of Extents valid for this layer
-     * you should use the getExtents() mehtod which will consider extents defined
+     * you should use the getExtents() method which will consider extents defined
      * as part of a Dimension and all those contributed by Parent layers.
      * <p>
      * This is an accessor; if you modify the provided list please call clearCache().
@@ -580,6 +580,12 @@ public class Layer implements Comparable<Layer> {
     }
 
     public void setLatLonBoundingBox(CRSEnvelope latLonBoundingBox) {
+        if( latLonBoundingBox.getSRSName() != null ){
+            String srsName = latLonBoundingBox.getSRSName();
+            if( !srsName.equals("CRS:84")){
+                throw new IllegalStateException("Layer LatLonBoundingBox srsName required to be null or CRS:84");
+            }
+        }
         this.latLonBoundingBox = latLonBoundingBox;
     }
 

--- a/modules/extension/wms/src/main/java/org/geotools/data/ows/WMSCapabilities.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/ows/WMSCapabilities.java
@@ -45,8 +45,46 @@ public class WMSCapabilities extends Capabilities {
         return layer;
     }
 
+    @Override
+    public void setVersion(String version) {
+        super.setVersion(version);
+        boolean forceXY = !getVersion().startsWith("1.3");
+        if( layer != null ){
+            fixLayerBoundingBox( layer, forceXY );
+            layer.clearCache();
+        }
+    }
+    
     public void setLayer(Layer layer) {
         this.layer = layer;
+        if( getVersion() != null ){
+            boolean forceXY = !getVersion().startsWith("1.3");
+            fixLayerBoundingBox( layer, forceXY );
+            layer.clearCache();
+        }
+    }
+    
+    /**
+     * Fix the provided layer's bounding box so that it can be correctly handled.
+     * <p>
+     * Call layer.clearCache() after this method.
+     * 
+     * @param layer
+     * @param forceXY true prior to WMS 1.3.0, false after WMS 1.3.0
+     */
+    static void fixLayerBoundingBox( Layer layer, boolean forceXY ){
+        if( layer == null ){
+            return;
+        }
+        if( layer.getLayerBoundingBoxes() != null ){
+            for( CRSEnvelope boundingBox : layer.getLayerBoundingBoxes() ){
+                String srsName = boundingBox.getSRSName();
+                boundingBox.setSRSName(srsName, forceXY);                
+            }
+        }
+        for( Layer child : layer.getChildren() ){
+            fixLayerBoundingBox(child, forceXY);
+        }
     }
         
     /**

--- a/modules/extension/wms/src/test/java/org/geotools/data/wms/test/LocalGeoServerOnlineTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/data/wms/test/LocalGeoServerOnlineTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2008-2012, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -23,91 +23,186 @@ import junit.framework.TestCase;
 
 import org.geotools.data.ResourceInfo;
 import org.geotools.data.ServiceInfo;
+import org.geotools.data.ows.CRSEnvelope;
 import org.geotools.data.ows.Layer;
 import org.geotools.data.ows.WMSCapabilities;
 import org.geotools.data.wms.WebMapServer;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import com.vividsolutions.jts.geom.Coordinate;
 
 /**
- * This test case assume you have a default geoserver installed
- * on 127.0.0.1 (ie localhost).
+ * This test case assume you have a default GeoServer 2.2 installed on 127.0.0.1 (ie localhost).
+ * <p>
+ * This is being used to look at WMS 1.1.1 vs WMS 1.3.0 compatibility issues for uDig.
+ * <p>
+ * 
+ * <pre><code>
+ * &lt;Layer queryable="1"&gt;
+ * &lt;Name&gt;nurc:Img_Sample&lt;/Name&gt;
+ *     &lt;Title&gt;North America sample imagery&lt;/Title&gt;
+ *     &lt;Abstract/&gt;
+ *     &lt;KeywordList&gt;
+ *     &lt;Keyword&gt;WCS&lt;/Keyword&gt;
+ *     &lt;Keyword&gt;worldImageSample&lt;/Keyword&gt;
+ *     &lt;Keyword&gt;worldImageSample_Coverage&lt;/Keyword&gt;
+ *     &lt;/KeywordList&gt;
+ *     &lt;CRS&gt;EPSG:4326&lt;/CRS&gt;
+ *     &lt;CRS&gt;CRS:84&lt;/CRS&gt;
+ *     &lt;EX_GeographicBoundingBox&gt;
+ *         &lt;westBoundLongitude&gt;-130.85168&lt;/westBoundLongitude&gt;
+ *         &lt;eastBoundLongitude&gt;-62.0054&lt;/eastBoundLongitude&gt;
+ *         &lt;southBoundLatitude&gt;20.7052&lt;/southBoundLatitude&gt;
+ *         &lt;northBoundLatitude&gt;54.1141&lt;/northBoundLatitude&gt;
+ *     &lt;/EX_GeographicBoundingBox&gt;
+ *     &lt;BoundingBox CRS="CRS:84" minx="-130.85168" miny="20.7052" maxx="-62.0054" maxy="54.1141"/&gt;
+ *     &lt;BoundingBox CRS="EPSG:4326" minx="20.7052" miny="-130.85168" maxx="54.1141" maxy="-62.0054"/&gt;
+ *     &lt;Style&gt;
+ *     &lt;Name&gt;raster&lt;/Name&gt;
+ *     &lt;Title&gt;Default Raster&lt;/Title&gt;
+ *     &lt;Abstract&gt;
+ *     A sample style that draws a raster, good for displaying imagery
+ *     &lt;/Abstract&gt;
+ *     &lt;LegendURL width="20" height="20"&gt;
+ *         &lt;Format&gt;image/png&lt;/Format&gt;
+ *         &lt;OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost:8080/geoserver/ows?service=WMS&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=Img_Sample"/&gt;
+ *     &lt;/LegendURL&gt;
+ *     &lt;/Style&gt;
+ * &lt;/Layer&gt;
+ * </code></pre>
+ * 
+ * </p>
  * 
  * @author Jody Garnett
- *
- *
- *
  * @source $URL$
  */
 public class LocalGeoServerOnlineTest extends TestCase {
+    static private String LOCAL_GEOSERVER = "http://127.0.0.1:8080/geoserver/ows?SERVICE=WMS&";
+
     static private WebMapServer wms;
+
     static private WMSCapabilities capabilities;
+
     static private URL serverURL;
     static {
         try {
-            serverURL = new URL("http://127.0.0.1:8080/geoserver/ows?SERVICE=WMS&");
+            serverURL = new URL(LOCAL_GEOSERVER);
         } catch (MalformedURLException e) {
             serverURL = null;
-        };
+        }
+        ;
     }
+
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        if( wms == null ){
+        System.setProperty("org.geotools.referencing.forceXY", "true"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (wms == null) {
             // do setup once!
-            if( serverURL != null ){
+            if (serverURL != null) {
                 try {
-                    wms = new WebMapServer( serverURL );
+                    wms = new WebMapServer(serverURL);
                     capabilities = wms.getCapabilities();
-                }
-                catch (Exception eek){
+                } catch (Exception eek) {
                     serverURL = null;
                     throw eek;
                 }
             }
-        }        
-    }
-        
-    public void testLocalGeoServer(){
-        assertNotNull( wms );
-        assertNotNull( capabilities );
-        Layer root = capabilities.getLayer();
-        assertNotNull( root );
-        assertNull( "root layer does not have a name", root.getName() );
-        assertNotNull( "title", root.getTitle() );
+        }
     }
 
-    public void testStates(){
-        Layer states = find( "topp:states" );
-        assertNotNull( states );  
-        
-        ResourceInfo info = wms.getInfo( states );
-        assertNotNull( info );
-        assertEquals( states.getTitle(), info.getTitle() );
-        
-        ReferencedEnvelope bounds = info.getBounds();
-        assertNotNull( bounds );
-        assertFalse( bounds.isEmpty() );
+    public void testLocalGeoServer() {
+        assertNotNull(wms);
+        assertNotNull(capabilities);
+
+        assertEquals("Version Negotiation", "1.3.0", capabilities.getVersion());
+        Layer root = capabilities.getLayer();
+        assertNotNull(root);
+        assertNull("root layer does not have a name", root.getName());
+        assertNotNull("title", root.getTitle());
     }
-    private Layer find( String name ){
-        for( Layer layer : capabilities.getLayerList() ){
-            if( name.equals( layer.getName() )){
+
+    public void testStates() {
+        Layer states = find("topp:states");
+        assertNotNull(states);
+
+        ResourceInfo info = wms.getInfo(states);
+        assertNotNull(info);
+        assertEquals(states.getTitle(), info.getTitle());
+
+        ReferencedEnvelope bounds = info.getBounds();
+        assertNotNull(bounds);
+        assertFalse(bounds.isEmpty());
+    }
+
+    private Layer find(String name, WMSCapabilities caps) {
+        for (Layer layer : caps.getLayerList()) {
+            if (name.equals(layer.getName())) {
                 return layer;
             }
         }
         return null;
     }
-    
-    public void testServiceInfo(){
+
+    private Layer find(String name) {
+        return find(name, capabilities);
+    }
+
+    public void testServiceInfo() {
         ServiceInfo info = wms.getInfo();
-        assertNotNull( info );
-        
-        assertEquals( serverURL, wms.getCapabilities().getRequest().getGetCapabilities().getGet() );
-        assertEquals( "GeoServer Web Map Service", info.getTitle() );
-        
-        assertNotNull( info.getDescription() );        
+        assertNotNull(info);
+
+        assertEquals(serverURL, wms.getCapabilities().getRequest().getGetCapabilities().getGet());
+        assertEquals("GeoServer Web Map Service", info.getTitle());
+
+        assertNotNull(info.getDescription());
+    }
+
+    String axisName(CoordinateReferenceSystem crs, int dimension ){
+        return crs.getCoordinateSystem().getAxis(dimension).getName().getCode();
     }
     
-    public void testResourceInfo(){
+    public void testImgSample130() {
+        Layer img_sample = find( "nurc:Img_Sample");
+        assertNotNull("Img_Sample layer found", img_sample );
+        CRSEnvelope latLon = img_sample.getLatLonBoundingBox();
+        assertEquals( "LatLonBoundingBox axis 0 name", "Geodetic longitude", axisName( latLon.getCoordinateReferenceSystem(), 0) );
+        assertEquals( "LatLonBoundingBox axis 0 name", "Geodetic latitude", axisName( latLon.getCoordinateReferenceSystem(), 1) );
+        
+        CRSEnvelope bounds = img_sample.getBoundingBoxes().get("EPSG:4326");
+        assertEquals( "EPSG:4326 axis 0 name", "Geodetic latitude", axisName( bounds.getCoordinateReferenceSystem(), 0) );
+        assertEquals( "EPSG:4326 axis 1 name", "Geodetic longitude", axisName( bounds.getCoordinateReferenceSystem(), 1) );
+        
+        assertEquals("axis order 0 min", latLon.getMinimum(1), bounds.getMinimum(0));
+        assertEquals("axis order 1 min", latLon.getMinimum(0), bounds.getMinimum(1));
+        assertEquals("axis order 1 max", latLon.getMaximum(0), bounds.getMaximum(1));
+        assertEquals("axis order 1 min", latLon.getMaximum(1), bounds.getMaximum(0));
+    }
+    
+    public void testImageSample111() throws Exception {
+        WebMapServer wms111 = new WebMapServer( new URL(serverURL +"&VERSION=1.1.1") );
+        WMSCapabilities caps = wms111.getCapabilities();
+        assertEquals( "1.1.1", caps.getVersion() );
+        
+        Layer img_sample = find("nurc:Img_Sample",caps );
+        assertNotNull("Img_Sample layer found", img_sample );
+        CRSEnvelope latLon = img_sample.getLatLonBoundingBox();
+        assertEquals( "LatLonBoundingBox axis 0 name", "Geodetic longitude", axisName( latLon.getCoordinateReferenceSystem(), 0) );
+        assertEquals( "LatLonBoundingBox axis 1 name", "Geodetic latitude", axisName( latLon.getCoordinateReferenceSystem(), 1) );
+      
+        CRSEnvelope bounds = img_sample.getBoundingBoxes().get("EPSG:4326");
+        assertEquals( "EPSG:4326 axis 0 name", "Geodetic longitude", axisName( bounds.getCoordinateReferenceSystem(), 0) );
+        assertEquals( "EPSG:4326 axis 1 name", "Geodetic latitude", axisName( bounds.getCoordinateReferenceSystem(), 1) );
+        
+        assertEquals("axis order 0 min", latLon.getMinimum(0), bounds.getMinimum(0));
+        assertEquals("axis order 1 min", latLon.getMinimum(1), bounds.getMinimum(1));
+        assertEquals("axis order 1 max", latLon.getMaximum(0), bounds.getMaximum(0));
+        assertEquals("axis order 1 min", latLon.getMaximum(1), bounds.getMaximum(1));
+        
+        
+        
+        
         
     }
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/LongitudeFirstFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/LongitudeFirstFactory.java
@@ -141,7 +141,7 @@ public class LongitudeFirstFactory extends DeferredAuthorityFactory implements C
      */
     private static int relativePriority() {
         try {
-            if (Boolean.getBoolean(SYSTEM_DEFAULT_KEY)) {
+            if (Boolean.getBoolean(GeoTools.FORCE_LONGITUDE_FIRST_AXIS_ORDER)) {
                 return +7;
             }
         } catch (SecurityException e) {


### PR DESCRIPTION
Bug report is an old but good difference between WMS 1.1.1 and WMS 1.3.0.

https://jira.codehaus.org/browse/GEOT-375

Sub task: 
https://jira.codehaus.org/browse/GEOT-4282 WMS 1.3.0 interpretation of CRSEnvelope srsName

This first pull request just fixes the handling of GetCapabilities so that CRSEnvelope can report back the correct CoordianteReferenceSystem to describe the srsName (even if the global forceXY hint is set).

A test case is provided working against a localhost GeoServer 2.2 instance.

This issue is related to https://jira.codehaus.org/browse/UDIG-1951
