### PR TITLE
[GEOT-4743] ImageIO-Ext-Gdal plugin doesn't make a null check on the input parameters.

### DIFF
--- a/modules/plugin/imageio-ext-gdal/src/main/java/org/geotools/coverageio/RasterLayerRequest.java
+++ b/modules/plugin/imageio-ext-gdal/src/main/java/org/geotools/coverageio/RasterLayerRequest.java
@@ -248,6 +248,10 @@ class RasterLayerRequest {
         //
         // //
         if (name.equals(AbstractGridFormat.USE_JAI_IMAGEREAD.getName())) {
+            Object value = param.getValue();
+            if (value == null) {
+                return;
+            }
             readType = param.booleanValue() ? ReadType.JAI_IMAGEREAD
                     : ReadType.DIRECT_READ;
             return;
@@ -259,6 +263,10 @@ class RasterLayerRequest {
         //
         // //
         if (name.equals(BaseGDALGridFormat.USE_MULTITHREADING.getName())) {
+            Object value = param.getValue();
+            if (value == null) {
+                return;
+            }
             useMultithreading = param.booleanValue();
             return;
         }
@@ -269,6 +277,10 @@ class RasterLayerRequest {
         //
         // //
         if (name.equals(AbstractGridFormat.OVERVIEW_POLICY.getName())) {
+            Object value = param.getValue();
+            if (value == null) {
+                return;
+            }
             overviewPolicy = (OverviewPolicy) param.getValue();
             return;
         }


### PR DESCRIPTION
Pleas look at the following JIRA: https://jira.codehaus.org/browse/GEOT-4743.

This pull requests add a null check on the input parameters in order to avoid a reading failure. 
