### PR TITLE
 GEOT-4830 add fallback mark to SLD Graphic render

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/style/ImageGraphicFactory.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/ImageGraphicFactory.java
@@ -60,7 +60,7 @@ public class ImageGraphicFactory implements ExternalGraphicFactory {
     static Set<String> supportedGraphicFormats = new HashSet<String>(Arrays.asList(ImageIO
             .getReaderMIMETypes()));
 
-    public Icon getIcon(Feature feature, Expression url, String format, int size) throws Exception {
+    public Icon getIcon(Feature feature, Expression url, String format, int size) {
         // check we do support the format
         if (!supportedGraphicFormats.contains(format.toLowerCase()))
             return null;
@@ -74,7 +74,12 @@ public class ImageGraphicFactory implements ExternalGraphicFactory {
         // get the image from the cache, or load it
         BufferedImage image = imageCache.get(location);
         if(image == null) {
-            image = ImageIO.read(location);
+            try {
+                image = ImageIO.read(location);
+            } catch (java.io.IOException ioe) {
+                LOGGER.warning("Unable to read image at " + location + " : " + ioe.getMessage());
+                return null;
+            }
             imageCache.put(location, image);
         }
         

--- a/modules/library/render/src/test/java/org/geotools/renderer/style/SLDStyleFactoryTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/style/SLDStyleFactoryTest.java
@@ -360,12 +360,12 @@ public class SLDStyleFactoryTest extends TestCase {
      }
     
     
-     public void testInfiniteLoopAvoidance() throws Exception {
+     public void testFallbackGraphicMark() throws Exception {
          PointSymbolizer symb = sf.createPointSymbolizer();
          ExternalGraphic eg = sf.createExternalGraphic("http://foo.com/invalid_or_missing_image_url", null);
          symb.getGraphic().graphicalSymbols().add(eg);
          
-         IconStyle2D icon = (IconStyle2D) sld.createPointStyle(feature, symb, range);
-         assertNull(icon);
+         Style2D icon = sld.createPointStyle(feature, symb, range);
+         assertNotNull(icon);
      }
 }


### PR DESCRIPTION
This fix applies to any 'failed' ExternalGraphics (unreachable at the
provided URI) and prevents nothing from being rendered as well as many
(one per feature) log messages and attempts to resolve the URI.

Additionally, the failed attempt is logged (once per render) as a
warning and contains the URI.
