### PR TITLE
Support resultType=hits for GET

### DIFF
--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_Protocol.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_Protocol.java
@@ -67,6 +67,7 @@ import net.opengis.wfs.GetFeatureType;
 import net.opengis.wfs.GetGmlObjectType;
 import net.opengis.wfs.LockFeatureType;
 import net.opengis.wfs.OutputFormatListType;
+import net.opengis.wfs.ResultTypeType;
 import net.opengis.wfs.TransactionType;
 import net.opengis.wfs.WFSCapabilitiesType;
 
@@ -78,6 +79,7 @@ import org.geotools.data.ows.HTTPClient;
 import org.geotools.data.ows.HTTPResponse;
 import org.geotools.data.wfs.protocol.http.HttpMethod;
 import org.geotools.data.wfs.protocol.wfs.GetFeature;
+import org.geotools.data.wfs.protocol.wfs.GetFeature.ResultType;
 import org.geotools.data.wfs.protocol.wfs.Version;
 import org.geotools.data.wfs.protocol.wfs.WFSOperationType;
 import org.geotools.data.wfs.protocol.wfs.WFSProtocol;
@@ -477,7 +479,10 @@ public class WFS_1_1_0_Protocol implements WFSProtocol {
             }
         }
         
-
+        if (request.getResultType() == ResultType.HITS) {
+        	getFeatureKvp.put("RESULTTYPE", ResultTypeType.HITS_LITERAL.getLiteral());
+        }
+        
         WFSResponse response = issueGetRequest(requestType, url, getFeatureKvp);
 
         return response;

--- a/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_ProtocolTest.java
+++ b/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/v1_1_0/WFS_1_1_0_ProtocolTest.java
@@ -702,7 +702,7 @@ public class WFS_1_1_0_ProtocolTest {
      * int featureHits = wfs.getFeatureHits(query); assertEquals(-1, featureHits); }
      */
 
-/**
+    /**
      * Test method for {@link WFS_1_1_0_Protocol#issueGetFeatureGET(net.opengis.wfs.GetFeatureType, Map)
      * 
      * @throws IOException
@@ -741,6 +741,54 @@ public class WFS_1_1_0_ProtocolTest {
         assertEquals("GetFeature", kvp.get("REQUEST"));
         assertEquals(GEOS_ARCHSITES.FEATURETYPENAME, kvp.get("TYPENAME"));
         assertEquals(defaultWfs11OutputFormat, kvp.get("OUTPUTFORMAT"));
+        assertNotNull(kvp.get("SRSNAME"));
+        assertNull(kvp.get("PROPERTYNAME"));
+        assertNull(kvp.get("MAXFEATURES"));
+        assertNull(kvp.get("FEATUREID"));
+        assertNull(kvp.get("FILTER"));
+    }
+
+    /**
+     * Test method for {@link WFS_1_1_0_Protocol#issueGetFeatureGET(net.opengis.wfs.GetFeatureType, Map)
+     * for resultType=hits.
+     * 
+     * @throws IOException
+     */
+    @Test
+    public void testIssueGetFeature_GET_HITS() throws IOException {
+        final InputStream responseContent = TestData.openStream(this, GEOS_ARCHSITES.DATA);
+
+        final TestHttpResponse httpResponse;
+        final String defaultWfs11OutputFormat = "text/xml; subtype=gml/3.1.1";
+        httpResponse = new TestHttpResponse(defaultWfs11OutputFormat, "UTF-16", responseContent);
+
+        TestHttpProtocol mockHttp = new TestHttpProtocol(httpResponse);
+
+        createTestProtocol(GEOS_ARCHSITES.CAPABILITIES, mockHttp, new GeoServerStrategy());
+
+        Query query = new Query(GEOS_ARCHSITES.FEATURETYPENAME);
+        GetFeature getFeature = new GetFeatureQueryAdapter(query, defaultWfs11OutputFormat,
+                "EPSG:4326", ResultType.HITS);
+
+        WFSResponse response;
+
+        response = wfs.issueGetFeatureGET(getFeature);
+
+        assertNotNull(response);
+        assertEquals(defaultWfs11OutputFormat, response.getContentType());
+        assertNotNull(response.getInputStream());
+        assertEquals(Charset.forName("UTF-16"), response.getCharacterEncoding());
+
+        URL baseUrl = mockHttp.targetUrl;
+        assertNotNull(baseUrl);
+        Map<String, String> kvp = requestKvp(baseUrl);
+        assertTrue(baseUrl.toExternalForm().startsWith("http://localhost:8080/geoserver/wfs?"));
+        assertEquals("WFS", kvp.get("SERVICE"));
+        assertEquals("1.1.0", kvp.get("VERSION"));
+        assertEquals("GetFeature", kvp.get("REQUEST"));
+        assertEquals(GEOS_ARCHSITES.FEATURETYPENAME, kvp.get("TYPENAME"));
+        assertEquals(defaultWfs11OutputFormat, kvp.get("OUTPUTFORMAT"));
+        assertEquals("hits", kvp.get("RESULTTYPE"));
         assertNotNull(kvp.get("SRSNAME"));
         assertNull(kvp.get("PROPERTYNAME"));
         assertNull(kvp.get("MAXFEATURES"));


### PR DESCRIPTION
Getting the feature count with "resultType=hits" from a WFS is currently only supported for POST requests. This PR adds support for "resultType=hits" for GET requests.
