### PR TITLE
this is a parch for GEOT-4297, it fix the bug in the geoperations names ...

### DIFF
--- a/modules/library/cql/src/main/java/org/geotools/filter/text/cql2/FilterToCQL.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/cql2/FilterToCQL.java
@@ -237,11 +237,11 @@ class FilterToCQL implements FilterVisitor {
     }
     public Object visit(Overlaps filter, Object extraData) {
     	checkLeftExpressionIsProperty(filter.getExpression1());
-    	return FilterToTextUtil.buildBinarySpatialOperator("OVERLAP", filter, extraData);
+    	return FilterToTextUtil.buildBinarySpatialOperator("OVERLAPS", filter, extraData);
     }
     public Object visit(Touches filter, Object extraData) {
     	checkLeftExpressionIsProperty(filter.getExpression1());
-    	return FilterToTextUtil.buildBinarySpatialOperator("TOUCH", filter, extraData);
+    	return FilterToTextUtil.buildBinarySpatialOperator("TOUCHES", filter, extraData);
     }
     	     
     public Object visit(Within filter, Object extraData) {

--- a/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/FilterToECQL.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/FilterToECQL.java
@@ -228,12 +228,12 @@ final class FilterToECQL implements FilterVisitor {
 
 	@Override
 	public Object visit(Overlaps filter, Object extraData) {
-    	return FilterToTextUtil.buildBinarySpatialOperator("OVERLAP", filter, extraData);
+    	return FilterToTextUtil.buildBinarySpatialOperator("OVERLAPS", filter, extraData);
 	}
 
 	@Override
 	public Object visit(Touches filter, Object extraData) {
-    	return FilterToTextUtil.buildBinarySpatialOperator("TOUCH", filter, extraData);
+    	return FilterToTextUtil.buildBinarySpatialOperator("TOUCHES", filter, extraData);
 	}
 
 	@Override

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/FilterToCQLTest.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/FilterToCQLTest.java
@@ -234,10 +234,35 @@ public class FilterToCQLTest{
     }
 
     @Test
-    public void testIntersects() throws Exception{
+    public void testIntersectsPoint() throws Exception{
     	
     	cqlTest("INTERSECTS(the_geom, POINT (1 2))");
     }
+    
+	@Test
+	public void testIntersects() throws Exception {
+		cqlTest("INTERSECTS(theGeom, POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0)))");
+	}
+
+	@Test
+	public void testOverlaps() throws Exception {
+		cqlTest("OVERLAPS(theGeom, POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0)))");
+	}
+
+	@Test
+	public void testCrosses() throws Exception {
+		cqlTest("CROSSES(theGeom, POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0)))");
+	}
+
+	@Test
+	public void testContains() throws Exception {
+		cqlTest("CONTAINS(theGeom, POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0)))");
+	}
+
+	@Test
+	public void testTouches() throws Exception {
+		cqlTest("TOUCHES(theGeom, POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0)))");
+	}
 
     protected void cqlTest( String cql ) throws Exception {
         Filter filter = CQL.toFilter(cql);


### PR DESCRIPTION
Fix the in FilterToCQL and FilterToECQL. The geooperations Touches and Crosses were corrected consistently with the new syntax of CQLl and ECQL 
