### PR TITLE
NestedAttributeExpresionImpl is incompatible with DuplicatingFilterVisitor (GEOT-4981)

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/filter/NestedAttributeExpression.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/filter/NestedAttributeExpression.java
@@ -34,11 +34,13 @@ import org.geotools.data.complex.filter.XPathUtil.StepList;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.Types;
 import org.geotools.filter.AttributeExpressionImpl;
+import org.geotools.filter.visitor.DuplicatingFilterVisitor;
 import org.geotools.xlink.XLINK;
 import org.opengis.feature.Attribute;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.ExpressionVisitor;
 
 /**
  * This class represents a list of expressions broken up from a single XPath expression that is
@@ -368,4 +370,11 @@ public class NestedAttributeExpression extends AttributeExpressionImpl {
         return exp;
     }
     
+    public Object accept(ExpressionVisitor visitor, Object extraData) {
+        //Workaround for GEOT-4981: NestedAttributeExpresionImpl is incompatible with DuplicatingFilterVisitor
+        if (visitor instanceof DuplicatingFilterVisitor) {
+            return new NestedAttributeExpression(fullSteps, rootMapping);
+        }
+        return visitor.visit(this,extraData);
+    }
 }


### PR DESCRIPTION
See GEOT-4891: NestedAttributeExpresionImpl is incompatible with DuplicatingFilterVisitor (https://jira.codehaus.org/browse/GEOT-4981)

Changes NestedAttributeExpression to overrides AttributeExpressionImpl.accept() and returen a copy of itself if visited by a DuplicatingFilterVisitor. 