### PR TITLE
GEOT-4307: fixed method visit(Id,Object) in CapabilitiesFilterSplitter a...

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/CapabilitiesFilterSplitter.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/CapabilitiesFilterSplitter.java
@@ -756,13 +756,13 @@ public class CapabilitiesFilterSplitter implements FilterVisitor, ExpressionVisi
     public Object visit(Id filter, Object notUsed) {
         if (original == null)
             original = filter;
-
-        // figure out how to check that this is top level.
-        // otherwise this is fine
-        if (!postStack.isEmpty()) {
+        
+        if (!fcs.supports(filter)) {
             postStack.push(filter);
+        } else {
+            preStack.push(filter);            
         }
-        preStack.push(filter);
+
         return null;
     }
 

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitor.java
@@ -739,16 +739,16 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
 	
 
 	    public Object visit(Id filter, Object notUsed) {
-	        if( original==null )
-	        	original=filter;
-
-	        // figure out how to check that this is top level.
-	        // otherwise this is fine
-	        if (!postStack.isEmpty()) {
-	        	postStack.push(filter);
+	        if (original == null)
+	            original = filter;
+	        
+	        if (!fcs.supports(filter)) {
+	            postStack.push(filter);
+	        } else {
+	            preStack.push(filter);            
 	        }
-	        preStack.push(filter);
-            return null;
+
+	        return null;
 	    }
         
 	    public Object visit(PropertyName expression, Object notUsed) {

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/CapabilitiesFilterSplitterTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/CapabilitiesFilterSplitterTest.java
@@ -23,8 +23,10 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.geotools.filter.Capabilities;
+import org.geotools.filter.capability.FilterCapabilitiesImpl;
 import org.junit.Before;
 import org.junit.Test;
+import org.opengis.filter.And;
 import org.opengis.filter.Filter;
 import org.opengis.filter.Id;
 import org.opengis.filter.Or;
@@ -168,6 +170,22 @@ public class CapabilitiesFilterSplitterTest extends AbstractCapabilitiesFilterSp
         assertEquals(filter, visitor.getFilterPre());
     }
 
+    @Test    
+    @SuppressWarnings("rawtypes")    
+    public void testVisitIdFilterWithNoIdCapabilities() throws Exception {
+        // Id Filter
+        HashSet ids = new HashSet();
+        ids.add(ff.featureId("david"));
+        Filter idFilter = ff.id(ids);
+
+        // no Id Capabilities
+        visitor = newVisitor(Capabilities.SIMPLE_COMPARISONS_OPENGIS);
+        idFilter.accept(visitor, null);
+        
+        assertEquals(Filter.INCLUDE, visitor.getFilterPre());
+        assertEquals(idFilter, visitor.getFilterPost());        
+    }    
+    
     @Test
     public void testFunctionFilter() throws Exception {
         simpleLogicalCaps.addType(BBOX.class);

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitorTest.java
@@ -154,6 +154,25 @@ public class PostPreProcessFilterSplittingVisitorTest extends AbstractPostPrePro
 		assertEquals(filter, visitor.getFilterPre());
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public void testVisitIdFilterWithNoIdCapabilities() throws Exception {
+	    // Id Filter
+	    HashSet ids = new HashSet();
+	    ids.add(ff.featureId("david"));
+	    Filter idFilter = ff.id(ids);
+
+	    // no Id Capabilities
+	    FilterCapabilities fc = new FilterCapabilities();
+            fc.addAll(FilterCapabilities.SIMPLE_COMPARISONS_OPENGIS);
+            fc.addType(And.class);
+
+            visitor = newVisitor(fc);
+            idFilter.accept(visitor, null);
+            
+            assertEquals(Filter.INCLUDE, visitor.getFilterPre());
+            assertEquals(idFilter, visitor.getFilterPost());	    
+	}
+	
 	public void testFunctionFilter() throws Exception {
 		simpleLogicalCaps.addType(BBOX.class);
         visitor=newVisitor(simpleLogicalCaps);


### PR DESCRIPTION
...nd PostPreProcessFilterSplittingVisitor

This is the related Jira: http://jira.codehaus.org/browse/GEOT-4307

Already fixed on master. This is the 2.7.x backport.
