### PR TITLE
Link to GeoTools project on JIRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ for more details.
 
 ## Bugs
 
-GeoTools uses [JIRA](http://www.codehaus.org/), hosted by 
+GeoTools uses [JIRA](https://jira.codehaus.org/browse/GEOT), hosted by 
 [CodeHaus](http://www.codehaus.org/), for issue tracking.
 
 ## Mailing Lists


### PR DESCRIPTION
Since GitHub issues aren't used, link users directly to the JIRA page for the project.
