### PR TITLE
[GEOT-4854] NetCDF reader fails if requesting a bounding box larger than the native one (backport on 11.x)

### DIFF
--- a/modules/unsupported/coverage-experiment/grib/src/test/java/org/geotools/coverage/io/grib/GribTest.java
+++ b/modules/unsupported/coverage-experiment/grib/src/test/java/org/geotools/coverage/io/grib/GribTest.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.coverage.io.grib;
 
+import static org.junit.Assert.*;
+
 import java.awt.geom.Point2D;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -27,15 +29,21 @@ import java.util.List;
 import javax.imageio.spi.ImageReaderSpi;
 
 import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.coverage.grid.io.GridFormatFinder;
 import org.geotools.coverage.io.netcdf.NetCDFDriver;
 import org.geotools.coverage.io.netcdf.NetCDFReader;
 import org.geotools.data.DataSourceException;
+import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.imageio.netcdf.NetCDFImageReaderSpi;
 import org.geotools.test.TestData;
-import org.junit.Test;
 import org.junit.Assert;
+import org.junit.Test;
+import org.opengis.coverage.grid.GridEnvelope;
+import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.parameter.ParameterValue;
 
 /**
  * Unit test for testing Grib data.
@@ -151,6 +159,64 @@ public class GribTest {
             float[] result_2 = new float[1];
             grid.evaluate(nodataPoint, result_2);
             Assert.assertTrue(Float.isNaN(result_2[0]));
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.dispose();
+                } catch (Throwable t) {
+                    // Does nothing
+                }
+            }
+        }
+    }
+
+    /**
+     * Test on a Grib image asking for a larger bounding box.
+     * 
+     * @throws DataSourceException
+     * @throws MalformedURLException
+     * @throws IOException
+     */
+    @Test
+    public void testGribImageWithLargeBBOX() throws MalformedURLException, IOException {
+        // Selection of the input file
+        final File inputFile = TestData.file(this, "sampleGrib.grb2");
+        // Get format
+        final AbstractGridFormat format = (AbstractGridFormat) GridFormatFinder.findFormat(
+                inputFile.toURI().toURL(), null);
+        final NetCDFReader reader = new NetCDFReader(inputFile, null);
+        Assert.assertNotNull(format);
+        Assert.assertNotNull(reader);
+        try {
+            // Selection of all the Coverage names
+            String[] names = reader.getGridCoverageNames();
+            Assert.assertNotNull(names);
+
+            // Name of the first coverage
+            String coverageName = names[0];
+
+            // Parsing metadata values
+            assertEquals("true", reader.getMetadataValue(coverageName, "HAS_TIME_DOMAIN"));
+
+            // Expanding the envelope
+            final ParameterValue<GridGeometry2D> gg = AbstractGridFormat.READ_GRIDGEOMETRY2D
+                    .createValue();
+            final GeneralEnvelope originalEnvelope = reader.getOriginalEnvelope(coverageName);
+            final GeneralEnvelope newEnvelope = new GeneralEnvelope(originalEnvelope);
+            newEnvelope.setCoordinateReferenceSystem(reader
+                    .getCoordinateReferenceSystem(coverageName));
+            newEnvelope.add(new DirectPosition2D(newEnvelope.getMinimum(0) - 10, newEnvelope
+                    .getMinimum(1) - 10));
+
+            // Selecting the same gridRange
+            GridEnvelope gridRange = reader.getOriginalGridRange(coverageName);
+            gg.setValue(new GridGeometry2D(gridRange, newEnvelope));
+
+            GeneralParameterValue[] values = new GeneralParameterValue[] { gg };
+            // Read with the larger BBOX
+            GridCoverage2D grid = reader.read(coverageName, values);
+            // Check if the result is not null
+            assertNotNull(grid);
         } finally {
             if (reader != null) {
                 try {

--- a/modules/unsupported/coverage-experiment/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFResponse.java
+++ b/modules/unsupported/coverage-experiment/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFResponse.java
@@ -600,8 +600,13 @@ class NetCDFResponse extends CoverageResponse{
             // take into account the fact that we might also decimate therefore
             // we cannot just use the crop grid to world but we need to correct
             // it.
-            final Rectangle sourceArea = CRS.transform(cropWorldToGrid, intersection)
-                    .toRectangle2D().getBounds();
+            Rectangle sourceArea = CRS.transform(cropWorldToGrid, intersection).toRectangle2D()
+                    .getBounds();
+            // Selection of the source original area for cropping the computed source area
+            // (may have negative values for the approximation)
+            final Rectangle initialArea = request.source.getSpatialDomain()
+                    .getRasterElements(true, null).iterator().next().toRectangle();
+            sourceArea = sourceArea.intersection(initialArea);
 
             if (sourceArea.isEmpty()) {
                 if (LOGGER.isLoggable(java.util.logging.Level.FINE)) {


### PR DESCRIPTION
Backport on 11.x of the JIRA: http://jira.codehaus.org/browse/GEOT-4854
