### PR TITLE
Update ShapefileDataStore.java

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
@@ -342,8 +342,11 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
                 header.addColumn(colName, 'C', Math.min(254, fieldLen), 0);
             } else if (Geometry.class.isAssignableFrom(colType)) {
                 continue;
+            //skip binary data types
+            } else if (colType == byte[].class) {
+                continue;
             } else {
-                throw new IOException("Unable to write : " + colType.getName());
+                throw new IOException("Unable to write column " +colName + " : " + colType.getName());
             }
         }
 


### PR DESCRIPTION
improvement: skip attributes on shapefile export whose data type is not supported

ShapefileDatastore throws exception when processing featuretype attributes of binary data type. Patch simply removes those attributes.

See http://osgeo-org.1560.x6.nabble.com/invalid-shapefile-archive-td5059110.html for a mailing list discussion
