### PR TITLE
Support wfs request urls with "&amp;" at the end

### DIFF
--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/protocol/http/HttpUtil.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/protocol/http/HttpUtil.java
@@ -49,10 +49,16 @@ public class HttpUtil {
     }
 
     public static String createUri(final URL baseUrl, final Map<String, String> queryStringKvp) {
-        final String query = baseUrl.getQuery();
+        String query = baseUrl.getQuery();
         Map<String, String> finalKvpMap = new HashMap<String, String>(queryStringKvp);
         if (query != null && query.length() > 0) {
             Map<String, String> userParams = new CaseInsensitiveMap(queryStringKvp);
+            
+            // there might be a "&amp;" at the end, make sure to remove it
+            if (query.endsWith("&amp;")) {
+            	query = query.substring(0, query.length() - 5);
+            }
+            
             String[] rawUrlKvpSet = query.split("&");
             for (String rawUrlKvp : rawUrlKvpSet) {
                 int eqIdx = rawUrlKvp.indexOf('=');

--- a/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/protocol/http/HttpUtilTest.java
+++ b/modules/unsupported/wfs/src/test/java/org/geotools/data/wfs/protocol/http/HttpUtilTest.java
@@ -1,0 +1,40 @@
+package org.geotools.data.wfs.protocol.http;
+
+import static org.junit.Assert.*;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class HttpUtilTest {
+
+	@Test
+	public void testCreateUri() throws MalformedURLException {
+		Map<String, String> queryStringKvp = new HashMap<String, String>();
+		queryStringKvp.put("service", "WFS");
+		queryStringKvp.put("version", "1.1.0");
+		queryStringKvp.put("request", "GetFeature");
+		queryStringKvp.put("typeName", "topp:states");
+		
+		URL url1 = new URL("http://localhost:8080/geoserver/topp/ows");
+		assertEquals(
+				"http://localhost:8080/geoserver/topp/ows?typeName=topp%3Astates&request=GetFeature&service=WFS&version=1.1.0",
+				HttpUtil.createUri(url1, queryStringKvp));
+		
+		// when the request url is read from the capabilities, there might be a "&amp;"
+		// at the end of the url
+		URL url2 = new URL("http://localhost:8080/map/mapserv?map=/opt/data/carto/world.www.map&amp;");
+		assertEquals(
+				"http://localhost:8080/map/mapserv?typeName=topp%3Astates&request=GetFeature&map=%2Fopt%2Fdata%2Fcarto%2Fworld.www.map&service=WFS&version=1.1.0",
+				HttpUtil.createUri(url2, queryStringKvp));
+		
+		URL url3 = new URL("http://localhost:8080/map/mapserv?map=/opt/data/carto/world.www.map&test=1");
+		assertEquals(
+				"http://localhost:8080/map/mapserv?typeName=topp%3Astates&test=1&request=GetFeature&map=%2Fopt%2Fdata%2Fcarto%2Fworld.www.map&service=WFS&version=1.1.0",
+				HttpUtil.createUri(url3, queryStringKvp));
+	}
+
+}


### PR DESCRIPTION
For WFS servers with urls like "http://localhost:8080/map/mapserv?map=/opt/data/carto/world.www.map&", the capabilities document might look like this:

```
...
<ows:Operation name="GetFeature">
  <ows:DCP>
    <ows:HTTP>
      <ows:Get xlink:type="simple" xlink:href="http://localhost:8080/map/mapserv?map=/opt/data/carto/world.www.map&amp;"/>     
      <ows:Post xlink:type="simple" xlink:href="http://localhost:8080/map/mapserv?map=/opt/data/carto/world.www.map&amp;"/>
    </ows:HTTP>
  </ows:DCP>
  ...
```

The "&" at the end of the url is a "&amp;amp;" in the capabilities, which is currently not handled properly.
