### PR TITLE
[GEOT-4607] GML3 bindings either fail to parse 2.5D data (srsDimension=3), or silently drop the third ordinate

### DIFF
--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/DirectPositionListTypeBinding.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/DirectPositionListTypeBinding.java
@@ -22,6 +22,7 @@ import javax.xml.namespace.QName;
 
 import org.geotools.geometry.DirectPosition1D;
 import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.DirectPosition3D;
 import org.geotools.geometry.jts.coordinatesequence.CoordinateSequences;
 import org.geotools.gml3.GML;
 import org.geotools.xml.AbstractComplexBinding;
@@ -98,11 +99,7 @@ public class DirectPositionListTypeBinding extends AbstractComplexBinding {
      * @generated modifiable
      */
     public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
-        int crsDimension = 2;
-        Node dimensions = (Node) node.getAttribute("srsDimension");
-        if (dimensions != null) {
-            crsDimension = ((Number) dimensions.getValue()).intValue();
-        }
+        int crsDimension = GML3ParsingUtils.dimensions(node);
         CoordinateReferenceSystem crs = GML3ParsingUtils.crs(node);
 
         // double[] values = (double[]) value;
@@ -132,7 +129,7 @@ public class DirectPositionListTypeBinding extends AbstractComplexBinding {
                 dps[i] = new DirectPosition1D(crs);
                 dps[i].setOrdinate(0, values[i].doubleValue());
             }
-        } else {
+        } else if(dim == 2){
             int ordinateIdx = 0;
             // HACK: not sure if its correct to assign ordinates 0 to 0 and 1 to
             // 1 or it should be inferred from the crs
@@ -142,6 +139,18 @@ public class DirectPositionListTypeBinding extends AbstractComplexBinding {
                 dps[coordIndex].setOrdinate(1, values[ordinateIdx + 1].doubleValue());
                 ordinateIdx += crsDimension;
             }
+        } else {
+            int ordinateIdx = 0;
+            // HACK: not sure if its correct to assign ordinates 0 to 0 and 1 to
+            // 1 or it should be inferred from the crs
+            for (int coordIndex = 0; coordIndex < coordCount; coordIndex++) {
+                dps[coordIndex] = new DirectPosition3D(crs); 
+                dps[coordIndex].setOrdinate(0, values[ordinateIdx].doubleValue());
+                dps[coordIndex].setOrdinate(1, values[ordinateIdx + 1].doubleValue());
+                dps[coordIndex].setOrdinate(2, values[ordinateIdx + 2].doubleValue());
+                ordinateIdx += crsDimension;
+            }
+
         }
 
         return dps;

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/GML3ParsingUtils.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/GML3ParsingUtils.java
@@ -89,6 +89,27 @@ public class GML3ParsingUtils {
     static CoordinateReferenceSystem crs(Node node) {
         return GML2ParsingUtils.crs(node);
     }
+    
+    /**
+     * Returns the number of dimensions for the specified node, eventually recursing up to find
+     * the parent node that has the indication of the dimensions (normally the top-most geometry
+     * element has it, not the posList). Returns 2 if no srsDimension attribute could be found. 
+     * 
+     * @param node
+     * @return
+     */
+    public static int dimensions(Node node) {
+        Node current = node;
+        while(current != null) {
+            Node dimensions = (Node) current.getAttribute("srsDimension");
+            if (dimensions != null) {
+                return ((Number) dimensions.getValue()).intValue();
+            }
+            current = current.getParent();
+        }
+        
+        return 2;
+    }
 
     static LineString lineString(Node node, GeometryFactory gf, CoordinateSequenceFactory csf) {
         return line(node, gf, csf, false);
@@ -165,4 +186,6 @@ public class GML3ParsingUtils {
 
         return null;
     }
+
+    
 }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/PointTypeBinding.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/PointTypeBinding.java
@@ -18,6 +18,7 @@ package org.geotools.gml3.bindings;
 
 import javax.xml.namespace.QName;
 
+import org.geotools.geometry.DirectPosition1D;
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.gml3.GML;
 import org.geotools.xml.AbstractComplexBinding;
@@ -119,7 +120,11 @@ public class PointTypeBinding extends AbstractComplexBinding {
         if (node.hasChild(DirectPosition.class)) {
             DirectPosition dp = (DirectPosition) node.getChildValue(DirectPosition.class);
 
-            return gFactory.createPoint(new Coordinate(dp.getOrdinate(0), dp.getOrdinate(1)));
+            if(dp instanceof DirectPosition2D) {
+                return gFactory.createPoint(new Coordinate(dp.getOrdinate(0), dp.getOrdinate(1)));
+            } else {
+                return gFactory.createPoint(new Coordinate(dp.getOrdinate(0), dp.getOrdinate(1), dp.getOrdinate(2)));
+            }
         }
 
         if (node.hasChild(Coordinate.class)) {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/DirectPositionListTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/DirectPositionListTypeBindingTest.java
@@ -18,6 +18,7 @@ package org.geotools.gml3.bindings;
 
 import org.geotools.geometry.DirectPosition1D;
 import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.DirectPosition3D;
 import org.geotools.gml3.GML;
 import org.geotools.gml3.GML3TestSupport;
 import org.opengis.geometry.DirectPosition;
@@ -76,13 +77,15 @@ public class DirectPositionListTypeBindingTest extends GML3TestSupport {
         assertNotNull(dps);
 
         assertEquals(2, dps.length);
-        assertTrue(dps[0] instanceof DirectPosition2D);
+        assertTrue(dps[0] instanceof DirectPosition3D);
 
         assertEquals(1d, dps[0].getOrdinate(0), 0d);
         assertEquals(2d, dps[0].getOrdinate(1), 0d);
+        assertEquals(1d, dps[0].getOrdinate(2), 0d);
 
         assertEquals(3d, dps[1].getOrdinate(0), 0d);
         assertEquals(4d, dps[1].getOrdinate(1), 0d);
+        assertEquals(5d, dps[1].getOrdinate(2), 0d);
     }
     
     public void testEncode2D() throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/GML3MockData.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/GML3MockData.java
@@ -36,7 +36,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryCollection;
@@ -81,6 +80,23 @@ public class GML3MockData {
 
         Element pos = element(qName("pos"), document, point);
         pos.appendChild(document.createTextNode("1.0 2.0 "));
+
+        return point;
+    }
+    
+    public static Element point3D(Document document, Node parent) {
+        return point3D(document, parent, true);
+    }
+    
+    public static Element point3D(Document document, Node parent, boolean addDimension) {
+        Element point = element(GML.Point, document, parent);
+        point.setAttribute("srsName", "urn:x-ogc:def:crs:EPSG:6.11.2:4326");
+        if(addDimension) {
+            point.setAttribute("srsDimension", "3");
+        }
+
+        Element pos = element(qName("pos"), document, point);
+        pos.appendChild(document.createTextNode("1.0 2.0 10.0"));
 
         return point;
     }
@@ -185,11 +201,39 @@ public class GML3MockData {
 
         return lineString;
     }
+    
+    public static Element lineStringWithPos3D(Document document, Node parent) {
+        Element lineString = element(qName("LineString"), document, parent);
+        lineString.setAttribute("srsDimension", "3");
+
+        Element pos = element(qName("pos"), document, lineString);
+        pos.appendChild(document.createTextNode("1.0 2.0 10.0"));
+
+        pos = element(qName("pos"), document, lineString);
+        pos.appendChild(document.createTextNode("3.0 4.0 20.0"));
+        
+        return lineString;
+    }
 
     public static Element lineStringWithPosList(Document document, Node parent) {
         Element lineString = element(qName("LineString"), document, parent);
         Element posList = element(qName("posList"), document, lineString);
         posList.appendChild(document.createTextNode("1.0 2.0 3.0 4.0"));
+
+        return lineString;
+    }
+    
+    public static Element lineStringWithPosList3D(Document document, Node parent) {
+        return lineStringWithPosList3D(document, parent, true);
+    }
+    
+    public static Element lineStringWithPosList3D(Document document, Node parent, boolean addSrsDimension) {
+        Element lineString = element(qName("LineString"), document, parent);
+        if(addSrsDimension) {
+            lineString.setAttribute("srsDimension", "3");
+        }
+        Element posList = element(qName("posList"), document, lineString);
+        posList.appendChild(document.createTextNode("1.0 2.0 10.0 3.0 4.0 20.0"));
 
         return lineString;
     }
@@ -238,6 +282,27 @@ public class GML3MockData {
 
         return linearRing;
     }
+    
+    public static Element linearRingWithPos3D(Document document, Node parent, boolean addSrsDimension) {
+        Element linearRing = element(qName("LinearRing"), document, parent);
+        if(addSrsDimension) {
+            linearRing.setAttribute("srsDimension", "3");
+        }
+
+        Element pos = element(qName("pos"), document, linearRing);
+        pos.appendChild(document.createTextNode("1.0 2.0 10.0"));
+
+        pos = element(qName("pos"), document, linearRing);
+        pos.appendChild(document.createTextNode("3.0 4.0 20.0"));
+
+        pos = element(qName("pos"), document, linearRing);
+        pos.appendChild(document.createTextNode("5.0 6.0 30.0"));
+
+        pos = element(qName("pos"), document, linearRing);
+        pos.appendChild(document.createTextNode("1.0 2.0 10.0"));
+
+        return linearRing;
+    }
 
     public static Element linearRingWithPosList(Document document, Node parent) {
         Element linearRing = element(qName("LinearRing"), document, parent);
@@ -246,6 +311,20 @@ public class GML3MockData {
 
         linearRing.appendChild(posList);
         posList.appendChild(document.createTextNode("1.0 2.0 3.0 4.0 5.0 6.0 1.0 2.0"));
+
+        return linearRing;
+    }
+    
+    public static Element linearRingWithPosList3D(Document document, Node parent, boolean addSrsDimension) {
+        Element linearRing = element(qName("LinearRing"), document, parent);
+        if(addSrsDimension) {
+            linearRing.setAttribute("srsDimension", "3");
+        }
+
+        Element posList = element(qName("posList"), document, linearRing);
+
+        linearRing.appendChild(posList);
+        posList.appendChild(document.createTextNode("1.0 2.0 10.0 3.0 4.0 20.0 5.0 6.0 30.0 1.0 2.0 10.0"));
 
         return linearRing;
     }
@@ -288,6 +367,10 @@ public class GML3MockData {
         return polygonWithPosList(document,parent,qName("Polygon"),false); 
     }
     
+    public static Element polygonWithPosList3D(Document document, Node parent) {
+        return polygonWithPosList3D(document,parent,qName("Polygon"),false); 
+    }
+    
     public static Element polygon(Document document, Node parent, QName name, boolean withInterior) {
         Element polygon = element(name, document, parent);
 
@@ -302,6 +385,25 @@ public class GML3MockData {
         return polygon;
     }
     
+    public static Element polygon3D(Document document, Node parent, boolean addSrsDimension) {
+        return polygonWithPos3D(document, parent, qName("Polygon"), true);
+    }
+    
+    public static Element polygonWithPos3D(Document document, Node parent, QName name, boolean addSrsDimension) {
+        Element polygon = element(name, document, parent);
+        if(addSrsDimension) {
+            polygon.setAttribute("srsDimension", "3");
+        }
+
+        Element exterior = element(qName("exterior"), document, polygon);
+        linearRingWithPos3D(document, exterior, false);
+        
+        Element interior = element(qName("interior"), document, polygon);
+        linearRingWithPos3D(document, interior, false);
+
+        return polygon;
+    }
+    
     public static Element polygonWithPosList(Document document, Node parent, QName name, boolean withInterior) {
         Element polygon = element(name, document, parent);
 
@@ -312,6 +414,25 @@ public class GML3MockData {
             Element interior = element(qName("interior"), document, polygon);
             linearRingWithPosList(document,interior);
         }
+
+        return polygon;
+    }
+    
+    public static Element polygonWithPosList3D(Document document, Node parent, boolean addSrsDimension) {
+        return polygonWithPosList3D(document, parent, qName("Polygon"), true);
+    }
+    
+    public static Element polygonWithPosList3D(Document document, Node parent, QName name, boolean addSrsDimension) {
+        Element polygon = element(name, document, parent);
+        if(addSrsDimension) {
+            polygon.setAttribute("srsDimension", "3");
+        }
+
+        Element exterior = element(qName("exterior"), document, polygon);
+        linearRingWithPosList3D(document, exterior, false);
+        
+        Element interior = element(qName("interior"), document, polygon);
+        linearRingWithPosList3D(document, interior, false);
 
         return polygon;
     }
@@ -337,6 +458,25 @@ public class GML3MockData {
 
         return multiPoint;
     }
+    
+    public static Element multiPoint3D(Document document, Node parent) {
+        Element multiPoint = element(qName("MultiPoint"), document, parent);
+        multiPoint.setAttribute("srsDimensions", "3");
+
+        // 2 pointMember elements
+        Element pointMember = element(qName("pointMember"), document, multiPoint);
+        point3D(document, pointMember, false);
+
+        pointMember = element(qName("pointMember"), document, multiPoint);
+        point3D(document, pointMember, false);
+
+        //1 pointMembers element with 2 members
+        Element pointMembers = element(qName("pointMembers"), document, multiPoint);
+        point3D(document, pointMembers, false);
+        point3D(document, pointMembers, false);
+
+        return multiPoint;
+    }
 
     public static MultiLineString multiLineString() {
         return gf.createMultiLineString(new LineString[] { lineString(), lineString() });
@@ -350,6 +490,19 @@ public class GML3MockData {
 
         lineStringMember = element(qName("lineStringMember"), document, multiLineString);
         lineString(document, lineStringMember);
+
+        return multiLineString;
+    }
+    
+    public static Element multiLineString3D(Document document, Node parent) {
+        Element multiLineString = element(qName("MultiLineString"), document, parent);
+        multiLineString.setAttribute("srsDimension", "3");
+
+        Element lineStringMember = element(qName("lineStringMember"), document, multiLineString);
+        lineStringWithPosList3D(document, lineStringMember, false);
+
+        lineStringMember = element(qName("lineStringMember"), document, multiLineString);
+        lineStringWithPosList3D(document, lineStringMember, false);
 
         return multiLineString;
     }
@@ -392,6 +545,21 @@ public class GML3MockData {
 
         return multiPolygon;
     }
+    
+    public static Element multiPolygon3D(Document document, Node parent) {
+        Element multiPolygon = element(qName("MultiPolygon"), document, parent);
+        multiPolygon.setAttribute("srsDimension", "3");
+        
+
+        Element polygonMember = element(qName("polygonMember"), document, multiPolygon);
+        polygon3D(document, polygonMember, false);
+
+        polygonMember = element(qName("polygonMember"), document, multiPolygon);
+        polygon3D(document, polygonMember, false);
+
+        return multiPolygon;
+    }
+
     
     public static Element multiSurface(Document document, Node parent) {
         return multiSurface(document, parent, true);

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/LineStringTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/LineStringTypeBindingTest.java
@@ -30,6 +30,7 @@ import com.vividsolutions.jts.geom.LineString;
  * @source $URL$
  */
 public class LineStringTypeBindingTest extends GML3TestSupport {
+    
     public void testPos() throws Exception {
         document.appendChild(GML3MockData.lineStringWithPos(document, null));
 
@@ -38,6 +39,16 @@ public class LineStringTypeBindingTest extends GML3TestSupport {
 
         assertEquals(new Coordinate(1d, 2d), line.getPointN(0).getCoordinate());
         assertEquals(new Coordinate(3d, 4d), line.getPointN(1).getCoordinate());
+    }
+    
+    public void testPos3D() throws Exception {
+        document.appendChild(GML3MockData.lineStringWithPos3D(document, null));
+
+        LineString line = (LineString) parse();
+        assertNotNull(line);
+
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(line.getPointN(0).getCoordinate()));
+        assertTrue(new Coordinate(3d, 4d, 20d).equals3D(line.getPointN(1).getCoordinate()));
     }
 
     public void testPosList() throws Exception {
@@ -48,6 +59,16 @@ public class LineStringTypeBindingTest extends GML3TestSupport {
 
         assertEquals(new Coordinate(1d, 2d), line.getPointN(0).getCoordinate());
         assertEquals(new Coordinate(3d, 4d), line.getPointN(1).getCoordinate());
+    }
+    
+    public void testPosList3D() throws Exception {
+        document.appendChild(GML3MockData.lineStringWithPosList3D(document, null));
+
+        LineString line = (LineString) parse();
+        assertNotNull(line);
+
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(line.getPointN(0).getCoordinate()));
+        assertTrue(new Coordinate(3d, 4d, 20d).equals3D(line.getPointN(1).getCoordinate()));
     }
     
     /**

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/LinearRingTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/LinearRingTypeBindingTest.java
@@ -28,6 +28,7 @@ import com.vividsolutions.jts.geom.LinearRing;
  * @source $URL$
  */
 public class LinearRingTypeBindingTest extends GML3TestSupport {
+    
     public void testPos() throws Exception {
         document.appendChild(GML3MockData.linearRingWithPos(document, null));
 
@@ -48,9 +49,33 @@ public class LinearRingTypeBindingTest extends GML3TestSupport {
 
         assertEquals(new Coordinate(1d, 2d), line.getPointN(0).getCoordinate());
         assertEquals(new Coordinate(3d, 4d), line.getPointN(1).getCoordinate());
-        assertEquals(new Coordinate(1d, 2d), line.getPointN(0).getCoordinate());
-        assertEquals(new Coordinate(3d, 4d), line.getPointN(1).getCoordinate());
         assertEquals(new Coordinate(5d, 6d), line.getPointN(2).getCoordinate());
         assertEquals(new Coordinate(1d, 2d), line.getPointN(3).getCoordinate());
     }
+    
+    public void testPos3D() throws Exception {
+        document.appendChild(GML3MockData.linearRingWithPos3D(document, null, true));
+
+        LinearRing line = (LinearRing) parse();
+        assertNotNull(line);
+
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(line.getPointN(0).getCoordinate()));
+        assertTrue(new Coordinate(3d, 4d, 20d).equals3D(line.getPointN(1).getCoordinate()));
+        assertTrue(new Coordinate(5d, 6d, 30d).equals3D(line.getPointN(2).getCoordinate()));
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(line.getPointN(3).getCoordinate()));
+    }
+
+    public void testPosList3D() throws Exception {
+        document.appendChild(GML3MockData.linearRingWithPosList3D(document, null, true));
+
+        LinearRing line = (LinearRing) parse();
+        assertNotNull(line);
+
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(line.getPointN(0).getCoordinate()));
+        assertTrue(new Coordinate(3d, 4d, 20d).equals3D(line.getPointN(1).getCoordinate()));
+        assertTrue(new Coordinate(5d, 6d, 30d).equals3D(line.getPointN(2).getCoordinate()));
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(line.getPointN(3).getCoordinate()));
+    }
+    
+    
 }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiLineStringTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiLineStringTypeBindingTest.java
@@ -21,7 +21,9 @@ import org.geotools.gml3.GML3TestSupport;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.MultiLineString;
 
 
@@ -31,6 +33,7 @@ import com.vividsolutions.jts.geom.MultiLineString;
  * @source $URL$
  */
 public class MultiLineStringTypeBindingTest extends GML3TestSupport {
+    
     public void test() throws Exception {
         GML3MockData.multiLineString(document, document);
 
@@ -38,6 +41,19 @@ public class MultiLineStringTypeBindingTest extends GML3TestSupport {
         assertNotNull(multiLineString);
 
         assertEquals(2, multiLineString.getNumGeometries());
+    }
+    
+    public void test3D() throws Exception {
+        GML3MockData.multiLineString3D(document, document);
+
+        MultiLineString multiLineString = (MultiLineString) parse();
+        assertNotNull(multiLineString);
+
+        assertEquals(2, multiLineString.getNumGeometries());
+        
+        LineString line = (LineString) multiLineString.getGeometryN(0);
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(line.getPointN(0).getCoordinate()));
+        assertTrue(new Coordinate(3d, 4d, 20d).equals3D(line.getPointN(1).getCoordinate()));
     }
 
     public void testEncode() throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiPointTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiPointTypeBindingTest.java
@@ -21,8 +21,10 @@ import org.geotools.gml3.GML3TestSupport;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.MultiPoint;
+import com.vividsolutions.jts.geom.Point;
 
 
 /**
@@ -31,6 +33,7 @@ import com.vividsolutions.jts.geom.MultiPoint;
  * @source $URL$
  */
 public class MultiPointTypeBindingTest extends GML3TestSupport {
+    
     public void test() throws Exception {
         GML3MockData.multiPoint(document, document);
 
@@ -38,6 +41,17 @@ public class MultiPointTypeBindingTest extends GML3TestSupport {
         assertNotNull(multiPoint);
 
         assertEquals(4, multiPoint.getNumPoints());
+    }
+    
+    public void test3D() throws Exception {
+        GML3MockData.multiPoint3D(document, document);
+
+        MultiPoint multiPoint = (MultiPoint) parse();
+        assertNotNull(multiPoint);
+
+        assertEquals(4, multiPoint.getNumPoints());
+        Point p = (Point) multiPoint.getGeometryN(0);
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(p.getCoordinate()));
     }
 
     public void testEncode() throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiPolygonTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiPolygonTypeBindingTest.java
@@ -21,8 +21,11 @@ import org.geotools.gml3.GML3TestSupport;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Polygon;
 
 
 /**
@@ -31,12 +34,27 @@ import com.vividsolutions.jts.geom.MultiPolygon;
  * @source $URL$
  */
 public class MultiPolygonTypeBindingTest extends GML3TestSupport {
+    
     public void test() throws Exception {
         GML3MockData.multiPolygon(document, document);
 
         MultiPolygon multiPolygon = (MultiPolygon) parse();
         assertNotNull(multiPolygon);
         assertEquals(2, multiPolygon.getNumGeometries());
+    }
+    
+    public void test3D() throws Exception {
+        GML3MockData.multiPolygon3D(document, document);
+
+        MultiPolygon multiPolygon = (MultiPolygon) parse();
+        assertNotNull(multiPolygon);
+        assertEquals(2, multiPolygon.getNumGeometries());
+        
+        Polygon polygon = (Polygon) multiPolygon.getGeometryN(0);
+        LineString exterior = polygon.getExteriorRing();
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(exterior.getCoordinateN(0)));
+        LineString interior = polygon.getInteriorRingN(0);
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(interior.getCoordinateN(0)));
     }
 
     public void testEncode() throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/PointTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/PointTypeBindingTest.java
@@ -32,12 +32,23 @@ import com.vividsolutions.jts.geom.Point;
  * @source $URL$
  */
 public class PointTypeBindingTest extends GML3TestSupport {
+    
     public void testPos() throws Exception {
         GML3MockData.point(document, document);
 
         Point p = (Point) parse();
         assertNotNull(p);
         assertEquals(new Coordinate(1d, 2d), p.getCoordinate());
+
+        assertTrue(p.getUserData() instanceof CoordinateReferenceSystem);
+    }
+    
+    public void testPos3D() throws Exception {
+        GML3MockData.point3D(document, document);
+
+        Point p = (Point) parse();
+        assertNotNull(p);
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(p.getCoordinate()));
 
         assertTrue(p.getUserData() instanceof CoordinateReferenceSystem);
     }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/PolygonTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/PolygonTypeBindingTest.java
@@ -20,6 +20,7 @@ import org.geotools.gml3.GML;
 import org.geotools.gml3.GML3TestSupport;
 import org.w3c.dom.Document;
 
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.Polygon;
 
@@ -30,11 +31,36 @@ import com.vividsolutions.jts.geom.Polygon;
  * @source $URL$
  */
 public class PolygonTypeBindingTest extends GML3TestSupport {
+    
     public void testNoInterior() throws Exception {
         GML3MockData.polygon(document, document);
 
         Polygon polygon = (Polygon) parse();
         assertNotNull(polygon);
+    }
+    
+    public void testPolygon3D() throws Exception {
+        GML3MockData.polygon3D(document, document, true);
+
+        Polygon polygon = (Polygon) parse();
+        assertNotNull(polygon);
+        
+        LineString exterior = polygon.getExteriorRing();
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(exterior.getCoordinateN(0)));
+        LineString interior = polygon.getInteriorRingN(0);
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(interior.getCoordinateN(0)));
+    }
+    
+    public void testPolygonPosList3D() throws Exception {
+        GML3MockData.polygonWithPosList3D(document, document, true);
+
+        Polygon polygon = (Polygon) parse();
+        assertNotNull(polygon);
+        
+        LineString exterior = polygon.getExteriorRing();
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(exterior.getCoordinateN(0)));
+        LineString interior = polygon.getInteriorRingN(0);
+        assertTrue(new Coordinate(1d, 2d, 10d).equals3D(interior.getCoordinateN(0)));
     }
     
     public void testEncode3D() throws Exception {


### PR DESCRIPTION
The changes are simple/mechanic, but I guess a quick review would not hurt.
The only "interesting" bit imho is searching for the srsDimension attribute in parent nodes, since typically it is found in the topmost geometry, not in the postlist or in the nested geometric elements
