### PR TITLE
[GEOT-4486] JDBCDataStore allow synonyms

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTypeNamesTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTypeNamesTest.java
@@ -1,0 +1,52 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.jdbc;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 
+ * @author r0bb3n
+ * 
+ */
+public abstract class JDBCTypeNamesTest extends JDBCTestSupport {
+	
+	
+	@Override
+    protected abstract JDBCTypeNamesTestSetup createTestSetup();
+
+	
+	public void testTypeNames() throws Exception{
+
+		String[] typeNamesArr = dataStore.getTypeNames();
+		assertNotNull("no types found", typeNamesArr);
+		List<String> typeNames = Arrays.asList(typeNamesArr);
+		assertFalse("no types found", typeNames.isEmpty());
+		
+		List<String> expected = ((JDBCTypeNamesTestSetup)setup).getExpectedTypeNames();
+		
+//		assertEquals("number of types unexpected ", expected.size(), typeNames.size());
+		
+		for (String expectedType : expected) {
+			String tn = tname(expectedType);
+			assertTrue("type not returned by database: " + tn, typeNames.contains(tn));
+		}
+		
+	}
+
+}

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTypeNamesTestSetup.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTypeNamesTestSetup.java
@@ -1,0 +1,72 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.jdbc;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+public abstract class JDBCTypeNamesTestSetup extends JDBCDelegatingTestSetup {
+
+	protected JDBCTypeNamesTestSetup(JDBCTestSetup delegate) {
+		super(delegate);
+	}
+
+	protected final void setUpData() throws Exception {
+		delegate.setUpData();
+
+		// kill all the data
+		try {
+			dropTypes();
+		} catch (SQLException e) {
+		}
+
+		// create all the data
+		createTypes();
+	}
+
+	/**
+	 * Creates a table with the following schema:
+	 * <p>
+	 * <code>ftntable( id:Integer; name:String; geom:POLYGON )</code>
+	 * </p>
+	 * Creates a view with the following schema:
+	 * <p>
+	 * <code>create view ftnview as select id, geom from ft_table</code>
+	 * </p>
+	 * In Addition to that, there should be some database specific type
+	 * structures like synonyms or aliases, if available. (should be )
+	 */
+	protected abstract void createTypes() throws Exception;
+
+	protected abstract void dropTypes() throws Exception;
+
+	/**
+	 * Returns expected type names as created in {@link #createTypes()}. At
+	 * least <code>ftntable</code> and <code>ftnview</code>.
+	 * 
+	 * @return
+	 */
+	protected List<String> getExpectedTypeNames(){
+		List<String> expectedTypeNames = new LinkedList<String>();
+		expectedTypeNames.add("ftntable");
+		expectedTypeNames.add("ftnview");
+		return expectedTypeNames;
+	}
+
+}

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2TypeNamesTest.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2TypeNamesTest.java
@@ -1,0 +1,29 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.h2;
+
+import org.geotools.jdbc.JDBCTypeNamesTest;
+import org.geotools.jdbc.JDBCTypeNamesTestSetup;
+
+public class H2TypeNamesTest extends JDBCTypeNamesTest {
+
+	@Override
+	protected JDBCTypeNamesTestSetup createTestSetup() {
+		return new H2TypeNamesTestSetup();
+	}
+
+}

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2TypeNamesTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2TypeNamesTestSetup.java
@@ -1,0 +1,40 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.h2;
+
+import org.geotools.jdbc.JDBCTypeNamesTestSetup;
+
+public class H2TypeNamesTestSetup extends JDBCTypeNamesTestSetup {
+
+	protected H2TypeNamesTestSetup() {
+		super(new H2TestSetup());
+	}
+
+	@Override
+	protected void createTypes() throws Exception {
+		run("CREATE TABLE \"geotools\".\"ftntable\" ("
+				+ "\"id\" INT, \"name\" VARCHAR, \"geom\" GEOMETRY)");
+		run("CREATE VIEW \"geotools\".\"ftnview\" AS SELECT \"id\", \"geom\" FROM \"geotools\".\"ftntable\"");
+	}
+
+	@Override
+	protected void dropTypes() throws Exception {
+		runSafe("DROP VIEW \"geotools\".\"ftnview\"");
+		runSafe("DROP TABLE \"geotools\".\"ftntable\"");
+	}
+
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleTypeNamesTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleTypeNamesTest.java
@@ -1,0 +1,29 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.oracle;
+
+import org.geotools.jdbc.JDBCTypeNamesTest;
+import org.geotools.jdbc.JDBCTypeNamesTestSetup;
+
+public class OracleTypeNamesTest extends JDBCTypeNamesTest {
+
+	@Override
+	protected JDBCTypeNamesTestSetup createTestSetup() {
+		return new OracleTypeNamesTestSetup();
+	}
+
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleTypeNamesTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleTypeNamesTestSetup.java
@@ -1,0 +1,52 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.oracle;
+
+import java.util.List;
+
+import org.geotools.jdbc.JDBCTypeNamesTestSetup;
+
+public class OracleTypeNamesTestSetup extends JDBCTypeNamesTestSetup {
+
+	protected OracleTypeNamesTestSetup() {
+		super(new OracleTestSetup());
+	}
+
+	@Override
+	protected void createTypes() throws Exception {
+		run("CREATE TABLE ftntable ("
+				+ "id INT, name VARCHAR(255), geom MDSYS.SDO_GEOMETRY)");
+		run("CREATE VIEW ftnview AS SELECT id, geom FROM ftntable");
+		run("CREATE SYNONYM ftnsyn FOR ftntable");
+
+	}
+
+	@Override
+	protected void dropTypes() throws Exception {
+		runSafe("DROP SYNONYM ftnsyn");
+		runSafe("DROP VIEW ftnview");
+		runSafe("DROP TABLE ftntable purge");
+	}
+	
+	@Override
+	protected List<String> getExpectedTypeNames() {
+		List<String> ret = super.getExpectedTypeNames();
+		ret.add("ftnsyn");
+		return ret;
+	}
+
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisTypeNamesTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisTypeNamesTest.java
@@ -1,0 +1,29 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCTypeNamesTest;
+import org.geotools.jdbc.JDBCTypeNamesTestSetup;
+
+public class PostgisTypeNamesTest extends JDBCTypeNamesTest {
+
+	@Override
+	protected JDBCTypeNamesTestSetup createTestSetup() {
+		return new PostgisTypeNamesTestSetup();
+	}
+
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisTypeNamesTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisTypeNamesTestSetup.java
@@ -1,0 +1,40 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCTypeNamesTestSetup;
+
+public class PostgisTypeNamesTestSetup extends JDBCTypeNamesTestSetup {
+
+	protected PostgisTypeNamesTestSetup() {
+		super(new PostGISTestSetup());
+	}
+
+	@Override
+	protected void createTypes() throws Exception {
+		run("CREATE TABLE \"ftntable\" ("
+				+ "\"id\" INT, \"name\" VARCHAR, \"geom\" GEOMETRY)");
+		run("CREATE VIEW \"ftnview\" AS SELECT \"id\", \"geom\" FROM \"ftntable\"");
+	}
+
+	@Override
+	protected void dropTypes() throws Exception {
+		runSafe("DROP VIEW \"ftnview\"");
+		runSafe("DROP TABLE \"ftntable\"");
+	}
+
+}

--- a/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteTypeNamesTest.java
+++ b/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteTypeNamesTest.java
@@ -1,0 +1,29 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.spatialite;
+
+import org.geotools.jdbc.JDBCTypeNamesTest;
+import org.geotools.jdbc.JDBCTypeNamesTestSetup;
+
+public class SpatiaLiteTypeNamesTest extends JDBCTypeNamesTest {
+
+	@Override
+	protected JDBCTypeNamesTestSetup createTestSetup() {
+		return new SpatiaLiteTypeNamesTestSetup();
+	}
+
+}

--- a/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteTypeNamesTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteTypeNamesTestSetup.java
@@ -1,0 +1,40 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.spatialite;
+
+import org.geotools.jdbc.JDBCTypeNamesTestSetup;
+
+public class SpatiaLiteTypeNamesTestSetup extends JDBCTypeNamesTestSetup {
+
+	protected SpatiaLiteTypeNamesTestSetup() {
+		super(new SpatiaLiteTestSetup());
+	}
+
+	@Override
+	protected void createTypes() throws Exception {
+		run("CREATE TABLE ftntable ("
+				+ "id INT, name VARCHAR, geom GEOMETRY)");
+		run("CREATE VIEW ftnview AS SELECT id, geom FROM ftntable");
+	}
+
+	@Override
+	protected void dropTypes() throws Exception {
+		runSafe("DROP VIEW ftnview");
+		runSafe("DROP TABLE ftntable");
+	}
+
+}


### PR DESCRIPTION
This is the new pull request on master for the synonym issue GEOT-4486. The prior one mistakenly applied to 8.x ( https://github.com/geotools/geotools/pull/209 ). 
