### PR TITLE
GEOT-4870 Some ID Filters are not escaped by ECQL.toCQL

### DIFF
--- a/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/FilterToECQL.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/FilterToECQL.java
@@ -114,7 +114,7 @@ final class FilterToECQL implements FilterVisitor {
 			Identifier identifier = iter.next();
 			String id = identifier.toString();
 			
-			boolean needsQuotes = id.lastIndexOf('.') != -1; 
+			boolean needsQuotes = !id.matches("[0-9]+");
 			
 			if( needsQuotes ) {
 			    ecql.append('\'');

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/ecql/FilterToECQLTest.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/ecql/FilterToECQLTest.java
@@ -39,7 +39,17 @@ public class FilterToECQLTest extends FilterToCQLTest {
 	public void id()throws Exception{
 		cqlTest("IN (1,2,3,4)");
 	}
-	
+
+    @Test
+    public void idString()throws Exception{
+        cqlTest("IN ('foo','bar')");
+    }
+
+    @Test
+    public void idUUID()throws Exception{
+        cqlTest("IN ('cb606c93-8642-4cff-84e8-1817e8307097')");
+    }
+
 	public void intersectWhithGeomExpressions() throws Exception {
     	cqlTest("INTERSECTS(POLYGON((1 2, 2 2, 2 3, 1 2)), POINT(1 2))");
 		
@@ -58,7 +68,7 @@ public class FilterToECQLTest extends FilterToCQLTest {
 
         String output = filter.accept( toECQL, null ).toString();
         Assert.assertNotNull( output );
-        Assert.assertEquals( cql, cql,output );        
+        Assert.assertEquals( cql, cql, output );
     }
 	
 	


### PR DESCRIPTION
- Changed the check in FilterToECQL to leave only strings of numbers unquoted.
- Added two quick example ID filters: one with a UUID, and the second with a pair of id names.
