### PR TITLE
Get ogr-bridj working on mac

### DIFF
--- a/modules/unsupported/ogr/ogr-bridj/src/main/java/org/geotools/data/ogr/bridj/OgrLibrary.java
+++ b/modules/unsupported/ogr/ogr-bridj/src/main/java/org/geotools/data/ogr/bridj/OgrLibrary.java
@@ -334,7 +334,7 @@ public class OgrLibrary {
 	public static native Pointer<? > OGRMalloc(@Ptr long size_t1);
 	public static native Pointer<? > OGRCalloc(@Ptr long size_t1, @Ptr long size_t2);
 	public static native Pointer<? > OGRRealloc(Pointer<? > voidPtr1, @Ptr long size_t1);
-	public static native Pointer<Byte > OGRStrdup(Pointer<Byte > charPtr1);
+	//public static native Pointer<Byte > OGRStrdup(Pointer<Byte > charPtr1);
 	public static native void OGRFree(Pointer<? > voidPtr1);
 	public static native Pointer<Byte > OGRGeometryTypeToName(ValuedEnum<OgrLibrary.OGRwkbGeometryType > eType);
 	public static native ValuedEnum<OgrLibrary.OGRwkbGeometryType > OGRMergeGeometryTypes(ValuedEnum<OgrLibrary.OGRwkbGeometryType > eMain, ValuedEnum<OgrLibrary.OGRwkbGeometryType > eExtra);

--- a/modules/unsupported/ogr/ogr-bridj/src/main/java/org/geotools/data/ogr/bridj/OsrLibrary.java
+++ b/modules/unsupported/ogr/ogr-bridj/src/main/java/org/geotools/data/ogr/bridj/OsrLibrary.java
@@ -395,7 +395,7 @@ public class OsrLibrary {
 	public static native int OSRIsProjected(Pointer<? > OGRSpatialReferenceH1);
 	public static native int OSRIsVertical(Pointer<? > OGRSpatialReferenceH1);
 	public static native int OSRIsSameGeogCS(Pointer<? > OGRSpatialReferenceH1, Pointer<? > OGRSpatialReferenceH2);
-	public static native int OSRIsVertCS(Pointer<? > OGRSpatialReferenceH1, Pointer<? > OGRSpatialReferenceH2);
+	//public static native int OSRIsVertCS(Pointer<? > OGRSpatialReferenceH1, Pointer<? > OGRSpatialReferenceH2);
 	public static native int OSRIsSame(Pointer<? > OGRSpatialReferenceH1, Pointer<? > OGRSpatialReferenceH2);
 	public static native int OSRSetLocalCS(Pointer<? > hSRS, Pointer<Byte > pszName);
 	public static native int OSRSetProjCS(Pointer<? > hSRS, Pointer<Byte > pszName);
@@ -423,7 +423,7 @@ public class OsrLibrary {
 	public static native int OSRAutoIdentifyEPSG(Pointer<? > hSRS);
 	public static native int OSREPSGTreatsAsLatLong(Pointer<? > hSRS);
 	public static native Pointer<Byte > OSRGetAxis(Pointer<? > hSRS, Pointer<Byte > pszTargetKey, int iAxis, Pointer<ValuedEnum<OsrLibrary.OGRAxisOrientation > > peOrientation);
-	public static native int OSRSetAxes(Pointer<Byte > pszTargetKey, Pointer<Byte > pszXAxisName, ValuedEnum<OsrLibrary.OGRAxisOrientation > eXAxisOrientation, Pointer<Byte > pszYAxisName, ValuedEnum<OsrLibrary.OGRAxisOrientation > eYAxisOrientation);
+	//public static native int OSRSetAxes(Pointer<Byte > pszTargetKey, Pointer<Byte > pszXAxisName, ValuedEnum<OsrLibrary.OGRAxisOrientation > eXAxisOrientation, Pointer<Byte > pszYAxisName, ValuedEnum<OsrLibrary.OGRAxisOrientation > eYAxisOrientation);
 	public static native int OSRSetACEA(Pointer<? > hSRS, double dfStdP1, double dfStdP2, double dfCenterLat, double dfCenterLong, double dfFalseEasting, double dfFalseNorthing);
 	public static native int OSRSetAE(Pointer<? > hSRS, double dfCenterLat, double dfCenterLong, double dfFalseEasting, double dfFalseNorthing);
 	public static native int OSRSetBonne(Pointer<? > hSRS, double dfStandardParallel, double dfCentralMeridian, double dfFalseEasting, double dfFalseNorthing);
@@ -465,7 +465,7 @@ public class OsrLibrary {
 	public static native int OSRSetTMG(Pointer<? > hSRS, double dfCenterLat, double dfCenterLong, double dfFalseEasting, double dfFalseNorthing);
 	public static native int OSRSetTMSO(Pointer<? > hSRS, double dfCenterLat, double dfCenterLong, double dfScale, double dfFalseEasting, double dfFalseNorthing);
 	public static native int OSRSetVDG(Pointer<? > hSRS, double dfCenterLong, double dfFalseEasting, double dfFalseNorthing);
-	public static native int OSRSetWagner(Pointer<? > hSRS, int nVariation, double dfFalseEasting, double dfFalseNorthing);
+	//public static native int OSRSetWagner(Pointer<? > hSRS, int nVariation, double dfFalseEasting, double dfFalseNorthing);
 	public static native void OSRCleanup();
 	public static native Pointer<? > OCTNewCoordinateTransformation(Pointer<? > hSourceSRS, Pointer<? > hTargetSRS);
 	public static native void OCTDestroyCoordinateTransformation(Pointer<? > OGRCoordinateTransformationH1);


### PR DESCRIPTION
The ogr-bridj unsupported modules doesn't currently work on a mac.  This pull requests comments out 4 lines of code to get it working.  See http://osgeo-org.1560.x6.nabble.com/Improvement-for-the-unsupported-OGR-module-td5096044.html for more details.
