### PR TITLE
Don't throw exceptions when encoding empty geometries to GeoJSON

### DIFF
--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/geom/GeometryJSON.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/geom/GeometryJSON.java
@@ -115,7 +115,11 @@ public class GeometryJSON {
      * @param output The output. See {@link GeoJSONUtil#toWriter(Object)} for details.
      */
     public void write(Geometry geometry, Object output) throws IOException {
-        GeoJSONUtil.encode(create(geometry), output);
+        if (geometry == null || geometry.getCoordinates().length == 0) {
+            GeoJSONUtil.encode("null", output); 
+        } else {
+            GeoJSONUtil.encode(create(geometry), output);
+        }
     }
 
     /**

--- a/modules/unsupported/geojson/src/test/java/org/geotools/geojson/GeometryJSONTest.java
+++ b/modules/unsupported/geojson/src/test/java/org/geotools/geojson/GeometryJSONTest.java
@@ -71,6 +71,7 @@ public class GeometryJSONTest extends GeoJSONTestSupport {
      
     public void testLineWrite() throws Exception {
         assertEquals(lineText(), gjson.toString(line()));
+        assertEquals(line2Text(), gjson.toString(line2()));
         assertEquals(line3dText(), gjson.toString(line3d()));
     }
     
@@ -79,8 +80,17 @@ public class GeometryJSONTest extends GeoJSONTestSupport {
             "{'type': 'LineString', 'coordinates': [[100.1,0.1],[101.1,1.1]]}");
     }
 
+    String line2Text() {
+        return strip("null");
+    }
+
     LineString line() {
         LineString l = gf.createLineString(array(new double[][]{{100.1, 0.1},{101.1,1.1}}));
+        return l;
+    }
+
+    LineString line2() {
+        LineString l = gf.createLineString(array(new double[][]{}));
         return l;
     }
     
@@ -96,6 +106,7 @@ public class GeometryJSONTest extends GeoJSONTestSupport {
     
     public void testLineRead() throws Exception {
         assertTrue(line().equals(gjson.readLine(reader(lineText()))));
+        assertNull(gjson.readLine(reader(line2Text())));
         assertTrue(line3d().equals(gjson.readLine(reader(line3dText()))));
     }
        


### PR DESCRIPTION
This PR fixes a bug that was causing the GeoJSON encoder to throw exceptions when asked to encode empty geometries.  GeoJSON specifies that geometries with no coordinates are invalid so I treated such geometries as equivalent to null.  It is no longer the case that encoding followed by decoding will give back an equal value but I believe it is worth it to avoid the unhandled exception.
