### PR TITLE
Correction for bug on directed graphs

### DIFF
--- a/modules/extension/graph/src/main/java/org/geotools/graph/traverse/standard/DijkstraIterator.java
+++ b/modules/extension/graph/src/main/java/org/geotools/graph/traverse/standard/DijkstraIterator.java
@@ -266,7 +266,11 @@ public class DijkstraIterator extends SourceGraphIterator {
   }
   
   protected Iterator getRelated(Graphable current) {
-    return(current.getRelated());	
+    if ( current instanceof DirectedGraphable ) {
+      return ((DirectedGraphable)current).getOutRelated() ;
+    } else {
+      return (current.getRelated());
+    }
   }
   
   /**

--- a/modules/extension/graph/src/main/java/org/geotools/graph/traverse/standard/DijkstraIterator.java
+++ b/modules/extension/graph/src/main/java/org/geotools/graph/traverse/standard/DijkstraIterator.java
@@ -24,6 +24,7 @@ import org.geotools.graph.structure.Edge;
 import org.geotools.graph.structure.Graph;
 import org.geotools.graph.structure.GraphVisitor;
 import org.geotools.graph.structure.Graphable;
+import org.geotools.graph.structure.DirectedGraphable;
 import org.geotools.graph.structure.Node;
 import org.geotools.graph.traverse.GraphTraversal;
 import org.geotools.graph.traverse.basic.SourceGraphIterator;


### PR DESCRIPTION
Correct list of related edges when a directed graph is used (must use getOutRelated insted of getRelated)