### PR TITLE
GEOT-4789: Fixed empty lines support in labels rendering

### DIFF
--- a/modules/library/render/pom.xml
+++ b/modules/library/render/pom.xml
@@ -168,6 +168,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+    </dependency>
   </dependencies>
   
    <build>

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelPainter.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelPainter.java
@@ -74,6 +74,8 @@ import com.vividsolutions.jts.geom.GeometryFactory;
  */
 public class LabelPainter {
     
+    private static final String NOT_EMPTY_STRING = " ";
+
     /**
      * Epsilon used for comparisons with 0
      */
@@ -163,6 +165,7 @@ public class LabelPainter {
         if(labelItem.getAutoWrap() <= 0) {
             // no need for auto-wrapping, we already have the proper split
             for (String line : splitted) {
+                line = checkForEmptyLine(line);
                 FontRenderContext frc = graphics.getFontRenderContext();
                 TextLayout layout = new TextLayout(line, labelItem.getTextStyle().getFont(), frc);
                 LineInfo info = new LineInfo(line, layoutSentence(line, labelItem), layout);
@@ -179,7 +182,7 @@ public class LabelPainter {
 
             // accumulate the lines
             for (int i = 0; i < splitted.length; i++) {
-                String line = splitted[i];
+                String line = checkForEmptyLine(splitted[i]);
 
                 // build the line break iterator that will split lines at word
                 // boundaries when the wrapping length is exceeded
@@ -217,11 +220,9 @@ public class LabelPainter {
                     // centering)
 
                     String extracted = line.substring(prevPosition, newPosition).trim();
-                    if(!"".equals(extracted)) {
-	                    LineInfo info = new LineInfo(extracted, layoutSentence(extracted, labelItem),
-	                            layout);
-	                    lines.add(info);
-                    }
+                    LineInfo info = new LineInfo(extracted, layoutSentence(
+                            extracted, labelItem), layout);
+                    lines.add(info);
                     prevPosition = newPosition;
                 }
             }
@@ -265,6 +266,20 @@ public class LabelPainter {
             info.y = labelY;
         }
         normalizeBounds(labelBounds);
+    }
+
+    /**
+     * Fix for GEOT-4789: a label line cannot be empty,
+     * to avoid exceptions in layout and measuring.
+     * 
+     * @param line
+     * @return
+     */
+    private String checkForEmptyLine(String line) {
+        if(line == null || line.equals("")) {
+            return NOT_EMPTY_STRING;
+        }
+        return line;
     }
 
     /**

--- a/modules/library/render/src/test/java/org/geotools/renderer/label/LabelPainterTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/label/LabelPainterTest.java
@@ -1,0 +1,87 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2014, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.label;
+
+import static org.junit.Assert.assertEquals;
+
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.font.FontRenderContext;
+import java.awt.geom.AffineTransform;
+
+import org.geotools.geometry.jts.LiteShape2;
+import org.geotools.referencing.operation.transform.ProjectiveTransform;
+import org.geotools.renderer.label.LabelCacheImpl.LabelRenderingMode;
+import org.geotools.renderer.style.TextStyle2D;
+import org.geotools.styling.StyleFactory;
+import org.geotools.styling.StyleFactoryImpl;
+import org.geotools.styling.TextSymbolizer;
+import org.geotools.styling.TextSymbolizerImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.operation.TransformException;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+public class LabelPainterTest {
+
+    private static GeometryFactory geometryFactory = new GeometryFactory();
+    private static StyleFactory styleFactory = new StyleFactoryImpl();
+    private Graphics2D graphics;
+    private TextStyle2D style;
+    private TextSymbolizer symbolizer;
+    LiteShape2 shape;
+    
+    @Before
+    public void setUp() throws TransformException, FactoryException {
+        graphics = Mockito.mock(Graphics2D.class);
+        Mockito.when(graphics.getFontRenderContext()).thenReturn(
+                new FontRenderContext(new AffineTransform(),
+                        RenderingHints.VALUE_TEXT_ANTIALIAS_DEFAULT,
+                        RenderingHints.VALUE_FRACTIONALMETRICS_DEFAULT));
+        style = new TextStyle2D();
+        style.setFont(new Font("Serif", Font.PLAIN, 10));
+        shape = new LiteShape2(
+                geometryFactory.createPoint(new Coordinate(10, 10)),
+                ProjectiveTransform.create(new AffineTransform()), null, false);
+        symbolizer = styleFactory.createTextSymbolizer();
+    }
+    
+    @Test
+    public void testEmptyLinesInLabel() {
+        LabelPainter painter = new LabelPainter(graphics, LabelRenderingMode.STRING);
+        LabelCacheItem labelItem = new LabelCacheItem("LAYERID", style, shape,
+                "line1\n\nline2", symbolizer);
+        labelItem.setAutoWrap(0);
+        painter.setLabel(labelItem);
+        assertEquals(3, painter.getLineCount());
+    }
+    
+    @Test
+    public void testEmptyLinesInLabelWithAutoWrap() {
+        LabelPainter painter = new LabelPainter(graphics, LabelRenderingMode.STRING);
+        LabelCacheItem labelItem = new LabelCacheItem("LAYERID", style, shape,
+                "line1\n\nline2", symbolizer);
+        labelItem.setAutoWrap(100);
+        painter.setLabel(labelItem);
+        assertEquals(3, painter.getLineCount());
+    }
+}


### PR DESCRIPTION
When empty lines are present in a multiline label, layout and measuring code throws exceptions
