### PR TITLE
world file writer accepts awt.geom.AffineTransform but doesn't write it out

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/WorldFileWriter.java
+++ b/modules/library/main/src/main/java/org/geotools/data/WorldFileWriter.java
@@ -26,7 +26,7 @@ import java.io.OutputStreamWriter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.geotools.referencing.operation.matrix.AffineTransform2D;
+import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.geotools.referencing.operation.transform.ProjectiveTransform;
 import org.geotools.resources.i18n.ErrorKeys;

--- a/modules/library/main/src/test/java/org/geotools/data/WorldFileWriterTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/WorldFileWriterTest.java
@@ -1,0 +1,31 @@
+package org.geotools.data;
+
+import static org.junit.Assert.*;
+
+import java.awt.geom.AffineTransform;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+
+import org.junit.Test;
+
+public class WorldFileWriterTest {
+
+    @Test
+    public void testWrite() throws Exception {
+        AffineTransform at = new AffineTransform(42.34, 0, 0, -42.34,347671.10, 5196940.18);
+
+        File tmp = File.createTempFile("write", "wld", new File("target"));
+        new WorldFileWriter(tmp, at);
+
+        BufferedReader r = new BufferedReader(new FileReader(tmp));
+        assertEquals(42.34, Double.parseDouble(r.readLine()), 0.1);
+        assertEquals(0, Double.parseDouble(r.readLine()), 0.1);
+        assertEquals(0, Double.parseDouble(r.readLine()), 0.1);
+        assertEquals(-42.34, Double.parseDouble(r.readLine()), 0.1);
+        assertEquals(347671.10, Double.parseDouble(r.readLine()), 0.1);
+        assertEquals(5196940.18, Double.parseDouble(r.readLine()), 0.1);
+
+        assertNull(r.readLine());
+    }
+}


### PR DESCRIPTION
Looks like a mix up between org.geotools.referencing.operation.matrix.AffineTransform2D and org.geotools.referencing.operation.transform.AffineTransform2D
