### PR TITLE
GEOT-4511 -- replace references to <version>X-SNAPSHOT</version> with the version supplied in the tag

### DIFF
--- a/build/release/build_release.sh
+++ b/build/release/build_release.sh
@@ -66,10 +66,15 @@ if [ `is_primary_branch_num $tag` == "1" ]; then
   exit 1
 fi
 
+# split up the tag to find the major version of geotools
+geotools_pom_version=$( echo $tag | awk 'BEGIN { FS = "."} ; { print($1) }')-SNAPSHOT
+
+
 echo "Building release with following parameters:"
 echo "  branch = $branch"
 echo "  revision = $rev"
 echo "  tag = $tag"
+echo "  replace references to $geotools_pom_version with $tag"
 
 mvn -version
 
@@ -114,6 +119,11 @@ fi
 
 # create a release branch
 git checkout -b rel_$tag $rev
+
+# replace snapshot version references in pom.xml files with the version specified 
+# as the tag (eg 9-SNAPSHOT --> 9.3)
+find . -name pom.xml | xargs sed -i "s/<version>$geotools_pom_version<\/version>/<version>$tag<\/version>/g"
+
 
 # update versions
 pushd build > /dev/null


### PR DESCRIPTION
Hi Andrea,

I've had a look at the build script you pointed me at and added in the one-liner I used to fix all the pom.xml files.

I think this should do what we want.  I'm not sure how I can do an end-to-end test on the script because it starts trying to checkout files from git, etc by itself and this file isn't committed yet.  If I comment out all the git actions, I can see the pom.xml files get fixed up correctly.  I tried a release tag of 9.3 and and it replaced <version>9-SNAPSHOT</version> with <version>9.3</version> as I would expect.

This probably needs futher testing before being used but should be pretty close to what's needed.

HTH...

Geoff
