### PR TITLE
GEOT-4386 improved SchemaFactory speed moving app-schema-resolver stuff to gt-xml

### DIFF
--- a/docs/user/library/xml/index.rst
+++ b/docs/user/library/xml/index.rst
@@ -35,3 +35,4 @@ you to what is available.
    geometry
    filter
    style
+   resolving

--- a/docs/user/library/xml/resolving.rst
+++ b/docs/user/library/xml/resolving.rst
@@ -1,0 +1,43 @@
+Schema Resolving
+----------------
+
+XSD Schema resolving is done through the ``SchemaResolver`` class. 
+
+
+SchemaResolver
+^^^^^^^^^^^^^^
+
+This supports resolution of schemas obtained from an OASIS Catalog, the Java classpath, or cached network download, or all three.
+
+This class will resolve any resource type, but it is designed to aid relative imports between XML Schemas; to do this it keeps a reverse-lookup table to convert resolved locations back to their original locations, facilitating correct determination of relative imports and includes. To ensure that this works, use a single instance of ``SchemaResolver`` to resolve a schema and all its dependencies.
+
+Optional ``SchemaResolver`` constructors arguments allow configuration of permitted resolution methods.
+
+OASIS Catalog
+'''''''''''''
+
+The resolver can be configured to use an `OASIS Catalog <http://www.oasis-open.org/committees/entity/spec-2001-08-06.html>`_ to resolve schema locations. The resolver uses catalog URI semantics to locate schemas, so ``uri`` or ``rewriteURI`` entries should be present in your catalog.
+
+Example::
+
+    SchemaResolver resolver = new SchemaResolver(SchemaCatalog.build(DataUtilities.fileToURL(new File("/path/to/catalog.xml"))));
+
+
+Classpath
+'''''''''
+
+Schema resolution on the classpath is always enabled. For example, a schema ``http://schemas.example.org/exampleml/exml.xsd`` resolves to ``/org/example/schemas/exampleml/exml.xsd`` on the classpath. To create a resolver with only support for schemas on the classpath, use the default constructor::
+
+    SchemaResolver resolver = new SchemaResolver();
+
+
+Cache
+'''''
+
+If the resolver is configured to use a cache, schemas not resolved by other methods will be downloaded from the network and stored in the cache directory. For example, a schema published at ``http://schemas.example.org/exampleml/exml.xsd`` would be downloaded and stored as ``org/example/schemas/exampleml/exml.xsd`` in the cache directory.
+
+Example::
+
+    SchemaResolver resolver = new SchemaResolver(new SchemaCache(new File("/path/to/schema-cache"), true));
+
+If downloads are not enabled, a prepopulated cache will still be used, but missing schemas will not be downloaded.

--- a/modules/extension/app-schema/app-schema-resolver/pom.xml
+++ b/modules/extension/app-schema/app-schema-resolver/pom.xml
@@ -39,6 +39,11 @@
     </developers>
 
     <dependencies>
+		<dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-xml</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.geotools.xsd</groupId>
             <artifactId>gt-xsd-core</artifactId>

--- a/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/xml/AppSchemaCatalog.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/xml/AppSchemaCatalog.java
@@ -17,13 +17,10 @@
 
 package org.geotools.xml;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
-import java.util.logging.Logger;
 
 import org.apache.xml.resolver.Catalog;
-import org.apache.xml.resolver.CatalogManager;
+import org.geotools.xml.resolver.SchemaCatalog;
 
 /**
  * Support for application schema resolution in an <a
@@ -37,93 +34,16 @@ import org.apache.xml.resolver.CatalogManager;
  *
  * @source $URL$
  */
-public class AppSchemaCatalog {
-
-    private static final Logger LOGGER = org.geotools.util.logging.Logging
-            .getLogger(AppSchemaCatalog.class.getPackage().getName());
-
-    private final Catalog catalog;
-
+public class AppSchemaCatalog extends SchemaCatalog {
+    
     /**
      * Use {@link #build(URL)} to construct an instance.
      * 
      * @param catalog
      */
-    private AppSchemaCatalog(Catalog catalog) {
-        this.catalog = catalog;
-    }
-
-    /**
-     * Return schema location resolved in the catalog if possible. <tt>rewriteURI</tt> semantics are
-     * used.
-     * 
-     * @param location
-     *            typically an absolute http/https URL.
-     * @return null if location not found in the catalog
-     */
-    public String resolveLocation(String location) {
-        String resolvedLocation = null;
-        try {
-            resolvedLocation = catalog.resolveURI(location);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        if (resolvedLocation != null) {
-            InputStream input = null;
-            try {
-                // verify existence of resource
-                // could be a file, jar resource, or other
-                input = (new URL(resolvedLocation)).openStream();
-                // catalog hit
-                LOGGER.fine("Catalog resolved " + location + " to " + resolvedLocation);
-            } catch (IOException e) {
-                // catalog miss
-                LOGGER.fine("Catalog did not resolve " + location + " to " + resolvedLocation
-                        + " despite matching catalog entry because an error occurred: "
-                        + e.getMessage());
-                resolvedLocation = null;
-            } finally {
-                if (input != null) {
-                    try {
-                        input.close();
-                    } catch (IOException e) {
-                        // we tried
-                    }
-                }
-            }
-        }
-        return resolvedLocation;
-    }
-
-    /**
-     * Build a private {@link Catalog}, that is, not the static instance that {@link CatalogManager}
-     * returns by default.
-     * 
-     * <p>
-     * 
-     * Care must be taken to use only private {@link Catalog} instances if there will ever be more
-     * than one OASIS Catalog used in a single class loader (i.e. a single maven test run),
-     * otherwise {@link Catalog} contents will be an amalgam of the entries of both OASIS Catalog
-     * files, with likely unintended or incorrect results. See GEOT-2497.
-     * 
-     * @param catalogLocation
-     *            URL of OASIS Catalog
-     * @return a private Catalog
-     */
-    static Catalog buildPrivateCatalog(URL catalogLocation) {
-        CatalogManager catalogManager = new CatalogManager();
-        catalogManager.setUseStaticCatalog(false);
-        catalogManager.setVerbosity(0);
-        catalogManager.setIgnoreMissingProperties(true);
-        Catalog catalog = catalogManager.getCatalog();
-        try {
-            catalog.parseCatalog(catalogLocation);
-        } catch (IOException e) {
-            throw new RuntimeException("Error trying to load OASIS catalog from URL "
-                    + catalogLocation.toString(), e);
-        }
-        return catalog;
-    }
+    protected AppSchemaCatalog(Catalog catalog) {
+        super(catalog);
+    }    
 
     /**
      * Build an catalog using the given OASIS Catalog file URL.

--- a/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/xml/AppSchemaResolver.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/xml/AppSchemaResolver.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import org.geotools.xml.resolver.SchemaResolver;
+
 /**
  * Application schema resolver that maps absolute URLs to local URL resources.
  * 
@@ -49,35 +51,9 @@ import java.util.logging.Logger;
  *
  * @source $URL$
  */
-public class AppSchemaResolver {
+public class AppSchemaResolver extends SchemaResolver {
 
-    private static final Logger LOGGER = org.geotools.util.logging.Logging
-            .getLogger(AppSchemaResolver.class.getPackage().getName());
-
-    /**
-     * A local OASIS catalog (null if not present).
-     */
-    private AppSchemaCatalog catalog;
-
-    /**
-     * True if schemas can be resolved on the classpath.
-     */
-    private boolean classpath = true;
-
-    /**
-     * Cache of schemas with optional downloading support(null if not present).
-     */
-    private AppSchemaCache cache;
-
-    /**
-     * Maps a resolved location (a URL used to obtain a schema from a file or the classpath) to the
-     * original HTTP URL used to obtain it. This is required so that relative imports can be
-     * resolved if they cross resolution boundaries. For example, an import ../../../om/.. used to
-     * import om in a schema, where one is supplied locally and the other must be downloaded and
-     * cached. Another example is when the schemas are in different jar files.
-     */
-    private Map<String, String> resolvedLocationToOriginalLocationMap = new HashMap<String, String>();
-
+    
     /**
      * Constructor.
      * 
@@ -85,10 +61,9 @@ public class AppSchemaResolver {
      * @param classpath whether schemas can be located on the classpath
      * @param cache
      */
-    public AppSchemaResolver(AppSchemaCatalog catalog, boolean classpath, AppSchemaCache cache) {
-        this.catalog = catalog;
-        this.classpath = classpath;
-        this.cache = cache;
+    public AppSchemaResolver(AppSchemaCatalog catalog, boolean classpath,
+            AppSchemaCache cache) {
+        super(catalog, classpath, cache);
     }
 
     /**
@@ -98,14 +73,14 @@ public class AppSchemaResolver {
      * @param cache
      */
     public AppSchemaResolver(AppSchemaCatalog catalog, AppSchemaCache cache) {
-        this(catalog, true, cache);
+        super(catalog, cache);
     }
 
     /**
      * Convenience constructor for a resolver with neither catalog nor cache (just classpath).
      */
     public AppSchemaResolver() {
-        this(null, null);
+        super();
     }
 
     /**
@@ -114,7 +89,7 @@ public class AppSchemaResolver {
      * @param catalog
      */
     public AppSchemaResolver(AppSchemaCatalog catalog) {
-        this(catalog, null);
+        super(catalog);
     }
 
     /**
@@ -123,186 +98,6 @@ public class AppSchemaResolver {
      * @param cache
      */
     public AppSchemaResolver(AppSchemaCache cache) {
-        this(null, cache);
-    }
-
-    /**
-     * Resolve an absolute or relative URL to a local file or jar URL. Relative URLs are resolved
-     * against a context schema URL if provided.
-     * 
-     * @param location
-     *            an absolute or relative URL for a schema
-     * @param context
-     *            an absolute URL specifying the context schema of a relative location, or null if
-     *            none
-     * @return the string representation of a file or jar URL
-     * @throws RuntimeException
-     *             if a local resource could not be found
-     */
-    public String resolve(String location, String context) {
-        URI locationUri;
-        try {
-            locationUri = new URI(location);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-        if (!locationUri.isAbsolute()) {
-            // Location is relative, so need to resolve against context.
-            if (context == null) {
-                throw new RuntimeException("Could not determine absolute schema location for "
-                        + location + " because context schema location is unknown");
-            }
-            // Find the original absolute http/https (canonical) URL used to obtain the
-            // context schema, so relative imports can be honoured across resolution source
-            // boundaries or jar file boundaries.
-            String originalContext = resolvedLocationToOriginalLocationMap.get(context);
-            if (originalContext == null) {
-                // Do not know any better context, so treat as original.
-                originalContext = context;
-            }
-            // Resolve the location URI against the context URI to make it absolute.
-            URI contextUri;
-            try {
-                contextUri = new URI(originalContext);
-            } catch (URISyntaxException e) {
-                throw new RuntimeException(e);
-            }
-            locationUri = contextUri.resolve(locationUri);
-        }
-        return resolve(locationUri.toString());
-    }
-
-    /**
-     * Resolve an absolute URL to a local file or jar URL.
-     * 
-     * @param location
-     *            an absolute URL
-     * @return the string representation of a file or jar URL
-     * @throws RuntimeException
-     *             if a local resource could not be found
-     */
-    public String resolve(String location) {
-        String resolvedLocation = null;
-        // Already resolved?
-        if (location.startsWith("file:") || location.startsWith("jar:file:")) {
-            resolvedLocation = location;
-        }
-        // Use catalog if one supplied.
-        if (resolvedLocation == null && catalog != null) {
-            resolvedLocation = catalog.resolveLocation(location);
-        }
-        // Look on classpath.
-        if (resolvedLocation == null && classpath) {
-            resolvedLocation = resolveClasspathLocation(location);
-        }
-        // Use download cache.
-        if (resolvedLocation == null && cache != null) {
-            resolvedLocation = cache.resolveLocation(location);
-        }
-        // Fail if still not resolved.
-        if (resolvedLocation == null) {
-            throw new RuntimeException(String.format("Failed to resolve %s", location));
-        }
-        resolvedLocationToOriginalLocationMap.put(resolvedLocation, location);
-        LOGGER.fine(String.format("Resolved %s -> %s", location, resolvedLocation));
-        return resolvedLocation;
-    }
-
-    /**
-     * Return the Simple HTTP Resource Path for an absolute http/https URL.
-     * 
-     * @param location
-     *            not null
-     * @return the resource path with a leading slash
-     * @see #getSimpleHttpResourcePath(URI)
-     */
-    public static String getSimpleHttpResourcePath(String location) {
-        URI locationUri;
-        try {
-            locationUri = new URI(location);
-        } catch (URISyntaxException e) {
-            return null;
-        }
-        return getSimpleHttpResourcePath(locationUri);
-    }
-
-    /**
-     * Return the Simple HTTP Resource Path for an absolute http/https URL.
-     * 
-     * <p>
-     * 
-     * The Simple HTTP Resource Path maps an HTTP or HTTPS URL to a path on the classpath or
-     * relative to some other root. To form the Simple HTTP Resource Path from an http/https URL:
-     * 
-     * <ol>
-     * <li>Protocol, port, fragment, and query are ignored.</li>
-     * <li>Take the host name, split it into its components, reverse their order, prepend a forward
-     * slash to each, and concatenate them.</li>
-     * <li>Append the path component of the URL.</li>
-     * </ol>
-     * 
-     * For example <code>http://schemas.example.org/exampleml/exml.xsd</code> becomes
-     * <code>/org/example/schemas/exampleml/exml.xsd</code> .
-     * 
-     * <p>
-     * 
-     * The Simple HTTP Resource Path always starts with a forward slash (if not null).
-     * 
-     * @param location
-     *            not null
-     * @return the Simple HTTP Resource Path as a string, or null if the URI is not an absolute
-     *         HTTP/HTTPS URL.
-     */
-    public static String getSimpleHttpResourcePath(URI location) {
-        String scheme = location.getScheme();
-        if (scheme == null || !(scheme.equals("http") || scheme.equals("https"))) {
-            return null;
-        } else {
-            String host = location.getHost();
-            String path = location.getPath();
-            String[] hostParts = host.split("\\.");
-            StringBuffer buffer = new StringBuffer();
-            for (int i = hostParts.length - 1; i >= 0; i--) {
-                buffer.append("/");
-                buffer.append(hostParts[i]);
-            }
-            buffer.append(path);
-            return buffer.toString();
-        }
-    }
-
-    /**
-     * Return the URL for a resource found on the classpath at the Simple HTTP Resource Path. This
-     * allows (for example) schema documents in jar files to be loaded from the classpath using
-     * their canonical HTTP URLs.
-     * 
-     * @param location
-     * @return the URL or null if not found
-     */
-    public static URL getClasspathResourceUrl(String location) {
-        String path = getSimpleHttpResourcePath(location);
-        if (path == null) {
-            return null;
-        } else {
-            return AppSchemaResolver.class.getResource(path);
-        }
-    }
-
-    /**
-     * Return the string representation of URL for a resource found on the classpath at the Simple
-     * HTTP Resource Path. This allows (for example) schema documents in jar files to be loaded from
-     * the classpath using their canonical HTTP URLs.
-     * 
-     * @param location
-     * @return the string representation of a classpath URL, or null if not found
-     */
-    public static String resolveClasspathLocation(String location) {
-        URL url = getClasspathResourceUrl(location);
-        if (url == null) {
-            return null;
-        } else {
-            return getClasspathResourceUrl(location).toExternalForm();
-        }
-    }
-
+        super(cache);
+    }    
 }

--- a/modules/library/xml/pom.xml
+++ b/modules/library/xml/pom.xml
@@ -95,6 +95,19 @@
       <artifactId>gt-xsd-wfs</artifactId>
       <version>${project.version}</version>
     </dependency>
+	
+	<!--  xml schema resolver dependencies -->
+	<dependency>
+		<groupId>org.apache.xml</groupId>
+		<artifactId>xml-commons-resolver</artifactId>
+		<version>1.2</version>
+	</dependency>
+	<dependency>
+		<groupId>org.geotools.schemas</groupId>
+		<artifactId>geosciml-2.0</artifactId>
+		<version>2.0.2-4</version>
+		<scope>test</scope>
+	</dependency>
     
     <!--  xml/xsd dependencies -->
     <dependency>

--- a/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
@@ -17,6 +17,7 @@
 package org.geotools.xml;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -32,12 +33,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.geotools.referencing.ReferencingFactoryFinder;
+import org.geotools.xml.resolver.SchemaCache;
+import org.geotools.xml.resolver.SchemaResolver;
 import org.geotools.xml.schema.Attribute;
 import org.geotools.xml.schema.AttributeGroup;
 import org.geotools.xml.schema.ComplexType;
@@ -66,6 +70,9 @@ import org.xml.sax.SAXException;
  * @version $Id$
  */
 public class SchemaFactory {
+
+    private static final Logger LOGGER = Logger.getLogger(SchemaFactory.class.getName());
+
     protected static SchemaFactory is = new SchemaFactory();
 
     /*
@@ -76,11 +83,47 @@ public class SchemaFactory {
      */
     private Map schemas = loadSchemas();
 
+    /**
+     * Schema Resolver: uses local versions of schemas or cached ones if available.
+     */
+    File cacheDir;    
+    private SchemaResolver resolver;
+
     /*
      * The SAX parser to use if one is required ... isn't loaded until first
      * use.
      */
     private SAXParser parser;
+
+    
+    
+    /**
+     * Default constructor.
+     */
+    protected SchemaFactory() {
+        super();
+        initResolver();
+    }
+
+    /**
+     * Initialize the schema resolver.
+     */
+    private void initResolver() {
+        try {
+            if(System.getProperty("schema.factory.cache", null) == null) {
+                File tempFolder = File.createTempFile("schema", "cache");
+                tempFolder.delete();
+                tempFolder.mkdirs();
+                cacheDir = tempFolder;
+            } else {
+                cacheDir = new File(System.getProperty("schema.factory.cache"));
+            }
+            
+            resolver = new SchemaResolver(new SchemaCache(cacheDir, true));
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, e.getMessage(), e);
+        }
+    }
 
     protected static SchemaFactory getInstance() {
         return is;
@@ -277,10 +320,15 @@ public class SchemaFactory {
             XSISAXHandler.setLogLevel(level);
 
             try {
-                parser.parse(desiredSchema.toString(), contentHandler);
+                parser.parse(resolveSchema(desiredSchema), contentHandler);
             } catch (IOException e) {
-                // TODO error handler should be notified of a connectionexception: operation timed out.
-                throw new SAXException(e);
+                // tries to parse directly from original URL
+                try {
+                    parser.parse(desiredSchema.toString(), contentHandler);
+                } catch (IOException e1) {
+                    throw new SAXException(e1);
+                }
+
             }
 
             Schema schema = contentHandler.getSchema();
@@ -303,7 +351,7 @@ public class SchemaFactory {
                 XSISAXHandler.setLogLevel(level);
 
                 try {
-                    parser.parse(desiredSchema.toString(), contentHandler);
+                    parser.parse(resolveSchema(desiredSchema), contentHandler);
                 } catch (IOException e) {
                     throw new SAXException(e);
                 }
@@ -314,6 +362,14 @@ public class SchemaFactory {
         }
 
         return (Schema) schemas.get(targetNamespace);
+    }
+
+    /**
+     * @param desiredSchema
+     * @return
+     */
+    private String resolveSchema(URI schema) {
+        return resolver.resolve(schema.toString());
     }
 
     protected XSISAXHandler getSAXHandler(URI uri) {

--- a/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaCache.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaCache.java
@@ -1,0 +1,490 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2010-2012, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.xml.resolver;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.geotools.data.DataUtilities;
+
+/**
+ * Cache containing XML schemas. (Should also work for other file types.)
+ * 
+ * <p>
+ * 
+ * If configured to permit downloading, schemas not present in the cache are downloaded from the network.
+ * 
+ * <p>
+ * 
+ * Only http/https URLs are supported.
+ * 
+ * <p>
+ * 
+ * Files are stored according to the Simple HTTP Resource Path (see {@link SchemaResolver#getSimpleHttpResourcePath(URI))}.
+ * 
+ * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
+ * 
+ * 
+ * 
+ * @source $URL$
+ */
+public class SchemaCache {
+
+    private static final Logger LOGGER = org.geotools.util.logging.Logging
+            .getLogger(SchemaCache.class.getPackage().getName());
+
+    /**
+     * The default block read size used when downloading a file.
+     */
+    private static final int DEFAULT_DOWNLOAD_BLOCK_SIZE = 4096;
+
+    /**
+     * This is the default value of the keep query flag used when building an automatically configured SchemaCache.
+     */
+    private static final boolean DEFAULT_KEEP_QUERY = true;
+
+    /**
+     * Filenames used to recognise a GeoServer data directory if automatic configuration is enabled.
+     */
+    private static final String[] GEOSERVER_DATA_DIRECTORY_FILENAMES = { "global.xml", "wcs.xml",
+            "wfs.xml", "wms.xml" };
+
+    /**
+     * Subdirectories used to recognise a GeoServer data directory if automatic configuration is enabled.
+     */
+    private static final String[] GEOSERVER_DATA_DIRECTORY_SUBDIRECTORIES = { "styles",
+            "workspaces" };
+
+    /**
+     * Name of the subdirectory of a GeoServer data directory (or other directory) used for the cache if automatic configuration is enabled.
+     */
+    private static final String CACHE_DIRECTORY_NAME = "app-schema-cache";
+
+    /**
+     * Is support for automatic detection of GeoServer data directories or existing cache directories enabled? It is useful to disable this in tests,
+     * to prevent downloading.
+     */
+    private static boolean automaticConfigurationEnabled = true;
+
+    /**
+     * Root directory of the cache.
+     */
+    private final File directory;
+
+    /**
+     * True if resources not found in the cache are downloaded from the net.
+     */
+    private final boolean download;
+    
+    /**
+     * Set of locations currently in download. Allows resolving a location
+     * to a partially downloaded file.
+     */
+    final static Set<String> locationsInDownload = new HashSet<String>();
+    
+    /**
+     * True if query string components should be part of the discriminator for
+     */
+    private final boolean keepQuery;
+
+    /**
+     * A cache of XML schemas (or other file types) rooted in the given directory, with optional downloading.
+     * 
+     * @param directory the directory in which downloaded schemas are stored
+     * @param download is downloading of schemas permitted. If false, only schemas already present in the cache will be resolved.
+     */
+    public SchemaCache(File directory, boolean download) {
+        this(directory, download, false);
+    }
+
+    /**
+     * A cache of XML schemas (or other file types) rooted in the given directory, with optional downloading.
+     * 
+     * @param directory the directory in which downloaded schemas are stored
+     * @param download is downloading of schemas permitted. If false, only schemas already present in the cache will be resolved.
+     * @param keepQuery indicates whether or not the query components should be included in the path. If this is set to true then the query portion is
+     *        converted to an MD5 message digest and that string is used to identify the file in the cache.
+     */
+    public SchemaCache(File directory, boolean download, boolean keepQuery) {
+        this.directory = directory;
+        this.download = download;
+        this.keepQuery = keepQuery;
+    }
+
+    /**
+     * Return the root directory of the cache.
+     */
+    public File getDirectory() {
+        return directory;
+    }
+    
+    /**
+     * Return the temp directory for not cached downloads (those
+     * occurring during another download, to avoid conflicts among threads).
+     */
+    public File getTempDirectory() {
+        try {
+            File tempFolder = File.createTempFile("schema", "cache");
+            tempFolder.delete();
+            tempFolder.mkdirs();
+            return tempFolder;
+        } catch (IOException e) {
+            LOGGER.severe("Can't create temporary folder");
+            throw new RuntimeException(e);
+        }
+    
+    }
+
+    /**
+     * Are schemas not already present in the cache downloaded from the network?
+     */
+    public boolean isDownloadAllowed() {
+        return download;
+    }
+
+    /**
+     * Recursively delete a directory or file.
+     * 
+     * @param file
+     */
+    protected static void delete(File file) {
+        if (file.isDirectory()) {
+            for (File f : file.listFiles()) {
+                delete(f);
+            }
+        }
+        file.delete();
+    }
+
+    /**
+     * Store the bytes in the given file, creating any necessary intervening directories.
+     * 
+     * @param file
+     * @param bytes
+     */
+    protected static void store(File file, byte[] bytes) {
+        OutputStream output = null;
+        try {
+            if (file.getParentFile() != null && !file.getParentFile().exists()) {
+                file.getParentFile().mkdirs();
+            }
+            output = new BufferedOutputStream(new FileOutputStream(file));
+            output.write(bytes);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (output != null) {
+                try {
+                    output.close();
+                } catch (Exception e) {
+                    // we tried
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieve the contents of a remote URL.
+     * 
+     * @param location and absolute http/https URL.
+     * @return the bytes contained by the resource, or null if it could not be downloaded
+     */
+    protected static byte[] download(String location) {        
+        URI locationUri;
+        try {
+            locationUri = new URI(location);
+        } catch (URISyntaxException e) {
+            return null;
+        }
+        return download(locationUri);
+    }
+
+    /**
+     * Retrieve the contents of a remote URL.
+     * 
+     * @param location and absolute http/https URL.
+     * @return the bytes contained by the resource, or null if it could not be downloaded
+     */
+    protected static byte[] download(URI location) {
+        return download(location, DEFAULT_DOWNLOAD_BLOCK_SIZE);
+    }
+
+    /**
+     * Retrieve the contents of a remote URL.
+     * 
+     * @param location and absolute http/https URL.
+     * @param blockSize download block size
+     * @return the bytes contained by the resource, or null if it could not be downloaded
+     */
+    protected static byte[] download(URI location, int blockSize) {        
+        try {
+            URL url = location.toURL();
+            String protocol = url.getProtocol();
+            if (protocol == null || !(protocol.equals("http") || protocol.equals("https"))) {
+                LOGGER.warning("Unexpected download URL protocol: " + protocol);
+                return null;
+            }
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(10000);
+            connection.setUseCaches(false);
+            connection.connect();
+            if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                LOGGER.warning(String.format("Unexpected response \"%d %s\" while downloading %s",
+                        connection.getResponseCode(), connection.getResponseMessage(),
+                        location.toString()));
+                return null;
+            }
+            // read all the blocks into a list
+            InputStream input = null;
+            List<byte[]> blocks = new LinkedList<byte[]>();
+            try {
+                input = connection.getInputStream();
+                while (true) {
+                    byte[] block = new byte[blockSize];
+                    int count = input.read(block);
+                    if (count == -1) {
+                        // end-of-file
+                        break;
+                    } else if (count == blockSize) {
+                        // full block
+                        blocks.add(block);
+                    } else {
+                        // short block
+                        byte[] shortBlock = new byte[count];
+                        System.arraycopy(block, 0, shortBlock, 0, count);
+                        blocks.add(shortBlock);
+                    }
+                }
+            } finally {
+                if (input != null) {
+                    try {
+                        input.close();
+                    } catch (Exception e) {
+                        // we tried
+                    }
+                }
+            }
+            // concatenate all the blocks
+            int totalCount = 0;
+            for (byte[] b : blocks) {
+                totalCount += b.length;
+            }
+            byte[] bytes = new byte[totalCount];
+            int position = 0;
+            for (byte[] b : blocks) {
+                System.arraycopy(b, 0, bytes, position, b.length);
+                position += b.length;
+            }
+            return bytes;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Return the local file URL of a schema, downloading it if not found in the cache.
+     * 
+     * @param location the absolute http/https URL of the schema
+     * @return the canonical local file URL of the schema, or null if not found
+     */
+    public String resolveLocation(String location) {
+        String path = SchemaResolver.getSimpleHttpResourcePath(location, this.keepQuery);
+        if (path == null) {
+            return null;
+        }
+        String relativePath = path.substring(1);
+        File file;
+        try {
+            file = new File(getDirectory(), relativePath).getCanonicalFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        // if the location is already in download we start a temporary download 
+        // for the current thread and we won't cache it at the end
+        boolean isTemp = false;
+        synchronized (locationsInDownload) {
+            if (!locationsInDownload.contains(location)) {
+                if (file.exists()) {
+                    return DataUtilities.fileToURL(file).toExternalForm();
+                }
+            } else {
+                // the location is already in download, we can't wait for it to
+                // complete, so we download another (temporary) copy and return that
+                isTemp = true;
+                try {
+                    // new file in a temporary folder
+                    file = new File(getTempDirectory(), relativePath)
+                            .getCanonicalFile();
+                } catch (IOException e) {
+                    LOGGER.severe("Can't create temporary file: "
+                            + file.getAbsolutePath());
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        if (isDownloadAllowed()) {
+            // add location to downloading list
+            startDownload(location, file, isTemp);
+    
+            byte[] bytes = download(location);
+            if (bytes == null) {
+                endDownload(location, isTemp);
+                return null;
+            }
+            store(file, bytes);
+            LOGGER.info("Cached XML schema: " + location);
+            endDownload(location, isTemp);
+            if (isTemp) {
+                file.deleteOnExit();
+            }
+    
+            return DataUtilities.fileToURL(file).toExternalForm();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param location
+     * @param isTemp
+     */
+    private void endDownload(String location, boolean isTemp) {
+        if(!isTemp) {
+            synchronized(locationsInDownload) {
+                locationsInDownload.remove(location);                        
+            }
+        }
+    }
+
+    /**
+     * Adds the given file / location to the list of files in download.
+     * 
+     * @param location
+     * @param file
+     */
+    private void startDownload(String location, File file, boolean isTemp) {
+        if(!isTemp) {
+            synchronized(locationsInDownload) {
+                locationsInDownload.add(location);
+                try {
+                    // we create an empty placeholder to be sure the file exists
+                    // for other threads to check
+                    file.getParentFile().mkdirs();
+                    file.createNewFile();
+                } catch (IOException e) {
+                    locationsInDownload.remove(location);
+                    LOGGER.severe("Can't create cache file: "+file.getAbsolutePath());
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * If automatic configuration is enabled, recursively search parent directories of file url for a GeoServer data directory or directory containing
+     * an existing cache. If found, use it to create a cache in the "app-schema-cache" subdirectory with downloading enabled.
+     * 
+     * @param url a URL for a file in a GeoServer data directory.
+     * @return a cache in the "app-schema-cache" subdirectory or null if not found or automatic configuration disabled.
+     */
+    public static SchemaCache buildAutomaticallyConfiguredUsingFileUrl(URL url) {
+        if (!automaticConfigurationEnabled) {
+            return null;
+        }
+        File file = DataUtilities.urlToFile(url);
+        while (true) {
+            if (file == null) {
+                return null;
+            }
+            if (isSuitableDirectoryToContainCache(file)) {
+                return new SchemaCache(new File(file, CACHE_DIRECTORY_NAME), true,
+                        DEFAULT_KEEP_QUERY);
+            }
+            file = file.getParentFile();
+        }
+    }
+
+    /**
+     * Turn off support for automatic configuration of a cache in GeoServer data directory or detection of an existing cache. Intended for testing.
+     * Automatic configuration is enabled by default.
+     */
+    public static void disableAutomaticConfiguration() {
+        automaticConfigurationEnabled = false;
+    }
+
+    /**
+     * The opposite of {@link #disableAutomaticConfiguration()}. Automatic configuration is enabled by default.
+     */
+    public static void enableAutomaticConfiguration() {
+        automaticConfigurationEnabled = true;
+    }
+
+    /**
+     * Is automatic configuration enabled? Automatic configuration is enabled by default.
+     * 
+     * @see #disableAutomaticConfiguration()
+     */
+    public static boolean isAutomaticConfigurationEnabled() {
+        return automaticConfigurationEnabled;
+    }
+
+    /**
+     * Guess whether a file is a GeoServer data directory or contains an existing app-schema-cache subdirectory.
+     * 
+     * @param directory the candidate file
+     * @return true if it has the files and subdirectories expected of a GeoServer data directory, or contains an existing app-schema-cache
+     *         subdirectory
+     */
+    static boolean isSuitableDirectoryToContainCache(File directory) {
+        if (directory.isDirectory() == false) {
+            return false;
+        }
+        if ((new File(directory, CACHE_DIRECTORY_NAME)).isDirectory()) {
+            return true;
+        }
+        for (String filename : GEOSERVER_DATA_DIRECTORY_FILENAMES) {
+            File file = new File(directory, filename);
+            if (!file.isFile()) {
+                return false;
+            }
+        }
+        for (String subdirectory : GEOSERVER_DATA_DIRECTORY_SUBDIRECTORIES) {
+            File dir = new File(directory, subdirectory);
+            if (!dir.isDirectory()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}
+

--- a/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaCatalog.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaCatalog.java
@@ -1,0 +1,139 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2010-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.xml.resolver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.logging.Logger;
+
+import org.apache.xml.resolver.Catalog;
+import org.apache.xml.resolver.CatalogManager;
+
+/**
+ * Support for XML schema resolution in an <a
+ * href="http://www.oasis-open.org/committees/entity/spec-2001-08-06.html">OASIS Catalog</a> (with
+ * URI resolution semantics).
+ * 
+ * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
+ * @see
+ *
+ *
+ *
+ * @source $URL$
+ */
+public class SchemaCatalog {
+
+    private static final Logger LOGGER = org.geotools.util.logging.Logging
+            .getLogger(SchemaCatalog.class.getPackage().getName());
+
+    private final Catalog catalog;
+
+    /**
+     * Use {@link #build(URL)} to construct an instance.
+     * 
+     * @param catalog
+     */
+    protected SchemaCatalog(Catalog catalog) {
+        this.catalog = catalog;
+    }
+
+    /**
+     * Return schema location resolved in the catalog if possible. <tt>rewriteURI</tt> semantics are
+     * used.
+     * 
+     * @param location
+     *            typically an absolute http/https URL.
+     * @return null if location not found in the catalog
+     */
+    public String resolveLocation(String location) {
+        String resolvedLocation = null;
+        try {
+            resolvedLocation = catalog.resolveURI(location);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        if (resolvedLocation != null) {
+            InputStream input = null;
+            try {
+                // verify existence of resource
+                // could be a file, jar resource, or other
+                input = (new URL(resolvedLocation)).openStream();
+                // catalog hit
+                LOGGER.fine("Catalog resolved " + location + " to " + resolvedLocation);
+            } catch (IOException e) {
+                // catalog miss
+                LOGGER.fine("Catalog did not resolve " + location + " to " + resolvedLocation
+                        + " despite matching catalog entry because an error occurred: "
+                        + e.getMessage());
+                resolvedLocation = null;
+            } finally {
+                if (input != null) {
+                    try {
+                        input.close();
+                    } catch (IOException e) {
+                        // we tried
+                    }
+                }
+            }
+        }
+        return resolvedLocation;
+    }
+
+    /**
+     * Build a private {@link Catalog}, that is, not the static instance that {@link CatalogManager}
+     * returns by default.
+     * 
+     * <p>
+     * 
+     * Care must be taken to use only private {@link Catalog} instances if there will ever be more
+     * than one OASIS Catalog used in a single class loader (i.e. a single maven test run),
+     * otherwise {@link Catalog} contents will be an amalgam of the entries of both OASIS Catalog
+     * files, with likely unintended or incorrect results. See GEOT-2497.
+     * 
+     * @param catalogLocation
+     *            URL of OASIS Catalog
+     * @return a private Catalog
+     */
+    protected static Catalog buildPrivateCatalog(URL catalogLocation) {
+        CatalogManager catalogManager = new CatalogManager();
+        catalogManager.setUseStaticCatalog(false);
+        catalogManager.setVerbosity(0);
+        catalogManager.setIgnoreMissingProperties(true);
+        Catalog catalog = catalogManager.getCatalog();
+        try {
+            catalog.parseCatalog(catalogLocation);
+        } catch (IOException e) {
+            throw new RuntimeException("Error trying to load OASIS catalog from URL "
+                    + catalogLocation.toString(), e);
+        }
+        return catalog;
+    }
+
+    /**
+     * Build an catalog using the given OASIS Catalog file URL.
+     * 
+     * @param catalogLocation
+     *            local file URL to an OASIS cCtalog
+     * @return
+     */
+    public static SchemaCatalog build(URL catalogLocation) {
+        return new SchemaCatalog(buildPrivateCatalog(catalogLocation));
+    }
+
+}

--- a/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaResolver.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaResolver.java
@@ -1,0 +1,397 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2010-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.xml.resolver;
+
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+
+/**
+ * XML Schema resolver that maps absolute URLs to local URL resources.
+ * 
+ * <p>
+ * 
+ * Resources are sought, in order:
+ * 
+ * <ol>
+ * 
+ * <li>In an <a href="http://www.oasis-open.org/committees/entity/spec-2001-08-06.html">OASIS
+ * Catalog</a> (with URI resolution semantics), which maps URLs to arbitrary filesystem locations.</li>
+ * 
+ * <li>On the classpath, where resources are located by their Simple HTTP Resource Path (see
+ * {@link #getSimpleHttpResourcePath(URI)}).
+ * 
+ * <li>In a cache, with optional downloading support.
+ * 
+ * </ol>
+ * 
+ * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
+ * 
+ * @source $URL$
+ */
+public class SchemaResolver {
+
+    private static final Logger LOGGER = org.geotools.util.logging.Logging
+            .getLogger(SchemaResolver.class.getPackage().getName());
+
+    /**
+     * A local OASIS catalog (null if not present).
+     */
+    private SchemaCatalog catalog;
+
+    /**
+     * True if schemas can be resolved on the classpath.
+     */
+    private boolean classpath = true;
+
+    /**
+     * Cache of schemas with optional downloading support(null if not present).
+     */
+    private SchemaCache cache;
+
+    /**
+     * Maps a resolved location (a URL used to obtain a schema from a file or the classpath) to the
+     * original HTTP URL used to obtain it. This is required so that relative imports can be
+     * resolved if they cross resolution boundaries. For example, an import ../../../om/.. used to
+     * import om in a schema, where one is supplied locally and the other must be downloaded and
+     * cached. Another example is when the schemas are in different jar files.
+     */
+    private Map<String, String> resolvedLocationToOriginalLocationMap = new ConcurrentHashMap<String, String>();
+
+    /**
+     * Constructor.
+     * 
+     * @param catalog
+     * @param classpath
+     *            whether schemas can be located on the classpath
+     * @param cache
+     */
+    public SchemaResolver(SchemaCatalog catalog, boolean classpath, SchemaCache cache) {
+        this.catalog = catalog;
+        this.classpath = classpath;
+        this.cache = cache;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param catalog
+     * @param cache
+     */
+    public SchemaResolver(SchemaCatalog catalog, SchemaCache cache) {
+        this(catalog, true, cache);
+    }
+
+    /**
+     * Convenience constructor for a resolver with neither catalog nor cache (just classpath).
+     */
+    public SchemaResolver() {
+        this(null, null);
+    }
+
+    /**
+     * Convenience constructor for a resolver with no cache.
+     * 
+     * @param catalog
+     */
+    public SchemaResolver(SchemaCatalog catalog) {
+        this(catalog, null);
+    }
+
+    /**
+     * Convenience constructor for a resolver with no catalog.
+     * 
+     * @param cache
+     */
+    public SchemaResolver(SchemaCache cache) {
+        this(null, cache);
+    }
+
+    /**
+     * Resolve an absolute or relative URL to a local file or jar URL. Relative URLs are resolved
+     * against a context schema URL if provided.
+     * 
+     * @param location
+     *            an absolute or relative URL for a schema
+     * @param context
+     *            an absolute URL specifying the context schema of a relative location, or null if
+     *            none
+     * @return the string representation of a file or jar URL
+     * @throws RuntimeException
+     *             if a local resource could not be found
+     */
+    public String resolve(String location, String context) {
+        URI locationUri;
+        try {
+            locationUri = new URI(location);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        if (!locationUri.isAbsolute()) {
+            // Location is relative, so need to resolve against context.
+            if (context == null) {
+                throw new RuntimeException("Could not determine absolute schema location for "
+                        + location + " because context schema location is unknown");
+            }
+            // Find the original absolute http/https (canonical) URL used to obtain the
+            // context schema, so relative imports can be honoured across resolution source
+            // boundaries or jar file boundaries.
+            String originalContext = resolvedLocationToOriginalLocationMap.get(context);
+            if (originalContext == null) {
+                // Do not know any better context, so treat as original.
+                originalContext = context;
+            }
+            // Resolve the location URI against the context URI to make it absolute.
+            URI contextUri;
+            try {
+                contextUri = new URI(originalContext);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+            locationUri = contextUri.resolve(locationUri);
+        }
+        return resolve(locationUri.toString());
+    }
+
+    /**
+     * Resolve an absolute URL to a local file or jar URL.
+     * 
+     * @param location
+     *            an absolute URL
+     * @return the string representation of a file or jar URL
+     * @throws RuntimeException
+     *             if a local resource could not be found
+     */
+    public String resolve(String location) {
+        String resolvedLocation = null;
+        // Already resolved?
+        if (location.startsWith("file:") || location.startsWith("jar:file:")) {
+            resolvedLocation = location;
+        }
+        // Use catalog if one supplied.
+        if (resolvedLocation == null && catalog != null) {
+            resolvedLocation = catalog.resolveLocation(location);
+        }
+        // Look on classpath.
+        if (resolvedLocation == null && classpath) {
+            resolvedLocation = resolveClasspathLocation(location);
+        }
+        // Use download cache.
+        if (resolvedLocation == null && cache != null) {
+            resolvedLocation = cache.resolveLocation(location);
+        }
+        // Fail if still not resolved.
+        if (resolvedLocation == null) {
+            throw new RuntimeException(String.format("Failed to resolve %s", location));
+        }
+        synchronized(this) {
+            if(!resolvedLocationToOriginalLocationMap.containsKey(resolvedLocation)) {
+                resolvedLocationToOriginalLocationMap.put(resolvedLocation, location);
+            }
+        }
+        LOGGER.fine(String.format("Resolved %s -> %s", location, resolvedLocation));
+        return resolvedLocation;
+    }
+
+    /**
+     * Return the Simple HTTP Resource Path for an absolute http/https URL. Does not include query
+     * components in the path.
+     * 
+     * @param location
+     *            not null
+     * @return the resource path with a leading slash
+     * @see #getSimpleHttpResourcePath(URI)
+     */
+    public static String getSimpleHttpResourcePath(String location) {
+        return getSimpleHttpResourcePath(location, false);
+    }
+
+    /**
+     * Return the Simple HTTP Resource Path for an absolute http/https URL.
+     * 
+     * @param location
+     *            not null
+     * @param keepQuery
+     *            indicates whether or not the query components should be included in the path. If
+     *            this is set to true then the query portion is converted to an MD5 message digest
+     *            and that string is used to identify the file in the cache.
+     * @return the resource path with a leading slash
+     * @see #getSimpleHttpResourcePath(URI, boolean)
+     */
+    public static String getSimpleHttpResourcePath(String location, boolean keepQuery) {
+        URI locationUri;
+        try {
+            locationUri = new URI(location);
+        } catch (URISyntaxException e) {
+            return null;
+        }
+        return getSimpleHttpResourcePath(locationUri, keepQuery);
+    }
+
+    /**
+     * Return the Simple HTTP Resource Path for an absolute http/https URL.
+     * 
+     * <p>
+     * 
+     * The Simple HTTP Resource Path maps an HTTP or HTTPS URL to a path on the classpath or
+     * relative to some other root. To form the Simple HTTP Resource Path from an http/https URL:
+     * 
+     * <ol>
+     * <li>Protocol, port, fragment, and query are ignored.</li>
+     * <li>Take the host name, split it into its components, reverse their order, prepend a forward
+     * slash to each, and concatenate them.</li>
+     * <li>Append the path component of the URL.</li>
+     * </ol>
+     * 
+     * For example <code>http://schemas.example.org/exampleml/exml.xsd</code> becomes
+     * <code>/org/example/schemas/exampleml/exml.xsd</code> .
+     * 
+     * <p>
+     * 
+     * The Simple HTTP Resource Path always starts with a forward slash (if not null). Does not
+     * include query components in the path.
+     * 
+     * @param location
+     *            not null
+     * @return the Simple HTTP Resource Path as a string, or null if the URI is not an absolute
+     *         HTTP/HTTPS URL.
+     */
+    public static String getSimpleHttpResourcePath(URI location) {
+        return getSimpleHttpResourcePath(location, false);
+    }
+
+    /**
+     * Return the Simple HTTP Resource Path for an absolute http/https URL.
+     * 
+     * <p>
+     * 
+     * The Simple HTTP Resource Path maps an HTTP or HTTPS URL to a path on the classpath or
+     * relative to some other root. To form the Simple HTTP Resource Path from an http/https URL:
+     * 
+     * <ol>
+     * <li>Protocol, port, fragment, and query are ignored.</li>
+     * <li>Take the host name, split it into its components, reverse their order, prepend a forward
+     * slash to each, and concatenate them.</li>
+     * <li>Append the path component of the URL.</li>
+     * </ol>
+     * 
+     * For example <code>http://schemas.example.org/exampleml/exml.xsd</code> becomes
+     * <code>/org/example/schemas/exampleml/exml.xsd</code> .
+     * 
+     * <p>
+     * 
+     * The Simple HTTP Resource Path always starts with a forward slash (if not null). Does not
+     * include query components in the path.
+     * 
+     * @param location
+     *            not null
+     * @param keepQuery
+     *            indicates whether or not the query components should be included in the path. If
+     *            this is set to true then the query portion is converted to an MD5 message digest
+     *            and that string is used to identify the file in the cache.
+     * @return the Simple HTTP Resource Path as a string, or null if the URI is not an absolute
+     *         HTTP/HTTPS URL.
+     */
+    public static String getSimpleHttpResourcePath(URI location, boolean keepQuery) {
+        String scheme = location.getScheme();
+        if (scheme == null || !(scheme.equals("http") || scheme.equals("https"))) {
+            return null;
+        } else {
+            String host = location.getHost();
+            String path = location.getPath();
+            String[] hostParts = host.split("\\.");
+            StringBuilder builder = new StringBuilder();
+            for (int i = hostParts.length - 1; i >= 0; i--) {
+                builder.append("/");
+                builder.append(hostParts[i]);
+            }
+            builder.append(path);
+            String query = location.getQuery();
+            if (keepQuery && query != null) {
+                builder.append(".");
+                builder.append(stringToMD5String(query));
+                builder.append(".xsd");
+            }
+            return builder.toString();
+        }
+    }
+
+    /**
+     * Return the URL for a resource found on the classpath at the Simple HTTP Resource Path. This
+     * allows (for example) schema documents in jar files to be loaded from the classpath using
+     * their canonical HTTP URLs.
+     * 
+     * @param location
+     * @return the URL or null if not found
+     */
+    public static URL getClasspathResourceUrl(String location) {
+        String path = getSimpleHttpResourcePath(location);
+        if (path == null) {
+            return null;
+        } else {
+            return SchemaResolver.class.getResource(path);
+        }
+    }
+
+    /**
+     * Return the string representation of URL for a resource found on the classpath at the Simple
+     * HTTP Resource Path. This allows (for example) schema documents in jar files to be loaded from
+     * the classpath using their canonical HTTP URLs.
+     * 
+     * @param location
+     * @return the string representation of a classpath URL, or null if not found
+     */
+    public static String resolveClasspathLocation(String location) {
+        URL url = getClasspathResourceUrl(location);
+        if (url == null) {
+            return null;
+        } else {
+            return getClasspathResourceUrl(location).toExternalForm();
+        }
+    }
+
+    /**
+     * Convert a string into an MD5 digest.
+     * 
+     * @param message
+     *            The string whose MD5 digest you want to generate.
+     * 
+     * @return An MD5 digest generated from message, this string is always 32 characters long. Or
+     *         returns null if there was an error.
+     */
+    private static String stringToMD5String(String message) {
+        byte[] bytesOfMessage = null;
+        MessageDigest md = null;
+        try {
+            bytesOfMessage = message.getBytes("UTF-8");
+            md = MessageDigest.getInstance("MD5");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return String.format("%032x", new BigInteger(1, md.digest(bytesOfMessage)));
+    }
+
+}
+

--- a/modules/library/xml/src/site/apt/review.apt
+++ b/modules/library/xml/src/site/apt/review.apt
@@ -13,3 +13,50 @@ Module xml
       http://jira.codehaus.org/browse/GEOT-1877
 
   Original purpose and authors not known, left to Jody/Justin.
+  
+  KNOWN ISSUES:
+  
+    * src/test/resources/org/example/schemas/wfs20/DescribeFeatureType_Example01_Response.xsd
+    
+      Are taken from the OGC WFS 2.0 specification.
+      
+      [Ben: I added the OGC Software Notice at module root and prominent comments in the files with links and copyright notice.]
+  
+Contributor Review (taken from pom.xml and source code files):
+
+    * all code prvided by Ben Caradoc-Davies was done under LGPL, CSIRO code contribution agreement
+    
+    * Niels should be listed in the pom.xml [Ben: noted, but I disagree as he only contributed one file]
+    
+  CODE REVIEW
+  
+    * @author tags should not use "," as apaprenty that lists multiple authors
+      we tend to use:
+         
+      INCORRECT: @author Ben Caradoc-Davies, CSIRO Earth Science and Resource Engineering
+      CORRECT: @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
+      
+      [FIXED]
+      
+  
+* test resources
+  ~~~~~~~~~~~~~~
+  
+    * org.example.schemas.wfs20 - known issue; content from wfs 2.0 specification. Add OGC license
+      to the base of the project folder and we should be good for this one [DONE; comments in files as well]
+    
+    * test-data/cache/org/example/schemas/cache-test attribution missing.
+    * test-data/cache/org/example/schemas/catalog-test attribution missing.    
+    * test-data attribution missing in general (Example01.xml handles attribtue well)
+
+* Clarification from Ben Caradoc-Davies
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    
+     
+    * All *.xsd files in src/test/resources/test-data are my original work.
+    
+    * OGC state that schemas and related docs (i.e. example response) can be treated under their software licence:
+      http://www.opengeospatial.org/ogc/legalfaq#DTD
+      We will apply this to schemas in documents as well.
+      
+    * Note that the OGC content is only used for automated testing and never supplied to users of app-schema-resolver.

--- a/modules/library/xml/src/test/java/org/geotools/xml/SchemaFactoryResolveTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/SchemaFactoryResolveTest.java
@@ -1,0 +1,112 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.xml;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+
+import junit.framework.TestCase;
+
+/**
+ * @author "Mauro Bartolomeoli - mauro.bartolomeoli@geo-solutions.it"
+ *
+ */
+public class SchemaFactoryResolveTest extends TestCase {
+
+    private static File tempFolder = null;
+    
+    @Override
+    protected void setUp() throws Exception {        
+        super.setUp();
+        // reinitialize SchemaFactory singleton instance for every test, to clean caches
+        SchemaFactory.is = new SchemaFactory();
+        if(tempFolder == null) {
+            tempFolder = File.createTempFile("schema", "cache");
+            tempFolder.delete();
+            tempFolder.deleteOnExit();
+            System.setProperty("schema.factory.cache", tempFolder.getAbsolutePath());
+        }
+    }
+    
+    
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        if(tempFolder.exists()) {
+            delete(tempFolder, true);
+        }
+    }
+
+
+
+    public void testLocalPathResolve() throws Exception {
+        assertNotNull(SchemaFactory.getInstance(
+                URI.create("http://www.w3.org/XML/1998/namespace/test"),
+                URI.create("http://geotools.org/xml/test.xsd")));
+    }
+    
+    public void testCachedPathResolve() throws Exception {
+        File folder = new File(tempFolder.getAbsolutePath() + File.separator
+                + "org" + File.separator + "geotools" + File.separator + "xml");
+        folder.mkdirs();
+        
+        copy("/org/geotools/xml/test.xsd", "cached.xsd", folder);
+        copy("/org/geotools/xml/XMLSchema.dtd", "XMLSchema.dtd", folder);
+        copy("/org/geotools/xml/datatypes.dtd", "datatypes.dtd", folder);
+
+        
+        assertNotNull(SchemaFactory.getInstance(
+                URI.create("http://www.w3.org/XML/1998/namespace/cached"),
+                URI.create("http://geotools.org/xml/cached.xsd")));
+    }
+    
+    public void testRemotePathResolve() throws Exception {
+        assertNotNull(SchemaFactory.getInstance(
+                URI.create("http://www.w3.org/XML/1998/namespace/remote"),
+                URI.create("http://www.w3.org/2001/03/xml.xsd")));
+    }
+   
+    private void delete(File f, boolean onlyContent) {
+       if(f.isDirectory()) {
+           for(File file : f.listFiles()) {
+               delete(file, false);
+           }
+           if(!onlyContent) {
+               f.delete();
+           }
+       } else {
+           f.delete();
+       }
+    }
+    
+    private void copy(String sourceFile, String name, File outFolder) throws IOException {
+        InputStream in = this.getClass().getResource(sourceFile).openStream();
+        OutputStream out = new FileOutputStream(outFolder.getAbsolutePath()+File.separator+name);
+        final byte[]    buffer = new byte[4096];        
+        int count;
+        while ((count = in.read(buffer)) >= 0) {
+            out.write(buffer, 0, count);
+        }
+        out.close();
+        in.close();
+    }
+}

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheOnlineTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheOnlineTest.java
@@ -1,0 +1,211 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2010-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.xml.resolver;
+
+import java.io.File;
+import java.net.URI;
+
+import org.geotools.data.DataUtilities;
+import org.geotools.test.OnlineTestSupport;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Online test for {@link SchemaCatalog}.
+ * 
+ * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
+ *
+ *
+ *
+ * @source $URL$
+ */
+public class SchemaCacheOnlineTest extends OnlineTestSupport {
+
+    /**
+     * Downloaded files are stored in this directory. We intentionally use a non-canonical cache
+     * directory to test that resolved locations are canonical.
+     */
+    private static final File CACHE_DIRECTORY = new File(
+            "target/schema-cache/../schema-cache");
+
+    /**
+     * Schema that is downloaded.
+     */
+    private static final String SCHEMA_LOCATION = "http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd";
+
+    /**
+     * Filename of the schema.
+     */
+    private static final String SCHEMA_FILENAME;
+
+    static {
+        String[] parts = SCHEMA_LOCATION.split("/");
+        SCHEMA_FILENAME = parts[parts.length - 1];
+    }
+
+    /**
+     * @see org.geotools.test.OnlineTestSupport#getFixtureId()
+     */
+    @Override
+    protected String getFixtureId() {
+        return "schema-resolver";
+    }
+
+    /**
+     * @see org.geotools.test.OnlineTestSupport#before()
+     */
+    @Before
+    @Override
+    public void before() throws Exception {
+        super.before();
+        SchemaCache.delete(CACHE_DIRECTORY);
+    }
+
+    /**
+     * @see org.geotools.test.OnlineTestSupport#after()
+     */
+    @After
+    @Override
+    public void after() throws Exception {
+        super.after();
+        SchemaCache.delete(CACHE_DIRECTORY);
+        SchemaCache.locationsInDownload.clear();
+    }
+
+    /**
+     * Test download of schema via http.
+     */
+    @Test
+    public void downloadHttp() throws Exception {
+        check(SchemaCache.download(new URI(SCHEMA_LOCATION)));
+    }
+
+    /**
+     * Test download of schema via http with smaller block size.
+     */
+    @Test
+    public void downloadHttpWithSmallBlockSize() throws Exception {
+        check(SchemaCache.download(new URI(SCHEMA_LOCATION), 32));
+
+    }
+
+    /**
+     * Test download of schema via http with larger block size.
+     */
+    @Test
+    public void downloadHttpWithLargeBlockSize() throws Exception {
+        check(SchemaCache.download(new URI(
+                "http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd"), 65536));
+    }
+
+    /**
+     * Test download of schema via https.
+     */
+    @Test
+    public void downloadHttps() throws Exception {
+        check(SchemaCache.download(new URI("https://www.seegrid.csiro.au"
+                + "/subversion/GeoSciML/tags/2.0.0/schema/GeoSciML/geosciml.xsd")));
+    }
+
+    /**
+     * Basic sanity checks of schema and test store to disk.
+     */
+    private void check(byte[] bytes) {
+        Assert.assertTrue(bytes.length > 0);
+        String text = new String(bytes);
+        Assert.assertTrue(text.contains("GeoSciML"));
+        Assert.assertTrue(text.contains("<schema"));
+        Assert.assertTrue(text.contains("</schema>"));
+        File cachedFile = new File("target/test/test.xsd");
+        SchemaCache.delete(cachedFile);
+        Assert.assertFalse(cachedFile.exists());
+        SchemaCache.store(cachedFile, bytes);
+        Assert.assertTrue(cachedFile.exists());
+        Assert.assertEquals(bytes.length, cachedFile.length());
+    }
+
+    @Test
+    public void cache() throws Exception {
+        // expect failure when downloading disabled
+        {
+            SchemaCache cache = new SchemaCache(CACHE_DIRECTORY, false);
+            String location = cache.resolveLocation(SCHEMA_LOCATION);
+            Assert.assertNull(location);
+        }
+        // should succeed if able to download
+        {
+            SchemaCache cache = new SchemaCache(CACHE_DIRECTORY, true);
+            String location = cache.resolveLocation(SCHEMA_LOCATION);
+            Assert.assertNotNull(location);
+            Assert.assertTrue(location.startsWith("file:"));
+            Assert.assertTrue(location.endsWith(SCHEMA_FILENAME));
+            Assert.assertTrue(DataUtilities.urlToFile((new URI(location)).toURL()).exists());
+        }
+        // now that schema is is in the cache, should succeed even if downloading is disabled
+        {
+            SchemaCache cache = new SchemaCache(CACHE_DIRECTORY, false);
+            String location = cache.resolveLocation(SCHEMA_LOCATION);
+            Assert.assertNotNull(location);
+            Assert.assertTrue(location.startsWith("file:"));
+            Assert.assertTrue(location.endsWith(SCHEMA_FILENAME));
+            Assert.assertTrue(DataUtilities.urlToFile((new URI(location)).toURL()).exists());
+            // test that cache path is not canonical
+            Assert.assertFalse(CACHE_DIRECTORY.toString().equals(
+                    CACHE_DIRECTORY.getCanonicalFile().toString()));
+            // test that resolved location is canonical, despite cache directory not being canonical
+            Assert.assertEquals(location, DataUtilities.urlToFile((new URI(location)).toURL())
+                    .getCanonicalFile().toURI().toString());
+        }
+    }
+    
+    @Test
+    public void resolveAlreadyInDownload() throws Exception {        
+        File cacheDirectory = DataUtilities.urlToFile(SchemaCacheTest.class
+                .getResource("/test-data/cache"));
+        SchemaCache cache = new SchemaCache(cacheDirectory, true);
+        
+        String resolvedLocation = cache
+                .resolveLocation("http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd");
+        
+        Assert.assertTrue(resolvedLocation.startsWith("file:"));
+        Assert.assertTrue(resolvedLocation.endsWith("geosciml.xsd"));
+        Assert.assertTrue(resolvedLocation.startsWith(cacheDirectory
+                .getCanonicalFile().toURI().toString()));
+        Assert.assertTrue(DataUtilities.urlToFile(
+                (new URI(resolvedLocation)).toURL()).exists());
+        
+        // fake SchemaCache so that it thinks the location is in downloading
+        SchemaCache.locationsInDownload
+                .add("http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd");
+        
+        resolvedLocation = cache
+                .resolveLocation("http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd");
+        
+        Assert.assertTrue(resolvedLocation.startsWith("file:"));
+        Assert.assertTrue(resolvedLocation.endsWith("geosciml.xsd"));
+        // this time we have a temporary download
+        Assert.assertFalse(resolvedLocation.startsWith(cacheDirectory
+                .getCanonicalFile().toURI().toString()));
+        Assert.assertTrue(DataUtilities.urlToFile(
+                (new URI(resolvedLocation)).toURL()).exists());
+        
+    }
+
+}

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
@@ -1,0 +1,88 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2010-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.xml.resolver;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.geotools.data.DataUtilities;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link SchemaCache}.
+ * 
+ * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
+ *
+ *
+ * @source $URL$
+ */
+public class SchemaCacheTest {
+
+    /**
+     * Test the {@link SchemaCache#delete(File) method.
+     */
+    @Test
+    public void delete() throws Exception {
+        (new File("target/test/a/b/c")).mkdirs();
+        (new File("target/test/a/b/d/e/f")).mkdirs();
+        File f = new File("target/test/a/b/d/e/f/temp.txt");
+        PrintWriter printWriter = null;
+        try {
+            printWriter = new PrintWriter(f);
+            printWriter.println("Some text");
+        } finally {
+            if (printWriter != null) {
+                printWriter.close();
+            }
+        }
+        Assert.assertTrue((new File("target/test/a/b/d/e/f/temp.txt")).exists());
+        SchemaCache.delete(new File("target/test/a"));
+        Assert.assertFalse((new File("target/test/a")).exists());
+    }
+
+    /**
+     * Test resolution of a schema in an existing cache.
+     */
+    @Test
+    public void resolve() throws Exception {
+        // intentionally construct non-canonical cache directory
+        File cacheDirectory = new File(DataUtilities.urlToFile(SchemaCacheTest.class
+                .getResource("/test-data/cache")), "../cache");
+        SchemaResolver resolver = new SchemaResolver(
+                new SchemaCache(cacheDirectory, false));
+        String resolvedLocation = resolver
+                .resolve("http://schemas.example.org/cache-test/cache-test.xsd");
+        Assert.assertTrue(resolvedLocation.startsWith("file:"));
+        Assert.assertTrue(resolvedLocation.endsWith("cache-test.xsd"));
+        Assert.assertTrue(DataUtilities.urlToFile((new URI(resolvedLocation)).toURL()).exists());
+        // test that cache path is not canonical
+        Assert.assertFalse(cacheDirectory.toString().equals(
+                cacheDirectory.getCanonicalFile().toString()));
+        // test that resolved location is canonical, despite cache directory not being canonical
+        Assert.assertEquals(resolvedLocation,
+                DataUtilities.urlToFile((new URI(resolvedLocation)).toURL()).getCanonicalFile()
+                        .toURI().toString());
+    }
+    
+    
+
+}

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaResolverTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaResolverTest.java
@@ -1,0 +1,127 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2010-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.xml.resolver;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link SchemaResolver}.
+ * 
+ * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
+ * 
+ * @source $URL$
+ */
+public class SchemaResolverTest {
+
+    /**
+     * Test GeoSciML 2.0 canonical URL is correctly converted into a classpath URL.
+     */
+    @Test
+    public void geosciml20() {
+        String path = SchemaResolver
+                .getSimpleHttpResourcePath("http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd");
+        Assert.assertEquals(path, "/org/geosciml/www/geosciml/2.0/xsd/geosciml.xsd");
+        String classpathPath = SchemaResolver.class.getResource(path).toExternalForm();
+        Assert.assertTrue(classpathPath.startsWith("jar:file:/"));
+        Assert.assertTrue(classpathPath
+                .endsWith("!/org/geosciml/www/geosciml/2.0/xsd/geosciml.xsd"));
+    }
+
+    /**
+     * Test that the example in the javadoc for
+     * {@link SchemaResolver#getSimpleHttpResourcePath(java.net.URI)} does in fact work.
+     */
+    @Test
+    public void exampleHttp() {
+        String path = SchemaResolver
+                .getSimpleHttpResourcePath("http://schemas.example.org/exampleml/exml.xsd");
+        Assert.assertEquals("/org/example/schemas/exampleml/exml.xsd", path);
+    }
+
+    /**
+     * Test an https URL.
+     */
+    @Test
+    public void exampleHttps() {
+        String path = SchemaResolver
+                .getSimpleHttpResourcePath("https://schemas.example.org/exampleml/exml.xsd");
+        Assert.assertEquals("/org/example/schemas/exampleml/exml.xsd", path);
+    }
+
+    /**
+     * Test that port is ignored.
+     */
+    @Test
+    public void portIgnored() {
+        String path = SchemaResolver
+                .getSimpleHttpResourcePath("http://schemas.example.org:8080/exampleml/exml.xsd");
+        Assert.assertEquals("/org/example/schemas/exampleml/exml.xsd", path);
+    }
+
+    /**
+     * Test that a query is ignored.
+     */
+    @Test
+    public void queryIgnored() {
+        String path = SchemaResolver
+                .getSimpleHttpResourcePath("http://schemas.example.org/exampleml/exml.xsd?q=ignored");
+        Assert.assertEquals("/org/example/schemas/exampleml/exml.xsd", path);
+    }
+
+    /**
+     * Test that a query is converted to an MD5 hash where kept.
+     */
+    @Test
+    public void getSimpleHttpResourcePath_KeepQueryTrue_ReturnPathHasQueryComponent() {
+        String path = SchemaResolver
+                .getSimpleHttpResourcePath(
+                        "http://schemas.example.org/wfs?request=GetFeature&typename=sa:LocatedSpecimen&featureid=sa_LocatedSpecimen.2110193",
+                        true);
+        Assert.assertEquals("/org/example/schemas/wfs.0dd5330a4f06ea193985897a2cfd65d3.xsd", path);
+    }
+
+    /**
+     * Test that an ftp URL (not http/https) returns null.
+     */
+    @Test
+    public void ftpReturnsNull() {
+        Assert.assertNull(SchemaResolver
+                .getSimpleHttpResourcePath("ftp://schemas.example.org/exampleml/exml.xsd"));
+    }
+
+    /**
+     * Test that a jar URL (not http/https) returns null.
+     */
+    @Test
+    public void jarReturnsNull() {
+        Assert.assertNull(SchemaResolver
+                .getSimpleHttpResourcePath("jar:file:example.jar!/org/example/schemas/exampleml/exml.xsd"));
+    }
+
+    /**
+     * Test that a URL not http/https return null.
+     */
+    @Test
+    public void badlyFormattedUrlReturnsNull() {
+        Assert.assertNull(SchemaResolver
+                .getSimpleHttpResourcePath("http://schemas.example.org/exampleml/with spaces/exml.xsd"));
+    }
+
+}

--- a/modules/library/xml/src/test/resources/org/example/schemas/wfs20/DescribeFeatureType_Example01_Response.xsd
+++ b/modules/library/xml/src/test/resources/org/example/schemas/wfs20/DescribeFeatureType_Example01_Response.xsd
@@ -1,0 +1,86 @@
+<?xml version="1.0" ?>
+<!--
+    Adapted from Annex B.2.1 Example 1 in OpenGIS Web Feature Service 2.0 Interface Standard 09-025r1 (2011)
+    http://portal.opengeospatial.org/files/?artifact_id=39967
+    See: http://www.opengeospatial.org/standards/wfs
+    Copyright (C) 2011 Open Geospatial Consortium, Inc. All Rights Reserved.
+    http://www.opengeospatial.org/ogc/legal
+    Note that schemas are used under the OGC Software Notice:
+    http://www.opengeospatial.org/ogc/software
+    See: http://www.opengeospatial.org/ogc/legalfaq#DTD
+    The targetNamespace used here is not a published OGC namespace. The main change is formatting.
+-->
+<schema targetNamespace="http://www.someserver.com/myns" xmlns:myns="http://www.someserver.com/myns"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2"
+    elementFormDefault="qualified" version="2.0.0">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+    <element name="TreesA_1M" type="myns:TreesA_1M_Type" substitutionGroup="gml:AbstractFeature" />
+    <element name="RoadL_1M" type="myns:RoadL_1M_Type" substitutionGroup="gml:AbstractFeature" />
+    <element name="LakesA_1M" type="myns:LakesA_1M_Type" substitutionGroup="gml:AbstractFeature" />
+    <complexType name="TreesA_1M_Type">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="extent" type="gml:SurfacePropertyType" nillable="false" />
+                    <element name="id" nillable="true" minOccurs="0">
+                        <simpleType>
+                            <restriction base="integer">
+                                <totalDigits value="10" />
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <element name="treeType" nillable="true" minOccurs="0">
+                        <simpleType>
+                            <restriction base="string">
+                                <maxLength value="80" />
+                            </restriction>
+                        </simpleType>
+                    </element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="RoadL_1M_Type">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="centerLine" type="gml:CurvePropertyType" nillable="false" />
+                    <element name="designation" nillable="true" minOccurs="0">
+                        <simpleType>
+                            <restriction base="string">
+                                <maxLength value="30" />
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <element name="surfaceType" nillable="true" minOccurs="0">
+                        <simpleType>
+                            <restriction base="string">
+                                <maxLength value="30" />
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <element name="nLanes" nillable="true" minOccurs="0">
+                        <simpleType>
+                            <restriction base="integer">
+                                <totalDigits value="2" />
+                            </restriction>
+                        </simpleType>
+                    </element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="LakesA_1M_Type">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="extent" type="gml:SurfacePropertyType" />
+                    <element name="name" type="xsd:string" />
+                    <element name="waterType" type="xsd:string" minOccurs="0" />
+                    <element name="avgDepth" type="gml:MeasureType" minOccurs="0" />
+                    <element name="maxDepth" type="gml:MeasureType" minOccurs="0" />
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/modules/library/xml/src/test/resources/org/geotools/xml/XMLSchema.dtd
+++ b/modules/library/xml/src/test/resources/org/geotools/xml/XMLSchema.dtd
@@ -1,0 +1,402 @@
+<!-- DTD for XML Schemas: Part 1: Structures
+     Public Identifier: "-//W3C//DTD XMLSCHEMA 200102//EN"
+     Official Location: http://www.w3.org/2001/XMLSchema.dtd -->
+<!-- $Id: XMLSchema.dtd,v 1.31 2001/10/24 15:50:16 ht Exp $ -->
+<!-- Note this DTD is NOT normative, or even definitive. -->           <!--d-->
+<!-- prose copy in the structures REC is the definitive version -->    <!--d-->
+<!-- (which shouldn't differ from this one except for this -->         <!--d-->
+<!-- comment and entity expansions, but just in case) -->              <!--d-->
+<!-- With the exception of cases with multiple namespace
+     prefixes for the XML Schema namespace, any XML document which is
+     not valid per this DTD given redefinitions in its internal subset of the
+     'p' and 's' parameter entities below appropriate to its namespace
+     declaration of the XML Schema namespace is almost certainly not
+     a valid schema. -->
+
+<!-- The simpleType element and its constituent parts
+     are defined in XML Schema: Part 2: Datatypes -->
+<!ENTITY % xs-datatypes PUBLIC 'datatypes' 'datatypes.dtd' >
+
+<!ENTITY % p 'xs:'> <!-- can be overriden in the internal subset of a
+                         schema document to establish a different
+                         namespace prefix -->
+<!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
+                         also define %s as the suffix for the appropriate
+                         namespace declaration (e.g. :foo) -->
+<!ENTITY % nds 'xmlns%s;'>
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % schema "%p;schema">
+<!ENTITY % complexType "%p;complexType">
+<!ENTITY % complexContent "%p;complexContent">
+<!ENTITY % simpleContent "%p;simpleContent">
+<!ENTITY % extension "%p;extension">
+<!ENTITY % element "%p;element">
+<!ENTITY % unique "%p;unique">
+<!ENTITY % key "%p;key">
+<!ENTITY % keyref "%p;keyref">
+<!ENTITY % selector "%p;selector">
+<!ENTITY % field "%p;field">
+<!ENTITY % group "%p;group">
+<!ENTITY % all "%p;all">
+<!ENTITY % choice "%p;choice">
+<!ENTITY % sequence "%p;sequence">
+<!ENTITY % any "%p;any">
+<!ENTITY % anyAttribute "%p;anyAttribute">
+<!ENTITY % attribute "%p;attribute">
+<!ENTITY % attributeGroup "%p;attributeGroup">
+<!ENTITY % include "%p;include">
+<!ENTITY % import "%p;import">
+<!ENTITY % redefine "%p;redefine">
+<!ENTITY % notation "%p;notation">
+
+<!-- annotation elements -->
+<!ENTITY % annotation "%p;annotation">
+<!ENTITY % appinfo "%p;appinfo">
+<!ENTITY % documentation "%p;documentation">
+
+<!-- Customisation entities for the ATTLIST of each element type.
+     Define one of these if your schema takes advantage of the
+     anyAttribute='##other' in the schema for schemas -->
+
+<!ENTITY % schemaAttrs ''>
+<!ENTITY % complexTypeAttrs ''>
+<!ENTITY % complexContentAttrs ''>
+<!ENTITY % simpleContentAttrs ''>
+<!ENTITY % extensionAttrs ''>
+<!ENTITY % elementAttrs ''>
+<!ENTITY % groupAttrs ''>
+<!ENTITY % allAttrs ''>
+<!ENTITY % choiceAttrs ''>
+<!ENTITY % sequenceAttrs ''>
+<!ENTITY % anyAttrs ''>
+<!ENTITY % anyAttributeAttrs ''>
+<!ENTITY % attributeAttrs ''>
+<!ENTITY % attributeGroupAttrs ''>
+<!ENTITY % uniqueAttrs ''>
+<!ENTITY % keyAttrs ''>
+<!ENTITY % keyrefAttrs ''>
+<!ENTITY % selectorAttrs ''>
+<!ENTITY % fieldAttrs ''>
+<!ENTITY % includeAttrs ''>
+<!ENTITY % importAttrs ''>
+<!ENTITY % redefineAttrs ''>
+<!ENTITY % notationAttrs ''>
+<!ENTITY % annotationAttrs ''>
+<!ENTITY % appinfoAttrs ''>
+<!ENTITY % documentationAttrs ''>
+
+<!ENTITY % complexDerivationSet "CDATA">
+      <!-- #all or space-separated list drawn from derivationChoice -->
+<!ENTITY % blockSet "CDATA">
+      <!-- #all or space-separated list drawn from
+                      derivationChoice + 'substitution' -->
+
+<!ENTITY % mgs '%all; | %choice; | %sequence;'>
+<!ENTITY % cs '%choice; | %sequence;'>
+<!ENTITY % formValues '(qualified|unqualified)'>
+
+
+<!ENTITY % attrDecls    '((%attribute;| %attributeGroup;)*,(%anyAttribute;)?)'>
+
+<!ENTITY % particleAndAttrs '((%mgs; | %group;)?, %attrDecls;)'>
+
+<!-- This is used in part2 -->
+<!ENTITY % restriction1 '((%mgs; | %group;)?)'>
+
+%xs-datatypes;
+
+<!-- the duplication below is to produce an unambiguous content model
+     which allows annotation everywhere -->
+<!ELEMENT %schema; ((%include; | %import; | %redefine; | %annotation;)*,
+                    ((%simpleType; | %complexType;
+                      | %element; | %attribute;
+                      | %attributeGroup; | %group;
+                      | %notation; ),
+                     (%annotation;)*)* )>
+<!ATTLIST %schema;
+   targetNamespace      %URIref;               #IMPLIED
+   version              CDATA                  #IMPLIED
+   %nds;                %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+   xmlns                CDATA                  #IMPLIED
+   finalDefault         %complexDerivationSet; ''
+   blockDefault         %blockSet;             ''
+   id                   ID                     #IMPLIED
+   elementFormDefault   %formValues;           'unqualified'
+   attributeFormDefault %formValues;           'unqualified'
+   xml:lang             CDATA                  #IMPLIED
+   %schemaAttrs;>
+<!-- Note the xmlns declaration is NOT in the Schema for Schemas,
+     because at the Infoset level where schemas operate,
+     xmlns(:prefix) is NOT an attribute! -->
+<!-- The declaration of xmlns is a convenience for schema authors -->
+ 
+<!-- The id attribute here and below is for use in external references
+     from non-schemas using simple fragment identifiers.
+     It is NOT used for schema-to-schema reference, internal or
+     external. -->
+
+<!-- a type is a named content type specification which allows attribute
+     declarations-->
+<!-- -->
+
+<!ELEMENT %complexType; ((%annotation;)?,
+                         (%simpleContent;|%complexContent;|
+                          %particleAndAttrs;))>
+
+<!ATTLIST %complexType;
+          name      %NCName;                        #IMPLIED
+          id        ID                              #IMPLIED
+          abstract  %boolean;                       #IMPLIED
+          final     %complexDerivationSet;          #IMPLIED
+          block     %complexDerivationSet;          #IMPLIED
+          mixed (true|false) 'false'
+          %complexTypeAttrs;>
+
+<!-- particleAndAttrs is shorthand for a root type -->
+<!-- mixed is disallowed if simpleContent, overriden if complexContent
+     has one too. -->
+
+<!-- If anyAttribute appears in one or more referenced attributeGroups
+     and/or explicitly, the intersection of the permissions is used -->
+
+<!ELEMENT %complexContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %complexContent;
+          mixed (true|false) #IMPLIED
+          id    ID           #IMPLIED
+          %complexContentAttrs;>
+
+<!-- restriction should use the branch defined above, not the simple
+     one from part2; extension should use the full model  -->
+
+<!ELEMENT %simpleContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %simpleContent;
+          id    ID           #IMPLIED
+          %simpleContentAttrs;>
+
+<!-- restriction should use the simple branch from part2, not the 
+     one defined above; extension should have no particle  -->
+
+<!ELEMENT %extension; ((%annotation;)?, (%particleAndAttrs;))>
+<!ATTLIST %extension;
+          base  %QName;      #REQUIRED
+          id    ID           #IMPLIED
+          %extensionAttrs;>
+
+<!-- an element is declared by either:
+ a name and a type (either nested or referenced via the type attribute)
+ or a ref to an existing element declaration -->
+
+<!ELEMENT %element; ((%annotation;)?, (%complexType;| %simpleType;)?,
+                     (%unique; | %key; | %keyref;)*)>
+<!-- simpleType or complexType only if no type|ref attribute -->
+<!-- ref not allowed at top level -->
+<!ATTLIST %element;
+            name               %NCName;               #IMPLIED
+            id                 ID                     #IMPLIED
+            ref                %QName;                #IMPLIED
+            type               %QName;                #IMPLIED
+            minOccurs          %nonNegativeInteger;   #IMPLIED
+            maxOccurs          CDATA                  #IMPLIED
+            nillable           %boolean;              #IMPLIED
+            substitutionGroup  %QName;                #IMPLIED
+            abstract           %boolean;              #IMPLIED
+            final              %complexDerivationSet; #IMPLIED
+            block              %blockSet;             #IMPLIED
+            default            CDATA                  #IMPLIED
+            fixed              CDATA                  #IMPLIED
+            form               %formValues;           #IMPLIED
+            %elementAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- In the absence of type AND ref, type defaults to type of
+     substitutionGroup, if any, else the ur-type, i.e. unconstrained -->
+<!-- default and fixed are mutually exclusive -->
+
+<!ELEMENT %group; ((%annotation;)?,(%mgs;)?)>
+<!ATTLIST %group; 
+          name        %NCName;               #IMPLIED
+          ref         %QName;                #IMPLIED
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %groupAttrs;>
+
+<!ELEMENT %all; ((%annotation;)?, (%element;)*)>
+<!ATTLIST %all;
+          minOccurs   (1)                    #IMPLIED
+          maxOccurs   (1)                    #IMPLIED
+          id          ID                     #IMPLIED
+          %allAttrs;>
+
+<!ELEMENT %choice; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %choice;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %choiceAttrs;>
+
+<!ELEMENT %sequence; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %sequence;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %sequenceAttrs;>
+
+<!-- an anonymous grouping in a model, or
+     a top-level named group definition, or a reference to same -->
+
+<!-- Note that if order is 'all', group is not allowed inside.
+     If order is 'all' THIS group must be alone (or referenced alone) at
+     the top level of a content model -->
+<!-- If order is 'all', minOccurs==maxOccurs==1 on element/any inside -->
+<!-- Should allow minOccurs=0 inside order='all' . . . -->
+
+<!ELEMENT %any; (%annotation;)?>
+<!ATTLIST %any;
+            namespace       CDATA                  '##any'
+            processContents (skip|lax|strict)      'strict'
+            minOccurs       %nonNegativeInteger;   '1'
+            maxOccurs       CDATA                  '1'
+            id              ID                     #IMPLIED
+            %anyAttrs;>
+
+<!-- namespace is interpreted as follows:
+                  ##any      - - any non-conflicting WFXML at all
+
+                  ##other    - - any non-conflicting WFXML from namespace other
+                                  than targetNamespace
+
+                  ##local    - - any unqualified non-conflicting WFXML/attribute
+                  one or     - - any non-conflicting WFXML from
+                  more URI        the listed namespaces
+                  references
+
+                  ##targetNamespace ##local may appear in the above list,
+                    with the obvious meaning -->
+
+<!ELEMENT %anyAttribute; (%annotation;)?>
+<!ATTLIST %anyAttribute;
+            namespace       CDATA              '##any'
+            processContents (skip|lax|strict)  'strict'
+            id              ID                 #IMPLIED
+            %anyAttributeAttrs;>
+<!-- namespace is interpreted as for 'any' above -->
+
+<!-- simpleType only if no type|ref attribute -->
+<!-- ref not allowed at top level, name iff at top level -->
+<!ELEMENT %attribute; ((%annotation;)?, (%simpleType;)?)>
+<!ATTLIST %attribute;
+          name      %NCName;      #IMPLIED
+          id        ID            #IMPLIED
+          ref       %QName;       #IMPLIED
+          type      %QName;       #IMPLIED
+          use       (prohibited|optional|required) #IMPLIED
+          default   CDATA         #IMPLIED
+          fixed     CDATA         #IMPLIED
+          form      %formValues;  #IMPLIED
+          %attributeAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- default for use is optional when nested, none otherwise -->
+<!-- default and fixed are mutually exclusive -->
+<!-- type attr and simpleType content are mutually exclusive -->
+
+<!-- an attributeGroup is a named collection of attribute decls, or a
+     reference thereto -->
+<!ELEMENT %attributeGroup; ((%annotation;)?,
+                       (%attribute; | %attributeGroup;)*,
+                       (%anyAttribute;)?) >
+<!ATTLIST %attributeGroup;
+                 name       %NCName;       #IMPLIED
+                 id         ID             #IMPLIED
+                 ref        %QName;        #IMPLIED
+                 %attributeGroupAttrs;>
+
+<!-- ref iff no content, no name.  ref iff not top level -->
+
+<!-- better reference mechanisms -->
+<!ELEMENT %unique; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %unique;
+          name     %NCName;       #REQUIRED
+	  id       ID             #IMPLIED
+	  %uniqueAttrs;>
+
+<!ELEMENT %key;    ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %key;
+          name     %NCName;       #REQUIRED
+	  id       ID             #IMPLIED
+	  %keyAttrs;>
+
+<!ELEMENT %keyref; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %keyref;
+          name     %NCName;       #REQUIRED
+	  refer    %QName;        #REQUIRED
+	  id       ID             #IMPLIED
+	  %keyrefAttrs;>
+
+<!ELEMENT %selector; ((%annotation;)?)>
+<!ATTLIST %selector;
+          xpath %XPathExpr; #REQUIRED
+          id    ID          #IMPLIED
+          %selectorAttrs;>
+<!ELEMENT %field; ((%annotation;)?)>
+<!ATTLIST %field;
+          xpath %XPathExpr; #REQUIRED
+          id    ID          #IMPLIED
+          %fieldAttrs;>
+
+<!-- Schema combination mechanisms -->
+<!ELEMENT %include; (%annotation;)?>
+<!ATTLIST %include;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %includeAttrs;>
+
+<!ELEMENT %import; (%annotation;)?>
+<!ATTLIST %import;
+          namespace      %URIref; #IMPLIED
+          schemaLocation %URIref; #IMPLIED
+          id             ID       #IMPLIED
+          %importAttrs;>
+
+<!ELEMENT %redefine; (%annotation; | %simpleType; | %complexType; |
+                      %attributeGroup; | %group;)*>
+<!ATTLIST %redefine;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %redefineAttrs;>
+
+<!ELEMENT %notation; (%annotation;)?>
+<!ATTLIST %notation;
+	  name        %NCName;    #REQUIRED
+	  id          ID          #IMPLIED
+	  public      CDATA       #REQUIRED
+	  system      %URIref;    #IMPLIED
+	  %notationAttrs;>
+
+<!-- Annotation is either application information or documentation -->
+<!-- By having these here they are available for datatypes as well
+     as all the structures elements -->
+
+<!ELEMENT %annotation; (%appinfo; | %documentation;)*>
+<!ATTLIST %annotation; %annotationAttrs;>
+
+<!-- User must define annotation elements in internal subset for this
+     to work -->
+<!ELEMENT %appinfo; ANY>   <!-- too restrictive -->
+<!ATTLIST %appinfo;
+          source     %URIref;      #IMPLIED
+          id         ID         #IMPLIED
+          %appinfoAttrs;>
+<!ELEMENT %documentation; ANY>   <!-- too restrictive -->
+<!ATTLIST %documentation;
+          source     %URIref;   #IMPLIED
+          id         ID         #IMPLIED
+          xml:lang   CDATA      #IMPLIED
+          %documentationAttrs;>
+
+<!NOTATION XMLSchemaStructures PUBLIC
+           'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+<!NOTATION XML PUBLIC
+           'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >

--- a/modules/library/xml/src/test/resources/org/geotools/xml/datatypes.dtd
+++ b/modules/library/xml/src/test/resources/org/geotools/xml/datatypes.dtd
@@ -1,0 +1,203 @@
+<!--
+        DTD for XML Schemas: Part 2: Datatypes
+        $Id: datatypes.dtd,v 1.23 2001/03/16 17:36:30 ht Exp $
+        Note this DTD is NOT normative, or even definitive. - - the
+        prose copy in the datatypes REC is the definitive version
+        (which shouldn't differ from this one except for this comment
+        and entity expansions, but just in case)
+  -->
+
+<!--
+        This DTD cannot be used on its own, it is intended
+        only for incorporation in XMLSchema.dtd, q.v.
+  -->
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % simpleType "%p;simpleType">
+<!ENTITY % restriction "%p;restriction">
+<!ENTITY % list "%p;list">
+<!ENTITY % union "%p;union">
+<!ENTITY % maxExclusive "%p;maxExclusive">
+<!ENTITY % minExclusive "%p;minExclusive">
+<!ENTITY % maxInclusive "%p;maxInclusive">
+<!ENTITY % minInclusive "%p;minInclusive">
+<!ENTITY % totalDigits "%p;totalDigits">
+<!ENTITY % fractionDigits "%p;fractionDigits">
+<!ENTITY % length "%p;length">
+<!ENTITY % minLength "%p;minLength">
+<!ENTITY % maxLength "%p;maxLength">
+<!ENTITY % enumeration "%p;enumeration">
+<!ENTITY % whiteSpace "%p;whiteSpace">
+<!ENTITY % pattern "%p;pattern">
+
+<!--
+        Customisation entities for the ATTLIST of each element
+        type. Define one of these if your schema takes advantage
+        of the anyAttribute='##other' in the schema for schemas
+  -->
+
+<!ENTITY % simpleTypeAttrs "">
+<!ENTITY % restrictionAttrs "">
+<!ENTITY % listAttrs "">
+<!ENTITY % unionAttrs "">
+<!ENTITY % maxExclusiveAttrs "">
+<!ENTITY % minExclusiveAttrs "">
+<!ENTITY % maxInclusiveAttrs "">
+<!ENTITY % minInclusiveAttrs "">
+<!ENTITY % totalDigitsAttrs "">
+<!ENTITY % fractionDigitsAttrs "">
+<!ENTITY % lengthAttrs "">
+<!ENTITY % minLengthAttrs "">
+<!ENTITY % maxLengthAttrs "">
+<!ENTITY % enumerationAttrs "">
+<!ENTITY % whiteSpaceAttrs "">
+<!ENTITY % patternAttrs "">
+
+<!-- Define some entities for informative use as attribute
+        types -->
+<!ENTITY % URIref "CDATA">
+<!ENTITY % XPathExpr "CDATA">
+<!ENTITY % QName "NMTOKEN">
+<!ENTITY % QNames "NMTOKENS">
+<!ENTITY % NCName "NMTOKEN">
+<!ENTITY % nonNegativeInteger "NMTOKEN">
+<!ENTITY % boolean "(true|false)">
+<!ENTITY % simpleDerivationSet "CDATA">
+<!--
+        #all or space-separated list drawn from derivationChoice
+  -->
+
+<!--
+        Note that the use of 'facet' below is less restrictive
+        than is really intended:  There should in fact be no
+        more than one of each of minInclusive, minExclusive,
+        maxInclusive, maxExclusive, totalDigits, fractionDigits,
+        length, maxLength, minLength within datatype,
+        and the min- and max- variants of Inclusive and Exclusive
+        are mutually exclusive. On the other hand,  pattern and
+        enumeration may repeat.
+  -->
+<!ENTITY % minBound "(%minInclusive; | %minExclusive;)">
+<!ENTITY % maxBound "(%maxInclusive; | %maxExclusive;)">
+<!ENTITY % bounds "%minBound; | %maxBound;">
+<!ENTITY % numeric "%totalDigits; | %fractionDigits;">
+<!ENTITY % ordered "%bounds; | %numeric;">
+<!ENTITY % unordered
+   "%pattern; | %enumeration; | %whiteSpace; | %length; |
+   %maxLength; | %minLength;">
+<!ENTITY % facet "%ordered; | %unordered;">
+<!ENTITY % facetAttr 
+        "value CDATA #REQUIRED
+        id ID #IMPLIED">
+<!ENTITY % fixedAttr "fixed %boolean; #IMPLIED">
+<!ENTITY % facetModel "(%annotation;)?">
+<!ELEMENT %simpleType;
+        ((%annotation;)?, (%restriction; | %list; | %union;))>
+<!ATTLIST %simpleType;
+    name      %NCName; #IMPLIED
+    final     %simpleDerivationSet; #IMPLIED
+    id        ID       #IMPLIED
+    %simpleTypeAttrs;>
+<!-- name is required at top level -->
+<!ELEMENT %restriction; ((%annotation;)?,
+                         (%restriction1; |
+                          ((%simpleType;)?,(%facet;)*)),
+                         (%attrDecls;))>
+<!ATTLIST %restriction;
+    base      %QName;                  #IMPLIED
+    id        ID       #IMPLIED
+    %restrictionAttrs;>
+<!--
+        base and simpleType child are mutually exclusive,
+        one is required.
+
+        restriction is shared between simpleType and
+        simpleContent and complexContent (in XMLSchema.xsd).
+        restriction1 is for the latter cases, when this
+        is restricting a complex type, as is attrDecls.
+  -->
+<!ELEMENT %list; ((%annotation;)?,(%simpleType;)?)>
+<!ATTLIST %list;
+    itemType      %QName;             #IMPLIED
+    id        ID       #IMPLIED
+    %listAttrs;>
+<!--
+        itemType and simpleType child are mutually exclusive,
+        one is required
+  -->
+<!ELEMENT %union; ((%annotation;)?,(%simpleType;)*)>
+<!ATTLIST %union;
+    id            ID       #IMPLIED
+    memberTypes   %QNames;            #IMPLIED
+    %unionAttrs;>
+<!--
+        At least one item in memberTypes or one simpleType
+        child is required
+  -->
+
+<!ELEMENT %maxExclusive; %facetModel;>
+<!ATTLIST %maxExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxExclusiveAttrs;>
+<!ELEMENT %minExclusive; %facetModel;>
+<!ATTLIST %minExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minExclusiveAttrs;>
+
+<!ELEMENT %maxInclusive; %facetModel;>
+<!ATTLIST %maxInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxInclusiveAttrs;>
+<!ELEMENT %minInclusive; %facetModel;>
+<!ATTLIST %minInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minInclusiveAttrs;>
+
+<!ELEMENT %totalDigits; %facetModel;>
+<!ATTLIST %totalDigits;
+        %facetAttr;
+        %fixedAttr;
+        %totalDigitsAttrs;>
+<!ELEMENT %fractionDigits; %facetModel;>
+<!ATTLIST %fractionDigits;
+        %facetAttr;
+        %fixedAttr;
+        %fractionDigitsAttrs;>
+
+<!ELEMENT %length; %facetModel;>
+<!ATTLIST %length;
+        %facetAttr;
+        %fixedAttr;
+        %lengthAttrs;>
+<!ELEMENT %minLength; %facetModel;>
+<!ATTLIST %minLength;
+        %facetAttr;
+        %fixedAttr;
+        %minLengthAttrs;>
+<!ELEMENT %maxLength; %facetModel;>
+<!ATTLIST %maxLength;
+        %facetAttr;
+        %fixedAttr;
+        %maxLengthAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %enumeration; %facetModel;>
+<!ATTLIST %enumeration;
+        %facetAttr;
+        %enumerationAttrs;>
+
+<!ELEMENT %whiteSpace; %facetModel;>
+<!ATTLIST %whiteSpace;
+        %facetAttr;
+        %fixedAttr;
+        %whiteSpaceAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %pattern; %facetModel;>
+<!ATTLIST %pattern;
+        %facetAttr;
+        %patternAttrs;>

--- a/modules/library/xml/src/test/resources/org/geotools/xml/test.xsd
+++ b/modules/library/xml/src/test/resources/org/geotools/xml/test.xsd
@@ -1,0 +1,117 @@
+<?xml version='1.0'?>
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" >
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang or xml:space attributes
+        on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .>
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .>
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/>
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang" type="xs:language">
+  <xs:annotation>
+   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values . . .</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="space" default="preserve">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>

--- a/modules/library/xml/src/test/resources/test-data/cache/org/example/schemas/cache-test/cache-test-inner.xsd
+++ b/modules/library/xml/src/test/resources/test-data/cache/org/example/schemas/cache-test/cache-test-inner.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://schemas.example.org/demo" xmlns:ex="http://schemas.example.org/demo"
+    xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0" xmlns="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+
+    <import namespace="urn:cgi:xmlns:CGI:GeoSciML:2.0" schemaLocation="http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd" />
+
+    <element name="InnerGeologicUnit" substitutionGroup="gsml:GeologicFeature" type="gsml:GeologicUnitType" />
+
+</schema>
+

--- a/modules/library/xml/src/test/resources/test-data/cache/org/example/schemas/cache-test/cache-test.xsd
+++ b/modules/library/xml/src/test/resources/test-data/cache/org/example/schemas/cache-test/cache-test.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://schemas.example.org/demo" xmlns:ex="http://schemas.example.org/demo"
+    xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0" xmlns="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+
+    <import namespace="urn:cgi:xmlns:CGI:GeoSciML:2.0" schemaLocation="http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd" />
+    
+    <include schemaLocation="cache-test-inner.xsd" />
+
+    <element name="GeologicUnit" substitutionGroup="gsml:GeologicFeature" type="ex:CommentedGeologicUnitType" />
+
+    <complexType name="CommentedGeologicUnitType">
+        <complexContent>
+            <extension base="gsml:GeologicUnitType">
+                <sequence>
+                    <element name="comment" type="string" />
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+
+</schema>
+

--- a/modules/library/xml/src/test/resources/test-data/cache/org/example/schemas/catalog-test/catalog-cache-test-inner.xsd
+++ b/modules/library/xml/src/test/resources/test-data/cache/org/example/schemas/catalog-test/catalog-cache-test-inner.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://schemas.example.org/demo" xmlns:ex="http://schemas.example.org/demo"
+    xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0" xmlns="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+
+    <import namespace="urn:cgi:xmlns:CGI:GeoSciML:2.0" schemaLocation="http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd" />
+
+    <element name="InnerGeologicUnit" substitutionGroup="gsml:GeologicFeature" type="gsml:GeologicUnitType" />
+
+</schema>
+

--- a/modules/library/xml/src/test/resources/test-data/cache/org/example/schemas/catalog-test/catalog-cache-test.xsd
+++ b/modules/library/xml/src/test/resources/test-data/cache/org/example/schemas/catalog-test/catalog-cache-test.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://schemas.example.org/demo" xmlns:ex="http://schemas.example.org/demo"
+    xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0" xmlns="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+
+    <import namespace="urn:cgi:xmlns:CGI:GeoSciML:2.0" schemaLocation="http://www.geosciml.org/geosciml/2.0/xsd/geosciml.xsd" />
+
+    <include schemaLocation="catalog-cache-test-inner.xsd" />
+
+    <element name="GeologicUnit" substitutionGroup="gsml:GeologicFeature" type="ex:CommentedGeologicUnitType" />
+
+    <complexType name="CommentedGeologicUnitType">
+        <complexContent>
+            <extension base="gsml:GeologicUnitType">
+                <sequence>
+                    <element name="comment" type="string" />
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+
+</schema>


### PR DESCRIPTION
This is the backporting of AppSchemaResolver, AppSchemaCatalog and AppSchemaCache migration to gt-xml already done on master.
This is a more safe version, mantaining compatibility classes in app-schema-resolver, extending the gt-xml ones.
