### PR TITLE
[GEOT-4807] Upgrade ImageIO-Ext version from 1.1.9 to 1.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <javadoc.maxHeapSize>1024M</javadoc.maxHeapSize>
     <test.forkMode>once</test.forkMode>
     <src.output>${basedir}/target</src.output>
-    <imageio.ext.version>1.1.9</imageio.ext.version>
+    <imageio.ext.version>1.1.10</imageio.ext.version>
     <jt.version>1.3.1</jt.version>
     <jvm.opts></jvm.opts>
     <maven.build.timestamp.format>dd-MMM-yyyy HH:mm</maven.build.timestamp.format>


### PR DESCRIPTION
Please look at the following JIRA: http://jira.codehaus.org/browse/GEOT-4807.
