### PR TITLE
Add support for the citext extension in PostGIS.

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -336,8 +336,13 @@ public class PostGISDialect extends BasicSQLDialect {
             throws SQLException {
         
         String typeName = columnMetaData.getString("TYPE_NAME");
+        
         if("uuid".equalsIgnoreCase(typeName)) {
             return UUID.class;
+        }
+        
+        if("citext".equalsIgnoreCase(typeName)) {
+    	    return String.class;
         }
         
         String gType = null;


### PR DESCRIPTION
This change allows the citext type to be used in features, allowing indexed case
insensitive queries. There probably could be better handling for extension types
in general for the PostGISDialect, but I'm not entirely sure what that design
would be, so I just followed the pattern set by the uuid type.

This potentially closes [GEOT-2356](http://jira.codehaus.org/browse/GEOT-2356).
