### PR TITLE
Improvments to CQL/ECQL parsing with regard to date/dateime parsing.

### DIFF
--- a/modules/library/cql/src/main/java/org/geotools/filter/text/cql2/CQLCompiler.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/cql2/CQLCompiler.java
@@ -323,6 +323,9 @@ public class CQLCompiler extends CQLParser implements ICompiler{
         case JJTPERIOD_WITH_DURATION_DATE_NODE:
             return this.builder.buildPeriodDurationAndDate();
 
+        case JJTTPTEQUALS_DATETIME_NODE:
+            return this.builder.buildTEquals();
+
         case JJTTPBEFORE_DATETIME_NODE:
             return buildBeforePredicate();
 

--- a/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/ECQLCompiler.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/ECQLCompiler.java
@@ -344,6 +344,10 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
                 // ----------------------------------------
                 // temporal predicate actions
                 // ----------------------------------------
+            case JJTDATE_NODE:
+                return this.builder
+                        .buildDateExpression(getTokenInPosition(0));
+
             case JJTDATETIME_NODE:
                 return this.builder
                         .buildDateTimeExpression(getTokenInPosition(0));
@@ -360,6 +364,9 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
 
             case JJTPERIOD_WITH_DURATION_DATE_NODE:
                 return this.builder.buildPeriodDurationAndDate();
+
+            case JJTTPTEQUALS_DATETIME_NODE:
+                return this.builder.buildTEquals();
 
             case JJTTPBEFORE_DATETIME_NODE:
                 return buildBefore();

--- a/modules/library/cql/src/main/jjtree/CQLGrammar.jjt
+++ b/modules/library/cql/src/main/jjtree/CQLGrammar.jjt
@@ -203,6 +203,7 @@ TOKEN [IGNORE_CASE]: /* geometry markers */
 
 TOKEN [IGNORE_CASE]: /* temporal expression*/
 {
+	<TEQUALS: "tequals">  |
 	<BEFORE: "before"> 	| 
 	<DURING: "during"> 	|
 	<AFTER:  "after">  	|
@@ -288,7 +289,7 @@ TOKEN [IGNORE_CASE]: /* Literals */
 	< DURATION:  ("P" <DUR_DATE> |  "T" <DUR_TIME>) > |
 	
 	< #FULL_DATE: <DIGIT><DIGIT><DIGIT><DIGIT> "-" <DIGIT><DIGIT> "-" <DIGIT><DIGIT> > |
-    < #TIME_ZONE: ("Z") | (("+"|"-") <DIGIT><DIGIT> ":" <DIGIT><DIGIT>) > |	
+    < #TIME_ZONE: ("Z") | (("+"|"-") <DIGIT><DIGIT> (":")? <DIGIT><DIGIT>) > |	
 	< #UTC_TIME: <DIGIT><DIGIT> ":" <DIGIT><DIGIT> ":" <DIGIT><DIGIT> ("." (<DIGIT>)+)? (<TIME_ZONE>)? > |
 	< DATE_TIME : <FULL_DATE>"T"<UTC_TIME> > |
 
@@ -642,7 +643,8 @@ void NullPredicate() :
  *   	<temporal predicate>
  * ---------------------------------------- *
  * <temporal predicate> ::= 
- *    <attribute_name> BEFORE <date-time expression>
+ *	  <attribute_name> TEQUAL <date-time expression>
+ *	| <attribute_name> BEFORE <date-time expression>
  *	| <attribute_name> BEFORE OR DURING <period>
  *	| <attribute_name> DURING <period>
  *	| <attribute_name> DURING OR AFTER <period>
@@ -651,10 +653,17 @@ void NullPredicate() :
 void TemporalPredicate() #void:
 {}
 {
-		<BEFORE> TemporalPredicateBefore() 	
+		<TEQUALS> TemporalPredicateTEquals()  
+	|	<BEFORE> TemporalPredicateBefore() 	
 	|   <AFTER>	 TemporalPredicateAfter()	
 	|	<DURING> TemporalPredicateDuring()	
 	
+}
+
+void TemporalPredicateTEquals()#TPTEquals_DateTime_Node:
+{}
+{
+    DateTimeExpression()  
 }
 
 void TemporalPredicateBefore()#void:

--- a/modules/library/cql/src/main/jjtree/ECQLGrammar.jjt
+++ b/modules/library/cql/src/main/jjtree/ECQLGrammar.jjt
@@ -173,6 +173,7 @@ TOKEN [IGNORE_CASE]: /* geometry markers */
 
 TOKEN [IGNORE_CASE]: /* temporal expression*/
 {
+	<TEQUALS: "tequals">  | 
 	<BEFORE: "before"> 	| 
 	<DURING: "during"> 	|
 	<AFTER:  "after">  	|
@@ -258,8 +259,9 @@ TOKEN [IGNORE_CASE]: /* Literals */
 	< DURATION:  ("P" <DUR_DATE> |  "T" <DUR_TIME>) > |
 	
 	< #FULL_DATE: <DIGIT><DIGIT><DIGIT><DIGIT> "-" <DIGIT><DIGIT> "-" <DIGIT><DIGIT> > |
-    < #TIME_ZONE: ("Z") | (("+"|"-") <DIGIT><DIGIT> ":" <DIGIT><DIGIT>) > | 
+    < #TIME_ZONE: ("Z") | (("+"|"-") <DIGIT><DIGIT> (":")? <DIGIT><DIGIT>) > | 
     < #UTC_TIME: <DIGIT><DIGIT> ":" <DIGIT><DIGIT> ":" <DIGIT><DIGIT> ("." (<DIGIT>)+)? (<TIME_ZONE>)? > |
+	< DATE : <FULL_DATE>(<TIME_ZONE>)? > |
 	< DATE_TIME : <FULL_DATE>"T"<UTC_TIME> > |
 
     < IDENTIFIER: (<LETTER> (<LETTER>|<DIGIT>)*) | <DOUBLE_QUOTE> (<ANY>)+ <DOUBLE_QUOTE> > |
@@ -729,7 +731,8 @@ void NullPredicate() :
  *   	<temporal predicate>
  * ---------------------------------------- *
  * <temporal predicate> ::= 
- *    <attribute_name> BEFORE <date-time expression>
+ *	  <attribute_name> TEQUALS <date-time expression>
+ *	| <attribute_name> BEFORE <date-time expression>
  *	| <attribute_name> BEFORE OR DURING <period>
  *	| <attribute_name> DURING <period>
  *	| <attribute_name> DURING OR AFTER <period>
@@ -753,9 +756,16 @@ void TemporalPredicateHead() #void:
 void TemporalPredicateTail() #void:
 {}
 {
-        <BEFORE> TemporalPredicateBefore()  
+        <TEQUALS> TemporalPredicateTEquals()  
+    |   <BEFORE> TemporalPredicateBefore()  
     |   <AFTER>  TemporalPredicateAfter()   
     |   <DURING> TemporalPredicateDuring()  
+}
+
+void TemporalPredicateTEquals()#TPTEQUALS_DateTime_Node:
+{}
+{
+    DateTimeExpression()  
 }
 
 void TemporalPredicateBefore()#void:
@@ -989,9 +999,18 @@ void AttributeTail() #Compound_Attribute_Node:
 void Literal() #void :
 {}
 {
-		NumericLiteral()
+		DateLiteral()
+	|  	NumericLiteral()
 	| 	GeneralLiteral()	
 }
+
+void DateLiteral() #void :
+{}
+{
+    <DATE> #Date_Node
+  | <DATE_TIME> #DateTime_Node
+}
+
 void NumericLiteral() #void :
 {}
 {

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/CQLComparisonPredicateTest.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/CQLComparisonPredicateTest.java
@@ -278,6 +278,4 @@ public class CQLComparisonPredicateTest {
         Assert.assertNotNull("expects filter not null", actual);
         Assert.assertEquals("this is not the filter expected", expected, actual);
     }
-    
-
 }

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/CQLTemporalPredicateTest.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/CQLTemporalPredicateTest.java
@@ -245,16 +245,21 @@ public class CQLTemporalPredicateTest {
 			Literal literalDate = (Literal) expr2;
 			Date actualDate = (Date) literalDate.getValue();
 
-			Date expectedDate = dateFormatter.parse("2008-09-09 17:00:00 " +  offset);
+			Date expectedDate = dateFormatter.parse("2008-09-09 17:00:00" +  offset);
 
 			Assert.assertEquals(expectedDate, actualDate);
 
 		}
 
 		{
+		    //JD: there was a bug in this test case with the date format, litte "z" has to 
+		    // specified as a named timezone, not an offset, so it was just being ignored
+		    // plus the offset was wrong
 			// test offset GMT-01:00
-	        final DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssz");
-			final String offset = "GMT+01:00";
+	        //final DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssz");
+		//    final String offset = "GMT+01:00";
+                final DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+			final String offset = "GMT-01:00";
 	        TimeZone tz = TimeZone.getTimeZone(offset);
 	        dateFormatter.setTimeZone(tz);
 
@@ -267,7 +272,8 @@ public class CQLTemporalPredicateTest {
 			Literal literalDate = (Literal) expr2;
 			Date actualDate = (Date) literalDate.getValue();
         
-			Date expectedDate = dateFormatter.parse("2008-09-09 17:00:00 " +  offset);
+			//Date expectedDate = dateFormatter.parse("2008-09-09 17:00:00 " +  offset);
+			Date expectedDate = dateFormatter.parse("2008-09-09 17:00:00");
 
 			Assert.assertEquals(expectedDate, actualDate);
 		}
@@ -615,6 +621,17 @@ public class CQLTemporalPredicateTest {
         }
     }
     
-    
-    
+    @Test
+    public void equal() throws Exception {
+        //-------------------------------------------------------------
+        // <attribute_name> TEQUALS <date-time expression>
+        // -------------------------------------------------------------
+        // ATTR1 = 2006-12-31T01:30:00Z
+        Filter resultFilter = CompilerUtil.parseFilter(this.language, FilterCQLSample.FILTER_EQUAL_DATETIME);
+        Assert.assertNotNull("not null expected", resultFilter);
+
+        Filter expected = FilterCQLSample.getSample(FilterCQLSample.FILTER_EQUAL_DATETIME);
+        Assert.assertEquals(expected, resultFilter);
+
+    }
 }

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/FilterCQLSample.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/FilterCQLSample.java
@@ -44,6 +44,7 @@ import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.temporal.After;
 import org.opengis.filter.temporal.Before;
 import org.opengis.filter.temporal.During;
+import org.opengis.filter.temporal.TEquals;
 import org.opengis.temporal.Instant;
 import org.opengis.temporal.Period;
 
@@ -70,7 +71,7 @@ public class FilterCQLSample {
     private static final FilterFactory FACTORY = CommonFactoryFinder.getFilterFactory((Hints) null);
 
     private static final String DATE_TIME_FORMATTER = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-    
+
     private static final Calendar CALENDAR = Calendar.getInstance();
     public static final String LESS_FILTER_SAMPLE = "ATTR1 < 1";
     public static final String LESS_EQ_FILTER_SAMPLE = "ATTR1 <= 1";
@@ -84,6 +85,7 @@ public class FilterCQLSample {
     public static final String PROPERTY_IS_NOT_NULL = "ATTR1 IS NOT NULL";
     private static final String FIRST_DATE = "2006-11-30T01:30:00Z";
     private static final String LAST_DATE = "2006-12-31T01:30:00Z";
+    public static final String FILTER_EQUAL_DATETIME = "ATTR1 TEQUALS " + FIRST_DATE;
     public static final String FILTER_BEFORE_DATE = "ATTR1 BEFORE " + FIRST_DATE;
     public static final String FILTER_BEFORE_PERIOD_BETWEEN_DATES = "ATTR1 BEFORE " + FIRST_DATE
         + "/" + LAST_DATE;
@@ -220,7 +222,20 @@ public class FilterCQLSample {
 
             SAMPLES.put(PROPERTY_IS_NOT_NULL, notNullFilter);
         }
+        {
+            TEquals tEqualsFilter = null;
 
+            try {
+                SimpleDateFormat dateFormatter = new SimpleDateFormat(DATE_TIME_FORMATTER);
+                Date dateTime = dateFormatter.parse(FIRST_DATE);
+                tEqualsFilter = FACTORY.tequals(FACTORY.property("ATTR1"), FACTORY.literal(dateTime));
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+
+            // ATTR1 BEFORE 2006-12-31T01:30:00Z
+            SAMPLES.put(FILTER_EQUAL_DATETIME, tEqualsFilter);
+        }
         {
             // ---------------------------------------
             // Result filter for BEFORE tests


### PR DESCRIPTION
- modified grammer adding TEQUALS operator
- modified grammer to allow for date literals in regular binary comparison
- fixed some issues with regard to timezone offset handling
- made date/time/timezone extraction more robust with regular expressions
