### PR TITLE
GEOS-6216: POST bbox query with complex attribute specified results in the wrong axis order

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/spatial/ReprojectingFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/spatial/ReprojectingFilterVisitor.java
@@ -103,7 +103,13 @@ public class ReprojectingFilterVisitor extends DuplicatingFilterVisitor {
             return super.visit(filter, extraData);
 
         // grab the property data
-        PropertyName propertyName = ff.property(filter.getPropertyName());
+        PropertyName propertyName = null;
+        // get the expression as is to preserve namespace context
+        if (filter.getExpression1() instanceof PropertyName) {
+            propertyName = (PropertyName) filter.getExpression1();
+        } else if (filter.getExpression2() instanceof PropertyName) {
+            propertyName = (PropertyName) filter.getExpression2();
+        }
         CoordinateReferenceSystem targetCrs = findPropertyCRS(propertyName);
 
         // if there is a mismatch, reproject and replace


### PR DESCRIPTION
Part 2 of https://github.com/geoserver/geoserver/pull/454: 

ReprojectingFilterVisitor shouldn't create a new bbox property name without the namespace context.
Getting the expression instead will preserve the namespace context. 
