### PR TITLE
Updated ContentDataStore tutorial with new CSVDataStore implementation

### DIFF
--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
@@ -1,0 +1,116 @@
+/* GeoTools - The Open Source Java GIS Toolkit
+ * http://geotools.org
+ *
+ * (C) 2010-2014, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.data.csv;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentDataStore;
+import org.geotools.data.store.ContentEntry;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.feature.NameImpl;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.Name;
+
+import com.csvreader.CsvReader;
+import com.csvreader.CsvWriter;
+import com.vividsolutions.jts.geom.Point;
+
+/**
+ * DataStore for Comma Separated Value (CSV) files.
+ * 
+ * @author Jody Garnett (Boundless)
+ */
+public class CSVDataStore extends ContentDataStore {
+ // header end
+
+    // constructor start
+    File file;
+
+    public CSVDataStore( File file ){
+        this.file = file;
+    }
+    // constructor end
+
+    // reader start
+    /**
+     * Allow read access to file; for our package visible "friends".
+     * Please close the reader when done.
+     * @return CsvReader for file
+     */
+    CsvReader read() throws IOException {
+        Reader reader = new FileReader(file);
+        CsvReader csvReader = new CsvReader(reader);
+        return csvReader;
+    }
+    // reader end
+
+    // createTypeNames start
+    protected List<Name> createTypeNames() throws IOException {
+        String name = file.getName();
+        name = name.substring(0, name.lastIndexOf('.'));
+
+        Name typeName = new NameImpl( name );
+        return Collections.singletonList(typeName);
+    }
+    // createTypeNames end
+    
+    // createSchema start
+    @Override
+    public void createSchema(SimpleFeatureType featureType) throws IOException {
+        List<String> header = new ArrayList<String>();
+        GeometryDescriptor geometryDescrptor = featureType.getGeometryDescriptor();
+        if (geometryDescrptor != null
+                && CRS.equalsIgnoreMetadata(DefaultGeographicCRS.WGS84,
+                        geometryDescrptor.getCoordinateReferenceSystem())
+                && geometryDescrptor.getType().getBinding().isAssignableFrom(Point.class)) {
+            header.add("LAT");
+            header.add("LON");
+        } else {
+            throw new IOException("Unable use LAT/LON to represent " + geometryDescrptor);
+        }
+        for (AttributeDescriptor descriptor : featureType.getAttributeDescriptors()) {
+            if (descriptor instanceof GeometryDescriptor)
+                continue;
+            header.add(descriptor.getLocalName());
+        }
+        // Write out header, producing an empty file of the correct type
+        CsvWriter writer = new CsvWriter(new FileWriter(file),',');
+        try {
+            writer.writeRecord( header.toArray(new String[header.size()]));
+        }
+        finally {
+            writer.close();
+        }
+    }
+    // createSchema end
+
+    // createFeatureSource start
+    @Override
+    protected ContentFeatureSource createFeatureSource(ContentEntry entry) throws IOException {
+        if (file.canWrite()) {
+            return new CSVFeatureStore(entry, Query.ALL);
+        } else {
+            return new CSVFeatureSource(entry, Query.ALL);
+        }
+    }
+    // createFeatureSource end
+}

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
@@ -1,0 +1,127 @@
+/* GeoTools - The Open Source Java GIS Toolkit
+ * http://geotools.org
+ *
+ * (C) 2010-2014, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file. Use it well and enjoy!
+ */
+// header start
+package org.geotools.data.csv;
+
+import java.awt.RenderingHints.Key;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.geotools.data.DataStore;
+import org.geotools.data.DataStoreFactorySpi;
+import org.geotools.util.KVP;
+import org.geotools.util.logging.Logging;
+
+/**
+ * Provide access to CSV Files.
+ *
+ * @source $URL$
+ */
+public class CSVDataStoreFactory implements DataStoreFactorySpi {
+    /**
+     * Public "no argument" constructor called by Factory Service Provider (SPI) entry listed in
+     * META-INF/services/org.geotools.data.DataStoreFactorySPI
+     */
+    public CSVDataStoreFactory() {
+    }
+
+    /** No implementation hints required at this time */
+    public Map<Key, ?> getImplementationHints() {
+        return Collections.emptyMap();
+    }
+
+    // definition end
+    // metadata start
+    public String getDisplayName() {
+        return "CSV";
+    }
+
+    public String getDescription() {
+        return "Comma delimited text file.";
+    }
+
+    /** Confirm DataStore availability, null if unknown */
+    Boolean isAvailable = null;
+
+    /**
+     * Test to see if this DataStore is available, for example if it has all the appropriate libraries to construct an instance.
+     * 
+     * This method is used for interactive applications, so as to not advertise support for formats that will not function.
+     * 
+     * @return <tt>true</tt> if and only if this factory is available to create DataStores.
+     */
+    public synchronized boolean isAvailable() {
+        if (isAvailable == null) {
+            try {
+                Class<?> cvsReaderType = Class.forName("com.csvreader.CsvReader");
+                isAvailable = cvsReaderType != null;
+            } catch (ClassNotFoundException e) {
+                isAvailable = false;
+            }
+        }
+        return isAvailable;
+    }
+
+    // metadata end
+
+    // getParametersInfo start
+    /** Parameter description of information required to connect */
+    public static final Param FILE_PARAM = new Param("file", File.class, "Comma seperated value file", true,
+            null, new KVP(Param.EXT, "csv"));
+
+    public Param[] getParametersInfo() {
+        return new Param[] { FILE_PARAM };
+    }
+
+    // getParametersInfo end
+    // canProcess start
+    /**
+     * Works for csv file.
+     * 
+     * @param params connection parameters
+     * @return true for connection parameters indicating a csv file
+     */
+    public boolean canProcess(Map<String, Serializable> params) {
+        try {
+            File file = (File) FILE_PARAM.lookUp(params);
+            if (file != null) {
+                return file.getPath().toLowerCase().endsWith(".csv");
+            }
+        } catch (IOException e) {
+            // ignore as we are expected to return true or false
+        }
+        return false;
+    }
+
+    // canProcess end
+
+    // createDataStore start
+    public DataStore createDataStore(Map<String, Serializable> params) throws IOException {
+        File file = (File) FILE_PARAM.lookUp(params);
+        return new CSVDataStore(file);
+    }
+    // createDataStore end
+    
+    private static final Logger LOGGER = Logging.getLogger("org.geotools.data.csv");
+    
+    // createNewDataStore start
+    public DataStore createNewDataStore(Map<String, Serializable> params) throws IOException {
+        File file = (File) FILE_PARAM.lookUp(params);
+        if (file.exists() ){
+            LOGGER.warning("File already exsists: "+file);
+        }
+        return new CSVDataStore(file);
+    }
+    // createNewDataStore end
+
+}

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java
@@ -1,0 +1,165 @@
+/* GeoTools - The Open Source Java GIS Toolkit
+ * http://geotools.org
+ *
+ * (C) 2010-2014, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.data.csv;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+import org.geotools.data.FeatureReader;
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentState;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.opengis.feature.IllegalAttributeException;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import com.csvreader.CsvReader;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+/**
+ * 
+ *
+ * @source $URL$
+ */
+public class CSVFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeature> {
+    
+    /** State used when reading file */
+    protected ContentState state;
+    
+    /**
+     * Current row number - used in the generation of FeatureId.
+     * TODO: Subclass ContentState to track row
+     */
+    private int row;
+
+    protected CsvReader reader;
+    
+    /** Utility class used to build features */
+    protected SimpleFeatureBuilder builder;
+
+    /** Factory class for goemetry creation */
+    private GeometryFactory geometryFactory;
+
+    public CSVFeatureReader(ContentState contentState, Query query) throws IOException {
+        this.state = contentState;
+        CSVDataStore csv = (CSVDataStore) contentState.getEntry().getDataStore();
+        reader = csv.read(); // this may throw an IOException if it could not connect
+        boolean header = reader.readHeaders();
+        if (! header ){
+            throw new IOException("Unable to read csv header");
+        }
+        builder = new SimpleFeatureBuilder( state.getFeatureType() );
+        geometryFactory = JTSFactoryFinder.getGeometryFactory(null);
+        row = 0;
+    }
+    /** Access FeatureType (documenting avaiable attributes) */
+    public SimpleFeatureType getFeatureType() {
+        return (SimpleFeatureType) state.getFeatureType();
+    }
+    // class definition end
+    
+    // read start
+    /** The next feature */
+    private SimpleFeature next;
+    
+    /**
+     * Access the next feature (if available).
+     * 
+     * @return SimpleFeature read from property file
+     * @throws IOException If problem encountered reading file
+     * @throws IllegalAttributeException for invalid data
+     * @throws NoSuchElementException If hasNext() indicates no more features are available
+     */
+    public SimpleFeature next() throws IOException, IllegalArgumentException,
+            NoSuchElementException {
+        SimpleFeature feature;
+        if( next != null ){
+            feature = next;
+            next = null;
+        }
+        else {
+            feature = readFeature();
+        }
+        return feature;
+    }
+    /**
+     * Check if additional content is available.
+     * 
+     * @return <code>true</code> if additional content is available
+     * @throws IOException
+     */
+    public boolean hasNext() throws IOException {
+        if( next != null ){
+            return true;
+        }
+        else if (reader == null ){
+            return false;
+        }
+        else {
+            next = readFeature(); // read next feature so we can check
+            return next != null;
+        }
+    }
+    // read end
+    
+    // parse start
+    /** Read a line of content from CSVReader and parse into values */
+    SimpleFeature readFeature() throws IOException {
+        if( reader == null ){
+            throw new IOException("FeatureReader is closed; no additional features can be read");
+        }
+        boolean read = reader.readRecord(); // read the "next" record
+        if( read == false ){
+            close(); // automatic close to be nice
+            return null; // no additional features are available
+        }
+        Coordinate coordinate = new Coordinate();
+        for( String column : reader.getHeaders() ){
+            String value = reader.get(column);
+            if( "lat".equalsIgnoreCase(column)){
+                coordinate.y = Double.valueOf( value.trim() );
+            }
+            else if( "lon".equalsIgnoreCase(column)){
+                coordinate.x = Double.valueOf( value.trim() );
+            }
+            else {
+                builder.set(column, value );
+            }
+        }
+        builder.set("Location", geometryFactory.createPoint( coordinate ) );
+        
+        return this.buildFeature();
+    }
+    
+    /** Build feature using the current row number to generate FeatureId */
+    protected SimpleFeature buildFeature() {
+        row += 1;
+        return builder.buildFeature( state.getEntry().getTypeName()+"."+row );
+    }
+    // parse end
+
+    // close start
+    /**
+     * Close the FeatureReader when not in use.
+     * 
+     * @throws IOException
+     */
+    public void close() throws IOException {
+        if( reader != null ){
+            reader.close();
+            reader = null;
+        }
+        builder = null;
+        geometryFactory = null;
+        next = null;
+    }
+    // close start
+}

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
@@ -1,0 +1,135 @@
+/* GeoTools - The Open Source Java GIS Toolkit
+ * http://geotools.org
+ *
+ * (C) 2010-2014, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.data.csv;
+
+import java.io.IOException;
+
+import org.geotools.data.FeatureReader;
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentEntry;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.opengis.feature.FeatureVisitor;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+
+import com.csvreader.CsvReader;
+import com.vividsolutions.jts.geom.Point;
+/**
+ * Read-only access to CSV File.
+ * 
+ * @author Jody Garnett (Boundless)
+ */
+public class CSVFeatureSource extends ContentFeatureSource {
+
+    public CSVFeatureSource(ContentEntry entry, Query query) {
+        super(entry, query);
+    }
+
+    // getDataStore start
+    /**
+     * Access parent CSVDataStore.
+     */
+    public CSVDataStore getDataStore() {
+        return (CSVDataStore) super.getDataStore();
+    }
+    // getDataStore end
+
+    // reader start
+    protected FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(Query query)
+            throws IOException {
+        return new CSVFeatureReader(getState(), query);
+    }
+
+    // reader end
+
+    // count start
+    protected int getCountInternal(Query query) throws IOException {
+        if (query.getFilter() == Filter.INCLUDE) {
+            CsvReader reader = getDataStore().read();
+            try {
+                boolean connect = reader.readHeaders();
+                if (connect == false) {
+                    throw new IOException("Unable to connect");
+                }
+                int count = 0;
+                while (reader.readRecord()) {
+                    count += 1;
+                }
+                return count;
+            } finally {
+                reader.close();
+            }
+        }
+        return -1; // feature by feature scan required to count records
+    }
+    // count end
+
+    // bounds start
+    /**
+     * Implementation that generates the total bounds (many file formats record this information in the header)
+     */
+    protected ReferencedEnvelope getBoundsInternal(Query query) throws IOException {
+        return null; // feature by feature scan required to establish bounds
+    }
+    // bounds end
+
+    // schema start
+    protected SimpleFeatureType buildFeatureType() throws IOException {
+
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName(entry.getName());
+
+        // read headers
+        CsvReader reader = getDataStore().read();
+        try {
+            boolean success = reader.readHeaders();
+            if (success == false) {
+                throw new IOException("Header of CSV file not available");
+            }
+
+            // we are going to hard code a point location
+            // columns like lat and lon will be gathered into a
+            // Point called Location
+            builder.setCRS(DefaultGeographicCRS.WGS84); // <- Coordinate reference system
+            builder.add("Location", Point.class);
+
+            for (String column : reader.getHeaders()) {
+                if ("lat".equalsIgnoreCase(column)) {
+                    continue; // skip as it is part of Location
+                }
+                if ("lon".equalsIgnoreCase(column)) {
+                    continue; // skip as it is part of Location
+                }
+                builder.add(column, String.class);
+            }
+
+            // build the type (it is immutable and cannot be modified)
+            final SimpleFeatureType SCHEMA = builder.buildFeatureType();
+            return SCHEMA;
+        } finally {
+            reader.close();
+        }
+    }
+    // schema end
+    
+    // visitor start
+    /**
+     * Make handleVisitor package visible allowing CSVFeatureStore to delegate to
+     * this implementation.
+     */
+    @Override
+    protected boolean handleVisitor(Query query, FeatureVisitor visitor) throws IOException {
+        return super.handleVisitor(query, visitor);
+    }
+    // visitor start
+}

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
@@ -1,0 +1,139 @@
+/* GeoTools - The Open Source Java GIS Toolkit
+ * http://geotools.org
+ *
+ * (C) 2010-2014, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.data.csv;
+
+import java.io.IOException;
+
+import org.geotools.data.FeatureReader;
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Query;
+import org.geotools.data.QueryCapabilities;
+import org.geotools.data.ResourceInfo;
+import org.geotools.data.Transaction;
+import org.geotools.data.store.ContentEntry;
+import org.geotools.data.store.ContentFeatureStore;
+import org.geotools.data.store.ContentState;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.feature.FeatureVisitor;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.Name;
+
+/**
+ * Read-write access to CSV File.
+ * 
+ * @author Jody Garnett (Boundless)
+ * @author Ian Turton (Envitia)
+ */
+public class CSVFeatureStore extends ContentFeatureStore {
+    public CSVFeatureStore(ContentEntry entry, Query query) {
+        super(entry, query);
+    }
+    // header end
+    // getWriter start
+    //
+    // CSVFeatureStore implementations
+    //
+    @Override
+    protected FeatureWriter<SimpleFeatureType, SimpleFeature> getWriterInternal(Query query,
+            int flags) throws IOException {
+        return new CSVFeatureWriter(getState(), query);
+    }
+    // getWriter end
+    
+    // transaction start
+    /**
+     * Delegate used for FeatureSource methods (We do this because Java cannot inherit from both ContentFeatureStore and CSVFeatureSource at the same
+     * time
+     */
+    CSVFeatureSource delegate = new CSVFeatureSource(entry, query) {
+        @Override
+        public void setTransaction(Transaction transaction) {
+            super.setTransaction(transaction);
+            CSVFeatureStore.this.setTransaction(transaction); // Keep these two implementations on the same transaction
+        }
+    };
+
+    @Override
+    public void setTransaction(Transaction transaction) {
+        super.setTransaction(transaction);
+        if( delegate.getTransaction() != transaction ){
+            delegate.setTransaction( transaction );
+        }
+    }
+    // transaction end
+    
+    // internal start
+    //
+    // Internal Delegate Methods
+    // Implement FeatureSource methods using CSVFeatureSource implementation
+    //
+    @Override
+    protected SimpleFeatureType buildFeatureType() throws IOException {
+        return delegate.buildFeatureType();
+    }
+
+    @Override
+    protected ReferencedEnvelope getBoundsInternal(Query query) throws IOException {
+        return delegate.getBoundsInternal(query);
+    }
+
+    @Override
+    protected int getCountInternal(Query query) throws IOException {
+        return delegate.getCountInternal(query);
+    }
+    
+    @Override
+    protected FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(Query query)
+            throws IOException {
+        return delegate.getReaderInternal(query);
+    }
+    @Override
+    protected boolean handleVisitor(Query query, FeatureVisitor visitor) throws IOException {
+        return delegate.handleVisitor(query, visitor);
+    }
+    // internal end
+    
+    // public start
+    //
+    // Public Delegate Methods
+    // Implement FeatureSource methods using CSVFeatureSource implementation
+    //
+    @Override
+    public CSVDataStore getDataStore() {
+        return delegate.getDataStore();
+    }
+
+    @Override
+    public ContentEntry getEntry() {
+        return delegate.getEntry();
+    }
+
+    public Transaction getTransaction() {
+        return delegate.getTransaction();
+    }
+
+    public ContentState getState() {
+        return delegate.getState();
+    }
+
+    public ResourceInfo getInfo() {
+        return delegate.getInfo();
+    }
+
+    public Name getName() {
+        return delegate.getName();
+    }
+
+    public QueryCapabilities getQueryCapabilities() {
+        return delegate.getQueryCapabilities();
+    }
+    // public start
+
+}

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
@@ -1,0 +1,185 @@
+/* GeoTools - The Open Source Java GIS Toolkit
+ * http://geotools.org
+ *
+ * (C) 2010-2014, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.data.csv;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.NoSuchElementException;
+
+import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentState;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.opengis.feature.Property;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import com.csvreader.CsvReader;
+import com.csvreader.CsvWriter;
+import com.vividsolutions.jts.geom.Point;
+
+/**
+ * Iterator supporting writing of feature content.
+ *
+ * @author Jody Garnett (Boundless)
+ * @author Lee Breisacher
+ */
+public class CSVFeatureWriter implements FeatureWriter<SimpleFeatureType, SimpleFeature> {
+    /** State of current transaction */
+    private ContentState state;
+
+    /** Delegate handing reading of original file */
+    private CSVFeatureReader delegate;
+    
+    /** Temporary file used to stage output */
+    private File temp;
+
+    /** CsvWriter used for temp file output */
+    private CsvWriter csvWriter;
+
+    /** Current feature available for modification, may be null if feature removed */
+    private SimpleFeature currentFeature;
+    
+    /** Flag indicating we have reached the end of the file */
+    private boolean appending = false;
+    
+    /** Row count used to generate FeatureId when appending */
+    int nextRow = 0;
+    // header end
+    // constructor start
+    public CSVFeatureWriter(ContentState state, Query query) throws IOException {
+        this.state = state;
+        String typeName = query.getTypeName();
+        File file = ((CSVDataStore) state.getEntry().getDataStore()).file;
+        File directory = file.getParentFile();
+        this.temp = File.createTempFile(typeName + System.currentTimeMillis(), "csv", directory);
+        this.csvWriter = new CsvWriter(new FileWriter(this.temp), ',');
+        this.delegate = new CSVFeatureReader(state,query);
+        this.csvWriter.writeRecord(delegate.reader.getHeaders());
+    }
+    // constructor end
+    
+    // featureType start
+    @Override
+    public SimpleFeatureType getFeatureType() {
+        return state.getFeatureType();
+    }
+    // featureType end
+
+    // hasNext start
+    @Override
+    public boolean hasNext() throws IOException {
+        if( csvWriter == null ){
+            throw new IOException("Writer has been closed");
+        }
+        if (this.appending) {
+            return false; // reader has no more contents
+        }
+        return delegate.hasNext();
+    }
+    // hasNext end
+    
+    // next start
+    @Override
+    public SimpleFeature next() throws IOException, IllegalArgumentException,
+            NoSuchElementException {
+        if( csvWriter == null ){
+            throw new IOException("Writer has been closed");
+        }
+        if (this.currentFeature != null) {
+            this.write(); // the previous one was not written, so do it now.
+        }
+        try {
+            if( !appending ){
+                if( delegate.reader != null && delegate.hasNext() ){
+                    this.currentFeature = delegate.next();
+                    return this.currentFeature;
+                }
+                else {
+                    this.appending = true;
+                }
+            }
+            SimpleFeatureType featureType = state.getFeatureType();
+            String fid = featureType.getTypeName()+"."+nextRow;
+            Object values[] = DataUtilities.defaultValues( featureType );
+            
+            this.currentFeature = SimpleFeatureBuilder.build( featureType, values, fid );
+            return this.currentFeature;
+        }
+        catch (IllegalArgumentException invalid ){
+            throw new IOException("Unable to create feature:"+invalid.getMessage(),invalid);
+        }
+    }
+    // next end
+    
+    // remove start
+    /**
+     * Mark our {@link #currentFeature} feature as null, it will be skipped when written effectively removing it.
+     */
+    public void remove() throws IOException {
+        this.currentFeature = null; // just mark it done which means it will not get written out.
+    }
+    // remove end
+    
+    // write start
+    public void write() throws IOException {
+        if (this.currentFeature == null) {
+            return; // current feature has been deleted
+        }
+        for (Property property : currentFeature.getProperties()) {
+            Object value = property.getValue();
+            if (value == null) {
+                this.csvWriter.write("");
+            } else if (value instanceof Point) {
+                Point point = (Point) value;
+                this.csvWriter.write(Double.toString(point.getX()));
+                this.csvWriter.write(Double.toString(point.getY()));
+            } else {
+                String txt = value.toString();
+                this.csvWriter.write(txt);
+            }
+        }
+        this.csvWriter.endRecord();
+        nextRow++;
+        this.currentFeature = null; // indicate that it has been written
+    }
+    // write end
+    
+    // close start
+    @Override
+    public void close() throws IOException {
+        if( csvWriter == null ){
+            throw new IOException("Writer alread closed");
+        }
+        if (this.currentFeature != null) {
+            this.write(); // the previous one was not written, so do it now.
+        }
+        // Step 1: Write out remaining contents (if applicable)
+        while (hasNext()) {
+            next();
+            write();
+        }
+        csvWriter.close();
+        csvWriter = null;
+        if( delegate != null ){
+            this.delegate.close();
+            this.delegate = null;
+        }
+        // Step 2: Replace file contents
+        File file = ((CSVDataStore) state.getEntry().getDataStore()).file;
+        
+        Files.copy(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING );
+    }
+    // close end
+
+}

--- a/docs/user/tutorial/datastore/index.rst
+++ b/docs/user/tutorial/datastore/index.rst
@@ -31,6 +31,7 @@ quickly be distributed to to all GeoTools users.
    write
    optimisation
    qa
+   strategy
 
 .. note::
    

--- a/docs/user/tutorial/datastore/optimisation.rst
+++ b/docs/user/tutorial/datastore/optimisation.rst
@@ -165,7 +165,7 @@ in play.
 
 
 
-. note:: Challenge
+.. note:: Challenge
 
   The canRetype() operations is easy to support, check the query and only provide values for the
   requested attributes. This is an especially valuable Optimization to perform at a low-level as

--- a/docs/user/tutorial/datastore/qa.rst
+++ b/docs/user/tutorial/datastore/qa.rst
@@ -11,12 +11,12 @@ Since this tutorial has been written the result has been broken out into a disti
 Unsupported Module
 ^^^^^^^^^^^^^^^^^^
 
-Good tutorials do not just teach, they get pressed into production. By popular request the CSVDataStore outlined in this tutorial is available as an "unsupported" plugin:
+Good tutorials do not just teach, they get pressed into production. The CSVDataStore outlined in the original tutorial was forked into geoserver with some modifications. You can see the :doc:`strategy page </tutorial/datastore/strategy>` for details on the changes. The original tutorial code is still available here:
 
-* :download:`CSVDataStore.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStore.java>`
-* :download:`CSVDataStoreFactory.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java>`
-* :download:`CSVFeatureReader.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureReader.java>`
-* :download:`CSVFeatureSource.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureSource.java>`
+* :download:`CSVDataStore.java </../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java>`
+* :download:`CSVDataStoreFactory.java </../src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java>`
+* :download:`CSVFeatureReader.java </../src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java>`
+* :download:`CSVFeatureSource.java </../src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java>`
 * :download:`META-INF/services/org.geotools.data.DataStoreFactorySpi </../../modules/unsupported/csv/src/main/resources/META-INF/services/org.geotools.data.DataStoreFactorySpi>`
 
 To get an idea of what kind of "extra work" is required for a supported module:
@@ -31,17 +31,6 @@ Directory Support
 Earlier copies of this tutorial would read an entire directory of files at a time. This functionality has been factored out into a support class and is used by implementations such as ShapefileDataStore.
 
 The same steps can be taken to CSVDataStore - although it is a real trade off between the code being clear vs less typing.
-
-GeoServer Fork
-^^^^^^^^^^^^^^
-
-This is more interesting, the code was forked in order to add new abilities:
-   
-* `org.geoserver.importer.csv <https://github.com/geoserver/geoserver/tree/master/src/extension/importer/core/src/main/java/org/geoserver/importer/csv>`_ (GitHub)
-
-The implementation is strictly concerned with reading content (as part of an import process) and has added a nifty CSVStrategy (with implementations for CSVAttributesOnly, CSVLatLonStrategy, CSVSpecifiedLatLngStrategy and SpecifiedWKTStrategy).
-
-Sounds like a sensible addition.
    
 Info
 ^^^^

--- a/docs/user/tutorial/datastore/source.rst
+++ b/docs/user/tutorial/datastore/source.rst
@@ -36,21 +36,22 @@ Our initial implementation will result in a read-only datastore for accessing CS
 
 #. To begin create the file CSVDataStore extending ContentDataStore
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
       :language: java
-      :start-after: // header start
+      :prepend: package org.geotools.tutorial.csv;
+      :start-after: package org.geotools.data.csv;
       :end-before: // header end
 
 #. Add the reader
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
       :language: java
       :start-after: // reader start
       :end-before: // reader end
 
 #. We are going to be working with a single CSV file
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
       :language: java
       :start-after: // constructor start
       :end-before: // constructor end
@@ -66,7 +67,7 @@ Our initial implementation will result in a read-only datastore for accessing CS
 
    After all that lead-in you will be disappointed to note that our list will be a single value - the name of the CSV file.
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
       :language: java
       :start-after: // createTypeNames start
       :end-before: // createTypeNames end
@@ -85,7 +86,7 @@ Our initial implementation will result in a read-only datastore for accessing CS
 
 #. Implement createFeatureSource. Technically the **ContentEntry** is provided as "parameter object" holding the type name requested by the user, and any other context known to the DataStore.
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
       :language: java
       :start-after: // createFeatureSource start
       :end-before: // createFeatureSource end
@@ -99,21 +100,22 @@ Next we can create the **CSVFeatureSource** mentioned above. This class is respo
 
 #. Create the file CSVFeatureSource.
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureSource.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
       :language: java
-      :start-after: // header
+      :prepend: package org.geotools.tutorial.csv;
+      :start-after: package org.geotools.data.csv;
       :end-before: // getDataStore start
 
 #. To assist others we can type narrow our **getDataStore()** method to explicitly to return a **CSVDataStore**. In addition to being accurate, this prevents a lot of casts resulting in more readable code.
   
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureSource.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
       :language: java
       :start-after: // getDataStore start
       :end-before: // getDataStore end
 
 #. The method **getReaderInternal( Query )** used to provide streaming access to out data - reading one feature at a time. The **CSVFeatureReader** returned is similar to an iterator, and is implemented in the next section.
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureSource.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
       :language: java
       :start-after: // reader start
       :end-before: // reader end
@@ -128,14 +130,14 @@ Next we can create the **CSVFeatureSource** mentioned above. This class is respo
    
    For CSV files we can check to see if the Query includes all features - in which case we can skip over the header and quickly count the number of lines in our file. This is much faster than reading and parsing each feature one at a time.
    
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureSource.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
       :language: java
       :start-after: // count start
       :end-before: // count end
       
 #. The second optimisation requires an implementation of **getBoundsInternal(Query)** making use of any spatial index, or header, record the data bounds. This value is used when rendering to determine the clipping area.
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureSource.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
       :language: java
       :start-after: // bounds start
       :end-before: // bounds end
@@ -146,7 +148,7 @@ Next we can create the **CSVFeatureSource** mentioned above. This class is respo
    
    The FeatureType generated here is based on the CSV Header, along with a few educated guesses to recognise LAT and LON columns as comprising a single Location.
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureSource.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
       :language: java
       :start-after: // schema start
       :end-before: // schema end
@@ -177,14 +179,16 @@ line by line, parsing Features as we go. Because this class actually does some w
 
 1. Create the class **CSVFeatureReader** as follows:
    
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureReader.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java
       :language: java
+      :prepend: package org.geotools.tutorial.csv;
+      :start-after: package org.geotools.data.csv;
       :end-before: // class definition end
       :append: }
 
 2. Implement the iterator next() and hasNext() methods using a field to hold the value to return next.
    
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureReader.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java
       :language: java
       :start-after: // read start
       :end-before: // read end
@@ -194,7 +198,7 @@ line by line, parsing Features as we go. Because this class actually does some w
 
 3. Using the **CSVReader** library to parse the content saves a lot of work - and lets us focus on building features. The utility class **FeatureBuilder** gathers up state, employing a **FeatureFactory** on your behalf to construct each feature.
    
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureReader.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java
       :language: java
       :start-after: // parse start
       :end-before: // parse end
@@ -203,7 +207,7 @@ line by line, parsing Features as we go. Because this class actually does some w
 
 4. Finally we can **close()** the CSVFeatureReader when no longer used. Returning any system resources (in this case an open file handle).
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVFeatureReader.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java
       :language: java
       :start-after: // close start
       :end-before: // cose end
@@ -240,15 +244,17 @@ information and the ability to create new physical storage.
      
    Create CSVDataStoreFactory as follows:
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStoreFactory.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
       :language: java
+      :prepend: package org.geotools.tutorial.csv;
+      :start-after: package org.geotools.data.csv;
       :end-before: // definition end
 
 2. We have a couple of methods to describe the DataStore.
 
    This *isAvaialble* method is interesting in that it can become a performance bottleneck if not implemented efficiently. DataStoreFactorySPI factories *all* called when a user attempts to connect, only the factories marked as *available* are shortlisted for further interaction.
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStoreFactory.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
       :language: java
       :start-after: // metadata start
       :end-before: // metadata end
@@ -261,7 +267,7 @@ information and the ability to create new physical storage.
    
    The API contract is open ended (we cannot hope to guess all the options needed in the future). The helper class **KVP** provides an easy to use implementation of **Map<String,Object>**. The keys used here are formally defined as static constants - complete with javadoc describing their use. If several authors agree on a new hint it will be added to these static constants.
    
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStoreFactory.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
       :language: java
       :start-after: // getParametersInfo start
       :end-before: // getParametersInfo end
@@ -282,7 +288,7 @@ information and the ability to create new physical storage.
       
 4. Next we have some code to check if a set of provided connection parameters can actually be used.
    
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStoreFactory.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
       :language: java
       :start-after: // canProcess start
       :end-before: // canProcess end
@@ -300,7 +306,7 @@ information and the ability to create new physical storage.
      
    Since initially our DataStore is read-only we will just throw an UnsupportedOperationException at this time.
 
-   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv/CSVDataStoreFactory.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
       :language: java
       :start-after: // createNewDataStore start
       :end-before: // createNewDataStore end

--- a/docs/user/tutorial/datastore/store.rst
+++ b/docs/user/tutorial/datastore/store.rst
@@ -32,7 +32,7 @@ Now that we are going to be writing files we can fill in the createNewDataStore 
 
 1. Open up CSVDataStoreFactory and fill in the method **createNewDataStore( Map params )** which we skipped over earlier.
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
       :language: java
       :start-after: // createNewDataStore start
       :end-before: // createNewDataStore end
@@ -43,7 +43,7 @@ Now that we are going to be writing files we can fill in the createNewDataStore 
    Because GeoTools is a well mannered library it can be configured to use different logging
    engines. This allows it to integrate smoothly with larger projects.
 
-#. To see this change in context review :download:`CSVDataStoreFactory.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java>`
+#. To see this change in context review :download:`CSVDataStoreFactory.java </../src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java>`
    from the **gt-csv** plugin.
    
 There is no DataStoreFinder method for creating new content. We expect this method to be called
@@ -65,7 +65,7 @@ functionality.
    
    Add createSchema( featureType ):
    
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
       :language: java
       :start-after: // createSchema start
       :end-before: // createSchema end
@@ -77,12 +77,12 @@ functionality.
    
    The **FeatureStore** interface provides additional methods allowing the modification of content.
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
       :language: java
       :start-after: // createFeatureSource start
       :end-before: // createFeatureSource end
 
-#. If you would like to review the **gt-csv** plugin has the completed :download:`CSVDataStore.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStore.java>`
+#. If you would like to review the **gt-csv** plugin has the completed :download:`CSVDataStore.java </../src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java>`
    file.
    
 CSVFeatureStore
@@ -112,7 +112,7 @@ are always on the same transaction, but other than that this approach is working
 
 #. Create **CSVFeatureStore**:
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
       :language: java
       :start-after: package org.geotools.data.csv;
       :end-before: // header end
@@ -121,7 +121,7 @@ are always on the same transaction, but other than that this approach is working
 #. Our first responsibility is to implement a CSVFeatureWriter for internal use. Transaction and Event
    Notification are handled by wrappers applied to our CSVFeatureWriter.
     
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
       :language: java
       :start-after: // getWriter start
       :end-before: // getWriter end
@@ -152,14 +152,14 @@ are always on the same transaction, but other than that this approach is working
 
 #. Next we can set up our delegate, taking care to ensure both use the same Transaction.
    
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
       :language: java
       :start-after: // transaction start
       :end-before: // transaction end
       
 #. Use the delegate to implement the internal ContentDataStore methods. 
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
       :language: java
       :start-after: // internal start
       :end-before: // internal end
@@ -167,7 +167,7 @@ are always on the same transaction, but other than that this approach is working
    We have to do one "fix" to allow handle visitor method to be called - add the following to
       **CSVFeatureSource**.
       
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureSource.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
       :language: java
       :start-after: // visitor start
       :end-before: // visitor end
@@ -180,12 +180,11 @@ are always on the same transaction, but other than that this approach is working
       
 #. Use the delegate to implement the public FeatureSource methods.
    
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureStore.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
       :language: java
       :start-after: // public start
-      :end-before: // public end
 
-#. You can see what this looks like in context by reviewing :download:`CSVFeatureStore.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureStore.java>`
+#. You can see what this looks like in context by reviewing :download:`CSVFeatureStore.java </../src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java`
    from the **gt-csv** plugin.
 
 CSVFeatureWriter
@@ -286,7 +285,7 @@ Now that we have some idea of what is riding on top, lets implement our CSVFeatu
 
 #. Create the file CSVFeatureWriter.java:
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
       :language: java
       :start-after: package org.geotools.data.csv;
       :end-before: // header end
@@ -303,14 +302,14 @@ Now that we have some idea of what is riding on top, lets implement our CSVFeatu
    
    Putting all that together:
    
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
       :language: java
       :start-after: // constructor start
       :end-before: // constructor end
 
 #. Add FeatureWriter.getFeatureType() implementation:
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
       :language: java
       :start-after: // featureType start
       :end-before: // featureType end
@@ -318,7 +317,7 @@ Now that we have some idea of what is riding on top, lets implement our CSVFeatu
 #. Add hasNext() implementation, making use of delegate before switching over to 
    returning false when appending.
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
       :language: java
       :start-after: // hasNext start
       :end-before: // hasNext end
@@ -336,7 +335,7 @@ Now that we have some idea of what is riding on top, lets implement our CSVFeatu
    
    Here is what that looks like:
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
       :language: java
       :start-after: // next start
       :end-before: // next end
@@ -352,14 +351,14 @@ Now that we have some idea of what is riding on top, lets implement our CSVFeatu
 
 7. Add remove() implementation, marking the currentFeature as null.
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
       :language: java
       :start-after: // remove start
       :end-before: // remove end
 
 6. Add write() implementation:
    
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
       :language: java
       :start-after: // write start
       :end-before: // write end
@@ -379,11 +378,11 @@ Now that we have some idea of what is riding on top, lets implement our CSVFeatu
    
    The last thing our FeatureWriter must do is replace the existing File with our new one.
 
-   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+   .. literalinclude:: /../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
       :language: java
       :start-after: // close start
       :end-before: // close end
 
-#. You can see what this looks like in context by reviewing :download:`CSVFeatureWriter.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java>`
+#. You can see what this looks like in context by reviewing :download:`CSVFeatureWriter.java </../src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java`
    from the **gt-csv** plugin.
    

--- a/docs/user/tutorial/datastore/strategy.rst
+++ b/docs/user/tutorial/datastore/strategy.rst
@@ -1,0 +1,252 @@
+:Author: Travis Brundage
+:Thanks: geotools-devel list
+:Version: |release|
+:License: Creative Commons with attribution
+
+Strategy Patterns
+-----------------
+
+Since this tutorial has been written the result has been broken out into a distinct **gt-csv** module. This work has also been forked into service as part of the GeoServer importer module. In GeoServer's fork, many interesting updates were made to add new abilities. The implementation is strictly concerned with reading content (as part of an import process) and has added a nifty CSVStrategy (with implementations for CSVAttributesOnly, CSVLatLonStrategy, CSVSpecifiedLatLngStrategy and SpecifiedWKTStrategy). In this section we'll discuss the new implementation with strategy objects. If you want to follow along with the code, it is available as an unsupported plugin:
+
+* :download:`CSVDataStore.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStore.java>`
+* :download:`CSVDataStoreFactory.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java>`
+* :download:`CSVFeatureReader.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureReader.java>`
+* :download:`CSVIterator.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVIterator.java>`
+* :download:`CSVFeatureSource.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureSource.java>`
+* :download:`CSVFileState.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFileState.java>`
+* :download:`CSVStrategy </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVStrategy.java>`
+* :download:`AbstractCSVStrategy.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/AbstractCSVStrategy.java>`
+* :download:`CSVAttributesOnlyStrategy.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVAttributesOnlyStrategy.java>`
+* :download:`CSVLatLonStrategy.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVLatLonStrategy.java>`
+* :download:`CSVSpecifiedLatLngStrategy.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVSpecifiedLatLngStrategy.java>`
+* :download:`CSVSpecifiedWKTStrategy.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVSpecifiedWKTStrategy.java>`
+* :download:`CSVStrategySupport.java </../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVStrategySupport.java>`
+
+CSVDataStore
+^^^^^^^^^^^^
+
+CSVDataStore now uses a CSVStrategy and CSVFileState. The CSVFileState holds information about the file we are reading from. CSVStrategy is a generic interface for the strategy objects CSVDataStore can use.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStore.java
+      :language: java
+      :start-after: import org.opengis.filter.Filter;
+      :end-before: public Name getTypeName() {
+
+Using the CSVFileState to do work for us, the **createTypeNames()** method is much simpler.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStore.java
+      :language: java
+      :lines: 40-47
+
+CSVDataStore now implements the FileDataStore interface to ensure a standard for operations which are performed by FileDataStores. As such, it must override its methods. Note the use of the CSVStrategy in order to determine the schema. Depending on the strategy defined, the schema for this store will be different. For this implementation, the CSVDataStore is read only, so the write methods throw a new UnsupportedOperationException.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStore.java
+      :language: java
+      :lines: 55-90
+
+CSVDataStoreFactory
+^^^^^^^^^^^^^^^^^^^
+
+The new architecture with the added strategy objects expands the CSVDataStoreFactory's capabilities. It comprises of more Param fields now.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java
+      :language: java
+      :start-after: import org.geotools.util.KVP;
+      :end-before: @Override
+
+Much of the class's structure is improved to be more compartmentalized. The metadata is mostly the same with some data now being held in class fields rather than literals.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java
+      :language: java
+      :lines: 55-68
+
+The method **isAvailable()** just attempts to read the class, and if it succeeds, returns true.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java
+      :language: java
+      :lines: 99-107
+
+The **canProcess(Map<String, Serializable> params)** method was made more tolerant, now accepting URL and File params through the **fileFromParams(Map<String, Serializable> params)** method. It will try File first, then URL before giving up.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java
+      :language: java
+      :lines: 70-97
+
+Finally, the different strategies are implemented in the **createDataStoreFromFile()** method. The method is overloaded to make some parameters optional, which the class will then fill in for us.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java
+      :language: java
+      :lines: 114-182
+
+CSVFeatureReader
+^^^^^^^^^^^^^^^^
+
+The CSVFeatureReader now delegates much of the functionality to a new class called CSVIterator as well as the CSVStrategy. The resulting code is very clean and short.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureReader.java
+      :language: java
+      :start-after: import org.opengis.feature.simple.SimpleFeatureType;
+
+CSVIterator
+^^^^^^^^^^^
+
+The CSVIterator is a helper class primarily for CSVFeatureReader. Much of the old code is now implemented here, and has the added benefit of allowing an iterator to be instantiated for use elsewhere, making the code more general than before. With the addition of the CSVFileState, the class now reads from it instead of the CSVDataStore.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVIterator.java
+      :language: java
+      :start-after: import com.csvreader.CsvReader;
+      :end-before: private SimpleFeature buildFeature(String[] csvRecord) {
+
+Because we're now using strategy objects to implement functionality, the readFeature() method no longer makes any assumptions about the nature of the data. It is delegated to the strategy to make such a decision. The resulting method is shorter, just passing what it reads off to builders to implement based on the strategy.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVIterator.java
+      :language: java
+      :lines: 54-60
+
+CSVFeatureSource
+^^^^^^^^^^^^^^^^
+
+CSVFeatureSource retains the same basic structure, but the code is assisted by the new classes. It now overloads the constructor:
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureSource.java
+      :language: java
+      :start-after: import org.opengis.feature.simple.SimpleFeatureType;
+      :end-before: public CSVDataStore getDataStore() {
+
+The **getBoundsInternal(Query query)** method is now implemented by making use of the methods provdied by ContentFeatureSource. A new ReferencedEnvelope is created to store the bounds for this feature source. It uses the feature type (**getSchema()**) to determine the CRS (**getCoordinateReferenceSystem()**) - this information is used to construct the bounds for the feature. The FeatureReader is now created by using the Query and CSVStrategy - the **getReader()** method calls **getReaderInternal(Query query)** which shows how it is created. Finally, using the reader, the features are cycled through and included in the bounds in order to calculate the bounds for this entire datastore.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureSource.java
+      :language: java
+      :lines: 41-54
+
+The **getReaderInternal(Query query)** method now utilizes the strategy of the CSVDataStore rather than state to reflect the changes to the CSVFeatureReader design.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureSource.java
+      :language: java
+      :lines: 69-73
+
+The **getCountInternal(Query query)** method uses the same idea as **getBoundsInternal(Query query)** - it now utilizes the Query and CSVStrategy to obtain a FeatureReader, then simply counts them.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureSource.java
+      :language: java
+      :lines: 56-67
+
+The **buildFeatureType()** method is now very simple using **getSchema()** to grab the feature type of the datastore.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureSource.java
+      :language: java
+      :lines: 75-77
+
+CSVFileState
+^^^^^^^^^^^^
+
+The CSVFileState is a new class to assist with File manipulation in our CSVDataStore. It will hold some information about our :file:`.csv` file and allow it to be opened for reading.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFileState.java
+      :language: java
+      :start-after: import com.csvreader.CsvReader;
+      :end-before: public CsvReader openCSVReader() throws IOException {
+
+The class opens the file for reading, ensures it is the correct CSV format, and gives back a CSVReader to read the file through a stream.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFileState.java
+      :language: java
+      :lines: 94-106
+
+The **readCSVHeaders()** and **getCSVHeaders()** methods grab the headers from the file (thus, leaving just the data).
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFileState.java
+      :language: java
+      :lines: 108-131
+
+CSVStrategy
+^^^^^^^^^^^
+
+CSVStrategy is a basic interface which defines our strategy pattern for the CSVDataStore. What this essentially is saying is that the included methods' implementation will be injected into our CSVDataStore to use.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVStrategy.java
+      :language: java
+      :start-after: import org.opengis.feature.simple.SimpleFeatureType;
+
+AbstractCSVStrategy
+^^^^^^^^^^^^^^^^^^^
+
+The AbstractCSVStrategy defines an abstract class which can be subclassed into specific strategies. The strategy objects are used by the CSVDataStore to determine how certain methods will operate: by passing the strategy objects into the CSVDataStore, their implementation is utilized. This is the basic concept of the strategy design pattern. Through this design, we can continue extending the abilities of the CSVDataStore in the future much more easily. It will simply require specifiying a new Strategy class.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/AbstractCSVStrategy.java
+      :language: java
+      :start-after: import org.opengis.feature.simple.SimpleFeatureType;
+      :end-before: protected abstract SimpleFeatureType buildFeatureType();
+
+The class defines some of the CSVStrategy's methods as well as adding one more for subclasses to define - **buildFeatureType()**. So in the end, subclasses of AbstractCSVStrategy will need to implement **createFeature(String recordId, String[] csvRecord)** and **buildFeatureType()**, while **getFeatureType()** and **iterator()** are provided for them.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/AbstractCSVStrategy.java
+      :language: java
+      :start-after: }
+
+CSVAttributesOnlyStrategy
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The CSVAttributesOnlyStrategy is the simplest implementation. It directly reads the file and obtains the values as attributes for the feature. The feature type is built using helper methods from a support class which will be visited later. The headers from the :file:`.csv` file are read in as attributes for this feature. Each header is an attribute defined in that column, and each row provides the values for all the attributes of one feature. The csvRecord parameter contains one line of data read in from the file, and each String is mapped to its attribute. The SimpleFeatureBuilder utility class uses all the data to build this feature. 
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVAttributesOnlyStrategy.java
+      :language: java
+      :start-after: import org.opengis.feature.simple.SimpleFeatureType;
+
+CSVLatLonStrategy
+^^^^^^^^^^^^^^^^^
+
+The CSVLatLonStrategy provides the additional component of supplanting Latitude and Longitude fields with a Point geometry. We search through the headers to see if there is a match for both Latitude and Longitude, and if so, we remove those attributes and replace it with the Point geometry.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVLatLonStrategy.java
+      :language: java
+      :start-after: import com.vividsolutions.jts.geom.Point;
+      :end-before: @Override
+
+When creating the feature, we check to see if we're in the Latitude column and take it as our y value, and check to see if we're in the Longitude column and take it as our x value. If we found Lat/Lon columns, we convert the x and y into a Point geometry and pass it to our feature builder. The atrribute name is predefined to be "locations" for the Geometry Column.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVLatLonStrategy.java
+      :language: java
+      :lines: 74-112
+
+CSVSpecifiedLatLngStrategy
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The CSVSpecifiedLatLngStrategy behaves similarly to the CSVLatLonStrategy class with just a few minor differences. First, the Latitude and Longitude columns are specified (with a specific string, such as "lat" and "lon"). Further, the points constructed can have a different specified attribute name. However, the default is still "locations" for the Geometry Column if nothing is specified.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVSpecifiedLatLngStrategy.java
+      :language: java
+      :start-after: import com.vividsolutions.jts.geom.Point;
+
+
+CSVSpecifiedWKTStrategy
+^^^^^^^^^^^^^^^^^^^^^^^
+
+CSVSpecifiedWKTStrategy is the strategy used for a Well-Known-Text (WKT) format. Similar to the CSVSpecifiedLatLngStrategy, a specified WKT must be passed to the strategy to be used to parse for the WKT. If found, it attaches the Geometry class to the WKT in the header.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVSpecifiedWKTStrategy.java
+      :language: java
+      :lines: 22-41
+
+In creating a feature, the line is parsed for the WKT field specified before, and if found, attempts to read a Geometry object from the file. If for some reason the field is unparseable, it will just be set to a null value. The builder utility will then build this feature after the line has been fully read.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVSpecifiedWKTStrategy.java
+      :language: java
+      :lines: 43-71
+
+
+CSVStrategySupport
+^^^^^^^^^^^^^^^^^^
+
+The support class commonly used by all the strategy objects is CSVStrategySupport. It provides helper methods common to most strategies but that are not themselves a part of creating a strategy (and so do not belong in AbstractCSVStrategy). The **createBuilder()** methods are helpers that set some of the common portions for the SimpleFeatureBuilder utility object, such as the type name, coordinate reference system, namespace URI, and then the column headers.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVStrategySupport.java
+      :language: java
+      :start-after: import com.csvreader.CsvReader;
+      :end-before: public static Map<String, Class<?>> findMostSpecificTypesFromData(CsvReader csvReader,
+
+The **findMostSpecificTypesFromData(CsvReader csvReader, String[] headers)** method attempts to find the type of the data being read. It attempts to read it as an Integer first, and if the format is incorrect, it tries a Double next, and if the format is still incorrect, it just defaults to a String type.
+
+   .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVStrategySupport.java
+      :language: java
+      :lines: 54-100


### PR DESCRIPTION
A new directory called csv2 was created for the old tutorial to link to. This directory contains the current geotools implementation of CSVDataStore.

In pull request #652 the unsupported module contains the new implementation for CSVDataStore which is being backported from geoserver. Thus, when both pull requests are accepted, there will be no duplication of code.

The strategy.rst file describes the new changes made in the updated implementation.
