### PR TITLE
reducing warning about arcsde libs from warning to fine

### DIFF
--- a/modules/plugin/arcsde/datastore/src/main/java/org/geotools/arcsde/ArcSDERasterFormatFactory.java
+++ b/modules/plugin/arcsde/datastore/src/main/java/org/geotools/arcsde/ArcSDERasterFormatFactory.java
@@ -58,7 +58,7 @@ public class ArcSDERasterFormatFactory implements GridFormatFactorySpi {
             LOGGER.fine(SeConnection.class.getName() + " is in place.");
             LOGGER.fine(PeCoordinateSystem.class.getName() + " is in place.");
         } catch (Throwable t) {
-            LOGGER.log(Level.WARNING, "ArcSDE Java API seems to not be on your classpath. Please"
+            LOGGER.log(Level.FINE, "ArcSDE Java API seems to not be on your classpath. Please"
                     + " verify that all needed jars are. ArcSDE data stores"
                     + " will not be available.", t);
             return false;


### PR DESCRIPTION
When the arcsde raster format factory is on the classpath but the libs are not available it logs excessive warnings anytime a format lookup is performed. Following suite after the gdal based format factories this reduces the warning to fine. 
