### PR TITLE
added LoggingHTTPClient

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/ows/DelegateHTTPClient.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/DelegateHTTPClient.java
@@ -1,0 +1,83 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.ows;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+
+public class DelegateHTTPClient implements HTTPClient {
+
+    protected HTTPClient delegate;
+
+    
+    public DelegateHTTPClient(HTTPClient delegate)  {
+        this.delegate = delegate;
+    }
+
+    
+    @Override
+    public HTTPResponse post(URL url, InputStream postContent, String postContentType) throws IOException {
+        return delegate.post(url, postContent, postContentType);
+    }
+
+    @Override    
+    public HTTPResponse get(URL url) throws IOException {
+        return delegate.get(url);
+    }
+    
+    @Override
+    public String getUser() {
+        return delegate.getUser();
+    }
+    
+    @Override
+    public void setUser(String user) {
+        delegate.setUser(user);
+    }
+
+    @Override
+    public String getPassword() {
+        return delegate.getPassword();
+    }
+
+    @Override
+    public void setPassword(String password) {
+        delegate.setPassword(password);
+    }
+
+    @Override
+    public int getConnectTimeout() {
+        return delegate.getConnectTimeout();
+    }
+
+    @Override
+    public void setConnectTimeout(int connectTimeout) {
+        delegate.setConnectTimeout(connectTimeout);
+    }
+
+    @Override
+    public int getReadTimeout() {
+        return delegate.getReadTimeout();
+    }
+
+    @Override
+    public void setReadTimeout(int readTimeout) {
+        delegate.setReadTimeout(readTimeout);
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/data/ows/DelegateHTTPResponse.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/DelegateHTTPResponse.java
@@ -1,0 +1,51 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.ows;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class DelegateHTTPResponse implements HTTPResponse {
+
+    protected HTTPResponse delegate;
+
+    
+    public DelegateHTTPResponse(HTTPResponse delegate) {
+        this.delegate = delegate;
+    }
+    
+    
+    @Override
+    public void dispose() {
+        delegate.dispose();
+    }
+    
+    @Override
+    public String getContentType() {
+        return delegate.getContentType();
+    }
+    
+    @Override
+    public String getResponseHeader(String headerName) {
+        return delegate.getResponseHeader(headerName);
+    }
+    
+    @Override
+    public InputStream getResponseStream() throws IOException {
+        return delegate.getResponseStream();
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/data/ows/LoggingHTTPClient.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/LoggingHTTPClient.java
@@ -1,0 +1,98 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.ows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+
+public class LoggingHTTPClient extends DelegateHTTPClient {
+
+    private String charsetName;
+    private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
+    private static final Logger LOGGER = Logger.getLogger("org.geotools.data.ows.httpclient");
+    
+    
+    public LoggingHTTPClient(HTTPClient delegate)  {
+        this(delegate, "UTF-8");
+    }
+
+    public LoggingHTTPClient(HTTPClient delegate, String charsetName)  {
+        super(delegate);
+        this.charsetName = charsetName;
+    }
+
+    
+    @Override
+    public HTTPResponse post(URL url, InputStream postContent, String postContentType) throws IOException {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            copy(postContent, out);
+            LOGGER.finest("POST Request URL: " + url);
+            LOGGER.finest("POST Request Body: \n" + out.toString(charsetName));
+            
+            return new LoggingHTTPResponse(delegate.post(url, new ByteArrayInputStream(out.toByteArray()), 
+                    postContentType), charsetName);            
+        } else {
+            return delegate.post(url, postContent, postContentType);
+        }
+    }
+    
+    @Override
+    public HTTPResponse get(URL url) throws IOException {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("GET Request URL: " + url);            
+            return new LoggingHTTPResponse(delegate.get(url), charsetName);                        
+        } else {        
+            return delegate.get(url);
+        }
+    }
+    
+    public static void copy(InputStream input, OutputStream output) throws IOException {
+        byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+        int n = 0;
+        while (-1 != (n = input.read(buffer))) {
+            output.write(buffer, 0, n);
+        }
+    }
+    
+    class LoggingHTTPResponse extends DelegateHTTPResponse {
+
+        private InputStream input;
+        
+        public LoggingHTTPResponse(HTTPResponse delegate, String charsetName) throws IOException {
+            super(delegate);
+                        
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            LoggingHTTPClient.copy(delegate.getResponseStream(), output);
+            LOGGER.finest("Response: \n" + output.toString(charsetName));
+
+            input = new ByteArrayInputStream(output.toByteArray());
+        }
+
+        @Override
+        public InputStream getResponseStream() throws IOException {
+            return input;
+        }
+    }
+}


### PR DESCRIPTION
Hi,
to make debugging easier I've added a LoggingHTTPClient.
It implements HTTPClient and when the FINEST logging level is enabled in "org.geotools.data.ows.httpclient", it will log URLs requested, POST Request Body, and Response content.

Added files:
DelegateHTTPClient
DelegateHTTPResponse
LoggingHTTPClient

No changes in other files.
