### PR TITLE
Removed nonexistent Export-Package entry from MANIFEST.MF

### DIFF
--- a/modules/ogc/net.opengis.csw/META-INF/MANIFEST.MF
+++ b/modules/ogc/net.opengis.csw/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: net.opengis.cat.csw20,
- net.opengis.cat.csw20.impl,
- net.opengis.cat.csw20.util
+ net.opengis.cat.csw20.impl
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.emf.ecore.xmi;visibility:=reexport,


### PR DESCRIPTION
Eclipse JEE June SR1 notices that net.opengis.csw declares in its MANIFEST.MF an ExportPackage entry for net.opengis.cat.csw20.util, which does not exist. Eclipse treats this as an error. This buglet was likely introduced during the src refactoring around the time the csw modules were promoted to extension. The fix is to remove this entry.
