### PR TITLE
Add CRS info to GeoJSON output for CRS != WGS84

### DIFF
--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureJSON.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureJSON.java
@@ -285,22 +285,23 @@ public class FeatureJSON {
     public void writeFeatureCollection(FeatureCollection features, Object output) throws IOException {
         LinkedHashMap obj = new LinkedHashMap();
         obj.put("type", "FeatureCollection");
-        if (encodeFeatureCollectionBounds || encodeFeatureCollectionCRS) {
-            final ReferencedEnvelope bounds = features.getBounds();
-            
-            if (encodeFeatureCollectionBounds) {
-                obj.put("bbox", new JSONStreamAware() {
-                    public void writeJSONString(Writer out) throws IOException {
-                        JSONArray.writeJSONString(Arrays.asList(bounds.getMinX(),
-                                bounds.getMinY(),bounds.getMaxX(),bounds.getMaxY()), out);
-                    }
-                });
-            }
-            
-            if (encodeFeatureCollectionCRS) {
-                obj.put("crs", createCRS(bounds.getCoordinateReferenceSystem()));
-            }
+
+        final ReferencedEnvelope bounds = features.getBounds();
+        final CoordinateReferenceSystem crs = bounds.getCoordinateReferenceSystem();
+
+        if (encodeFeatureCollectionBounds) {
+            obj.put("bbox", new JSONStreamAware() {
+                public void writeJSONString(Writer out) throws IOException {
+                    JSONArray.writeJSONString(Arrays.asList(bounds.getMinX(),
+                            bounds.getMinY(),bounds.getMaxX(),bounds.getMaxY()), out);
+                }
+            });
         }
+
+        if (encodeFeatureCollectionCRS || !crs.getName().toString().equals("EPSG:WGS 84")) {
+            obj.put("crs", createCRS(crs));
+        }
+
         obj.put("features", new FeatureCollectionEncoder(features, gjson));
         GeoJSONUtil.encode(obj, output);
     }

--- a/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
+++ b/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
@@ -540,6 +540,49 @@ public class FeatureJSONTest extends GeoJSONTestSupport {
         assertEquals(strip(collectionText(false, true)), fjson.toString(collection()));
     }
 
+    public void testFeatureCollectionWithNonWGS84CRSWrite() throws Exception {
+        String json =
+            "{" +
+            "  'type': 'FeatureCollection'," +
+            "  'crs': {" +
+            "    'type': 'name'," +
+            "    'properties': {" +
+            "      'name': 'EPSG:3857'" +
+            "    }" +
+            "  }," +
+            "  'features': [" +
+            "    {" +
+            "      'type': 'Feature'," +
+            "      'geometry': {" +
+            "        'type': 'Point', " +
+            "        'coordinates': [2.003750834E7, 2.003750834E7]" +
+            "      }," +
+            "      'properties': {" +
+            "      }," +
+            "      'id': 'xyz.1'" +
+            "    }" +
+            "  ]" +
+            "}";
+
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.add("geom", Point.class, CRS.decode("EPSG:3857"));
+        tb.add("name", String.class);
+        tb.setName("xyz");
+        SimpleFeatureType schema = tb.buildFeatureType();
+
+        DefaultFeatureCollection fc = new DefaultFeatureCollection();
+
+        SimpleFeatureBuilder fb = new SimpleFeatureBuilder(schema);
+        fb.add(new WKTReader().read("POINT(20037508.34 20037508.34)"));
+        fc.add(fb.buildFeature("xyz.1"));
+
+        FeatureJSON fj = new FeatureJSON();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        fj.writeFeatureCollection(fc, os);
+
+        assertEquals(strip(json), os.toString());
+    }
+
     public void testFeatureCollectionWithCRSRead() throws Exception {
         String json = collectionText(true, true);
         FeatureCollection fcol = fjson.readFeatureCollection(strip(collectionText(true, true)));


### PR DESCRIPTION
This adds CRS info to the GeoJSON output for Feature Collections with CRS other than WGS 84 as per the GeoJSON spec. A test was added to cover the case when the CRS is other than WGS 84 and the flag to add CRS to the output is not set.
