### PR TITLE
Fix typing on retype, previously could get different defaultGeometry values

### DIFF
--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
@@ -602,7 +602,7 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
             if ( query.getPropertyNames() != Query.ALL_NAMES ) {
                 //rebuild the type and wrap the reader
                 SimpleFeatureType target = 
-                    SimpleFeatureTypeBuilder.retype(getSchema(), query.getPropertyNames());
+                    SimpleFeatureTypeBuilder.retype(reader.getFeatureType(), query.getPropertyNames());
                 
                 // do an equals check because we may have needlessly retyped (that is,
                 // the subclass might be able to only partially retype)

--- a/modules/library/main/src/main/java/org/geotools/feature/FeatureTypes.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/FeatureTypes.java
@@ -471,8 +471,12 @@ public class FeatureTypes {
     static boolean equals( SimpleFeatureType typeA, SimpleFeatureType typeB, boolean compareUserMaps) {
         if (typeA == typeB)
             return true;
-
+        
         if (typeA == null || typeB == null) {
+            return false;
+        }
+        
+        if (!typeA.equals(typeB)) {
             return false;
         }
         

--- a/modules/library/main/src/test/java/org/geotools/feature/FeatureTypesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/FeatureTypesTest.java
@@ -1,6 +1,8 @@
 package org.geotools.feature;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -83,4 +85,32 @@ public class FeatureTypesTest {
         Assert.assertEquals("Feature", types.get(0).getName().getLocalPart());
     }
     
+    @Test
+    public void testEquals() {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("SomeFeature");
+        builder.setCRS(null);
+        builder.add("name", String.class);
+        builder.add("geom1", Point.class);
+        builder.add("geom2", Point.class);
+        builder.setDefaultGeometry("geom1");
+        SimpleFeatureType ft1 = builder.buildFeatureType();
+        builder.setName("SomeFeature");
+        builder.setCRS(null);
+        builder.add("name", String.class);
+        builder.add("geom1", Point.class);
+        builder.add("geom2", Point.class);
+        builder.setDefaultGeometry("geom1");
+        SimpleFeatureType ft2 = builder.buildFeatureType();
+        assertTrue(FeatureTypes.equalsExact(ft1, ft2));
+        
+        builder.setName("SomeFeature");
+        builder.setCRS(null);
+        builder.add("name", String.class);
+        builder.add("geom1", Point.class);
+        builder.add("geom2", Point.class);
+        builder.setDefaultGeometry("geom2");
+        ft2 = builder.buildFeatureType();
+        assertFalse(FeatureTypes.equalsExact(ft1, ft2));
+    }
 }


### PR DESCRIPTION
https://jira.codehaus.org/browse/GEOT-4978

ContentFeatureSource.getSchema() would sometimes give a different value for default geometry than reader.getFeatureType().

This only occurs if the data store contains multiple geometries, with no geometry explicitly defined as the default geometry. It appears that getSchema was somehow getting a differently ordered list of attributes than the reader.  Because this error does not occur predictably, I am not sure that a viable test case for this issue is possible.