### PR TITLE
Rename all ReferenceEnvelope factory methods as create (GEOT-4338)

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/geometry/jts/JTS.java
+++ b/modules/library/api/src/main/java/org/geotools/geometry/jts/JTS.java
@@ -485,9 +485,9 @@ public final class JTS {
             if( envelope instanceof ReferencedEnvelope){
                 return envelope;
             }
-            return ReferencedEnvelope.reference( envelope,  DefaultGeographicCRS.WGS84 );
+            return ReferencedEnvelope.create( envelope,  DefaultGeographicCRS.WGS84 );
         }
-        ReferencedEnvelope initial = ReferencedEnvelope.reference( envelope, crs );
+        ReferencedEnvelope initial = ReferencedEnvelope.create( envelope, crs );
         return toGeographic( initial );
     }
     /**

--- a/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -764,9 +764,82 @@ public class ReferencedEnvelope extends Envelope implements org.opengis.geometry
 
         return buffer.append(']').toString();
     }
-    
     /**
-     * Utility method to ensure that an Envelope if a ReferencedEnvelope.
+     * Factory method to create the correct ReferencedEnvelope.
+     * 
+     * @param origional ReferencedEnvelope being duplicated
+     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
+     */
+    public static ReferencedEnvelope create( ReferencedEnvelope origional ){
+        if( origional instanceof ReferencedEnvelope3D ){
+            return new ReferencedEnvelope3D( (ReferencedEnvelope3D) origional );
+        }
+        return new ReferencedEnvelope( origional );
+    }
+    /**
+     * Factory method to create the correct ReferencedEnvelope implementation
+     * for the provided CoordinateReferenceSystem.
+     * 
+     * @param crs CoordinateReferenceSystem used to select ReferencedEnvelope implementation
+     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
+     */
+    public static ReferencedEnvelope create(CoordinateReferenceSystem crs) {
+        if (crs != null && crs.getCoordinateSystem().getDimension() > 2 ){
+            return new ReferencedEnvelope3D(crs);
+        }
+        return new ReferencedEnvelope(crs);
+    }
+
+    /**
+     * Utility method to create a ReferencedEnvelope from an opengis Envelope class,
+     * supporting 2d as well as 3d envelopes (returning the right class).
+     * 
+     * @param env The opgenis Envelope object
+     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
+     */
+    public static ReferencedEnvelope create(org.opengis.geometry.Envelope env,
+            CoordinateReferenceSystem crs) {
+
+        if (env == null) {
+            return null;
+        }
+
+        if (env.getDimension() >= 3) {
+            return new ReferencedEnvelope3D((ReferencedEnvelope3D) reference(env), crs);
+        }
+
+        return new ReferencedEnvelope(reference(env), crs);
+    }
+    /**
+     * Utility method to create a ReferencedEnvelope from an opengis Envelope class,
+     * supporting 2d as well as 3d envelopes (returning the right class).
+     * 
+     * @param env The opgenis Envelope object
+     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
+     */
+    public static ReferencedEnvelope create(ReferencedEnvelope env, CoordinateReferenceSystem crs) {
+        return create( (org.opengis.geometry.Envelope) env, crs );
+    }
+    /**
+     * Utility method to create a ReferencedEnvelope from an JTS Envelope class,
+     * supporting 2d as well as 3d envelopes (returning the right class).
+     * 
+     * @param env The JTS Envelope object
+     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
+     */
+    public static ReferencedEnvelope create(Envelope env, CoordinateReferenceSystem crs) {
+        if (env == null) {
+            return null;
+        }
+        if (crs.getCoordinateSystem().getDimension() >= 3) {
+            return new ReferencedEnvelope3D( env.getMinX(), env.getMaxX(), env.getMinY(), env.getMaxY(), Double.NaN, Double.NaN, crs );
+        }
+        
+        return new ReferencedEnvelope( env, crs );
+    }
+
+    /**
+     * Cast to a ReferencedEnvelope (used to ensure that an Envelope if a ReferencedEnvelope).
      * <p>
      * This method first checks if <tt>e</tt> is an instanceof {@link ReferencedEnvelope},
      * if it is, itself is returned. If not <code>new ReferencedEnvelpe(e,null)</code>
@@ -782,16 +855,30 @@ public class ReferencedEnvelope extends Envelope implements org.opengis.geometry
         if (e == null) {
             return null;
         } else {
-        	if (e instanceof ReferencedEnvelope3D) {
+            if (e instanceof ReferencedEnvelope3D) {
                 return (ReferencedEnvelope3D) e;
             }
-        	
+    
             if (e instanceof ReferencedEnvelope) {
                 return (ReferencedEnvelope) e;
             }
-
+    
             return new ReferencedEnvelope(e, null);
         }
+    }
+
+    /**
+     * Cast to a ReferencedEnvelope (used to ensure that an Envelope if a ReferencedEnvelope).
+     * <p>
+     * This method first checks if <tt>e</tt> is an instanceof {@link ReferencedEnvelope},
+     * if it is, itself is returned. If not <code>new ReferencedEnvelpe(e)</code>
+     * is returned.
+     * </p>
+     * @param e The envelope.
+     * @return
+     */
+    public static ReferencedEnvelope reference(BoundingBox e) {
+        return reference( (org.opengis.geometry.Envelope) e);
     }
 
     /**
@@ -804,90 +891,35 @@ public class ReferencedEnvelope extends Envelope implements org.opengis.geometry
      * @param e The envelope.
      * @return
      */
-    public static ReferencedEnvelope reference(BoundingBox e) {
+    public static ReferencedEnvelope reference(ReferencedEnvelope e) {
         return reference( (org.opengis.geometry.Envelope) e);
     }
-    
+
     /**
-     * Utility method to create a ReferencedEnvelope from an opengis Envelope class,
-     * supporting 2d as well as 3d envelopes (returning the right class).
+     * Cast to a ReferencedEnvelope (used to ensure that an Envelope if a ReferencedEnvelope).
+     * Supporting 2d as well as 3d envelopes (returning the right class).
      * 
      * @param env The opgenis Envelope object
      * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
      */
     public static ReferencedEnvelope reference(org.opengis.geometry.Envelope env) {
-    	
-    	if (env == null) {
-            return null;
-        }
-    	
-    	if (env instanceof ReferencedEnvelope3D) {
-            return (ReferencedEnvelope3D) env;
-        }
-
-        if (env instanceof ReferencedEnvelope) {
-            return (ReferencedEnvelope) env;
-        }    	
-    	
-    	if (env.getDimension() == 3) {
-    		return new ReferencedEnvelope3D(env);
-    	}
-    	
-    	return new ReferencedEnvelope(env);
-    }
     
-    /**
-     * Utility method to create a ReferencedEnvelope from an opengis Envelope class,
-     * supporting 2d as well as 3d envelopes (returning the right class).
-     * 
-     * @param env The opgenis Envelope object
-     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
-     */
-    public static ReferencedEnvelope reference(org.opengis.geometry.Envelope env, CoordinateReferenceSystem crs) {
-    	
-    	if (env == null) {
-            return null;
-        }
-    	   	  	    	
-    	if (env.getDimension() >= 3) {
-    		return new ReferencedEnvelope3D((ReferencedEnvelope3D) reference(env), crs);
-    	}
-    	
-    	return new ReferencedEnvelope(reference(env), crs);
-    }
-    /**
-     * Factory method to create the correct ReferencedEnvelope implementation
-     * for the provided CoordinateReferenceSystem.
-     * 
-     * @param crs CoordinateReferenceSystem used to select ReferencedEnvelope implementation
-     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
-     */
-    public static ReferencedEnvelope reference(CoordinateReferenceSystem crs) {
-        if (crs != null && crs.getCoordinateSystem().getDimension() > 2 ){
-            return new ReferencedEnvelope3D(crs);
-        }
-        return new ReferencedEnvelope(crs);
-    }
-
-    /**
-     * Utility method to create a ReferencedEnvelope from an JTS Envelope class,
-     * supporting 2d as well as 3d envelopes (returning the right class).
-     * 
-     * @param env The JTS Envelope object
-     * @return ReferencedEnvelope, ReferencedEnvelope3D if it is 3d
-     */
-    public static ReferencedEnvelope reference(Envelope env, CoordinateReferenceSystem crs) {
         if (env == null) {
             return null;
         }
-        if( env instanceof ReferencedEnvelope ){
-            
+    
+        if (env instanceof ReferencedEnvelope3D) {
+            return (ReferencedEnvelope3D) env;
         }
-        
-        if (crs.getCoordinateSystem().getDimension() >= 3) {
-            return new ReferencedEnvelope3D( env.getMinX(), env.getMaxX(), env.getMinY(), env.getMaxY(), Double.NaN, Double.NaN, crs );
+    
+        if (env instanceof ReferencedEnvelope) {
+            return (ReferencedEnvelope) env;
         }
-        
-        return new ReferencedEnvelope( env, crs );
+    
+        if (env.getDimension() == 3) {
+            return new ReferencedEnvelope3D(env);
+        }
+    
+        return new ReferencedEnvelope(env);
     }
 }

--- a/modules/library/api/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
+++ b/modules/library/api/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
@@ -148,7 +148,7 @@ public class ReferencedEnvelopeTest {
         catch (Exception expected){
         }
         
-        ReferencedEnvelope bounds2 = ReferencedEnvelope.reference( DefaultGeographicCRS.WGS84_3D );
+        ReferencedEnvelope bounds2 = ReferencedEnvelope.create( DefaultGeographicCRS.WGS84_3D );
         assertNotNull( bounds2 );
     }
 

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -1120,7 +1120,7 @@ public final class JDBCDataStore extends ContentDataStore
 
         Statement st = null;
         ResultSet rs = null;
-        ReferencedEnvelope bounds = ReferencedEnvelope.reference(featureType
+        ReferencedEnvelope bounds = ReferencedEnvelope.create(featureType
                 .getCoordinateReferenceSystem());
         try {
             // try optimized bounds computation only if we're targeting the entire table

--- a/modules/library/main/src/main/java/org/geotools/filter/spatial/DefaultCRSFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/spatial/DefaultCRSFilterVisitor.java
@@ -40,7 +40,7 @@ public class DefaultCRSFilterVisitor extends DuplicatingFilterVisitor {
             return super.visit(filter, extraData);
 
         try {  
-        	return getFactory(extraData).bbox(filter.getExpression1(), ReferencedEnvelope.reference(filter.getBounds(),defaultCrs));
+        	return getFactory(extraData).bbox(filter.getExpression1(), ReferencedEnvelope.create(filter.getBounds(),defaultCrs));
         } catch (Exception e) {
             throw new RuntimeException("Could not decode srs '" + srs + "'", e);
         }


### PR DESCRIPTION
ReferencedEnvelope.reference being used both as cast and as factory method, this pull request separates out the factory methods and gives them a nice clear name.

https://jira.codehaus.org/browse/GEOT-4338

This pull request should be issued at the same time as the following GeoServer pull request: https://github.com/geoserver/geoserver/pull/75
