### PR TITLE
Fix failing unit test for ogr module.  Fixes JIRA issue GEOT-4651.

### DIFF
--- a/modules/unsupported/ogr/ogr-core/src/test/java/org/geotools/data/ogr/OGRDataStoreTest.java
+++ b/modules/unsupported/ogr/ogr-core/src/test/java/org/geotools/data/ogr/OGRDataStoreTest.java
@@ -217,7 +217,7 @@ public abstract class OGRDataStoreTest extends TestCaseSupport {
     
     private void assertFeatureTypeEquals(SimpleFeatureType type1, SimpleFeatureType type2) {
         // general type assertions
-        assertEquals(type1.getName(), type2.getName());
+        assertEquals(type1.getTypeName(), type2.getTypeName());
         assertEquals(type1.getSuper(), type2.getSuper());
         assertEquals(type1.getAttributeCount(), type2.getAttributeCount());
         


### PR DESCRIPTION
The OGRDataStoreTest's assertFeatureTypeEquals is failing because the getName() includes the namespace which is different betweent the OGR and native GeoTools shape file schema.
