### PR TITLE
[GEOT-4879] Avoid reading the whole world when the requested area spans the dateline in pacific mercator

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/crs/MercatorHandlerFactory.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/crs/MercatorHandlerFactory.java
@@ -41,13 +41,17 @@ public class MercatorHandlerFactory implements ProjectionHandlerFactory {
         MapProjection mapProjection = CRS.getMapProjection(renderingEnvelope
                 .getCoordinateReferenceSystem());
         if (renderingEnvelope != null && mapProjection instanceof Mercator) {
+            ProjectionHandler handler;
+            double centralMeridian = mapProjection.getParameterValues()
+                    .parameter(AbstractProvider.CENTRAL_MERIDIAN.getName().getCode()).doubleValue();
             if(wrap && maxWraps > 0) {
-                double centralMeridian = mapProjection.getParameterValues().parameter(
-                        AbstractProvider.CENTRAL_MERIDIAN.getName().getCode()).doubleValue();
-                return new WrappingProjectionHandler(renderingEnvelope, VALID_AREA, sourceCrs, centralMeridian, maxWraps);
+                handler = new WrappingProjectionHandler(renderingEnvelope, VALID_AREA, sourceCrs,
+                        centralMeridian, maxWraps);
             } else {
-                return new ProjectionHandler(sourceCrs, VALID_AREA, renderingEnvelope);
+                handler = new ProjectionHandler(sourceCrs, VALID_AREA, renderingEnvelope);
+                handler.setCentralMeridian(centralMeridian);
             }
+            return handler;
         }
 
         return null;

--- a/modules/library/render/src/main/java/org/geotools/renderer/crs/WrappingProjectionHandler.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/crs/WrappingProjectionHandler.java
@@ -16,8 +16,6 @@
  */
 package org.geotools.renderer.crs;
 
-import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,7 +43,6 @@ import com.vividsolutions.jts.geom.Polygon;
  */
 public class WrappingProjectionHandler extends ProjectionHandler {
 
-    protected double radius;
     private int maxWraps;
 
     private boolean datelineWrappingCheckEnabled = true;
@@ -59,28 +56,8 @@ public class WrappingProjectionHandler extends ProjectionHandler {
             ReferencedEnvelope validArea, CoordinateReferenceSystem sourceCrs, double centralMeridian, int maxWraps) throws FactoryException {
         super(sourceCrs, validArea, renderingEnvelope);
         this.maxWraps = maxWraps;
-
-        try {
-            CoordinateReferenceSystem targetCRS = renderingEnvelope.getCoordinateReferenceSystem();
-            MathTransform mt = CRS.findMathTransform(WGS84, targetCRS, true);
-            double[] src = new double[] { centralMeridian, 0, 180 + centralMeridian, 0 };
-            double[] dst = new double[4];
-            mt.transform(src, 0, dst, 0, 2);
-
-            if(CRS.getAxisOrder(targetCRS) == CRS.AxisOrder.NORTH_EAST) {
-                radius = Math.abs(dst[3] - dst[1]);
-            }
-            else {
-                radius = Math.abs(dst[2] - dst[0]);
-            }
-            
-            if(radius <= 0) {
-                throw new RuntimeException("Computed Earth radius is 0, what is going on?");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Unexpected error computing the Earth radius "
-                    + "in the current projection", e);
-        }
+        // this will compute the radius
+        setCentralMeridian(centralMeridian);
     }
 
     @Override


### PR DESCRIPTION
Going to wait for the feature freeze end to commit this one, as the changes are not trivial
