### PR TITLE
GEOT-4784: NetCDF reader not disposed on finalize

### DIFF
--- a/modules/unsupported/coverage-experiment/coverage-api/src/main/java/org/geotools/imageio/GeoSpatialImageReader.java
+++ b/modules/unsupported/coverage-experiment/coverage-api/src/main/java/org/geotools/imageio/GeoSpatialImageReader.java
@@ -174,4 +174,10 @@ public abstract class GeoSpatialImageReader extends ImageReader implements FileS
     protected void initCatalog(File parentLocation, String databaseName) throws IOException {
         slicesCatalog = new CoverageSlicesCatalog(databaseName, parentLocation);
     }
+
+    @Override
+    protected void finalize() throws Throwable {
+        dispose();
+        super.finalize();
+    }
 }


### PR DESCRIPTION
Backporting to 11.x: GEOT-4784: NetCDF reader not disposed on finalize
