### PR TITLE
Add unit test for reading the writing SQLite. Fixes JIRA issue GEOT-4653

### DIFF
--- a/modules/unsupported/ogr/ogr-bridj/src/main/java/org/geotools/data/ogr/bridj/BridjOGR.java
+++ b/modules/unsupported/ogr/ogr-bridj/src/main/java/org/geotools/data/ogr/bridj/BridjOGR.java
@@ -322,6 +322,11 @@ public class BridjOGR implements OGR {
     }
 
     @Override
+    public String LayerGetFIDColumnName(Object layer) {
+         return getCString(OGR_L_GetFIDColumn((Pointer<?>) layer));
+    }
+    
+    @Override
     public String FieldGetName(Object field) {
         return getCString(OGR_Fld_GetNameRef((Pointer<?>)field));
     }

--- a/modules/unsupported/ogr/ogr-core/src/main/java/org/geotools/data/ogr/OGR.java
+++ b/modules/unsupported/ogr/ogr-core/src/main/java/org/geotools/data/ogr/OGR.java
@@ -140,6 +140,8 @@ public interface OGR {
     
     int LayerCreateFeature(Object layer, Object feature);
     
+    String LayerGetFIDColumnName(Object layer);
+    
     //
     // Field
     //

--- a/modules/unsupported/ogr/ogr-core/src/main/java/org/geotools/data/ogr/OGRDataStore.java
+++ b/modules/unsupported/ogr/ogr-core/src/main/java/org/geotools/data/ogr/OGRDataStore.java
@@ -270,6 +270,13 @@ public class OGRDataStore extends ContentDataStore {
                 String newName = ogr.FieldGetName(fd);
                 if (newName != null) {
                     String oldName = nameMap.get(newName);
+                    // Check case insensitive because sqlite can convert names to lowercase
+                    if (oldName == null) {
+                        oldName = nameMap.get(newName.toLowerCase());
+                    }
+                    if (oldName == null) {
+                        oldName = nameMap.get(newName.toUpperCase());
+                    }
                     for (int j = 0; j < schema.getAttributeCount(); j++) {
                         if (schema.getDescriptor(j).getLocalName().equals(oldName)) {
                             indexMap.put(j, i);

--- a/modules/unsupported/ogr/ogr-jni/src/main/java/org/geotools/data/ogr/jni/JniOGR.java
+++ b/modules/unsupported/ogr/ogr-jni/src/main/java/org/geotools/data/ogr/jni/JniOGR.java
@@ -293,6 +293,11 @@ public class JniOGR implements OGR {
     }
     
     @Override
+    public String LayerGetFIDColumnName(Object layer) {
+        return ((Layer)layer).GetFIDColumn();
+    }
+    
+    @Override
     public String FieldGetName(Object field) {
         return ((FieldDefn)field).GetName();
     }


### PR DESCRIPTION
Includes fix to sorting when using database based drivers that pass SQL straight through and thus dont have access to FID which is OGR SQL. Also adds LayerGetFIDColumnName to the OGR interface.
