### PR TITLE
GEOT-4450, Advanced support for YCbCr color space breaks ImageWorker 

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/image/ImageWorker.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/ImageWorker.java
@@ -152,9 +152,6 @@ public class ImageWorker {
     /** IMAGEIO_JPEG_IMAGE_WRITER_SPI */
     private static final CLibJPEGImageWriterSpi IMAGEIO_JPEG_IMAGE_WRITER_SPI = new CLibJPEGImageWriterSpi();
 
-    /** CS_PYCC */
-    private static final ColorSpace CS_PYCC = ColorSpace.getInstance(ColorSpace.CS_PYCC);
-
     /**
      * Raster space epsilon
      */
@@ -196,6 +193,21 @@ public class ImageWorker {
      * The logger to use for this class.
      */
     private final static Logger LOGGER = Logging.getLogger("org.geotools.image");
+    /** CS_PYCC */
+    static final ColorSpace CS_PYCC;
+    static{
+        ColorSpace cs=null;
+        try{
+            cs = ColorSpace.getInstance(ColorSpace.CS_PYCC);
+        } catch (Throwable t) {
+            if(LOGGER.isLoggable(Level.FINE)){
+                LOGGER.log(Level.FINE,t.getLocalizedMessage(),t);
+            }
+        }
+        
+        // assign, either null or the real CS
+       CS_PYCC=cs;
+    }    
 
     /**
      * If {@link Boolean#FALSE FALSE}, image operators are not allowed to
@@ -807,6 +819,10 @@ public class ImageWorker {
      * @see #forceColorSpaceYCbCr()
      */
     public final boolean isColorSpaceYCbCr() {
+        // check the presence of the PYCC.pf file that contains the profile for the YCbCr color space
+        if(ImageWorker.CS_PYCC==null){
+            throw new IllegalStateException("Unable to create an YCbCr profile most like since we are unable to locate the YCbCr color profile. Check the Java installation.");
+        }        
         final ColorModel cm = image.getColorModel();
         if(cm==null){
             return false;

--- a/modules/library/coverage/src/test/java/org/geotools/image/ImageWorkerTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/image/ImageWorkerTest.java
@@ -800,7 +800,11 @@ public final class ImageWorkerTest extends GridProcessingTestBase {
     @Test
     public void testYCbCr() {
         assertTrue("Assertions should be enabled.", ImageWorker.class.desiredAssertionStatus());
-        
+        // check the presence of the PYCC.pf file that contains the profile for the YCbCr color space
+        if(ImageWorker.CS_PYCC==null){
+            System.out.println("testYCbCr disabled since we are unable to locate the YCbCr color profile");
+            return;
+        }
         // RGB component color model
         ImageWorker worker = new ImageWorker(getSyntheticRGB(false));
         


### PR DESCRIPTION
See https://jira.codehaus.org/browse/GEOT-4450

Jira indicates this is fixed for 8.8, 9.1, 10-beta
