### PR TITLE
Changed ${project.version} to ${geotools.version}

### DIFF
--- a/docs/user/tutorial/process.rst
+++ b/docs/user/tutorial/process.rst
@@ -35,7 +35,7 @@ single result).
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-process</artifactId>
-      <version>${project.version}</version>
+      <version>${geotools.version}</version>
     </dependency>
 
 2. To start with we need to create a class that extends StaticMethodsProcessFactory:


### PR DESCRIPTION
Other tutorials leading up to the process tutorial used ${geotools.version} instead of ${project.version}. I've made this change to remain consistent.
