### PR TITLE
Fixed PropertyNameResolvingVisitor to return a blank name if the xpath is blank [GEOT-4972]

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
@@ -1028,7 +1028,10 @@ public class SimpleFeatureTypeBuilder {
 
         // add attributes in order
         for (int i = 0; i < types.size(); i++) {
-            b.add(original.getDescriptor(types.get(i)));
+            AttributeDescriptor descriptor = original.getDescriptor(types.get(i));
+            if (descriptor != null) {
+                b.add(descriptor);
+            }
         }
         
         // handle default geometry

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/PropertyNameResolvingVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/PropertyNameResolvingVisitor.java
@@ -49,6 +49,9 @@ public class PropertyNameResolvingVisitor extends DuplicatingFilterVisitor {
     }
     
     public Object visit(PropertyName expression, Object extraData) {
+        if ("".equals(expression.getPropertyName())) {
+            return super.visit(expression, extraData);
+        }
         AttributeDescriptor att = expression.evaluate( featureType, null);
         if ( att != null ) {
             return getFactory(extraData).property( att.getLocalName() );

--- a/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleTypeBuilderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleTypeBuilderTest.java
@@ -125,4 +125,17 @@ public class SimpleTypeBuilderTest extends TestCase {
                 "geo1" });
         assertEquals("geo1", retyped.getGeometryDescriptor().getLocalName());
     }
+    
+    public void testRetypeNull() {
+        builder.setName("testNull");
+        builder.add("geom", Polygon.class, DefaultGeographicCRS.WGS84);
+        SimpleFeatureType type = builder.buildFeatureType();
+
+        //A null value in the attribute list should not cause a failure
+        SimpleFeatureType retyped = SimpleFeatureTypeBuilder.retype(type, new String[] { null });
+        assertEquals(0, retyped.getAttributeCount());
+        
+        retyped = SimpleFeatureTypeBuilder.retype(type, new String[] { "geom", null });
+        assertEquals(1, retyped.getAttributeCount());
+    }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/PropertyNameResolvingFilterVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/PropertyNameResolvingFilterVisitorTest.java
@@ -20,9 +20,14 @@ import junit.framework.TestCase;
 
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.spatial.BBOX;
+
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
 
 /**
  * 
@@ -42,6 +47,8 @@ public class PropertyNameResolvingFilterVisitorTest extends TestCase {
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
         b.setName( "test" );
         b.add( "name", String.class );
+        b.add("geom", Polygon.class, DefaultGeographicCRS.WGS84);
+        b.setDefaultGeometry("geom");
         featureType = b.buildFeatureType();
     }
     
@@ -52,5 +59,15 @@ public class PropertyNameResolvingFilterVisitorTest extends TestCase {
         f = (PropertyIsEqualTo) f.accept( new PropertyNameResolvingVisitor(featureType),null);
         
         assertEquals( "name", f.getExpression1().toString() );
+    }
+    
+    public void testResolveEmptyName() {
+        //We use a geometry filter here to test that expression1 does not get filled with the default geometry
+        BBOX f = factory.bbox("", 0.0, 0.0, 1.0, 1.0, DefaultGeographicCRS.WGS84.toString());
+        assertEquals( "", f.getExpression1().toString() );
+        
+        f = (BBOX) f.accept( new PropertyNameResolvingVisitor(featureType),null);
+        
+        assertEquals( "", f.getExpression1().toString() );
     }
 }

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
@@ -443,6 +443,11 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
                 41.512517, null);
         q.setFilter(ff.bbox(ff.property(""), queryBounds));
         
+        //Read schema should contain the geometry property
+        assertEquals(3, ((ShapefileFeatureStore)fs).delegate.getReadSchema(q).getAttributeCount());
+        //Result schema should not contain the geometry property
+        assertEquals(2, ((ShapefileFeatureStore)fs).delegate.getResultSchema(q).getAttributeCount());
+        
         // grab the features
         SimpleFeatureCollection fc = fs.getFeatures(q);
         assertTrue(fc.size() > 0);


### PR DESCRIPTION
Additionial fixes required to avoid test failures:
Fix to SimpleFeatureTypeBuilder to exclude null values. 
Fix to ShapeFileFeatureSource.getReadSchema() to include geometry properties in a geometry query with no geometry properties included.