### PR TITLE
Refactor AbstractGridCoverage2DReader

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverage2DReader.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverage2DReader.java
@@ -295,7 +295,7 @@ public abstract class AbstractGridCoverage2DReader implements GridCoverage2DRead
      */
     protected Integer setReadParams(OverviewPolicy overviewPolicy, ImageReadParam readP,
             GeneralEnvelope requestedEnvelope, Rectangle requestedDim) throws IOException, TransformException {
-        return setReadParams(overviewPolicy, readP, requestedEnvelope, requestedDim);
+        return setReadParams(coverageName, overviewPolicy, readP, requestedEnvelope, requestedDim);
     }
 
     /**


### PR DESCRIPTION
remvoing all direct calls to the variables that assume one layer.

In a separate commit, the bad formatting is fixed, and the hard-to-navigate order is fixed (there was a bunch of methods before the attribute list), nothing else happens there. This way it is easy to see the real changes in the second commit.
