### PR TITLE
Allow WKTReader2 to parse MULTIPOINT((x1 y1), (x2 y2))

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/WKTReader2.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/WKTReader2.java
@@ -569,7 +569,56 @@ public class WKTReader2 extends WKTReader {
      * @throws ParseException if an unexpected token was encountered
      */
     private MultiPoint readMultiPointText() throws IOException, ParseException {
-        return geometryFactory.createMultiPoint(toPoints(getCoordinates()));
+        return geometryFactory.createMultiPoint(toPoints(getCoordinatesForMultiPoint()));
+    }
+
+    /**
+     * Get a Coordinate array for a MultiPoint.  Specifically handle both WKT styles:
+     * MULTIPOINT (111 -47, 110 -46.5) and MULTIPOINT ((111 -47), (110 -46.5)).
+     * @return An Array of Coordinates
+     * @throws IOException if an I/O error occurs
+     * @throws ParseException if an unexpected token was encountered
+     */
+    private Coordinate[] getCoordinatesForMultiPoint() throws IOException, ParseException {
+        String nextToken = getNextEmptyOrOpener();
+        if (nextToken.equals(EMPTY)) {
+            return new Coordinate[] {};
+        }
+
+        // Check for inner parens
+        boolean innerParens = false;
+        try {
+            String peek = getNextWord();
+            innerParens = peek.equals(L_PAREN);
+        } catch(ParseException ex) {
+            // Do nothing
+        } finally {
+            tokenizer.pushBack();
+        }
+
+        if (innerParens) {
+            ArrayList coordinates = new ArrayList();
+            Coordinate[] coords = getCoordinates();
+            coordinates.add(coords[0]);
+            nextToken = getNextCloserOrComma();
+            while (nextToken.equals(COMMA)) {
+                coords = getCoordinates();
+                coordinates.add(coords[0]);
+                nextToken = getNextCloserOrComma();
+            }
+            Coordinate[] array = new Coordinate[coordinates.size()];
+            return (Coordinate[]) coordinates.toArray(array);
+        } else {
+            ArrayList coordinates = new ArrayList();
+            coordinates.add(getPreciseCoordinate());
+            nextToken = getNextCloserOrComma();
+            while (nextToken.equals(COMMA)) {
+                coordinates.add(getPreciseCoordinate());
+                nextToken = getNextCloserOrComma();
+            }
+            Coordinate[] array = new Coordinate[coordinates.size()];
+            return (Coordinate[]) coordinates.toArray(array);
+        }
     }
 
     /**

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/WKTReader2Test.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/WKTReader2Test.java
@@ -18,12 +18,9 @@ package org.geotools.geometry.jts;
 
 import static org.junit.Assert.*;
 
+import com.vividsolutions.jts.geom.*;
 import org.junit.Test;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.io.WKTReader;
 /**
  * 
@@ -40,6 +37,34 @@ public class WKTReader2Test {
         Geometry geometry = reader.read(WKT);
         assertNotNull(geometry);
         assertTrue(geometry instanceof LineString);
+    }
+
+    @Test
+    public void multiPoint() throws Exception {
+        String WKT = "MULTIPOINT (111 -47, 110 -46.5)";
+        WKTReader reader = new WKTReader2();
+
+        Geometry geometry = reader.read(WKT);
+        assertNotNull(geometry);
+        assertTrue(geometry instanceof MultiPoint);
+        MultiPoint mp = (MultiPoint) geometry;
+        assertEquals(2, mp.getNumGeometries());
+        assertEquals(new Coordinate(111, -47), mp.getGeometryN(0).getCoordinate());
+        assertEquals(new Coordinate(110, -46.5), mp.getGeometryN(1).getCoordinate());
+    }
+
+    @Test
+    public void multiPointWithInnerParens() throws Exception {
+        String WKT = "MULTIPOINT ((111 -47), (110 -46.5))";
+        WKTReader reader = new WKTReader2();
+
+        Geometry geometry = reader.read(WKT);
+        assertNotNull(geometry);
+        assertTrue(geometry instanceof MultiPoint);
+        MultiPoint mp = (MultiPoint) geometry;
+        assertEquals(2, mp.getNumGeometries());
+        assertEquals(new Coordinate(111, -47), mp.getGeometryN(0).getCoordinate());
+        assertEquals(new Coordinate(110, -46.5), mp.getGeometryN(1).getCoordinate());
     }
 
     /**


### PR DESCRIPTION
Addresses issue #GEOT-4847

https://jira.codehaus.org/browse/GEOT-4847

Thanks!
Jared
