### PR TITLE
Allow the user to call MBTilesFiles.init() twice

### DIFF
--- a/modules/unsupported/mbtiles/src/main/resources/org/geotools/mbtiles/mbtiles.sql
+++ b/modules/unsupported/mbtiles/src/main/resources/org/geotools/mbtiles/mbtiles.sql
@@ -1,5 +1,5 @@
-CREATE TABLE metadata (name text, value text, CONSTRAINT pk_metadata PRIMARY KEY(name));
-CREATE TABLE tiles (zoom_level integer, tile_column integer, tile_row integer, tile_data blob, CONSTRAINT pk_tiles PRIMARY KEY(zoom_level, tile_column,tile_row));
-CREATE TABLE grids (zoom_level integer, tile_column integer, tile_row integer, grid blob, CONSTRAINT pk_grids PRIMARY KEY(zoom_level, tile_column,tile_row));
-CREATE TABLE grid_data (zoom_level integer, tile_column integer, tile_row integer, key_name text, key_json text, CONSTRAINT pk_griddata PRIMARY KEY(zoom_level, tile_column,tile_row,key_name));
+CREATE TABLE IF NOT EXISTS metadata (name text, value text, CONSTRAINT pk_metadata PRIMARY KEY(name));
+CREATE TABLE IF NOT EXISTS tiles (zoom_level integer, tile_column integer, tile_row integer, tile_data blob, CONSTRAINT pk_tiles PRIMARY KEY(zoom_level, tile_column,tile_row));
+CREATE TABLE IF NOT EXISTS grids (zoom_level integer, tile_column integer, tile_row integer, grid blob, CONSTRAINT pk_grids PRIMARY KEY(zoom_level, tile_column,tile_row));
+CREATE TABLE IF NOT EXISTS grid_data (zoom_level integer, tile_column integer, tile_row integer, key_name text, key_json text, CONSTRAINT pk_griddata PRIMARY KEY(zoom_level, tile_column,tile_row,key_name));
 

--- a/modules/unsupported/mbtiles/src/test/java/org/geotools/mbtiles/MBTilesFileTest.java
+++ b/modules/unsupported/mbtiles/src/test/java/org/geotools/mbtiles/MBTilesFileTest.java
@@ -38,7 +38,14 @@ public class MBTilesFileTest {
         
         file.close();        
     }
-    
+
+    @Test
+    public void testMBTilesInitTwice() throws IOException {
+        MBTilesFile file = new MBTilesFile();
+        file.init();
+        file.init();
+    }
+
     @Test
     public void testMBTilesTile() throws IOException, SQLException {
         


### PR DESCRIPTION
Add IF NOT EXISTS to CREATE TABLE statements, otherwise calling init() on an existing mbtiles file will fail.
