### PR TITLE
GEOT-4322: added Oracle SDO_NN function

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -1517,7 +1517,9 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
         if(params == null || params.size() <= idx) {
             if(mandatory) {
                 throw new IllegalArgumentException("Missing parameter number " + (idx + 1) 
-                        + "for function " + function.getName() + ", cannot encode in SQL");
+                        + " for function " + function.getName() + ", cannot encode in SQL");
+            } else {
+            	return null;
             }
         }
         return params.get(idx);

--- a/modules/plugin/jdbc/jdbc-oracle/pom.xml
+++ b/modules/plugin/jdbc/jdbc-oracle/pom.xml
@@ -118,4 +118,15 @@
     </profile>
   </profiles>
   
+  <!-- =========================================================== -->
+  <!--     Dependency Management                                   -->
+  <!-- =========================================================== -->
+  <dependencies>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-cql</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>  
+  
 </project>

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleFilterToSQL.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2012, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -21,16 +21,22 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.FilterFactoryImpl;
+import org.geotools.filter.function.FilterFunction_sdonn;
+import org.geotools.filter.text.cql2.CQL;
+import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.geometry.jts.JTS;
+import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.PreparedFilterToSQL;
 import org.geotools.jdbc.PreparedStatementSQLDialect;
+import org.geotools.jdbc.PrimaryKeyColumn;
 import org.geotools.jdbc.SQLDialect;
 import org.opengis.filter.Filter;
+import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.spatial.BBOX;
@@ -66,21 +72,17 @@ import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 
+
 /**
  * Oracle specific filter encoder.
  * 
  * @author Justin Deoliveira, OpenGEO
  * @author Andrea Aime, OpenGEO
- *
- *
+ * @author Davide Savazzi, GeoSolutions
  *
  * @source $URL$
  */
 public class OracleFilterToSQL extends PreparedFilterToSQL {
-    
-    /** Logger - for logging */
-    private static final Logger LOGGER = org.geotools.util.logging.Logging.getLogger(
-            "org.geotools.filter.SQLEncoderOracle");
 
     /** Contains filter type to SDO_RELATE mask type mappings */
     private static final Map<Class, String> SDO_RELATE_MASK_MAP = new HashMap<Class, String>() {
@@ -157,6 +159,8 @@ public class OracleFilterToSQL extends PreparedFilterToSQL {
         caps.addType(DWithin.class);
         caps.addType(Beyond.class);
         
+        caps.addType(FilterFunction_sdonn.class);
+        
         //temporal filters
         caps.addType(After.class);
         caps.addType(Before.class);
@@ -169,6 +173,167 @@ public class OracleFilterToSQL extends PreparedFilterToSQL {
         caps.addType(TEquals.class);
         
         return caps;
+    }
+    
+    @Override 
+    public Object visit(PropertyIsEqualTo filter, Object extraData) {
+        FilterFunction_sdonn sdoNnQuery = getSDO_NN_Query(filter);
+        if (sdoNnQuery != null) {
+            return visit(sdoNnQuery, extraData);
+        } else {
+            return super.visit(filter, extraData);
+        }
+    }
+
+    private FilterFunction_sdonn getSDO_NN_Query(PropertyIsEqualTo filter) {
+        Expression expr1 = filter.getExpression1();
+        Expression expr2 = filter.getExpression2();
+
+        if (expr2 instanceof FilterFunction_sdonn) {
+            // switch position
+            Expression tmp = expr1;
+            expr1 = expr2;
+            expr2 = tmp;
+        }
+
+        if (expr1 instanceof FilterFunction_sdonn) {
+            if (!(expr2 instanceof Literal)) {
+                throw new UnsupportedOperationException(
+                        "Unsupported usage of SDO_NN Oracle function: property must be TRUE");
+            }
+
+            Boolean nearest = (Boolean) evaluateLiteral((Literal) expr2, Boolean.class);
+            if (nearest == null || !nearest.booleanValue()) {
+                throw new UnsupportedOperationException(
+                        "Unsupported usage of SDO_NN Oracle function: property must be TRUE");
+            }
+
+            return (FilterFunction_sdonn) expr1;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Object visit(Function function, Object extraData) {
+        if (function instanceof FilterFunction_sdonn) {
+            throw new UnsupportedOperationException(
+                    "Unsupported usage of SDO_NN Oracle function: must be used in a Equals Filter");
+        }
+
+        return super.visit(function, extraData);
+    }
+
+    private Object visit(FilterFunction_sdonn sdoNnQuery, Object extraData) {
+        Expression geometryExp = getParameter(sdoNnQuery, 0, true);
+        Expression sdoNumResExp = getParameter(sdoNnQuery, 1, true);
+        Expression cqlLiteralExp = getParameter(sdoNnQuery, 2, false);
+        Expression sdoBatchSizeExp = getParameter(sdoNnQuery, 3, false);
+
+        try {
+            List<PrimaryKeyColumn> pkColumns = getPrimaryKey().getColumns();
+            if (pkColumns.size() > 1) {
+                throw new UnsupportedOperationException(
+                        "Unsupported usage of SDO_NN Oracle function: table with composite primary key");
+            }
+            PrimaryKeyColumn pkColumn = pkColumns.get(0);
+
+            StringBuffer sb = new StringBuffer();
+            dialect.encodeColumnName(pkColumn.getName(), sb);
+            sb.append(" in (select ");
+            dialect.encodeColumnName(pkColumn.getName(), sb);
+            sb.append(" from ");
+
+            if (getDatabaseSchema() != null) {
+                dialect.encodeSchemaName(getDatabaseSchema(), sb);
+                sb.append(".");
+            }
+
+            dialect.encodeTableName(getPrimaryKey().getTableName(), sb);
+
+            sb.append(" where SDO_NN(");
+
+            // geometry column name
+            dialect.encodeColumnName(featureType.getGeometryDescriptor().getLocalName(), sb);
+            sb.append(",");
+
+            // reference geometry
+            Geometry geomValue = (Geometry) evaluateLiteral((Literal) geometryExp, Geometry.class);
+            sb.append("?");
+            literalValues.add(clipToWorldFeatureTypeGeometry(geomValue));
+            literalTypes.add(Geometry.class);
+            SRIDs.add(getFeatureTypeGeometrySRID());
+
+            int sdo_num_res = getIntFromLiteral((Literal) sdoNumResExp);
+            if (sdoBatchSizeExp != null) {
+                // if sdo_batch_size is specified, sdo_num_res keyword is ignored
+                int sdo_batch_size = getIntFromLiteral((Literal) sdoBatchSizeExp); 
+                sb.append(",'sdo_batch_size=" + sdo_batch_size + "'");
+            } else if (cqlLiteralExp == null) {
+                sb.append(",'sdo_num_res=" + sdo_num_res + "'");
+            }
+
+            sb.append(") = 'TRUE' ");
+
+            if (cqlLiteralExp != null) {
+                try {
+                    sb.append("AND ");
+                    
+                    // flush
+                    out.write(sb.toString());
+                    sb.setLength(0);
+
+                    Filter cqlExp = CQL.toFilter((String) evaluateLiteral((Literal) cqlLiteralExp, String.class));
+                    cqlExp.accept(this, extraData);
+                } catch (CQLException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }
+
+            // if sdo_batch_size is specified, sdo_num_res keyword is ignored by SDO_NN function
+            // if cqlExp is specified, we can't use sdo_num_res
+            if (sdoBatchSizeExp != null || cqlLiteralExp != null) {
+                sb.append(" AND ROWNUM <= " + sdo_num_res);
+            }
+
+            sb.append(")");
+
+            out.write(sb.toString());
+
+        } catch (IOException ioe) {
+            throw new RuntimeException(IO_ERROR, ioe);
+        }
+
+        return extraData;
+    }
+
+    private int getIntFromLiteral(Literal literal) {
+        return ((Number) evaluateLiteral(literal, Number.class)).intValue();
+    }
+    
+    private Geometry clipToWorldFeatureTypeGeometry(Geometry geom) {
+        // Oracle cannot deal with filters using geometries that span beyond the whole world
+        if (isFeatureTypeGeometryGeodetic() && !WORLD.contains(geom.getEnvelopeInternal())) {
+            Geometry result = geom.intersection(JTS.toGeometry(WORLD));
+            if (result != null && !result.isEmpty()) {
+                if (result instanceof GeometryCollection) {
+                    result = distillSameTypeGeometries((GeometryCollection) result, geom);
+                } 
+                return result;
+            }
+        }
+        return geom;
+    }    
+    
+    private Integer getFeatureTypeGeometrySRID() {
+        return (Integer) featureType.getGeometryDescriptor().getUserData()
+                .get(JDBCDataStore.JDBC_NATIVE_SRID);
+    }
+	
+    private boolean isFeatureTypeGeometryGeodetic() {
+        Boolean geodetic = (Boolean) featureType.getGeometryDescriptor().getUserData()
+                .get(OracleDialect.GEODETIC);
+        return geodetic != null && geodetic;
     }
     
     @Override
@@ -222,7 +387,7 @@ public class OracleFilterToSQL extends PreparedFilterToSQL {
         }
         return e;
     }
-
+    
     /**
      * Returns true if the current geometry has the geodetic marker raised
      * @return

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/filter/function/FilterFunction_sdonn.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/filter/function/FilterFunction_sdonn.java
@@ -1,0 +1,53 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2012, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+import org.opengis.filter.expression.VolatileFunction;
+import org.opengis.geometry.Geometry;
+
+/**
+ * Oracle function SDO_NN to identify the nearest neighbors for a geometry
+ * 
+ * @author Davide Savazzi - GeoSolutions
+ */
+public class FilterFunction_sdonn extends FunctionExpressionImpl implements VolatileFunction {
+
+    public static FunctionName NAME = new FunctionNameImpl("sdo_nn", String.class,
+            // required parameters:
+            FunctionNameImpl.parameter("geometry", Geometry.class), 
+            FunctionNameImpl.parameter("sdo_num_res", Integer.class), 
+            // optional parameters:
+            FunctionNameImpl.parameter("cql_filter", String.class, 0, 1), 
+            FunctionNameImpl.parameter("sdo_batch_size", Integer.class, 0, 1));
+
+    public FilterFunction_sdonn() {
+        super(NAME);
+    }
+
+    @Override
+    public int getArgCount() {
+        return 0;
+    }
+
+    @Override
+    public Object evaluate(Object feature) {
+        throw new UnsupportedOperationException("Unsupported usage of SDO_NN Oracle function");
+    }
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -1,0 +1,1 @@
+org.geotools.filter.function.FilterFunction_sdonn

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/EmptyJDBCDataStoreAPITestSetup.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/EmptyJDBCDataStoreAPITestSetup.java
@@ -1,0 +1,39 @@
+package org.geotools.data.oracle;
+
+import org.geotools.jdbc.JDBCDataStoreAPITestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class EmptyJDBCDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
+
+	protected EmptyJDBCDataStoreAPITestSetup(JDBCTestSetup delegate) {
+		super(delegate);
+	}
+
+	@Override
+	protected void dropRoadTable() throws Exception {
+	}
+
+	@Override
+	protected void dropRiverTable() throws Exception {
+	}
+
+	@Override
+	protected void dropLakeTable() throws Exception {
+	}
+
+	@Override
+	protected void dropBuildingTable() throws Exception {
+	}
+
+	@Override
+	protected void createRoadTable() throws Exception {
+	}
+
+	@Override
+	protected void createRiverTable() throws Exception {
+	}
+
+	@Override
+	protected void createLakeTable() throws Exception {
+	}
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleNearestNeighborTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleNearestNeighborTest.java
@@ -1,0 +1,182 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2012, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.oracle;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.transform.TransformerException;
+
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.FilterTransformer;
+import org.geotools.jdbc.JDBCDataStoreAPITestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Function;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+
+
+public class OracleNearestNeighborTest extends JDBCTestSupport {
+
+    GeometryFactory geomFactory = new GeometryFactory();
+
+    @Override
+    protected JDBCDataStoreAPITestSetup createTestSetup() {
+        return new EmptyJDBCDataStoreAPITestSetup(new OracleTestSetup() {
+            @Override
+            protected void initializeDatabase() throws Exception {
+                super.initializeDatabase();
+                
+                // Non-Earth (meters)
+                int srid = 262148;
+
+                deleteSpatialTable("NEIGHBORS");
+
+                run("CREATE TABLE NEIGHBORS (id INT, magicnumber INT, geometry MDSYS.SDO_GEOMETRY, PRIMARY KEY(id))");
+
+                String sql = "INSERT INTO USER_SDO_GEOM_METADATA (TABLE_NAME, COLUMN_NAME, DIMINFO, SRID) "
+                        + "VALUES ('NEIGHBORS','geometry', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X',-180,180,0.5), "
+                        + "MDSYS.SDO_DIM_ELEMENT('Y',-90,90,0.5)), " + srid + ")";
+                run(sql);
+
+                sql = "CREATE INDEX NEIGHBORS_GEOMETRY_IDX ON NEIGHBORS(GEOMETRY) INDEXTYPE IS MDSYS.SPATIAL_INDEX "
+                        + "PARAMETERS ('SDO_INDX_DIMS=2 LAYER_GTYPE=\"POINT\"')";
+                run(sql);
+
+                int id = 0;
+                for (int i = 0; i < 5; i++) {
+                    for (int j = 0; j < 5; j++) {
+                        run("INSERT INTO NEIGHBORS (id, geometry, magicnumber) VALUES (" + (++id) + ","
+                                + pointSql(srid, i * 10, j * 10) + ", " + (i * j) + ")");
+                    }
+                }                
+            }          
+        });
+    }
+
+    public void testNearestNeighbor() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        ContentFeatureSource source = dataStore.getFeatureSource(tname("NEIGHBORS"));
+
+        SimpleFeatureIterator features = execSdoNN(source, ff, -10, -10, 1, -1, null);
+        try {
+            assertTrue(features.hasNext());
+            SimpleFeature f = features.next();
+            Point point = (Point) f.getDefaultGeometry();
+            assertEquals(0.0, point.getCoordinate().x);
+            assertEquals(0.0, point.getCoordinate().y);
+            assertFalse(features.hasNext());
+        } finally {
+            features.close();
+        }
+
+        features = execSdoNN(source, ff, 100, 100, 1, -1, null);
+        try {
+            assertTrue(features.hasNext());
+            SimpleFeature f = features.next();
+            Point point = (Point) f.getDefaultGeometry();
+            assertEquals(40.0, point.getCoordinate().x);
+            assertEquals(40.0, point.getCoordinate().y);
+            assertFalse(features.hasNext());
+        } finally {
+            features.close();
+        }
+
+        features = execSdoNN(source, ff, -10, -10, 3, -1, null);
+        try {
+            checkSizeAndMagicNumber(features, 3, -1);            
+        } finally {
+            features.close();
+        }
+
+        // test using sdo_batch_size hint
+        features = execSdoNN(source, ff, -10, -10, 3, 10, "magicnumber >= 10");
+        try {
+            checkSizeAndMagicNumber(features, 3, 10);            
+        } finally {
+            features.close();
+        }
+
+        // test using CQL and no batch_size
+        features = execSdoNN(source, ff, -10, -10, 3, -1, "magicnumber >= 15");
+        try {
+            checkSizeAndMagicNumber(features, 1, 10);
+        } finally {
+            features.close();
+        }
+
+        // test with limit greater than rows
+        features = execSdoNN(source, ff, -10, -10, 50, -1, null);
+        try {
+            checkSizeAndMagicNumber(features, 25, -1);
+        } finally {
+            features.close();
+        }
+    }
+
+    private void checkSizeAndMagicNumber(SimpleFeatureIterator features, int size, int magicNumberMinValue) {
+        int counter = 0;
+        while (features.hasNext()) {
+            SimpleFeature sf = features.next();
+            if (magicNumberMinValue > -1) {
+                int magicNumber = ((Number) sf.getAttribute("MAGICNUMBER")).intValue();
+                assertTrue(magicNumber >= magicNumberMinValue);
+            }
+            
+            counter++;
+        }
+        
+        assertEquals(size, counter);
+    }
+
+    private SimpleFeatureIterator execSdoNN(ContentFeatureSource source, FilterFactory2 ff,
+            double x, double y, int limit, int batch, String cql) throws IOException {
+        List<Expression> params = new ArrayList<Expression>();
+        params.add(ff.literal(point(x, y)));
+        params.add(ff.literal(limit));
+
+        if (cql != null) {
+            params.add(ff.literal(cql));
+
+            if (batch > 0) {
+                params.add(ff.literal(batch));
+            }
+        }
+
+        Function sdo_nn = ff.function("sdo_nn", params.toArray(new Expression[params.size()]));
+        PropertyIsEqualTo equalsFilter = ff.equal(sdo_nn, ff.literal(true), false);
+        Query query = new Query(tname("NEIGHBORS"), equalsFilter);
+        
+        SimpleFeatureCollection features = source.getFeatures(query);
+        return features.features();
+    }
+
+    private Point point(double x, double y) {
+        return geomFactory.createPoint(new Coordinate(x, y));
+    }
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleTestSetup.java
@@ -75,24 +75,14 @@ public class OracleTestSetup extends JDBCTestSetup {
             run("DROP TRIGGER ft1_pkey_trigger");
         } catch (Exception e) {
         }
-        try {
-            run("DROP TABLE ft1 purge");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        
         try {
             run("DROP SEQUENCE ft1_pkey_seq");
         } catch (Exception e) {
         }
      
-        run("DELETE FROM USER_SDO_GEOM_METADATA WHERE TABLE_NAME = 'FT1'");
-        
-        try {
-            run("DROP TABLE ft2 purge");
-        } catch (Exception e) {
-        }
-        run("DELETE FROM USER_SDO_GEOM_METADATA WHERE TABLE_NAME = 'FT2'");
-        
+        deleteSpatialTable("FT1");
+        deleteSpatialTable("FT2");
 
         String sql = "CREATE TABLE ft1 (" 
             + "id INT, geometry MDSYS.SDO_GEOMETRY, intProperty INT, "
@@ -111,17 +101,26 @@ public class OracleTestSetup extends JDBCTestSetup {
                         + " PARAMETERS ('SDO_INDX_DIMS=2 LAYER_GTYPE=\"POINT\"')";
         run(sql);
         
-        sql = "INSERT INTO ft1 VALUES (0," +
-            "MDSYS.SDO_GEOMETRY(2001,4326,SDO_POINT_TYPE(0.0,0.0,NULL),NULL,NULL), 0, 0.0,'zero')";
+        sql = "INSERT INTO ft1 VALUES (0," + pointSql(4326, 0, 0) + ", 0, 0.0,'zero')";
         run(sql);
-        sql = "INSERT INTO ft1 VALUES (1," + 
-            "MDSYS.SDO_GEOMETRY(2001,4326,SDO_POINT_TYPE(1.0,1.0,NULL),NULL,NULL), 1, 1.1,'one')";
+        sql = "INSERT INTO ft1 VALUES (1," + pointSql(4326, 1, 1) + ", 1, 1.1,'one')";
         run(sql);
 
-        sql = "INSERT INTO ft1 VALUES (2," + 
-            "MDSYS.SDO_GEOMETRY(2001,4326,SDO_POINT_TYPE(2.0,2.0,NULL),NULL,NULL), 2, 2.2,'two')";
+        sql = "INSERT INTO ft1 VALUES (2," + pointSql(4326, 2, 2) + ", 2, 2.2,'two')";
         run(sql);
     }
     
+    protected void deleteSpatialTable(String name) throws Exception {
+        try {
+            run("DROP TABLE " + name + " purge");
+        } catch (Exception e) {
+        }
 
+        run("DELETE FROM USER_SDO_GEOM_METADATA WHERE TABLE_NAME = '" + name + "'");
+    }
+
+    protected String pointSql(int srid, double x, double y) {
+        return "MDSYS.SDO_GEOMETRY(2001," + srid + ",SDO_POINT_TYPE(" + x + "," + y
+                + ",NULL),NULL,NULL)";
+    }
 }


### PR DESCRIPTION
Hi,

I've added an Oracle specific FilterFunction for nearest neighbor search: sdo_nn.
Required parameters:
- geometry - reference geometry
- sdo_num_res - number of results
  Optional parameters:
- cql_filter - an additional filter that must be satisfied
- sdo_batch_size - number of rows to be evaluated at a time

Usage example:

``` xml
<ogc:PropertyIsEqualTo>
  <ogc:Function name="sdo_nn">
      <ogc:Literal>  
        <gml:Point><gml:coordinates>-10,-10</gml:coordinates></gml:Point>
    </ogc:Literal>      
    <ogc:Literal>3</ogc:Literal>
  </ogc:Function>
  <ogc:Literal>true</ogc:Literal>
</ogc:PropertyIsEqualTo>
```

In a CQL filter:
cql_filter=sdo_nn(POINT(100 100),3)=true

Limitation:
it can be used only inside a PropertyIsEqualTo comparison and it can be compared only to 'true'.

Here's the discussion on gt-devel:
http://bit.ly/TwCg4D
