### PR TITLE
Update Maven site links for User doc and Download paths

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -7,7 +7,7 @@
     <menu name="Geotools" inherited="top">
       <item name ="User documentation" href="http://docs.geotools.org/latest/userguide"/>
       <item name="Download"     href="http://sourceforge.net/projects/geotools/files"/>
-      <item name="Full Javadoc" href="http://www.geotools.org/apidocs/"/>
+      <item name="Full Javadoc" href="http://docs.geotools.org/latest/javadocs"/>
       <item name="Legal review" href="review.html"/>
     </menu>
 


### PR DESCRIPTION
The codehaus links still exist, but appear to be very old because they reference geotools 2.x
