### PR TITLE
Fixed case mismatch failure on Oracle caused by GEOT-4851 changes

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCJoinTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCJoinTest.java
@@ -99,10 +99,10 @@ public abstract class JDBCJoinTest extends JDBCTestSupport {
 
         FilterFactory ff = dataStore.getFilterFactory();
         Query q = new Query(tname("ft1"));
-        q.setAlias("b");
+        q.setAlias(tname("b"));
         Join join = new Join(tname("ftjoin"), ff.equal(ff.property(aname("stringProperty")),
                 ff.property(aname("name")), true));
-        join.setAlias("a");
+        join.setAlias(tname("a"));
         q.getJoins().add(join);
 
         SimpleFeatureCollection features = dataStore.getFeatureSource(tname("ft1")).getFeatures(q);


### PR DESCRIPTION
I am not sure if the tnames are in the correct place, or whether this should be handled in Query and Join setAlias, or whatever uses those properties, so treat with caution. This appears to fix Oracle online tests.

See: http://jira.codehaus.org/browse/GEOT-4851
