### PR TITLE
WMS 1.3.0 support with transforms in Layer.getEnvelope and GetMap.setBounds( Envelope )

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/data/ows/CRSEnvelope.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/ows/CRSEnvelope.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.data.ows;
 
+import org.geotools.data.wms.request.AbstractGetMapRequest;
 import org.geotools.factory.GeoTools;
 import org.geotools.factory.Hints;
 import org.geotools.geometry.GeneralDirectPosition;
@@ -107,7 +108,7 @@ public class CRSEnvelope implements Envelope {
         this.maxY = maxY;
     }
     public CRSEnvelope(Envelope envelope) {
-        this.srsName = envelope.getCoordinateReferenceSystem().getIdentifiers().iterator().next().toString();
+        this.srsName = CRS.toSRS( envelope.getCoordinateReferenceSystem());
         //this.srsName = epsgCode;
         this.minX = envelope.getMinimum(0);
         this.maxX = envelope.getMaximum(0);
@@ -123,24 +124,12 @@ public class CRSEnvelope implements Envelope {
         synchronized (this) {
             if (crs == null) {
                 try {
-                    if( srsName != null ){
-                        if( forceXY == null ){
-                            crs = CRS.decode(srsName);
-                        }
-                        else if( forceXY == Boolean.TRUE ){
-                            crs = CRS.decode(srsName,true);
-                        }
-                        else if( srsName.startsWith("EPSG:") && Boolean.getBoolean(GeoTools.FORCE_LONGITUDE_FIRST_AXIS_ORDER)){
-                            // how do we look up the unmodified axis order?
-                            String explicit = srsName.replace("EPSG:", "urn:x-ogc:def:crs:EPSG:");
-                            crs = CRS.decode(explicit,false);
-                        }
-                        else {
-                            crs = CRS.decode(srsName,false);
-                        }                        
+                    String srs = srsName != null ? srsName : "CRS:84";
+                    if( forceXY == null ){
+                        crs = CRS.decode(srs);
                     }
                     else {
-                        crs = CRS.decode("CRS:84"); // implicit
+                        crs = AbstractGetMapRequest.toServerCRS(srsName, forceXY );
                     }
                 } catch (NoSuchAuthorityCodeException e) {
                     crs = DefaultEngineeringCRS.CARTESIAN_2D;

--- a/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetMapRequest.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetMapRequest.java
@@ -27,7 +27,15 @@ import java.util.Stack;
 import org.geotools.data.ows.CRSEnvelope;
 import org.geotools.data.ows.Layer;
 import org.geotools.data.ows.StyleImpl;
+import org.geotools.factory.GeoTools;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.opengis.geometry.BoundingBox;
+import org.opengis.geometry.Envelope;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.NoSuchAuthorityCodeException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.TransformException;
 
 /**
  * 
@@ -168,7 +176,10 @@ public abstract class AbstractGetMapRequest extends AbstractWMSRequest implement
      * server has declared that a Layer is not subsettable, then the Client
      * shall specify exactly the declared Bounding Box values in the GetMap
      * request and the Server may issue a Service Exception otherwise."
-     *
+     * <p>
+     * Yu must also call setSRS to provide the spatial reference system
+     * information (or CRS:84 will be assumed)
+     * 
      * @param bbox A string representing a bounding box in the format
      *        "minx,miny,maxx,maxy"
      */
@@ -176,26 +187,51 @@ public abstract class AbstractGetMapRequest extends AbstractWMSRequest implement
         //TODO enforce non-subsettable layers
         properties.setProperty(BBOX, bbox);
     }
-
-    public void setBBox(CRSEnvelope box){
-        StringBuffer sb = new StringBuffer();
-        sb.append(box.getMinX());
-        sb.append(",");
-        sb.append(box.getMinY()+",");
-        sb.append(box.getMaxX()+",");
-        sb.append(box.getMaxY());
-        setBBox(sb.toString());
+    
+    public static CoordinateReferenceSystem toServerCRS(String srsName, boolean forceXY) {
+        try {
+            if (srsName != null) {
+                if (forceXY) {
+                    return CRS.decode(srsName, true);
+                } else if (srsName.startsWith("EPSG:")
+                        && Boolean.getBoolean(GeoTools.FORCE_LONGITUDE_FIRST_AXIS_ORDER)) {
+                    // how do we look up the unmodified axis order?
+                    String explicit = srsName.replace("EPSG:", "urn:x-ogc:def:crs:EPSG::");
+                    return CRS.decode(explicit, false);
+                } else {
+                    return CRS.decode(srsName, false);
+                }
+            }
+            else {
+                return CRS.decode("CRS:84");
+            }
+        } catch (NoSuchAuthorityCodeException e) {
+        } catch (FactoryException e) {
+        }
+        return DefaultEngineeringCRS.CARTESIAN_2D;
     }
-    public void setBBox(BoundingBox box) {
-        StringBuffer sb = new StringBuffer();
-        sb.append(box.getMinX());
-        sb.append(",");
-        sb.append(box.getMinY());
-        sb.append(",");
-        sb.append(box.getMaxX());
-        sb.append(",");
-        sb.append(box.getMaxY());
+    /**
+     * Sets BBOX and SRS using the provided Envelope.
+     */
+    public void setBBox(Envelope envelope){
+        String version = properties.getProperty(VERSION);
+        boolean forceXY = version == null || !version.startsWith("1.3");
+        String srsName = CRS.toSRS( envelope.getCoordinateReferenceSystem() );
+        setSRS( srsName );
         
+        CoordinateReferenceSystem crs = toServerCRS( srsName, forceXY );
+        Envelope bbox;
+        try {
+            bbox = CRS.transform( envelope, crs);
+        } catch (TransformException e) {
+            bbox = envelope;
+        }
+        StringBuffer sb = new StringBuffer();
+        sb.append(bbox.getMinimum(0));
+        sb.append(",");
+        sb.append(bbox.getMinimum(1)+",");
+        sb.append(bbox.getMaximum(0)+",");
+        sb.append(bbox.getMaximum(1));
         setBBox(sb.toString());
     }
     /**

--- a/modules/extension/wms/src/main/java/org/geotools/data/wms/request/GetMapRequest.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/wms/request/GetMapRequest.java
@@ -24,6 +24,7 @@ import org.geotools.data.ows.Layer;
 import org.geotools.data.ows.Request;
 import org.geotools.data.ows.StyleImpl;
 import org.opengis.geometry.BoundingBox;
+import org.opengis.geometry.Envelope;
 
 /**
  * Construct a WMS getMap request.
@@ -224,8 +225,13 @@ public interface GetMapRequest extends Request{
      *        "minx,miny,maxx,maxy"
      */
     public void setBBox(String bbox);
-    public void setBBox(CRSEnvelope box);
-    public void setBBox(BoundingBox box);
+    
+    /**
+     * Sets the BBOX and SRS information from the provided Envelope (such as a CRSEnvelope).
+     * @param box
+     */
+    public void setBBox(Envelope box);
+    
     
     /**
      * From the Web Map Service Implementation Specification: "The required


### PR DESCRIPTION
TLDR: Use CRS.transform to handle bounding boxes correctly when served by Layer, or when added using GetMapRequest. Refactor out a common method for toServerCRS for consistent handling

For context of this issue see https://jira.codehaus.org/browse/GEOT-4283 WMS 1.3.0 GetMap Request

The main change here is a toServerCRS method which takes server version into account when determining a CoordinateReferenceSystem. 
- CRSEnvelope.getCoordinateReferenceSystem(). Use toServerCRS() to ensure the data structure matches the server description. This allows Layer.getEnvelope will then use a transform to process the data into the Envelope the user expects (according the global forceXY setting).
- GetMap.setBounds(Envelope): Uses toServerCRS() to transform the Envelope into the order expected by the Server.

Implementation notes:
- This pull request contains no changes to ft-referencing
- Considered delaying transform to server CRS until executing the GetMapRequest. Rejected to ensure the GetMapRequest matches what we send over.
- The methods used by WMS cascade - setBounds( String ) and setSRS( String ) remain fire and forget and do not make any attempt at consistency.
