### PR TITLE
Trace use of JDBCDataStore dispose

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
@@ -251,7 +251,9 @@ public abstract class JDBCDataStoreFactory extends AbstractDataStoreFactory {
         dataStore.setDataStoreFactory(this);
         
         //call subclass hook and return
-        return createDataStoreInternal(dataStore, params);
+        JDBCDataStore result = createDataStoreInternal(dataStore, params);
+        assert result.getDataSource()!=null;
+        return result;
     }
 
     /**


### PR DESCRIPTION
Some logging and assertions I added while identifying GEOS-6575 https://jira.codehaus.org/browse/GEOS-6575

Makes it easier to figure out what's responsible for a failure due to a disposed DataStore.
