### PR TITLE
GEOT-4327: fixed build failure in gt-epsq-hsql

### DIFF
--- a/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/CRSTest.java
+++ b/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/CRSTest.java
@@ -82,6 +82,12 @@ public class CRSTest extends TestCase {
         super(name);
     }
 
+    protected void tearDown() throws Exception {
+        System.clearProperty("org.geotools.referencing.forceXY");
+        Hints.removeSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER);
+        CRS.reset("all");
+    }    
+    
     /**
      * Tests the (latitude, longitude) axis order for EPSG:4326.
      */


### PR DESCRIPTION
Hi,

I've fixed a build issue in gt-epsq-hsql: test CRSTest didn't clean up its settings so the next executed test always failed in my environment (Windows 7, Java 6, Maven 2).

Test were all green only if executed one at a time.
