### PR TITLE
Use environmental variables to make testing OGR module easier.  Fixes JIRA issue  GEOT-4655.

### DIFF
--- a/modules/unsupported/ogr/ogr-bridj/pom.xml
+++ b/modules/unsupported/ogr/ogr-bridj/pom.xml
@@ -99,4 +99,25 @@
     </dependency>
   </dependencies>
   
+  <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkMode>once</forkMode>
+                    <argLine>-Djava.library.path="${env.GT_GDAL}"</argLine>
+                    <systemProperties>
+                        <GDAL_LIBRARY_NAME>${env.GDAL_LIBRARY_NAME}</GDAL_LIBRARY_NAME>
+                    </systemProperties>
+                    <environmentVariables>
+                        <PATH>${env.GT_GDAL};${env.PATH}</PATH>
+                        <DYLD_LIBRARY_PATH>${env.GT_GDAL};${env.DYLD_LIBRARY_PATH}</DYLD_LIBRARY_PATH>
+                        <LD_LIBRARY_PATH>${env.GT_GDAL};${env.LD_LIBRARY_PATH}</LD_LIBRARY_PATH>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+  
 </project>

--- a/modules/unsupported/ogr/ogr-jni/pom.xml
+++ b/modules/unsupported/ogr/ogr-jni/pom.xml
@@ -91,4 +91,23 @@
   <properties>
     <gdal.version>1.8.1</gdal.version>
   </properties>
+  
+  <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkMode>once</forkMode>
+                    <argLine>-Djava.library.path="${env.GT_GDAL}"</argLine>
+                    <environmentVariables>
+                        <PATH>${env.GT_GDAL};${env.PATH}</PATH>
+                        <DYLD_LIBRARY_PATH>${env.GT_GDAL};${env.DYLD_LIBRARY_PATH}</DYLD_LIBRARY_PATH>
+                        <LD_LIBRARY_PATH>${env.GT_GDAL};${env.LD_LIBRARY_PATH}</LD_LIBRARY_PATH>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+   </build>
+  
 </project>


### PR DESCRIPTION
Add environmental variables to the maven surefire plugin to make it easier to test the OGR modules. It uses GT_GDAL to identify the path to the GDAL native libraries and GDAL_LIBRARY_NAME to support bride.
