### PR TITLE
Encode elements with xs:nil='true' when they are nullable, but minOccurs=1

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ElementEncoder.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ElementEncoder.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.xml.impl;
 
+import java.util.logging.Logger;
+
 import org.eclipse.xsd.XSDAttributeDeclaration;
 import org.eclipse.xsd.XSDElementDeclaration;
 import org.eclipse.xsd.XSDTypeDefinition;
@@ -23,7 +25,7 @@ import org.picocontainer.MutablePicoContainer;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import java.util.logging.Logger;
+import org.xml.sax.helpers.NamespaceSupport;
 
 
 /**
@@ -81,7 +83,9 @@ public class ElementEncoder {
      * @return The encoded value as an element.
      */
     public Element encode(Object value, XSDElementDeclaration element,Document document, XSDTypeDefinition container) {
-        ElementEncodeExecutor executor = new ElementEncodeExecutor(value, element, document, logger);
+        ElementEncodeExecutor executor = new ElementEncodeExecutor(value, element, document,
+                logger,
+                (NamespaceSupport) context.getComponentInstanceOfType(NamespaceSupport.class));
         BindingVisitorDispatch.walk(value, bindingWalker, element, executor, container, context);
         return executor.getEncodedElement();
     }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/GetPropertyExecutor.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/GetPropertyExecutor.java
@@ -75,7 +75,7 @@ public class GetPropertyExecutor implements BindingWalker.Visitor {
 
             Object parent = this.parent;
 
-            if ((binding.getType() != null)
+            if (parent != null && (binding.getType() != null)
                     && !binding.getType().isAssignableFrom(parent.getClass())) {
                 LOGGER.fine(parent + " (" + parent.getClass().getName() + ") "
                     + " is not of type " + binding.getType().getName());

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/ComplexSupportXSAnyTypeBinding.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/ComplexSupportXSAnyTypeBinding.java
@@ -127,6 +127,10 @@ public class ComplexSupportXSAnyTypeBinding extends XSAnyTypeBinding {
     @SuppressWarnings("unchecked")
     @Override
     public List getProperties(Object object, XSDElementDeclaration element) throws Exception {
+        if(object == null) {
+            return null;
+        }
+        
         List<Object[/* 2 */]> properties = new ArrayList<Object[/* 2 */]>();
         XSDTypeDefinition typeDef = element.getTypeDefinition();
         boolean isAnyType = typeDef.getName() != null && typeDef.getTargetNamespace() != null

--- a/modules/extension/xsd/xsd-gml3/src/test/resources/org/geotools/gml3/bindings/test.xsd
+++ b/modules/extension/xsd/xsd-gml3/src/test/resources/org/geotools/gml3/bindings/test.xsd
@@ -12,8 +12,8 @@
 			<xsd:extension base="gml:AbstractFeatureType">
 				<xsd:sequence>
 					<xsd:element name="geom" type="gml:PointPropertyType"/>
-					<xsd:element name="count" type="xsd:int"/>
-					<xsd:element name="date" type="xsd:date"/>			
+					<xsd:element name="count" type="xsd:int" nillable="true"/>
+					<xsd:element name="date" type="xsd:date" nillable="true"/>			
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/modules/extension/xsd/xsd-gml3/src/test/resources/org/geotools/gml3/v3_2/test.xsd
+++ b/modules/extension/xsd/xsd-gml3/src/test/resources/org/geotools/gml3/v3_2/test.xsd
@@ -12,8 +12,8 @@
 			<xsd:extension base="gml:AbstractFeatureType">
 				<xsd:sequence>
 					<xsd:element name="geom" type="gml:PointPropertyType"/>
-					<xsd:element name="count" type="xsd:int"/>
-					<xsd:element name="date" type="xsd:date"/>			
+					<xsd:element name="count" type="xsd:int" nillable="true"/>
+					<xsd:element name="date" type="xsd:date" nillable="true"/>			
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>


### PR DESCRIPTION
This tentative patch tries make sure we encode valid XML for cases in which the schema says a certain element has minOccurs=1, it's nillable, and the attribute in question is null in the data we're encoding.
Basically, we cannot omit the element, but we need to encode an empty one with xs:nil="true" as the attribute.

One thing I'm not sure how to handle is adding the http://www.w3.org/2001/XMLSchema namespace if the  caller did not add it, right now it's hard coded, but it's not right, e.g., geoserver code forces the presence of it using the xsi prefix instead, and we end up with two prefix declarations.
