### PR TITLE
[GEOT-4488] Properly encode Not filters

### DIFF
--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/FilterParsingUtils.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/FilterParsingUtils.java
@@ -33,6 +33,7 @@ import org.opengis.filter.BinaryComparisonOperator;
 import org.opengis.filter.BinaryLogicOperator;
 import org.opengis.filter.Filter;
 import org.opengis.filter.Id;
+import org.opengis.filter.Not;
 import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.PropertyIsNull;
@@ -86,7 +87,7 @@ public class FilterParsingUtils {
         }
 
         //&lt;xsd:element ref="ogc:logicOps"/&gt;
-        if ("logicOps".equals(name) && filter instanceof BinaryLogicOperator) {
+        if ("logicOps".equals(name) && (filter instanceof BinaryLogicOperator || filter instanceof Not)) {
             return filter;
         }
 

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCFilterTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCFilterTypeBindingTest.java
@@ -82,5 +82,10 @@ public class OGCFilterTypeBindingTest extends FilterTestSupport {
 
         assertEquals("ogc:Filter", doc.getDocumentElement().getNodeName());
         assertEquals(1, doc.getElementsByTagNameNS(OGC.NAMESPACE, "And").getLength());
+
+        doc = encode(FilterMockData.not(), OGC.Filter);
+
+        assertEquals("ogc:Filter", doc.getDocumentElement().getNodeName());
+        assertEquals(1, doc.getElementsByTagNameNS(OGC.NAMESPACE, "Not").getLength());
     }
 }

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/FilterTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/FilterTypeBindingTest.java
@@ -82,6 +82,11 @@ public class FilterTypeBindingTest extends FilterTestSupport {
 
         assertEquals("ogc:Filter", doc.getDocumentElement().getNodeName());
         assertEquals(1, doc.getElementsByTagNameNS(OGC.NAMESPACE, "And").getLength());
+
+        doc = encode(FilterMockData.not(), OGC.Filter);
+
+        assertEquals("ogc:Filter", doc.getDocumentElement().getNodeName());
+        assertEquals(1, doc.getElementsByTagNameNS(OGC.NAMESPACE, "Not").getLength());
     }
     
     public void testEncodeDateTimeLiterals() throws Exception {


### PR DESCRIPTION
A bug in FilterParsingUtils leads to xsd-filter producing <ogc:Filter/> when you try to encode a filter with Not at the top level. This just adds a check for it when the property extractor goes looking for properties and adds an addition check to a couple of unit tests.
