### PR TITLE
Revert the code to set the matchCase parameter using Boolean.valueOf()

### DIFF
--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
@@ -98,7 +98,7 @@ public class OGCPropertyIsLikeTypeBinding extends AbstractComplexBinding {
         boolean matchCase = true;
 
         if (node.getAttributeValue("matchCase") != null){
-            matchCase = Boolean.valueOf((String)node.getAttributeValue("matchCase"));
+            matchCase = Boolean.valueOf(node.getAttributeValue("matchCase").toString());
         }
 
         if (escape == null) {


### PR DESCRIPTION
The new version in commit 04362d82c1ff9fdaee30b5a43baea1c39058ee0a uses the explicit cast to boolean which throws a ClassCastException. See comment below.
