### PR TITLE
Avoid NPE in MergeSortDumper

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/sort/MergeSortDumper.java
+++ b/modules/library/main/src/main/java/org/geotools/data/sort/MergeSortDumper.java
@@ -63,8 +63,9 @@ class MergeSortDumper {
             if (sb != SortBy.NATURAL_ORDER && sb != SortBy.REVERSE_ORDER) {
                 AttributeDescriptor ad = schema.getDescriptor(sb.getPropertyName()
                         .getPropertyName());
+                if(ad==null) return false;
                 Class<?> binding = ad.getType().getBinding();
-                if (ad == null || !Comparable.class.isAssignableFrom(binding) 
+                if (!Comparable.class.isAssignableFrom(binding) 
                         || Geometry.class.isAssignableFrom(binding)) {
                     return false;
                 }

--- a/modules/library/main/src/test/java/org/geotools/data/sort/SortedReaderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/sort/SortedReaderTest.java
@@ -1,5 +1,6 @@
 package org.geotools.data.sort;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -44,6 +45,7 @@ public class SortedReaderTest {
     SortBy[] peopleDesc;
 
     SortBy[] fidAsc;
+    SortBy[] notExistAsc;
 
     SimpleFeatureType schema;
 
@@ -118,6 +120,7 @@ public class SortedReaderTest {
         peopleAsc = new SortBy[] { ff.sort("PERSONS", SortOrder.ASCENDING) };
         peopleDesc = new SortBy[] { ff.sort("PERSONS", SortOrder.DESCENDING) };
         dateAsc = new SortBy[] { ff.sort("date", SortOrder.ASCENDING) };
+        notExistAsc = new SortBy[] { ff.sort("doesNotExist", SortOrder.ASCENDING) };
         fidAsc = new SortBy[] { SortBy.NATURAL_ORDER };
     }
 
@@ -131,6 +134,7 @@ public class SortedReaderTest {
         assertTrue(SortedFeatureReader.canSort(schema, peopleAsc));
         assertTrue(SortedFeatureReader.canSort(schema, peopleDesc));
         assertTrue(SortedFeatureReader.canSort(schema, fidAsc));
+        assertFalse(SortedFeatureReader.canSort(schema, notExistAsc));
     }
 
     @Test


### PR DESCRIPTION
canSort was checking if the descriptor is null after calling a method on it.
