### PR TITLE
Construct ReferencedEnvelope or ReferencedEnvelope3D based on CoordinateReferenceSystem

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -284,9 +284,11 @@ public class ReferencedEnvelope extends Envelope implements org.opengis.geometry
             final int expected = getDimension();
             final int dimension = crs.getCoordinateSystem().getDimension();
             if (dimension > expected) {
+                // check dimensions and choose ReferencedEnvelope or ReferencedEnvelope3D
+                // or the factory method ReferencedEnvelope.reference( CoordinateReferenceSystem )
                 throw new MismatchedDimensionException(Errors.format(
-                        ErrorKeys.MISMATCHED_DIMENSION_$3, crs.getName().getCode(),
-                        new Integer(dimension), new Integer(expected)));
+                    ErrorKeys.MISMATCHED_DIMENSION_$3, crs.getName().getCode(),
+                    new Integer(dimension), new Integer(expected)));
             }
         }
     }
@@ -836,4 +838,17 @@ public class ReferencedEnvelope extends Envelope implements org.opengis.geometry
     	return new ReferencedEnvelope(reference(env), crs);
     }
     
+    /**
+     * Utility method to create a ReferencedEnvelope from an opengis Envelope class,
+     * supporting 2d as well as 3d envelopes (returning the right class).
+     * 
+     * @param env The opgenis Envelope object
+     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
+     */
+    public static ReferencedEnvelope reference(CoordinateReferenceSystem crs) {
+        if (crs != null && crs.getCoordinateSystem().getDimension() > 2 ){
+            return new ReferencedEnvelope3D(crs);
+        }
+        return new ReferencedEnvelope(crs);
+    }
 }

--- a/modules/library/api/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
+++ b/modules/library/api/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
@@ -2,10 +2,12 @@ package org.geotools.geometry.jts;
 
 import static org.junit.Assert.*;
 
+import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Test;
 import org.opengis.geometry.MismatchedReferenceSystemException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import java.awt.geom.Rectangle2D;
@@ -135,6 +137,19 @@ public class ReferencedEnvelopeTest {
 
         assertFalse(env1.boundsEquals2D(env2, eps));
 
+    }
+    
+    @Test
+    public void testFactoryMethod() throws Exception {
+        try {
+            ReferencedEnvelope bounds = new ReferencedEnvelope( DefaultGeographicCRS.WGS84_3D );
+            fail("ReferencedEnvelope should not be able to represent 3D CRS such as GDA94");
+        }
+        catch (Exception expected){
+        }
+        
+        ReferencedEnvelope bounds2 = ReferencedEnvelope.reference( DefaultGeographicCRS.WGS84_3D );
+        assertNotNull( bounds2 );
     }
 
 }


### PR DESCRIPTION
https://jira.codehaus.org/browse/GEOT-4325

I am chasing down GEOS-5474, where the ContentDataStore methods to calculate bounds have not been informed of the difference between ReferncedEnvelope and ReferencedEnvelope3D yet.

I kind of expect this is a widespread issue, since the ReferencedEnvelope constructor is now willing to fail (not even a warning just fail).

This first pull request just introduced a factory method: ReferencedEnvelope.reference( CoordinateReferenceSystem).

The next step will be using Oracle data store as an excuse to review how ReferencedEnvelope is handled by JDBCDataStore and friends.
