### PR TITLE
GEOT-4650

### DIFF
--- a/modules/unsupported/ogr/ogr-bridj/src/test/java/org/geotools/data/ogr/bridj/BridjGeometryMapperTest.java
+++ b/modules/unsupported/ogr/ogr-bridj/src/test/java/org/geotools/data/ogr/bridj/BridjGeometryMapperTest.java
@@ -10,6 +10,7 @@ public class BridjGeometryMapperTest extends GeometryMapperTest {
     @Override
     protected void setUp() throws Exception {
         GdalInit.init();
+        super.setUp();
     }
 
 }


### PR DESCRIPTION
The ogr-bridj GeometryMapperTest does not call super.setUp() so the test doesn't run correctly.  Fixes GEOT-4650.
