### PR TITLE
remove the final modifier to ContentFeatureStore.addFeatures method.

### DIFF
--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureStore.java
@@ -208,7 +208,7 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
      * is written its id is obtained and added to the returned set.
      * </p>
      */
-    public final List<FeatureId> addFeatures(Collection collection)
+    public List<FeatureId> addFeatures(Collection collection)
         throws IOException {
         
         // gather up id's
@@ -234,7 +234,7 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
      * </p>
      * @param featureCollection
      */
-    public final List<FeatureId> addFeatures(FeatureCollection<SimpleFeatureType,SimpleFeature> featureCollection)
+    public List<FeatureId> addFeatures(FeatureCollection<SimpleFeatureType,SimpleFeature> featureCollection)
         throws IOException {
         // gather up id's
         List<FeatureId> ids = new LinkedList<FeatureId>();


### PR DESCRIPTION
ContentFeatureStore.addFeatures works by grabbing a FeatureWriter from
the concrete subclass, but it can be the case that that's not the best
way of doing so for a given immplementation, so removing the final modifier
from the method allows for further optimizations on the subclasses where
appropriate while keeping the default behavior.
