### PR TITLE
Fixed typo in geopackage

### DIFF
--- a/modules/unsupported/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
+++ b/modules/unsupported/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
@@ -1337,7 +1337,7 @@ public class GeoPackage {
                 q.add("zoom_level >= " + lowZoom);
             }
             if (highZoom != null) {
-                q.add("zoom_level <= " + lowZoom);
+                q.add("zoom_level <= " + highZoom);
             }
             if (lowCol != null) {
                 q.add("tile_column >= " + lowCol);


### PR DESCRIPTION
It appears there was a typo in the Tile Reader section of the main GeoPackage class during the check for zoom levels.
