### PR TITLE
Fixed graphic transform with multi line label

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelPainter.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelPainter.java
@@ -465,7 +465,12 @@ public class LabelPainter {
                         .getWidth() / 2.0 + offsetX, -1.0 * labelBounds.getHeight() / 2.0 + offsetY)), null, null,
                         false, false);
 
+                // resize graphic and transform it based on the position of the last line
                 graphic = resizeGraphic(graphic);
+                AffineTransform graphicTx = new AffineTransform(transform);
+                LineInfo lastLine = lines.get(lines.size() - 1);
+                graphicTx.translate(lastLine.x, lastLine.y);
+                graphics.setTransform(graphicTx);
                 shapePainter.paint(graphics, tempShape, graphic, graphic.getMaxScale());
             }
             


### PR DESCRIPTION
Labels with multiple lines and a graphic are not rendered correctly because the transform is incorrect on the graphic.

See http://osgeo-org.1560.x6.nabble.com/TextSymbolizer-with-multi-line-Label-and-Graphic-td5128438.html
