### PR TITLE
ContentFeatureStore writer flag for commit

### DIFF
--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVDataStore.java
@@ -6,7 +6,7 @@
  * This file is hereby placed into the Public Domain. This means anyone is
  * free to do whatever they wish with this file. Use it well and enjoy!
  */
-package org.geotools.data.csv;
+package org.geotools.tutorial.csv2;
 
 import java.io.File;
 import java.io.FileReader;

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVDataStoreFactory.java
@@ -7,7 +7,7 @@
  * free to do whatever they wish with this file. Use it well and enjoy!
  */
 // header start
-package org.geotools.data.csv;
+package org.geotools.tutorial.csv2;
 
 import java.awt.RenderingHints.Key;
 import java.io.File;

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureReader.java
@@ -6,7 +6,7 @@
  * This file is hereby placed into the Public Domain. This means anyone is
  * free to do whatever they wish with this file. Use it well and enjoy!
  */
-package org.geotools.data.csv;
+package org.geotools.tutorial.csv2;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureSource.java
@@ -6,7 +6,7 @@
  * This file is hereby placed into the Public Domain. This means anyone is
  * free to do whatever they wish with this file. Use it well and enjoy!
  */
-package org.geotools.data.csv;
+package org.geotools.tutorial.csv2;
 
 import java.io.IOException;
 

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureStore.java
@@ -6,7 +6,7 @@
  * This file is hereby placed into the Public Domain. This means anyone is
  * free to do whatever they wish with this file. Use it well and enjoy!
  */
-package org.geotools.data.csv;
+package org.geotools.tutorial.csv2;
 
 import java.io.IOException;
 

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
@@ -6,7 +6,7 @@
  * This file is hereby placed into the Public Domain. This means anyone is
  * free to do whatever they wish with this file. Use it well and enjoy!
  */
-package org.geotools.data.csv;
+package org.geotools.tutorial.csv2;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVWriteTest.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVWriteTest.java
@@ -6,7 +6,7 @@
  * This file is hereby placed into the Public Domain. This means anyone is
  * free to do whatever they wish with this file. Use it well and enjoy!
  */
-package org.geotools.data.csv;
+package org.geotools.tutorial.csv2;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +35,7 @@ import org.geotools.factory.Hints;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.JTSFactoryFinder;
-import org.geotools.test.TestData;
+import org.geotools.tutorial.csv.CSVTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,8 +76,7 @@ public class CSVWriteTest {
             System.exit(1);
         }
         file = new File(tmp, "locations.csv");
-
-        URL resource = TestData.getResource(CSVWriteTest.class, "locations.csv");
+        URL resource = CSVTest.class.getResource("locations.csv");
         Files.copy(resource.openStream(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
     }
     

--- a/modules/library/api/src/main/java/org/geotools/data/AutoCommitTransaction.java
+++ b/modules/library/api/src/main/java/org/geotools/data/AutoCommitTransaction.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 
 /**
- * This is used to represent the absense of a Transaction and the use of
+ * This is used to represent the absence of a Transaction and the use of
  * AutoCommit.
  *
  * <p>
@@ -162,7 +162,7 @@ class AutoCommitTransaction implements Transaction {
      * AutoCommit does not save State.
      *
      * <p>
-     * While symetry would be good, state should be commited not stored for
+     * While symmetry would be good, state should be committed not stored for
      * later.
      * </p>
      *

--- a/modules/library/api/src/main/java/org/geotools/data/Transaction.java
+++ b/modules/library/api/src/main/java/org/geotools/data/Transaction.java
@@ -137,11 +137,6 @@ public interface Transaction {
      * This may be used to provide hints to DataStore implementations, it
      * operates as a blackboard for client, SimpleFeatureSource communication.
      * </p>
-     *
-     * <p>
-     * If this proves successful addAuthorization/getAuthorization will be
-     * replaced with this mechanism.
-     * </p>
      */
     Object getProperty(Object key);
 

--- a/modules/library/data/.gitignore
+++ b/modules/library/data/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/target/
+/target/

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentDataStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentDataStore.java
@@ -102,12 +102,13 @@ import com.vividsolutions.jts.geom.GeometryFactory;
  */
 public abstract class ContentDataStore implements DataStore {
 
-    /**
-     * writer flags
-     */
+    /** Flag writer for adding new content */
     protected final static int WRITER_ADD = 0x01<<0;
+    /** Flag writer for updating content in place */
     protected final static int WRITER_UPDATE = 0x01<<1;
-    
+    /** Flag writer for commit (AUTO_COMMIT with no events) */
+    protected final static int WRITER_COMMIT = 0x01<<2;
+
     /**
      * name, entry map
      */

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureStore.java
@@ -155,12 +155,12 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
                     }
                 }
             } else {
-                DiffTransactionState state = (DiffTransactionState) getTransaction().getState(
-                        getEntry());
+                DiffTransactionState state = (DiffTransactionState) getTransaction()
+                        .getState(getEntry());
                 // reader will take care of filtering
                 // DiffContentWriter takes care of events
                 FeatureReader<SimpleFeatureType, SimpleFeature> reader = getReader(query);
-                writer = new DiffContentFeatureWriter(this, state.getDiff(), reader);
+                writer = state.diffWriter( this, reader );
             }
         } else {
             writer = getWriterInternal(query, flags);
@@ -177,9 +177,9 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
         }
         // Use InProcessLockingManager to assert write locks?
         if (!canLock()) {
-            LockingManager lockingManager = getDataStore().getLockingManager();
-            writer = ((InProcessLockingManager) lockingManager).checkedWriter(writer,
-                    transaction);
+            InProcessLockingManager lockingManager = (InProcessLockingManager) getDataStore()
+                    .getLockingManager();
+            writer = lockingManager.checkedWriter(writer, transaction);
         }
         // Finished
         return writer;

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureStore.java
@@ -87,11 +87,12 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
         SimpleFeatureStore,
         FeatureLocking<SimpleFeatureType, SimpleFeature> {
 
-    /**
-     * writer flags
-     */
+    /** Flag writer for adding new content */
     protected final int WRITER_ADD = ContentDataStore.WRITER_ADD;
+    /** Flag writer for updating content in place */
     protected final int WRITER_UPDATE = ContentDataStore.WRITER_UPDATE;
+    /** Flag writer for commit (AUTO_COMMIT with no events) */
+    protected final int WRITER_COMMIT = ContentDataStore.WRITER_COMMIT;
     
     /**
      * Creates the content feature store.
@@ -144,12 +145,25 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
         FeatureWriter<SimpleFeatureType, SimpleFeature> writer;
 
         if (!canTransact() && transaction != null && transaction != Transaction.AUTO_COMMIT) {
-            DiffTransactionState state = (DiffTransactionState) getTransaction().getState(getEntry());
-            FeatureReader<SimpleFeatureType, SimpleFeature> reader = getReader(query);
-            writer = new DiffContentFeatureWriter(this, state.getDiff(), reader);
+            if ((flags | WRITER_COMMIT) == WRITER_COMMIT) {
+                // Simple simple writer with no events or locking
+                writer = getWriterInternal(query, flags);
+                // filtering may not be needed
+                if (!canFilter()) {
+                    if (query.getFilter() != null && query.getFilter() != Filter.INCLUDE) {
+                        writer = new FilteringFeatureWriter(writer, query.getFilter());
+                    }
+                }
+            } else {
+                DiffTransactionState state = (DiffTransactionState) getTransaction().getState(
+                        getEntry());
+                // reader will take care of filtering
+                // DiffContentWriter takes care of events
+                FeatureReader<SimpleFeatureType, SimpleFeature> reader = getReader(query);
+                writer = new DiffContentFeatureWriter(this, state.getDiff(), reader);
+            }
         } else {
             writer = getWriterInternal(query, flags);
-
             // events
             if (!canEvent()){
                 writer = new EventContentFeatureWriter(this, writer );
@@ -160,15 +174,13 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
                     writer = new FilteringFeatureWriter(writer, query.getFilter());
                 }
             }
-
-            // Use InProcessLockingManager to assert write locks?
-            if (!canLock()) {
-                LockingManager lockingManager = getDataStore().getLockingManager();
-                writer = ((InProcessLockingManager) lockingManager).checkedWriter(writer,
-                        transaction);
-            }
         }
-        
+        // Use InProcessLockingManager to assert write locks?
+        if (!canLock()) {
+            LockingManager lockingManager = getDataStore().getLockingManager();
+            writer = ((InProcessLockingManager) lockingManager).checkedWriter(writer,
+                    transaction);
+        }
         // Finished
         return writer;
     }
@@ -182,6 +194,7 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
      * <ul>
      *   <li>reprojection</li>
      *   <li>filtering</li>
+     *   <li>events</li>
      *   <li>max feature limiting</li>
      *   <li>sorting</li>
      *   <li>locking</li>
@@ -190,6 +203,7 @@ public abstract class ContentFeatureStore extends ContentFeatureSource implement
      * <ul>
      *   <li>{@link #canReproject()}</li>
      *   <li>{@link #canFilter()}</li>
+     *   <li>{@link #canEvent()}</li>
      *   <li>{@link #canLimit()}</li>
      *   <li>{@link #canSort()}</li>
      *   <li>{@link #canLock()}</li>

--- a/modules/library/data/src/main/java/org/geotools/data/store/DiffContentFeatureWriter.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/DiffContentFeatureWriter.java
@@ -38,11 +38,11 @@ import org.opengis.feature.simple.SimpleFeatureType;
  * </p>
  * 
  * <p>
- * The api has been implemented in terms of FeatureReader<SimpleFeatureType, SimpleFeature> to make
- * explicit that no Features are writen out by this Class.
+ * The API has been implemented in terms of FeatureReader<SimpleFeatureType, SimpleFeature> to make
+ * explicit that no Features are written out by this Class.
  * </p>
  * 
- * @author Jody Garnett, Refractions Research
+ * @author Jody Garnett (Refractions Research)
  * 
  * @see DiffContentState
  * 
@@ -55,7 +55,7 @@ public class DiffContentFeatureWriter implements FeatureWriter<SimpleFeatureType
 
     protected Diff diff;
 
-    SimpleFeature next; // next value aquired by hasNext()
+    SimpleFeature next; // next value acquired by hasNext()
 
     SimpleFeature live; // live value supplied by FeatureReader
 

--- a/modules/library/data/src/main/java/org/geotools/data/store/DiffTransactionState.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/DiffTransactionState.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import org.geotools.data.DataSourceException;
 import org.geotools.data.Diff;
+import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureWriter;
 import org.geotools.data.Transaction;
 import org.geotools.data.TransactionStateDiff;
@@ -134,7 +135,7 @@ public class DiffTransactionState implements Transaction.State {
         ContentFeatureSource source = (ContentFeatureSource) dataStore.getFeatureSource(name);
         if (source instanceof ContentFeatureStore) {
             // request a plain writer with no events, filtering or locking checks
-            store = (ContentFeatureStore) dataStore.getFeatureSource(name);
+            store = (ContentFeatureStore) dataStore.getFeatureSource(name, transaction);
             writer = store.getWriter(Filter.INCLUDE, ContentDataStore.WRITER_COMMIT);
         } else {
             throw new UnsupportedOperationException("not writable");
@@ -241,5 +242,20 @@ public class DiffTransactionState implements Transaction.State {
      */
     public synchronized void addAuthorization(String AuthID) throws IOException {
         // not required for TransactionStateDiff
+    }
+    
+    /**
+     * Provides a wrapper on the provided reader which gives a diff writer.
+     *
+     * @param contentFeatureStore ContentFeatureStore 
+     * @param reader FeatureReader requiring diff support
+     *
+     * @return FeatureWriter with diff support
+     */
+    public FeatureWriter<SimpleFeatureType, SimpleFeature> diffWriter(
+            ContentFeatureStore contentFeatureStore,
+            FeatureReader<SimpleFeatureType, SimpleFeature> reader) {
+        
+        return new DiffContentFeatureWriter( contentFeatureStore, diff, reader);
     }
 }

--- a/modules/library/data/src/main/java/org/geotools/data/store/DiffTransactionState.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/DiffTransactionState.java
@@ -133,8 +133,9 @@ public class DiffTransactionState implements Transaction.State {
         ContentDataStore dataStore = entry.getDataStore();
         ContentFeatureSource source = (ContentFeatureSource) dataStore.getFeatureSource(name);
         if (source instanceof ContentFeatureStore) {
+            // request a plain writer with no events, filtering or locking checks
             store = (ContentFeatureStore) dataStore.getFeatureSource(name);
-            writer = store.getWriter(Filter.INCLUDE);
+            writer = store.getWriter(Filter.INCLUDE, ContentDataStore.WRITER_COMMIT);
         } else {
             throw new UnsupportedOperationException("not writable");
         }

--- a/modules/library/data/src/test/java/org/geotools/data/store/ContentFeatureSourceEventsTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/store/ContentFeatureSourceEventsTest.java
@@ -139,10 +139,10 @@ public class ContentFeatureSourceEventsTest extends AbstractContentTest {
 
         store1.getTransaction().commit();
 
-        assertEquals(2, listener1.events.size());
-        assertEquals(2, listener2.events.size());
+        assertEquals(1, listener1.events.size());
+        assertEquals(1, listener2.events.size());
 
-        event = listener2.getEvent(1);
+        event = listener2.getEvent(0);
         assertEquals(feature.getBounds(), event.getBounds());
         assertEquals(FeatureEvent.Type.COMMIT, event.getType());
 


### PR DESCRIPTION
Added diffWriter method to provide wrapper for ContentFeatureStore writer.
Fixed misc bugs:
 - Added transaction to store in DiffTransactionState.commit()
 - Brought locking wrapper outside of if statement in ContentFeatureStore.getWriter()
 - Tweaked ContentFeatureSourceEventsTest.java to match current results. It is now closer to expected behaviour (Although event handling still needs to be overhauled)
