### PR TITLE
GEOT4362 - wfs: added supported output format to GetFeature response par...

### DIFF
--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_1_0/parsers/Gml31GetFeatureResponseParserFactory.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_1_0/parsers/Gml31GetFeatureResponseParserFactory.java
@@ -53,8 +53,8 @@ public class Gml31GetFeatureResponseParserFactory implements WFSResponseParserFa
     private static final Logger LOGGER = Logging.getLogger("org.geotools.data.wfs");
 
     private static final String SUPPORTED_OUTPUT_FORMAT1 = "text/xml; subtype=gml/3.1.1";
-
     private static final String SUPPORTED_OUTPUT_FORMAT2 = "GML3";
+    private static final String SUPPORTED_OUTPUT_FORMAT3 = "text/xml; subType=gml/3.1.1/profiles/gmlsf/1.0.0/0";
 
     /**
      * @see WFSResponseParserFactory#isAvailable()
@@ -85,7 +85,8 @@ public class Gml31GetFeatureResponseParserFactory implements WFSResponseParserFa
 
     protected boolean isSupportedOutputFormat(String outputFormat) {
         boolean matches = SUPPORTED_OUTPUT_FORMAT1.equals(outputFormat)
-                || SUPPORTED_OUTPUT_FORMAT2.equals(outputFormat);
+                || SUPPORTED_OUTPUT_FORMAT2.equals(outputFormat)
+                || SUPPORTED_OUTPUT_FORMAT3.equals(outputFormat);
         return matches;
     }
 


### PR DESCRIPTION
Hi, 
this patch fixes issue GEOT-4362.

WFSDataStore is unable to execute a GetFeature on some ArcGIS servers because it doesn't support output format "text/xml; subType=gml/3.1.1/profiles/gmlsf/1.0.0/0".

I've just added this output format to Gml31GetFeatureResponseParserFactory and everything works now. Hope it's ok.
