### PR TITLE
2.7.x GEOT-4315 and GEOT-4318

### DIFF
--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_1_0/DefaultWFSStrategy.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_1_0/DefaultWFSStrategy.java
@@ -49,6 +49,7 @@ import org.geotools.filter.capability.FilterCapabilitiesImpl;
 import org.geotools.filter.v1_1.OGC;
 import org.geotools.filter.v1_1.OGCConfiguration;
 import org.geotools.filter.visitor.CapabilitiesFilterSplitter;
+import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.geotools.wfs.v1_1.WFSConfiguration;
 import org.geotools.xml.Configuration;
 import org.geotools.xml.Encoder;
@@ -276,6 +277,9 @@ public class DefaultWFSStrategy implements WFSStrategy {
      * @see WFSStrategy#splitFilters(WFS_1_1_0_Protocol, Filter)
      */
     public Filter[] splitFilters(Capabilities caps, Filter queryFilter) {
+        SimplifyingFilterVisitor simplifier = new SimplifyingFilterVisitor(); 
+        queryFilter = (Filter) queryFilter.accept(simplifier, null);
+        
         // ID Filters aren't allowed to be parameters in Logical or Comparison Operators
         
         FilterCapabilities filterCapabilities = caps.getContents();


### PR DESCRIPTION
Hi,

this patch fixes 
http://jira.codehaus.org/browse/GEOT-4315

DefaultWFSStrategy filters are appropriately splitted.

http://jira.codehaus.org/browse/GEOT-4318

SimplifyingFilterVisitor is used to clean up filters and WFS_1_1_0_DataStore.getCount(Query) uses validated filters, like in the method WFS_1_1_0_DataStore.executeGetFeatures(Query, Transaction).

Already fixed on master. This is the 2.7.x backport.
