### PR TITLE
Remove unnecessary System.err.println calls

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
@@ -702,7 +702,7 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
 
         URL finalURL = URIs.buildURL(baseUrl, requestParams);
         requestDebug("Built GET request for ", operation, ": ", finalURL);
-        System.err.println(finalURL.toExternalForm());
+        //System.err.println(finalURL.toExternalForm());
         return finalURL;
     }
 
@@ -765,7 +765,7 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
 
         requestTrace("Encoded ", request.getOperation(), " request: ", out);
 
-        System.err.println(out.toString());
+        //System.err.println(out.toString());
 
         return new ByteArrayInputStream(out.toByteArray());
 


### PR DESCRIPTION
wfs-ng module

There are unnecessary System.err.println calls in org.geotools.data.wfs.internal.AbstractWFSStrategy.java.  The text content being written to standard error is also being written out to log files.

I'm deploying GeoTools as a Jboss module and these calls cause the post contents of all WFS requests to be duplicated in the server.log file.  The first time it's recorded as INFO, but the second call (System.err.println) records it as ERROR.

These changes resolve GEOT-4914.