### PR TITLE
Fixes #GEOT-4720

### DIFF
--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureTypeHandler.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureTypeHandler.java
@@ -17,7 +17,7 @@
 package org.geotools.geojson.feature;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -50,7 +50,7 @@ public class FeatureTypeHandler extends DelegatingHandler<SimpleFeatureType>
 
   private boolean inFeatures = false;
 
-  private Map<String, Class<?>> propertyTypes = new HashMap<String, Class<?>>();
+  private Map<String, Class<?>> propertyTypes = new LinkedHashMap<String, Class<?>>();
 
   private boolean inProperties;
 
@@ -122,7 +122,9 @@ public class FeatureTypeHandler extends DelegatingHandler<SimpleFeatureType>
         List<AttributeDescriptor> attributeDescriptors = feature
             .getFeatureType().getAttributeDescriptors();
         for (AttributeDescriptor ad : attributeDescriptors) {
-          propertyTypes.put(ad.getLocalName(), ad.getType().getBinding());
+          if (!ad.equals(geom)) {
+            propertyTypes.put(ad.getLocalName(), ad.getType().getBinding());
+          }
         }
         delegate = NULL;
 
@@ -215,7 +217,11 @@ public class FeatureTypeHandler extends DelegatingHandler<SimpleFeatureType>
     if (propertyTypes != null) {
       Set<Entry<String, Class<?>>> entrySet = propertyTypes.entrySet();
       for (Entry<String, Class<?>> entry : entrySet) {
-        typeBuilder.add(entry.getKey(), entry.getValue());
+        Class<?> binding = entry.getValue();
+        if (binding.equals(Object.class)) {
+          binding = String.class;
+        }
+        typeBuilder.add(entry.getKey(), binding);
       }
     }
 

--- a/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
+++ b/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
@@ -580,12 +580,16 @@ public class FeatureJSONTest extends GeoJSONTestSupport {
       String collectionText = collectionText(true, true, false, false, true);
       SimpleFeatureType ftype = fjson.readFeatureCollectionSchema((strip(collectionText)), true);
       
-      assertNotNull(ftype.getDescriptor("double"));
-      assertEquals(Double.class, ftype.getDescriptor("double").getType().getBinding());
+      System.out.println("type: " + ftype);
+      
+      assertEquals(4, ftype.getAttributeCount());
+      
       assertNotNull(ftype.getDescriptor("int"));
-      assertEquals(Long.class, ftype.getDescriptor("int").getType().getBinding());
+      assertEquals(Long.class, ftype.getDescriptor(1).getType().getBinding());
+      assertNotNull(ftype.getDescriptor("double"));
+      assertEquals(Double.class, ftype.getDescriptor(2).getType().getBinding());
       assertNotNull(ftype.getDescriptor("string"));
-      assertEquals(String.class, ftype.getDescriptor("string").getType().getBinding());
+      assertEquals(String.class, ftype.getDescriptor(3).getType().getBinding());
       
       assertNotNull(ftype.getCoordinateReferenceSystem());
       
@@ -605,8 +609,8 @@ public class FeatureJSONTest extends GeoJSONTestSupport {
       SimpleFeatureType ftype = fjson.readFeatureCollectionSchema((strip(collectionText)), false);
       
       assertNotNull(ftype.getDescriptor("double"));
-      // type defined as Object as all values were null
-      assertEquals(Object.class, ftype.getDescriptor("double").getType().getBinding());
+      // type defaults to String as all values were null
+      assertEquals(String.class, ftype.getDescriptor("double").getType().getBinding());
       assertNotNull(ftype.getDescriptor("int"));
       assertEquals(Long.class, ftype.getDescriptor("int").getType().getBinding());
       assertNotNull(ftype.getDescriptor("string"));
@@ -802,5 +806,4 @@ public class FeatureJSONTest extends GeoJSONTestSupport {
         sb.append("}");
         return sb.toString();
     }
-    
 }


### PR DESCRIPTION
FeatureJSON#readFeatureCollectionSchema was adding a duplicate geometry
Binding now defaults to String if it cannot be determined (e.g. when all values of an attribute are NULL)
