### PR TITLE
Fix for GEOT-4319

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/gridshift/NADCONGridShiftFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/gridshift/NADCONGridShiftFactory.java
@@ -126,7 +126,7 @@ public class NADCONGridShiftFactory extends ReferencingFactory implements Buffer
                     return grid; // - Return
                 }
             }
-            throw new FactoryException("NTv2 Grid " + latGridURL + ", " + longGridURL
+            throw new FactoryException("NADCON Grid " + latGridURL + ", " + longGridURL
                     + " could not be created.");
         }
     }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/NTv2Transform.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/NTv2Transform.java
@@ -20,7 +20,6 @@ package org.geotools.referencing.operation.transform;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
-import java.net.URI;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -32,6 +31,7 @@ import org.geotools.parameter.ParameterGroup;
 import org.geotools.referencing.NamedIdentifier;
 import org.geotools.referencing.ReferencingFactoryFinder;
 import org.geotools.referencing.factory.IdentifiedObjectSet;
+import org.geotools.referencing.factory.gridshift.DataUtilities;
 import org.geotools.referencing.factory.gridshift.GridShiftLocator;
 import org.geotools.referencing.factory.gridshift.NTv2GridShiftFactory;
 import org.geotools.referencing.operation.MathTransformProvider;
@@ -59,7 +59,7 @@ import au.com.objectix.jgridshift.GridShiftFile;
  * This transformation depends on an external resource (the NTv2 grid file). If the file
  * is not available, a {@link NoSuchIdentifierException recoverable NoSuchIdentifierException}
  * will be thrown on instantiation.
- * 
+ *
  * @see {@link IdentifiedObjectSet IdentifiedObjectSet exception handling}.
  * @source $URL$
  * @version $Id$
@@ -69,80 +69,108 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
 
     /** Serial number for interoperability with different versions. */
     private static final long serialVersionUID = -3082112044314062512L;
-    
+
     /** Logger */
     protected static final Logger LOGGER = Logging.getLogger("org.geotools.referencing");
-    
-    /**
-     * The original grid name
-     */
-    private URI grid = null;
 
-    /** The grid file name as set in the constructor. */
-    private URL gridLocation = null;
-    
-    /**
-     * The grid shift to be used
-     */
-    private GridShiftFile gridShift; 
-    
     /**
      * The factory that loads the grid shift files
      */
-    private static NTv2GridShiftFactory FACTORY = new NTv2GridShiftFactory();
-    
+    private static final NTv2GridShiftFactory FACTORY = new NTv2GridShiftFactory();
+
+    /**
+     * The grid URL as set in the constructor.
+     */
+    private final URL gridLocation;
+
+    /**
+     * The grid shift to be used
+     */
+    private GridShiftFile gridShift;
+
     /**
      * The inverse of this transform. Will be created only when needed.
      */
     private transient MathTransform2D inverse;
-    
+
     /**
-     * Constructs a {@code NTv2Transform} from the specified grid shift file.
-     * 
+     * Constructs a {@code NTv2Transform} from the specified grid shift reference
+     * identifier. This identifier is passed to a {@code GridShiftLocator}.
+     *
      * This constructor checks for grid shift file availability, but
      * doesn't actually load the full grid into memory to preserve resources.
      *
-     * @param file NTv2 grid file name
+     * @param grid NTv2 grid file name reference
+     * @throws NullPointerException if invalid parameters are passed.
      * @throws NoSuchIdentifierException if the grid is not available.
      */
-    public NTv2Transform(URI file) throws NoSuchIdentifierException {
-        if (file == null) {
-            throw new NoSuchIdentifierException("No NTv2 Grid File specified.", null);
+    public NTv2Transform(String grid) throws NoSuchIdentifierException {
+        if (grid == null) {
+            throw new NullPointerException("No NTv2 Grid File specified.");
         }
-        
-        this.grid = file;
-        
-        gridLocation = locateGrid(grid.toString());
-        if(gridLocation == null) {
-            throw new NoSuchIdentifierException("Could not locate NTv2 Grid File " + file, null);
+
+        this.gridLocation = locateGrid(grid);
+        if(this.gridLocation == null) {
+            throw new NoSuchIdentifierException("Could not locate NTv2 Grid File " + grid, null);
         }
-        
+
+        validateLocation(this.gridLocation);
+    }
+
+    /**
+     * Constructs a {@code NTv2Transform} from the specified grid shift file URL.
+     *
+     * This constructor checks for grid shift file validity, but
+     * doesn't actually load the full grid into memory to preserve resources.
+     *
+     * @param gridURL NTv2 grid URL
+     * @throws NullPointerException if invalid parameters are passed.
+     * @throws NoSuchIdentifierException if the grid is not available.
+     */
+    public NTv2Transform(URL gridURL) throws NoSuchIdentifierException {
+        if (gridURL == null) {
+            throw new NullPointerException("No NTv2 Grid URL specified.");
+        }
+
+        this.gridLocation = gridURL;
+        validateLocation(this.gridLocation);
+    }
+
+    protected void validateLocation(final URL gridLocation) throws NoSuchIdentifierException {
         // Search for grid file
         if (!FACTORY.isNTv2Grid(gridLocation)) {
             throw new NoSuchIdentifierException("NTv2 Grid File not available.",
-                    file.toString());
+                    gridLocation.toString());
         }
     }
-    
-    URL locateGrid(String grid) {
+
+    protected static URL locateGrid(final String grid) {
         for (GridShiftLocator locator : ReferencingFactoryFinder.getGridShiftLocators(null)) {
             URL result = locator.locateGrid(grid);
             if(result != null) {
                 return result;
             }
         };
-        
+
         return null;
     }
-    
+
+    /**
+     * @returns A best guess at the grid filename, given the URL
+     */
+    private String getGridFilename() {
+        return DataUtilities.urlToFile(this.gridLocation).getName();
+    }
+
+
     /**
      * Returns a hash value for this transform.
      */
     @Override
     public int hashCode() {
-        return this.grid.hashCode();
+        return this.gridLocation.hashCode();
     }
-    
+
     /**
      * Compares the specified object with this one for equality.
      * Checks if {@code object} is {@code this} same instance, or a NTv2Transform
@@ -158,7 +186,7 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
     @Override
     public boolean equals(final Object object) {
         if(object==this) return true;
-        
+
         if (object!=null && getClass().equals(object.getClass())) {
             final NTv2Transform that = (NTv2Transform) object;
             return Utilities.equals(this.getParameterValues(),
@@ -166,7 +194,7 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
         }
         return false;
     }
-    
+
     /**
      * Returns the inverse of this transform.
      *
@@ -179,7 +207,7 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
         }
         return inverse;
     }
-    
+
     /**
      * Transforms a list of coordinate point ordinal values. This method is
      * provided for efficiently transforming many points. The supplied array
@@ -207,7 +235,7 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
             int dstOff, int numPts) throws TransformException {
         bidirectionalTransform(srcPts,srcOff, dstPts, dstOff, numPts, true);
     }
-    
+
     /**
      * Inverse transform. See {@link #transform(double[], int, double[],
      *       int, int)}
@@ -247,16 +275,20 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
             int dstOff, int numPts, boolean forward) throws TransformException {
 
         boolean shifted;
-        
+
         if (gridShift == null) { // Create grid when first needed.
             try {
-                gridShift = FACTORY.createNTv2Grid(gridLocation);
+                synchronized(this) {
+                    if (gridShift == null) { // Make sure we only do this once if multithreaded
+                        gridShift = FACTORY.createNTv2Grid(gridLocation);
+                    }
+                }
             } catch (FactoryException e) {
                 throw new TransformException("NTv2 Grid " + gridLocation +
                         " Could not be created", e);
             }
         }
-        
+
         try {
             GridShift shift = new GridShift();
             while(--numPts >= 0) {
@@ -273,7 +305,7 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
                 } else {
                     if(LOGGER.isLoggable(Level.FINE)) {
                         LOGGER.log(Level.FINE, "Point (" + srcPts[srcOff-2] + ", " + srcPts[srcOff-1] +
-                                ") is not covered by '" + this.grid + "' NTv2 grid," +
+                                ") is not covered by '" + getGridFilename() + "' NTv2 grid," +
                 		    " it will not be shifted.");
                     }
                     dstPts[dstOff++]=srcPts[srcOff-2];
@@ -294,7 +326,7 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
     public int getTargetDimensions() {
         return 2;
     }
-    
+
     /**
      * Returns the parameter values for this math transform.
      *
@@ -302,14 +334,14 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
      */
     @Override
     public ParameterValueGroup getParameterValues() {
-        final ParameterValue<URI> file = new Parameter<URI>(Provider.FILE);
-        file.setValue(grid);
+        final ParameterValue<String> file = new Parameter<String>(Provider.FILE);
+        file.setValue(getGridFilename());
 
         return new ParameterGroup(Provider.PARAMETERS,
             new ParameterValue[] { file }
         );
     }
-    
+
     /**
      * Inverse of a {@link NTv2Transform}.
      *
@@ -386,20 +418,20 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
      * @author Oscar Fonts
      */
     public static class Provider extends MathTransformProvider {
-        
+
         private static final long serialVersionUID = -3710592152744574801L;
 
         /**
          * The operation parameter descriptor for the "Latitude and longitude difference file"
          * parameter value. The default value is "".
          */
-        public static final DefaultParameterDescriptor<URI> FILE = new DefaultParameterDescriptor<URI>(
+        public static final DefaultParameterDescriptor<String> FILE = new DefaultParameterDescriptor<String>(
             toMap(new NamedIdentifier[] {
                 new NamedIdentifier(Citations.EPSG, "Latitude and longitude difference file"),
                 new NamedIdentifier(Citations.EPSG, "8656")
             }),
-            URI.class, null, null, null, null, null, true);
-        
+            String.class, null, null, null, null, null, true);
+
         /**
          * The parameters group.
          */
@@ -409,14 +441,14 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
             }, new ParameterDescriptor[] {
                 FILE
             });
-        
+
         /**
          * Constructs a provider.
          */
         public Provider() {
             super(2, 2, PARAMETERS);
         }
-        
+
         /**
          * Returns the operation type.
          */
@@ -424,7 +456,7 @@ public class NTv2Transform extends AbstractMathTransform implements MathTransfor
         public Class<Transformation> getOperationType() {
             return Transformation.class;
         }
-        
+
         /**
          * Creates a math transform from the specified group of parameter
          * values.

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/NADCONTransformTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/NADCONTransformTest.java
@@ -18,7 +18,7 @@ package org.geotools.referencing.operation.transform;
 
 import static org.junit.Assert.*;
 
-import java.net.URI;
+import java.net.URL;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +50,7 @@ public class NADCONTransformTest {
      */
     @Before
     public void setUp() throws Exception {
-        transform = new NADCONTransform(new URI(STPAUL_LAS), new URI(STPAUL_LOS));
+        transform = new NADCONTransform(STPAUL_LAS, STPAUL_LOS);
     }
         
     /**
@@ -83,23 +83,23 @@ public class NADCONTransformTest {
         assertEquals(pvg.values().size(), 2);
         
         Object value = pvg.parameter("Latitude difference file").getValue();
-        assertTrue(value instanceof URI);
-        assertEquals(value.toString(), STPAUL_LAS);
+        assertTrue(value instanceof String);
+        assertEquals(value, STPAUL_LAS);
         
         value = pvg.parameter("Longitude difference file").getValue();
-        assertTrue(value instanceof URI);
-        assertEquals(value.toString(), STPAUL_LOS);
+        assertTrue(value instanceof String);
+        assertEquals(value, STPAUL_LOS);
     }
     
     /**
-     * Test method for {@link org.geotools.referencing.operation.transform.NADCONTransform#NADCONTransform(java.net.URI)}.
+     * Test method for {@link org.geotools.referencing.operation.transform.NADCONTransform#NADCONTransform(java.lang.String,java.lang.String)}.
      */
     @Test
     public void testNADCONTransform() throws Exception {
 
         try {
-            new NADCONTransform(null, null);
-        } catch (NoSuchIdentifierException e) {
+            new NADCONTransform((String)null, (String)null);
+        } catch (NullPointerException e) {
             assert true;
         }
     }

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/NTv2TransformTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/NTv2TransformTest.java
@@ -18,7 +18,7 @@ package org.geotools.referencing.operation.transform;
 
 import static org.junit.Assert.*;
 
-import java.net.URI;
+import java.net.URL;
 import java.util.Arrays;
 
 import org.junit.Before;
@@ -49,7 +49,7 @@ public class NTv2TransformTest {
      */
     @Before
     public void setUp() throws Exception {
-        transform = new NTv2Transform(new URI(TEST_GRID));
+        transform = new NTv2Transform(TEST_GRID);
     }
         
     /**
@@ -83,34 +83,34 @@ public class NTv2TransformTest {
         
         // Value accessible through its identifiers
         Object value = pvg.parameter("8656").getValue();
-        assertTrue(value instanceof URI);
-        assertEquals(value.toString(), TEST_GRID);
+        assertTrue(value instanceof String);
+        assertEquals(value, TEST_GRID);
 
         value = pvg.parameter("Latitude and longitude difference file").getValue();
-        assertTrue(value instanceof URI);
-        assertEquals(value.toString(), TEST_GRID);
+        assertTrue(value instanceof String);
+        assertEquals(value, TEST_GRID);
     }
     
     /**
-     * Test method for {@link org.geotools.referencing.operation.transform.NTv2Transform#NTv2Transform(java.net.URI)}.
+     * Test method for {@link org.geotools.referencing.operation.transform.NTv2Transform#NTv2Transform(java.lang.String)}.
      */
     @Test
     public void testNTv2Transform() throws Exception {
 
         try {
-            new NTv2Transform(null);
+            new NTv2Transform((String)null);
+        } catch (NullPointerException e) {
+            assert true;
+        }
+        
+        try {
+            new NTv2Transform(INEXISTENT_GRID);
         } catch (NoSuchIdentifierException e) {
             assert true;
         }
         
         try {
-            new NTv2Transform(new URI(INEXISTENT_GRID));
-        } catch (NoSuchIdentifierException e) {
-            return;
-        }
-        
-        try {
-            new NTv2Transform(new URI(INEXISTENT_GRID));
+            new NTv2Transform(new URL(INEXISTENT_GRID));
         } catch (NoSuchIdentifierException e) {
             return;
         }            
@@ -188,7 +188,7 @@ public class NTv2TransformTest {
     
     @Test
     public void testHashCodeEquals() throws Exception {
-        NTv2Transform t2 = new NTv2Transform(new URI(TEST_GRID));
+        NTv2Transform t2 = new NTv2Transform(TEST_GRID);
         assertEquals(transform, t2);
         assertEquals(transform.hashCode(), t2.hashCode());
     }


### PR DESCRIPTION
In a default configuration, the URI passed in to these classes was always
turned into a String and then passed to the ClassPathGridShiftLocator, which
attempted to load from the stringified URI. This rendered the loading of grid
shift files to be impossible.
This patch resolves that problem, taking Strings as before and using them as
references to pass into the GridShiftLocator instances. Additionally, the
classes now have a separate constructor that takes URLs directly.
