### PR TITLE
ContentFeatureSource simplifies all filters within all passed queries.

### DIFF
--- a/docs/user/library/main/data.rst
+++ b/docs/user/library/main/data.rst
@@ -363,10 +363,18 @@ A common task with gt-main is preparing a Query against a FeatureSource. DataUti
 
 * DataUtilities.mixQueries(Query, Query, String)
   
-  Safely combines two queries in a sensible manner.
+  Safely combines two queries in a sensible manner. The provided string is used for the name of the new query.
+
+* DataUtilities.simplifyFilter(Query)
+
+  Simplifies the filter contained in a query, eliminating non-functional clauses.
 
 * DataUtilities.resolvePropertyNames(Query, SimpleFeatureType)
 * DataUtilities.resolvePropertyNames(Filter, SimpleFeatureType)
+
+  These two methods rewrite full property names to simple attribute names. 
+  For example, property names such as "gml:name" are rewritten as simply "name".
+
 * DataUtilities.addMandatoryProperties(SimpleFeatureType, List<PropertyName>)
 
 SortBy

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
@@ -690,6 +690,7 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
     public void accepts( Query query, org.opengis.feature.FeatureVisitor visitor,
             org.opengis.util.ProgressListener progress) throws IOException {
         
+        query = DataUtilities.simplifyFilter(query);
         if( progress == null ) {
             progress = new NullProgressListener();
         }

--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -84,6 +84,7 @@ import org.geotools.feature.type.GeometryDescriptorImpl;
 import org.geotools.feature.type.GeometryTypeImpl;
 import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.filter.visitor.PropertyNameResolvingVisitor;
+import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.geometry.jts.WKTReader2;
 import org.geotools.metadata.iso.citation.Citations;
@@ -132,6 +133,7 @@ import com.vividsolutions.jts.geom.MultiPoint;
 import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
+
 import org.geotools.data.view.DefaultView;
 
 /**
@@ -2394,7 +2396,8 @@ public class DataUtilities {
      * it does not means that all the properties will be joined. You must create the query with the
      * names of the properties you want to load.</li>
      * <li>
-     * filter: the filtets of both queries are or'ed</li>
+     * filter: the filters of both queries are or'ed, then simplified using 
+     * SimplifiyingFilterVisitor</li>
      * <li>
      * <b>any other query property is ignored</b> and no guarantees are made of their return values,
      * so client code shall explicitly care of hints, startIndex, etc., if needed.</li>
@@ -2462,6 +2465,7 @@ public class DataUtilities {
         } else if ((filter2 != null) && !filter2.equals(Filter.INCLUDE)) {
             filter = ff.and(filter, filter2);
         }
+        filter = SimplifyingFilterVisitor.simplify(filter);
         Integer start = 0;
         if (firstQuery.getStartIndex() != null) {
             start = firstQuery.getStartIndex();
@@ -2488,6 +2492,18 @@ public class DataUtilities {
             mixed.setStartIndex(start);
         }
         return mixed;
+    }
+    
+    /**
+     * This method changes the query object by simplifying the filter using SimplifyingFilterVisitor
+     */
+    public static Query simplifyFilter(Query query) {
+        if (query == null) {
+            return query;
+        }
+        Filter filter = SimplifyingFilterVisitor.simplify(query.getFilter());
+        query.setFilter(filter);
+        return query;
     }
 
     /**

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -716,7 +716,16 @@ public class DataUtilitiesTest extends DataTestCase {
         assertTrue((Boolean) mixed.getHints().get(Hints.USE_PROVIDED_FID));
         assertTrue((Boolean) mixed.getHints().get(Hints.FEATURE_2D));
     }
-
+    
+    public void testSimplifyFilter() {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        Filter filter = ff.and(Filter.INCLUDE, Filter.INCLUDE);
+        Query query = new Query(Query.ALL);
+        query.setFilter(filter);
+        DataUtilities.simplifyFilter(query);
+        assertEquals(Filter.INCLUDE, query.getFilter());
+    }
+    
     public void testSpecNoCRS() throws Exception {
         String spec = "id:String,polygonProperty:Polygon";
         SimpleFeatureType ft = DataUtilities.createType("testType", spec);


### PR DESCRIPTION
DataUtilities.mixQueries modified to simplify filters.
DataUtilities.simplifyFilter(Query) method added to simplify the filter contained by a query.