### PR TITLE
Using renamed spatialite/sqlite jdbc driver

### DIFF
--- a/modules/plugin/jdbc/jdbc-spatialite/pom.xml
+++ b/modules/plugin/jdbc/jdbc-spatialite/pom.xml
@@ -66,7 +66,7 @@
   <dependencies>
     <dependency>
       <groupId>org.xerial</groupId>
-      <artifactId>sqlite-jdbc-spatialite</artifactId>
+      <artifactId>spatialite-jdbc</artifactId>
       <version>3.7.2-2.4</version>
     </dependency>
   </dependencies>

--- a/modules/plugin/jdbc/jdbc-spatialite/src/main/java/org/geotools/data/spatialite/SpatiaLiteDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-spatialite/src/main/java/org/geotools/data/spatialite/SpatiaLiteDataStoreFactory.java
@@ -26,8 +26,8 @@ import org.apache.commons.dbcp.BasicDataSource;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
-import org.sqlite.SQLiteConfig;
-import org.sqlite.SQLiteJDBCLoader;
+import org.spatialite.SQLiteConfig;
+import org.spatialite.SQLiteJDBCLoader;
 
 /**
  * DataStoreFactory for SpatiaLite database.
@@ -131,7 +131,7 @@ public class SpatiaLiteDataStoreFactory extends JDBCDataStoreFactory {
                 location = baseDirectory.getAbsolutePath() + File.separator + db;    
             }
         }
-        return "jdbc:sqlite:" + location;
+        return "jdbc:spatialite:" + location;
     }
     
     @Override

--- a/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-spatialite/src/test/java/org/geotools/data/spatialite/SpatiaLiteTestSetup.java
@@ -114,4 +114,14 @@ public class SpatiaLiteTestSetup extends JDBCTestSetup {
         
         return true;
     }
+
+    @Override
+    protected Properties createExampleFixture() {
+        Properties fixture = new Properties();
+        fixture.put( "driver","org.spatialite.JDBC");
+        fixture.put( "url","jdbc:spatialite:target/geotools");
+        fixture.put( "user","geotools");
+        fixture.put( "password","geotools");
+        return fixture;
+    }
 }


### PR DESCRIPTION
Address issues that arise from using both the normal and spatialite patched sqlite driver.
