### PR TITLE
Fix off-by-one bug in JDBCJoiningFeatureReader

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureReaderTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureReaderTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -16,14 +16,13 @@
  */
 package org.geotools.jdbc;
 
+import com.vividsolutions.jts.geom.Geometry;
 import org.geotools.data.DefaultQuery;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.Query;
 import org.geotools.data.Transaction;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-
-import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * 
@@ -32,8 +31,8 @@ import com.vividsolutions.jts.geom.Geometry;
  */
 public abstract class JDBCFeatureReaderTest extends JDBCTestSupport {
 
-    public void testNext() throws Exception {
-        Query query = new DefaultQuery( tname("ft1") );
+    protected void doTestNext(Query query, boolean exposePrimaryKeys) throws Exception {
+        dataStore.setExposePrimaryKeyColumns(exposePrimaryKeys);
         FeatureReader reader = dataStore.getFeatureReader( query, Transaction.AUTO_COMMIT );
         
         assertTrue( reader.hasNext() );
@@ -44,6 +43,12 @@ public abstract class JDBCFeatureReaderTest extends JDBCTestSupport {
         
         assertTrue( g.getUserData() instanceof CoordinateReferenceSystem );
         reader.close();
+    }
+
+    public void testNext() throws Exception {
+        Query query = new DefaultQuery( tname("ft1") );
+        doTestNext(query, false);
+        doTestNext(query, true);
     }
 
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCJoinTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCJoinTest.java
@@ -16,15 +16,9 @@
  */
 package org.geotools.jdbc;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.geotools.data.Join;
-import org.geotools.data.Query;
 import org.geotools.data.Join.Type;
+import org.geotools.data.Query;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.opengis.feature.simple.SimpleFeature;
@@ -33,6 +27,10 @@ import org.opengis.filter.FilterFactory;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 public abstract class JDBCJoinTest extends JDBCTestSupport {
 
@@ -111,8 +109,8 @@ public abstract class JDBCJoinTest extends JDBCTestSupport {
             assertEquals("two", f.getAttribute(aname("stringProperty")));
             
             SimpleFeature g = (SimpleFeature) f.getAttribute(aname("ftjoin"));
-            assertEquals(4, g.getAttributeCount());
-            assertEquals(2, ((Number)g.getAttribute(aname("id"))).intValue());
+            assertEquals(3, g.getAttributeCount());
+
             assertEquals("two", g.getAttribute(aname("name")));
         }
         finally {
@@ -164,7 +162,7 @@ public abstract class JDBCJoinTest extends JDBCTestSupport {
         Query q = new Query(tname("ft1"));
         Join j = new Join(tname("ftjoin"), 
             ff.equal(ff.property(aname("stringProperty")), ff.property(aname("name")), true));
-        j.filter(ff.greater(ff.property(aname("id")), ff.literal(1)));
+        j.filter(ff.greater(ff.property(aname("join1intProperty")), ff.literal(1)));
         q.getJoins().add(j);
         q.setFilter(ff.less(ff.property(aname("intProperty")), ff.literal(3)));
         
@@ -419,7 +417,7 @@ public abstract class JDBCJoinTest extends JDBCTestSupport {
             
             while(it.hasNext()) {
                 SimpleFeature f = it.next();
-                assertEquals(5, f.getAttributeCount());
+                assertEquals(4, f.getAttributeCount());
                 
                 SimpleFeature g = (SimpleFeature) f.getAttribute(tname("ft1"));
                 if ("three".equals(f.getAttribute(aname("name")))) {
@@ -460,7 +458,7 @@ public abstract class JDBCJoinTest extends JDBCTestSupport {
             
             while(it.hasNext()) {
                 SimpleFeature f = it.next();
-                assertEquals(6, f.getAttributeCount());
+                assertEquals(5, f.getAttributeCount());
                 Number nmb = (Number) f.getAttribute(aname("join1intProperty"));
                 Integer idx = nmb.intValue(); 
                 assertTrue(idx < 3);

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCJoiningFeatureReaderTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCJoiningFeatureReaderTest.java
@@ -1,0 +1,63 @@
+
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.jdbc;
+
+import org.geotools.data.DefaultQuery;
+import org.geotools.data.FeatureReader;
+import org.geotools.data.Join;
+import org.geotools.data.Query;
+import org.geotools.data.Transaction;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.FilterFactory;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import com.vividsolutions.jts.geom.Geometry;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public abstract class JDBCJoiningFeatureReaderTest extends JDBCFeatureReaderTest {
+
+    public void testNextHiddenPrimaryKeys() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+
+        Query query = new Query(tname("ftjoin"));
+        query.getJoins().add(new Join(tname("ft1"), 
+            ff.equal(ff.property(aname("name")), ff.property(aname("stringProperty")), true)));
+
+        query.getJoins().add(new Join(tname("ftjoin2"), 
+                ff.equal(ff.property(aname("join2intProperty")), ff.property(aname("join1intProperty")), true)));
+
+        doTestNext(query, false);
+    }
+
+    public void testNextExposedPrimaryKeys() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+
+        Query query = new Query(tname("ftjoin"));
+        query.getJoins().add(new Join(tname("ft1"), 
+            ff.equal(ff.property(aname("name")), ff.property(aname("stringProperty")), true)));
+
+        query.getJoins().add(new Join(tname("ftjoin2"), 
+                ff.equal(ff.property(aname("join2intProperty")), ff.property(aname("join1intProperty")), true)));
+
+        doTestNext(query, true);
+    }
+}

--- a/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2JoinTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2JoinTestSetup.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -16,10 +16,9 @@
  */
 package org.geotools.data.db2;
 
-import java.sql.Connection;
-
 import org.geotools.jdbc.JDBCJoinTestSetup;
-import org.geotools.jdbc.JDBCTestSetup;
+
+import java.sql.Connection;
 
 public class DB2JoinTestSetup extends JDBCJoinTestSetup {
 
@@ -33,7 +32,7 @@ public class DB2JoinTestSetup extends JDBCJoinTestSetup {
         Connection con = getDataSource().getConnection();
         
         String stmt = "create table "+DB2TestUtil.SCHEMA_QUOTED+
-                        ".\"ftjoin\" (\"id\" int ," +
+                        ".\"ftjoin\" (\"id\" int primary key," +
                         "\"name\" varchar(255), " +
                         " \"geom\" DB2GSE.ST_GEOMETRY, \"join1intProperty\" INT ) ";
                         
@@ -61,7 +60,7 @@ public class DB2JoinTestSetup extends JDBCJoinTestSetup {
                 .execute();
 
         stmt = "create table "+DB2TestUtil.SCHEMA_QUOTED+
-                ".\"ftjoin2\" (\"id\" int ," +
+                ".\"ftjoin2\" (\"id\" int primary key," +
                 "\"join2intProperty\" int, " +
                 "\"stringProperty2\" VARCHAR(255)) ";
                 

--- a/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2JoiningFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2JoiningFeatureReaderTest.java
@@ -1,0 +1,34 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2009, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.db2;
+
+import org.geotools.jdbc.JDBCJoiningFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class DB2JoiningFeatureReaderTest extends JDBCJoiningFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new DB2JoinTestSetup();
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2JoinTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2JoinTestSetup.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -26,7 +26,7 @@ public class H2JoinTestSetup extends JDBCJoinTestSetup {
 
     @Override
     protected void createJoinTable() throws Exception {
-        run( "CREATE TABLE \"geotools\".\"ftjoin\" ( \"id\" int, " + "\"name\" VARCHAR, \"geom\" GEOMETRY, \"join1intProperty\" int)" );
+        run( "CREATE TABLE \"geotools\".\"ftjoin\" ( \"id\" int primary key, " + "\"name\" VARCHAR, \"geom\" GEOMETRY, \"join1intProperty\" int)" );
         run("CALL AddGeometryColumn('geotools', 'ftjoin', 'geom', 4326, 'GEOMETRY', 2)");
         
         run( "INSERT INTO \"geotools\".\"ftjoin\" VALUES (0, 'zero', ST_GeomFromText('POLYGON ((-0.1 -0.1, -0.1 0.1, 0.1 0.1, 0.1 -0.1, -0.1 -0.1))', 4326), 0)");
@@ -34,7 +34,7 @@ public class H2JoinTestSetup extends JDBCJoinTestSetup {
         run( "INSERT INTO \"geotools\".\"ftjoin\" VALUES (2, 'two', ST_GeomFromText('POLYGON ((-10 -10, -10 10, 10 10, 10 -10, -10 -10))', 4326), 2)");
         run( "INSERT INTO \"geotools\".\"ftjoin\" VALUES (3, 'three', NULL, 3)");
         
-        run( "CREATE TABLE \"geotools\".\"ftjoin2\"(\"id\" int, \"join2intProperty\" int, \"stringProperty2\" varchar)");
+        run( "CREATE TABLE \"geotools\".\"ftjoin2\"(\"id\" int primary key, \"join2intProperty\" int, \"stringProperty2\" varchar)");
         run( "INSERT INTO \"geotools\".\"ftjoin2\" VALUES (0, 0, '2nd zero')");
         run( "INSERT INTO \"geotools\".\"ftjoin2\" VALUES (1, 1, '2nd one')");
         run( "INSERT INTO \"geotools\".\"ftjoin2\" VALUES (2, 2, '2nd two')");

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2JoiningFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2JoiningFeatureReaderTest.java
@@ -1,0 +1,34 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.h2;
+
+import org.geotools.jdbc.JDBCJoiningFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class H2JoiningFeatureReaderTest extends JDBCJoiningFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new H2JoinTestSetup();
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLJoinTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLJoinTestSetup.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -29,7 +29,7 @@ public class MySQLJoinTestSetup extends JDBCJoinTestSetup {
     protected void createJoinTable() throws Exception {
       //create some data  
         StringBuffer sb = new StringBuffer();
-        sb.append("CREATE TABLE ftjoin ").append("(id int, ")
+        sb.append("CREATE TABLE ftjoin ").append("(id int primary key, ")
           .append("name VARCHAR(255) COLLATE latin1_general_cs, geom POLYGON, join1intProperty int) ENGINE=InnoDB;");
         run(sb.toString());
 
@@ -53,7 +53,7 @@ public class MySQLJoinTestSetup extends JDBCJoinTestSetup {
         .append("3, 'three', NULL, 3);");
         run(sb.toString());
         
-        run( "CREATE TABLE ftjoin2(id int, join2intProperty int, stringProperty2 varchar(255))");
+        run( "CREATE TABLE ftjoin2(id int primary key, join2intProperty int, stringProperty2 varchar(255))");
         run( "INSERT INTO ftjoin2 VALUES (0, 0, '2nd zero')");
         run( "INSERT INTO ftjoin2 VALUES (1, 1, '2nd one')");
         run( "INSERT INTO ftjoin2 VALUES (2, 2, '2nd two')");

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLJoiningFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLJoiningFeatureReaderTest.java
@@ -1,0 +1,34 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mysql;
+
+import org.geotools.jdbc.JDBCJoiningFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class MySQLJoiningFeatureReaderTest extends JDBCJoiningFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new MySQLJoinTestSetup();
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleFeatureReaderTest.java
@@ -1,0 +1,34 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.oracle;
+
+import org.geotools.jdbc.JDBCFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class OracleFeatureReaderTest extends JDBCFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new OracleTestSetup();
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleJoinTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleJoinTestSetup.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -27,7 +27,7 @@ public class OracleJoinTestSetup extends JDBCJoinTestSetup {
     @Override
     protected void createJoinTable() throws Exception {
         String sql = "CREATE TABLE ftjoin (" 
-            + "id INT, name VARCHAR(255), geom MDSYS.SDO_GEOMETRY, join1intProperty INT)";
+            + "id INT PRIMARY KEY, name VARCHAR(255), geom MDSYS.SDO_GEOMETRY, join1intProperty INT)";
         run(sql);
         
         sql = "INSERT INTO USER_SDO_GEOM_METADATA (TABLE_NAME, COLUMN_NAME, DIMINFO, SRID ) " + 
@@ -57,7 +57,7 @@ public class OracleJoinTestSetup extends JDBCJoinTestSetup {
         sql = "INSERT INTO ftjoin VALUES (3, 'three', NULL, 3)";
         run(sql);
         
-        run( "CREATE TABLE ftjoin2( id INT, join2intProperty INT, stringProperty2 VARCHAR(255))");
+        run( "CREATE TABLE ftjoin2( id INT PRIMARY KEY, join2intProperty INT, stringProperty2 VARCHAR(255))");
         run( "INSERT INTO ftjoin2 VALUES (0, 0, '2nd zero')");
         run( "INSERT INTO ftjoin2 VALUES (1, 1, '2nd one')");
         run( "INSERT INTO ftjoin2 VALUES (2, 2, '2nd two')");

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleJoiningFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleJoiningFeatureReaderTest.java
@@ -1,0 +1,34 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.oracle;
+
+import org.geotools.jdbc.JDBCJoiningFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class OracleJoiningFeatureReaderTest extends JDBCJoiningFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new OracleJoinTestSetup();
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISTestSetup.java
@@ -16,15 +16,14 @@
  */
 package org.geotools.data.postgis;
 
-import java.sql.Connection;
-import java.util.Properties;
-
-import javax.sql.DataSource;
-
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.JDBCTestSetup;
 import org.geotools.util.Version;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.util.Properties;
 
 /**
  * 
@@ -86,9 +85,9 @@ public class PostGISTestSetup extends JDBCTestSetup {
     
     @Override
     protected void setUpData() throws Exception {
-        runSafe("DELETE FROM GEOMETRY_COLUMNS WHERE F_TABLE_NAME = 'ft1'");
-        runSafe("DROP TABLE \"ft1\"");
-        runSafe("DROP TABLE \"ft2\"");
+        run("DELETE FROM GEOMETRY_COLUMNS WHERE F_TABLE_NAME = 'ft1'");
+        run("DROP TABLE IF EXISTS \"ft1\"");
+        run("DROP TABLE IF EXISTS \"ft2\"");
         
         run("CREATE TABLE \"ft1\"(" //
                 + "\"id\" serial primary key, " //

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJoinTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJoinTestSetup.java
@@ -31,7 +31,7 @@ public class PostgisJoinTestSetup extends JDBCJoinTestSetup {
 
     @Override
     protected void createJoinTable() throws Exception {
-        run("CREATE TABLE \"ftjoin\" ( \"id\" int, " + "\"name\" VARCHAR, \"geom\" GEOMETRY, \"join1intProperty\" int)" );
+        run("CREATE TABLE \"ftjoin\" ( \"id\" int PRIMARY KEY, " + "\"name\" VARCHAR, \"geom\" GEOMETRY, \"join1intProperty\" int)" );
         run("INSERT INTO geometry_columns VALUES ('', 'public', 'ftjoin', 'geom', 2, 4326, 'GEOMETRY')");
         
         run( "INSERT INTO \"ftjoin\" VALUES (0, 'zero', ST_GeomFromText('POLYGON ((-0.1 -0.1, -0.1 0.1, 0.1 0.1, 0.1 -0.1, -0.1 -0.1))', 4326), 0)");
@@ -39,7 +39,7 @@ public class PostgisJoinTestSetup extends JDBCJoinTestSetup {
         run( "INSERT INTO \"ftjoin\" VALUES (2, 'two', ST_GeomFromText('POLYGON ((-10 -10, -10 10, 10 10, 10 -10, -10 -10))', 4326), 2)");
         run( "INSERT INTO \"ftjoin\" VALUES (3, 'three', NULL, 3)");
         
-        run( "CREATE TABLE \"ftjoin2\"(\"id\" int, \"join2intProperty\" int, \"stringProperty2\" varchar)");
+        run( "CREATE TABLE \"ftjoin2\"(\"id\" int PRIMARY KEY, \"join2intProperty\" int, \"stringProperty2\" varchar)");
         run( "INSERT INTO \"ftjoin2\" VALUES (0, 0, '2nd zero')");
         run( "INSERT INTO \"ftjoin2\" VALUES (1, 1, '2nd one')");
         run( "INSERT INTO \"ftjoin2\" VALUES (2, 2, '2nd two')");

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJoiningFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJoiningFeatureReaderTest.java
@@ -1,0 +1,34 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCJoiningFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class PostgisJoiningFeatureReaderTest extends JDBCJoiningFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new PostgisJoinTestSetup(new PostGISTestSetup());
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisJoiningFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisJoiningFeatureReaderTest.java
@@ -1,0 +1,35 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis.ps;
+
+import org.geotools.jdbc.JDBCJoiningFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.data.postgis.PostgisJoinTestSetup;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class PostgisJoiningFeatureReaderTest extends JDBCJoiningFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new PostgisJoinTestSetup(new PostGISPSTestSetup());
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteJoinTest.java
+++ b/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteJoinTest.java
@@ -1,0 +1,29 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.spatialite;
+
+import org.geotools.jdbc.JDBCJoinTest;
+import org.geotools.jdbc.JDBCJoinTestSetup;
+
+public class SpatiaLiteJoinTest extends JDBCJoinTest {
+
+    @Override
+    protected JDBCJoinTestSetup createTestSetup() {
+        return new SpatiaLiteJoinTestSetup();
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteJoinTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteJoinTestSetup.java
@@ -1,0 +1,51 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.spatialite;
+
+import org.geotools.jdbc.JDBCJoinTestSetup;
+
+public class SpatiaLiteJoinTestSetup extends JDBCJoinTestSetup {
+
+    protected SpatiaLiteJoinTestSetup() {
+        super(new SpatiaLiteTestSetup());
+    }
+
+    @Override
+    protected void createJoinTable() throws Exception {
+        run("CREATE TABLE ftjoin ( id int PRIMARY KEY, " + "name VARCHAR)");
+        run("SELECT AddGeometryColumn('ftjoin','geom',4326,'GEOMETRY',2)");
+        run("ALTER TABLE ftjoin add join1intProperty int)" );
+
+        run( "INSERT INTO ftjoin VALUES (0, 'zero', GeomFromText('POLYGON ((-0.1 -0.1, -0.1 0.1, 0.1 0.1, 0.1 -0.1, -0.1 -0.1))', 4326), 0)");
+        run( "INSERT INTO ftjoin VALUES (1, 'one', GeomFromText('POLYGON ((-1.1 -1.1, -1.1 1.1, 1.1 1.1, 1.1 -1.1, -1.1 -1.1))', 4326), 1)");
+        run( "INSERT INTO ftjoin VALUES (2, 'two', GeomFromText('POLYGON ((-10 -10, -10 10, 10 10, 10 -10, -10 -10))', 4326), 2)");
+        run( "INSERT INTO ftjoin VALUES (3, 'three', NULL, 3)");
+
+        run( "CREATE TABLE ftjoin2(id int PRIMARY KEY, join2intProperty int, stringProperty2 varchar)");
+        run( "INSERT INTO ftjoin2 VALUES (0, 0, '2nd zero')");
+        run( "INSERT INTO ftjoin2 VALUES (1, 1, '2nd one')");
+        run( "INSERT INTO ftjoin2 VALUES (2, 2, '2nd two')");
+        run( "INSERT INTO ftjoin2 VALUES (3, 3, '2nd three')");
+    }
+
+    @Override
+    protected void dropJoinTable() throws Exception {
+        runSafe( "DROP TABLE ftjoin" );
+        runSafe( "DROP TABLE ftjoin2" );
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteJoiningFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteJoiningFeatureReaderTest.java
@@ -1,0 +1,34 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.spatialite;
+
+import org.geotools.jdbc.JDBCJoiningFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class SpatiaLiteJoiningFeatureReaderTest extends JDBCJoiningFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new SpatiaLiteJoinTestSetup();
+    }
+
+}

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerJoinTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerJoinTestSetup.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -27,7 +27,7 @@ public class SQLServerJoinTestSetup extends JDBCJoinTestSetup {
     @Override
     protected void createJoinTable() throws Exception {
         
-        run( "CREATE TABLE ftjoin ( id int, name VARCHAR(10), geom GEOMETRY, join1intProperty int)" );
+        run( "CREATE TABLE ftjoin ( id int primary key, name VARCHAR(10), geom GEOMETRY, join1intProperty int)" );
         run("ALTER TABLE ftjoin ALTER COLUMN name VARCHAR(255) COLLATE Latin1_General_CS_AS");
         run( "INSERT INTO ftjoin VALUES (0, 'zero', geometry::STGeomFromText('POLYGON ((-0.1 -0.1, -0.1 0.1, 0.1 0.1, 0.1 -0.1, -0.1 -0.1))', 4326), 0)");
         run( "INSERT INTO ftjoin VALUES (1, 'one', geometry::STGeomFromText('POLYGON ((-1.1 -1.1, -1.1 1.1, 1.1 1.1, 1.1 -1.1, -1.1 -1.1))', 4326), 1)");
@@ -37,7 +37,7 @@ public class SQLServerJoinTestSetup extends JDBCJoinTestSetup {
         // won't work in sql server since the table has no primary key
         // run("CREATE SPATIAL INDEX _ftjoin_geometry_index on ftjoin(geom) WITH (BOUNDING_BOX = (-10, -10, 10, 10))");
         
-        run( "CREATE TABLE ftjoin2(id int, join2intProperty int, stringProperty2 varchar(255))");
+        run( "CREATE TABLE ftjoin2(id int primary key, join2intProperty int, stringProperty2 varchar(255))");
         run( "INSERT INTO ftjoin2 VALUES (0, 0, '2nd zero')");
         run( "INSERT INTO ftjoin2 VALUES (1, 1, '2nd one')");
         run( "INSERT INTO ftjoin2 VALUES (2, 2, '2nd two')");

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerJoiningFeatureReaderTest.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerJoiningFeatureReaderTest.java
@@ -1,0 +1,29 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2013, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.sqlserver;
+
+import org.geotools.jdbc.JDBCJoiningFeatureReaderTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class SQLServerJoiningFeatureReaderTest extends JDBCJoiningFeatureReaderTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new SQLServerJoinTestSetup();
+    }
+
+}


### PR DESCRIPTION
Prior to this commit, JDBCJoiningFeatureReader had an off-by-one bug its column cursor management for joins on DataStores with exposed primary keys. See [GEOS-5149](https://jira.codehaus.org/browse/GEOS-5149) for an example of the kind of behavior this bug was causing.

Also added logic to exercise primary key exposition in JDBCFeatureReaderTest, and extended JDBCFeatureReaderTest to exercise JDBCJoiningFeatureReader.
