### PR TITLE
GEOT-4462 add a parameter to choose if use OtherSRS in wfs getfeature

### DIFF
--- a/docs/user/library/data/wfs.rst
+++ b/docs/user/library/data/wfs.rst
@@ -81,6 +81,17 @@ The following connection parameters are defined for WFS.
 |                                            | You may relax this constraint when working with some WFS         |
 |                                            | implementations such as GeoServer.                               |
 +--------------------------------------------+------------------------------------------------------------------+
+| "WFSDataStoreFactory:USEDEFAULTSRS"        | Optional used override how GetFeature operations send srs to wfs |
+|                                            | server                                                           |
+|                                            |                                                                  |
+|                                            | * false use othersrs if query matches one of them                |
+|                                            | * true always use defaultsrs and reproject locally to query crs  |
+|                                            |                                                                  |
+|                                            | Choose if you prefer to always use DefaultSRS declared in        |
+|                                            | capabilities and reproject using GeoTools if necessary, or       |
+|                                            | use also OtherSRS if available.                                  |
+|                                            | The false value is currently supported in 1.1.0 protocol only.   |
++--------------------------------------------+------------------------------------------------------------------+
 
 Historical Note: We apologise for the long connection parameter keys, WFS was one of the first DataStores written and we were unsure at the
 time if they keys for each datastore would need to be unique or not. On the plus side you can see our devotion to stability.

--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/WFSDataStore.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/WFSDataStore.java
@@ -103,4 +103,9 @@ public interface WFSDataStore extends DataStore {
     public boolean isPreferPostOverGet();
     
     public void setNamespaceOverride(String namespaceOverride);
+
+    /**
+     * @param useDefaultSRS
+     */
+    public void setUseDefaultSRS(Boolean useDefaultSRS);
 }

--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/WFSDataStoreFactory.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/WFSDataStoreFactory.java
@@ -176,7 +176,7 @@ public class WFSDataStoreFactory extends AbstractDataStoreFactory {
     }
 
     /** Access with {@link WFSDataStoreFactory#getParametersInfo() */
-    private static final WFSFactoryParam<?>[] parametersInfo = new WFSFactoryParam[13];
+    private static final WFSFactoryParam<?>[] parametersInfo = new WFSFactoryParam[14];
 
     /**
      * Mandatory DataStore parameter indicating the URL for the WFS GetCapabilities document.
@@ -369,6 +369,18 @@ public class WFSDataStoreFactory extends AbstractDataStoreFactory {
         parametersInfo[12] = NAMESPACE = new WFSFactoryParam<String>(name, String.class,
                 description, null);
     }
+    
+    /**
+     * Optional {@code String} Flag to disable usage of OtherSRS in requests and
+     * always use DefaultSRS (eventually reprojecting locally the results)
+     */
+    public static final WFSFactoryParam<Boolean> USEDEFAULTSRS;
+    static {
+        String name = "usedefaultsrs";
+        String description = "Use always the declared DefaultSRS for requests and reproject locally if necessary";
+        parametersInfo[13] = USEDEFAULTSRS = new WFSFactoryParam<Boolean>(name,
+                Boolean.class, description, false);
+    }
 
     
     /**
@@ -400,6 +412,7 @@ public class WFSDataStoreFactory extends AbstractDataStoreFactory {
         final String wfsStrategy = (String) WFS_STRATEGY.lookUp(params);
         final Integer filterCompliance = (Integer) FILTER_COMPLIANCE.lookUp(params);
         final String namespaceOverride = (String) NAMESPACE.lookUp(params);
+        final Boolean useDefaultSRS = (Boolean) USEDEFAULTSRS.lookUp(params);
         
         if (((user == null) && (pass != null)) || ((pass == null) && (user != null))) {
             throw new IOException(
@@ -446,6 +459,7 @@ public class WFSDataStoreFactory extends AbstractDataStoreFactory {
             dataStore = new WFS_1_1_0_DataStore(wfs);
             dataStore.setMaxFeatures(maxFeatures);
             dataStore.setPreferPostOverGet(protocol);
+            dataStore.setUseDefaultSRS(useDefaultSRS);
         }
         dataStore.setNamespaceOverride(namespaceOverride);
 
@@ -609,6 +623,7 @@ public class WFSDataStoreFactory extends AbstractDataStoreFactory {
      * @see #TRY_GZIP
      * @see #LENIENT
      * @see #ENCODING
+     * @see #USEDEFAULTSRS
      */
     public Param[] getParametersInfo() {
         int length = parametersInfo.length;

--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_0_0/WFS_1_0_0_DataStore.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_0_0/WFS_1_0_0_DataStore.java
@@ -1156,4 +1156,10 @@ public class WFS_1_0_0_DataStore extends AbstractDataStore implements WFSDataSto
     public void setNamespaceOverride(String namespaceOverride) {
         this.namespaceOverride = namespaceOverride;
     }
+
+    @Override
+    public void setUseDefaultSRS(Boolean useDefaultSRS) {
+        throw new UnsupportedOperationException(
+                "Not used, this class needs to be adapted to the new architecture in the wfs.v_1_1_0 package");
+    }
 }

--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_DataStore.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_DataStore.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +33,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.xml.namespace.QName;
+
+import net.opengis.wfs.FeatureTypeType;
 
 import org.geotools.data.DataAccess;
 import org.geotools.data.DataSourceException;
@@ -46,6 +49,7 @@ import org.geotools.data.Query;
 import org.geotools.data.ReTypeFeatureReader;
 import org.geotools.data.SchemaNotFoundException;
 import org.geotools.data.Transaction;
+import org.geotools.data.crs.ForceCoordinateSystemFeatureReader;
 import org.geotools.data.crs.ReprojectFeatureReader;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.wfs.WFSDataStore;
@@ -117,6 +121,8 @@ public final class WFS_1_1_0_DataStore implements WFSDataStore {
     private boolean preferPostOverGet = false;
 
     private String namespaceOverride;
+    
+    private Boolean useDefaultSRS = false;
 
     /**
      * The WFS capabilities document.
@@ -360,13 +366,23 @@ public final class WFS_1_1_0_DataStore implements WFSDataStore {
         final SimpleFeatureType readerType = reader.getFeatureType();
 
         CoordinateReferenceSystem readerCrs = readerType.getCoordinateReferenceSystem();
-        if (queryCrs != null && !queryCrs.equals(readerCrs)) {
+        String serverSrs = getServerSrs(query);
+        if (queryCrs != null && serverSrs == null
+                && !queryCrs.equals(readerCrs)) {
             try {
                 reader = new ReprojectFeatureReader(reader, queryCrs);
             } catch (Exception e) {
                 throw new DataSourceException(e);
             }
         }
+        if(serverSrs != null) {
+            try {
+                reader = new ForceCoordinateSystemFeatureReader(reader, CRS.decode(serverSrs));
+            } catch (Exception e) {
+                throw new DataSourceException(e);
+            }
+        }
+         
 
         if (Filter.INCLUDE != postFilter) {
             reader = new FilteringFeatureReader<SimpleFeatureType, SimpleFeature>(reader,
@@ -385,6 +401,34 @@ public final class WFS_1_1_0_DataStore implements WFSDataStore {
             reader = new MaxFeatureReader<SimpleFeatureType, SimpleFeature>(reader, maxFeatures);
         }
         return reader;
+    }
+    
+    /**
+     * Gets the SRS to send to the server, if it matches the one given in the query.
+     * 
+     * @param query
+     * @return
+     */
+    private String getServerSrs(Query query) {
+        CoordinateReferenceSystem queryCrs = query.getCoordinateSystem();
+        if (queryCrs != null) {
+            Set<String> supportedCRSIdentifiers;
+            if (useDefaultSRS) {
+                supportedCRSIdentifiers = new HashSet<String>();
+                supportedCRSIdentifiers.add(wfs.getDefaultCRS(query.getTypeName()));
+            } else {
+                supportedCRSIdentifiers = wfs.getSupportedCRSIdentifiers(query
+                        .getTypeName());
+            }
+            String epsgCode = GML2EncodingUtils.epsgCode(queryCrs);
+            for (String supportedCRSIdentifier : supportedCRSIdentifiers) {
+                if (supportedCRSIdentifier.endsWith(":" + epsgCode)) {
+                    return supportedCRSIdentifier;
+                }
+            }
+        }
+        return null;
+    
     }
 
     /**
@@ -834,17 +878,17 @@ public final class WFS_1_1_0_DataStore implements WFSDataStore {
                         + "query will be performed in native CRS");
                 transform = true;
             } else {
-                epsgCode = "EPSG:" + epsgCode;
-                LOGGER.fine("Request CRS is " + epsgCode + ", checking if its supported for "
-                        + typeName);
-
-                Set<String> supportedCRSIdentifiers = wfs.getSupportedCRSIdentifiers(typeName);
-                if (supportedCRSIdentifiers.contains(epsgCode)) {
-                    LOGGER.fine(epsgCode + " is supported, request will be performed asking "
+                String serverEpsgCode = getServerSrs(query);
+                if (serverEpsgCode != null) {
+                    LOGGER.fine(serverEpsgCode
+                            + " is supported, request will be performed asking "
                             + "for reprojection over it");
+    
+                    epsgCode = serverEpsgCode;
                 } else {
                     LOGGER.fine(epsgCode + " is not supported for " + typeName
-                            + ". Query will be adapted to default CRS " + defaultCrs);
+                            + ". Query will be adapted to default CRS "
+                            + defaultCrs);
                     transform = true;
                 }
                 if (transform) {
@@ -877,5 +921,10 @@ public final class WFS_1_1_0_DataStore implements WFSDataStore {
             maxFeatures = Math.min(maxFeaturesDataStoreLimit, maxFeatures);
         }
         return maxFeatures;
+    }
+
+    @Override
+    public void setUseDefaultSRS(Boolean useDefaultSRS) {
+        this.useDefaultSRS = useDefaultSRS;
     }
 }

--- a/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/v1_1_0/DataTestSupport.java
+++ b/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/v1_1_0/DataTestSupport.java
@@ -32,6 +32,8 @@ import org.apache.commons.io.IOUtils;
 import org.geotools.data.ows.HTTPClient;
 import org.geotools.data.ows.HTTPResponse;
 import org.geotools.data.ows.SimpleHttpClient;
+import org.geotools.data.wfs.protocol.wfs.GetFeature;
+import org.geotools.data.wfs.protocol.wfs.WFSResponse;
 import org.geotools.test.TestData;
 
 @SuppressWarnings("nls")
@@ -70,6 +72,17 @@ public final class DataTestSupport {
          * The FeatureType CRS as declared in the capabilities
          */
         final String CRS;
+        
+        /**
+         * The FeatureType Alternative CRS (if available) as declared in the capabilities
+         */
+        final String ALTERNATIVECRS;
+        
+        /**
+         * The FeatureType Alternative CRS in URN format (if available) as declared in
+         * the capabilities
+         */
+        final String URNCRS;
 
         /**
          * Location of a sample GetFeature response for this feature type
@@ -92,6 +105,37 @@ public final class DataTestSupport {
             TYPENAME = qName;
             FEATURETYPENAME = featureTypeName;
             CRS = crs;
+            ALTERNATIVECRS = crs;
+            URNCRS = crs;
+            CAPABILITIES = folder + "/GetCapabilities_1_1_0.xml";
+            SCHEMA = folder + "/DescribeFeatureType_" + qName.getLocalPart() + ".xsd";
+            DATA = folder + "/GetFeature_" + qName.getLocalPart() + ".xml";
+
+            checkResource(CAPABILITIES);
+            checkResource(SCHEMA);
+            checkResource(DATA);
+        }
+        
+        /**
+         * @param folder
+         *            the folder name under {@code test-data} where the test files for this feature
+         *            type are stored
+         * @param qName
+         *            the qualified type name (ns + local name)
+         * @param featureTypeName
+         *            the name as stated in the capabilities
+         * @param crs
+         *            the default feature type CRS as stated in the capabilities
+         * @param alternativecrs
+         *            the default feature type CRS as stated in the capabilities
+         */
+        TestDataType(final String folder, final QName qName, final String featureTypeName,
+                final String crs, final String alternativecrs, final String urncrs) {
+            TYPENAME = qName;
+            FEATURETYPENAME = featureTypeName;
+            CRS = crs;
+            ALTERNATIVECRS = alternativecrs;
+            URNCRS = urncrs;
             CAPABILITIES = folder + "/GetCapabilities_1_1_0.xml";
             SCHEMA = folder + "/DescribeFeatureType_" + qName.getLocalPart() + ".xsd";
             DATA = folder + "/GetFeature_" + qName.getLocalPart() + ".xml";
@@ -132,7 +176,7 @@ public final class DataTestSupport {
 
     public static final TestDataType CUBEWERX_GOVUNITCE = new TestDataType("CubeWerx_nsdi",
             new QName("http://www.fgdc.gov/framework/073004/gubs", "GovernmentalUnitCE"),
-            "gubs:GovernmentalUnitCE", "EPSG:4269");
+            "gubs:GovernmentalUnitCE", "EPSG:4269", "EPSG:4326", "EPSG:3857");
 
     public static final TestDataType CUBEWERX_ROADSEG = new TestDataType("CubeWerx_nsdi",
             new QName("http://www.fgdc.gov/framework/073004/transportation", "RoadSeg"),
@@ -182,6 +226,7 @@ public final class DataTestSupport {
     public static class TestWFS_1_1_0_Protocol extends WFS_1_1_0_Protocol {
 
         private URL describeFeatureTypeUrlOverride;
+        private GetFeature request;
 
         public TestWFS_1_1_0_Protocol(InputStream capabilitiesReader, HTTPClient http)
                 throws IOException {
@@ -206,6 +251,28 @@ public final class DataTestSupport {
             }
             return describeFeatureTypeUrlOverride;
         }
+
+        @Override
+        public WFSResponse issueGetFeatureGET(GetFeature request)
+                throws IOException {
+            this.request = request;
+            return super.issueGetFeatureGET(request);
+        }
+
+        @Override
+        public WFSResponse issueGetFeaturePOST(GetFeature request)
+                throws IOException {
+            this.request = request;
+            return super.issueGetFeaturePOST(request);
+        }
+
+        /**
+         * @return the request
+         */
+        public GetFeature getRequest() {
+            return request;
+        }
+        
     }
 
     public static class TestHttpProtocol extends SimpleHttpClient {

--- a/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_DataStoreTest.java
+++ b/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_DataStoreTest.java
@@ -34,12 +34,20 @@ import org.geotools.data.FeatureReader;
 import org.geotools.data.Query;
 import org.geotools.data.SchemaNotFoundException;
 import org.geotools.data.Transaction;
+import org.geotools.data.crs.ForceCoordinateSystemFeatureReader;
+import org.geotools.data.crs.ReprojectFeatureReader;
+import org.geotools.data.wfs.protocol.wfs.GetFeature;
 import org.geotools.data.wfs.v1_1_0.DataTestSupport.TestHttpProtocol;
 import org.geotools.data.wfs.v1_1_0.DataTestSupport.TestHttpResponse;
+import org.geotools.gml2.bindings.GML2EncodingUtils;
+import org.geotools.referencing.CRS;
 import org.geotools.test.TestData;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.NoSuchAuthorityCodeException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * Unit test suite for {@link WFS_1_1_0_DataStore}
@@ -112,6 +120,150 @@ public class WFS_1_1_0_DataStoreTest {
         assertNotNull(schema);
     }
 
+    /**
+     * Test for the useDefaultSRS parameter set to true. Query in a CRS different
+     * from the DefaultSRS should be done in DefaultSRS and then reprojected.
+     * 
+     * @throws IOException
+     * @throws NoSuchAuthorityCodeException
+     * @throws FactoryException
+     */
+    @Test
+    public void tesUseDefaultSRS() throws IOException,
+            NoSuchAuthorityCodeException, FactoryException {
+        final InputStream dataStream = TestData.openStream(this,
+                CUBEWERX_GOVUNITCE.DATA);
+        TestHttpResponse httpResponse = new TestHttpResponse(
+                "text/xml; subtype=gml/3.1.1", "UTF-8", dataStream);
+        TestHttpProtocol mockHttp = new TestHttpProtocol(httpResponse);
+        createTestProtocol(CUBEWERX_GOVUNITCE.CAPABILITIES, mockHttp);
+    
+        // override the describe feature type url so it loads from the test resource
+        URL describeUrl = TestData.getResource(this, CUBEWERX_GOVUNITCE.SCHEMA);
+        wfs.setDescribeFeatureTypeURLOverride(describeUrl);
+    
+        WFS_1_1_0_DataStore ds = new WFS_1_1_0_DataStore(wfs);
+        Query query = new Query(CUBEWERX_GOVUNITCE.FEATURETYPENAME);
+    
+        // use the OtherSRS
+        CoordinateReferenceSystem otherCrs = CRS
+                .decode(CUBEWERX_GOVUNITCE.ALTERNATIVECRS);
+        query.setCoordinateSystem(otherCrs);
+        FeatureReader<SimpleFeatureType, SimpleFeature> featureReader;
+        featureReader = ds.getFeatureReader(query, Transaction.AUTO_COMMIT);
+        assertNotNull(featureReader);
+        assertTrue(featureReader instanceof ForceCoordinateSystemFeatureReader);
+        assertEquals(otherCrs, featureReader.getFeatureType()
+                .getCoordinateReferenceSystem());
+        GetFeature request = wfs.getRequest();
+        assertEquals(CUBEWERX_GOVUNITCE.ALTERNATIVECRS, request.getSrsName());
+    
+        // use an SRS not supported by server
+        CoordinateReferenceSystem unknownCrs = CRS.decode("EPSG:3003");
+        query.setCoordinateSystem(unknownCrs);
+    
+        featureReader = ds.getFeatureReader(query, Transaction.AUTO_COMMIT);
+        assertNotNull(featureReader);
+        assertTrue(featureReader instanceof ReprojectFeatureReader);
+        assertEquals(unknownCrs, featureReader.getFeatureType()
+                .getCoordinateReferenceSystem());
+        request = wfs.getRequest();
+        assertEquals(CUBEWERX_GOVUNITCE.CRS, request.getSrsName());
+    }
+    
+    /**
+     * Test for the useDefaultSRS parameter set to false. Query in a CRS listed in
+     * OtherSRS should be done in OtherSRS and not reprojected.
+     * 
+     * @throws IOException
+     * @throws NoSuchAuthorityCodeException
+     * @throws FactoryException
+     */
+    @Test
+    public void tesUseOtherSRS() throws IOException, NoSuchAuthorityCodeException,
+            FactoryException {
+        final InputStream dataStream = TestData.openStream(this,
+                CUBEWERX_GOVUNITCE.DATA);
+        TestHttpResponse httpResponse = new TestHttpResponse(
+                "text/xml; subtype=gml/3.1.1", "UTF-8", dataStream);
+        TestHttpProtocol mockHttp = new TestHttpProtocol(httpResponse);
+        createTestProtocol(CUBEWERX_GOVUNITCE.CAPABILITIES, mockHttp);
+    
+        // override the describe feature type url so it loads from the test resource
+        URL describeUrl = TestData.getResource(this, CUBEWERX_GOVUNITCE.SCHEMA);
+        wfs.setDescribeFeatureTypeURLOverride(describeUrl);
+    
+        WFS_1_1_0_DataStore ds = new WFS_1_1_0_DataStore(wfs);
+        ds.setUseDefaultSRS(true);
+        Query query = new Query(CUBEWERX_GOVUNITCE.FEATURETYPENAME);
+    
+        // use the OtherSRS
+        CoordinateReferenceSystem otherCrs = CRS
+                .decode(CUBEWERX_GOVUNITCE.ALTERNATIVECRS);
+        query.setCoordinateSystem(otherCrs);
+        FeatureReader<SimpleFeatureType, SimpleFeature> featureReader;
+        featureReader = ds.getFeatureReader(query, Transaction.AUTO_COMMIT);
+        assertNotNull(featureReader);
+        assertTrue(featureReader instanceof ReprojectFeatureReader);
+        assertEquals(otherCrs, featureReader.getFeatureType()
+                .getCoordinateReferenceSystem());
+        GetFeature request = wfs.getRequest();
+        assertEquals(CUBEWERX_GOVUNITCE.CRS, request.getSrsName());
+    
+        // use an SRS not supported by server
+        CoordinateReferenceSystem unknownCrs = CRS.decode("EPSG:3003");
+        query.setCoordinateSystem(unknownCrs);
+    
+        featureReader = ds.getFeatureReader(query, Transaction.AUTO_COMMIT);
+        assertNotNull(featureReader);
+        assertTrue(featureReader instanceof ReprojectFeatureReader);
+        assertEquals(unknownCrs, featureReader.getFeatureType()
+                .getCoordinateReferenceSystem());
+        request = wfs.getRequest();
+        assertEquals(CUBEWERX_GOVUNITCE.CRS, request.getSrsName());
+    }
+    
+    /**
+     * Test for the useDefaultSRS parameter set to false and OtherSRS specified in
+     * urn form. Query in a CRS listed in OtherSRS should be done in OtherSRS and
+     * not reprojected.
+     * 
+     * @throws IOException
+     * @throws NoSuchAuthorityCodeException
+     * @throws FactoryException
+     */
+    @Test
+    public void tesUseOtherSRSUsingURN() throws IOException,
+            NoSuchAuthorityCodeException, FactoryException {
+        final InputStream dataStream = TestData.openStream(this,
+                CUBEWERX_GOVUNITCE.DATA);
+        TestHttpResponse httpResponse = new TestHttpResponse(
+                "text/xml; subtype=gml/3.1.1", "UTF-8", dataStream);
+        TestHttpProtocol mockHttp = new TestHttpProtocol(httpResponse);
+        createTestProtocol(CUBEWERX_GOVUNITCE.CAPABILITIES, mockHttp);
+    
+        // override the describe feature type url so it loads from the test resource
+        URL describeUrl = TestData.getResource(this, CUBEWERX_GOVUNITCE.SCHEMA);
+        wfs.setDescribeFeatureTypeURLOverride(describeUrl);
+    
+        WFS_1_1_0_DataStore ds = new WFS_1_1_0_DataStore(wfs);
+        Query query = new Query(CUBEWERX_GOVUNITCE.FEATURETYPENAME);
+    
+        // use the OtherSRS
+        CoordinateReferenceSystem otherCrs = CRS.decode(CUBEWERX_GOVUNITCE.URNCRS);
+        query.setCoordinateSystem(otherCrs);
+        FeatureReader<SimpleFeatureType, SimpleFeature> featureReader;
+        featureReader = ds.getFeatureReader(query, Transaction.AUTO_COMMIT);
+        assertNotNull(featureReader);
+        assertTrue(featureReader instanceof ForceCoordinateSystemFeatureReader);
+    
+        assertEquals(GML2EncodingUtils.epsgCode(otherCrs),
+                GML2EncodingUtils.epsgCode(featureReader.getFeatureType()
+                        .getCoordinateReferenceSystem()));
+        GetFeature request = wfs.getRequest();
+        assertEquals("urn:ogc:def:crs:EPSG::3857", request.getSrsName());
+    }
+    
     @Test
     public void tesGetFeatureReader() throws IOException {
         final InputStream dataStream = TestData.openStream(this, CUBEWERX_GOVUNITCE.DATA);

--- a/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_ProtocolTest.java
+++ b/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_ProtocolTest.java
@@ -499,7 +499,7 @@ public class WFS_1_1_0_ProtocolTest {
         supportedCRSs = wfs.getSupportedCRSIdentifiers(CUBEWERX_GOVUNITCE.FEATURETYPENAME);
         // capabilities defines more crs's for this ftype
         assertNotNull(supportedCRSs);
-        assertEquals(2, supportedCRSs.size());
+        assertEquals(3, supportedCRSs.size());
         assertTrue(supportedCRSs.contains("EPSG:4269"));
         assertTrue(supportedCRSs.contains("EPSG:4326"));
     }

--- a/modules/unsupported/wfs/src/test/resources/org/geotools/data/wfs/v1_1_0/test-data/CubeWerx_nsdi/GetCapabilities_1_1_0.xml
+++ b/modules/unsupported/wfs/src/test/resources/org/geotools/data/wfs/v1_1_0/test-data/CubeWerx_nsdi/GetCapabilities_1_1_0.xml
@@ -395,6 +395,7 @@
       <Title>Governmental Unit (County or Equivalent)</Title>
       <DefaultSRS>EPSG:4269</DefaultSRS>
       <OtherSRS>EPSG:4326</OtherSRS>
+      <OtherSRS>urn:ogc:def:crs:EPSG::3857</OtherSRS>
       <ows:WGS84BoundingBox>
         <ows:LowerCorner>-179.14221197 18.9108417</ows:LowerCorner>
         <ows:UpperCorner>-66.94983061 71.35256069</ows:UpperCorner>


### PR DESCRIPTION
Fixed OtherSRS usage in WFS 1.1.0 DataStore and added an option to allow choosing if OtherSRS have to be considered at all, or if the DefaultSRS should be always preferred (reprojecting results locally when necessary).
