### PR TITLE
GEOT-4324: CapabilitiesFilterSplitter optimization

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/CapabilitiesFilterSplitter.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/CapabilitiesFilterSplitter.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2012, Open Source Geospatial Foundation (OSGeo)
  *    
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -644,8 +644,45 @@ public class CapabilitiesFilterSplitter implements FilterVisitor, ExpressionVisi
             original = filter;
 
         if (!fcs.supports(filter)) {
-            postStack.push(filter);
-            return;
+            // logical operators aren't supported
+            
+            // if the logical operator is AND            
+            if (filter instanceof And) {
+                // test if one of its children is supported
+                Iterator<Filter> it = ((And) filter).getChildren().iterator();
+                Filter supportedChild = null;
+                List<Filter> otherChildren = new ArrayList<Filter>();
+                while (it.hasNext()) {
+                    Filter child = (Filter) it.next();
+                    if (supportedChild == null && fcs.supports(child)) {
+                        supportedChild = child;
+                    } else {
+                        otherChildren.add(child);
+                    }
+                }
+                
+                if (supportedChild == null) {
+                    // no child supported
+                    postStack.push(filter);
+                    return;                                    
+                } else {
+                    // found at least one child supported
+                    
+                    // push the first supported child on preStack
+                    preStack.push(supportedChild);
+                    
+                    // push other children on postStack
+                    if (otherChildren.size() == 1) {
+                        postStack.push(otherChildren.get(0));
+                    } else {
+                        postStack.push(ff.and(otherChildren));
+                    }
+                    return;
+                }
+            } else {
+                postStack.push(filter);
+                return;                
+            }
         }
 
         int i = postStack.size();


### PR DESCRIPTION
Hi,

I've created a patch for jira http://jira.codehaus.org/browse/GEOT-4324  

When logical operators aren't supported, CapabilitiesFilterSplitter can search AND children and eventually use a supported child putting it on the preStack, and putting the remaining children on the postStack.
