### PR TITLE
Adds kml:name element when dumping as KML 2.2

### DIFF
--- a/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/bindings/NameBinding.java
+++ b/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/bindings/NameBinding.java
@@ -9,6 +9,8 @@ import org.geotools.xml.AbstractComplexBinding;
 import org.geotools.xml.Binding;
 import org.geotools.xml.ElementInstance;
 import org.geotools.xml.Node;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 public class NameBinding extends AbstractComplexBinding {
 
@@ -49,5 +51,10 @@ public class NameBinding extends AbstractComplexBinding {
             }
         }
         return super.parse(instance, node, value);
+    }
+
+    public Element encode(Object object, Document document, Element value) throws Exception {
+        value.setTextContent(object.toString());
+        return value;
     }
 }

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLEncodingTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLEncodingTest.java
@@ -21,7 +21,7 @@ public class KMLEncodingTest extends KMLTestSupport {
     public void testEncodePoint() throws Exception {
         Point p = new GeometryBuilder().point(1,2);
         Document d = encode(p, KML.Point);
-        
+
         assertEquals("Point", d.getDocumentElement().getLocalName());
         Element e = getElementByQName(d, KML.coordinates);
         assertNotNull(e);
@@ -48,7 +48,7 @@ public class KMLEncodingTest extends KMLTestSupport {
         GeometryFactory geomFactory = new GeometryFactory();
         DefaultFeatureCollection collection = new DefaultFeatureCollection("internal", null);
         SimpleFeatureType type = DataUtilities.createType("location",
-                "geom:Point,attr1:String,attr2:Integer");
+                "geom:Point,name:String,attr2:Integer");
 
         Point point1 = geomFactory.createPoint(new Coordinate(40, 50));
         Point point2 = geomFactory.createPoint(new Coordinate(30, 45));
@@ -88,18 +88,23 @@ public class KMLEncodingTest extends KMLTestSupport {
         assertTrue(KML.Placemark.getLocalPart().equals(Placemark2.getLocalName()));
         assertTrue(KML.Placemark.getLocalPart().equals(Placemark3.getLocalName()));
 
-        // ExtendedData (first feature)
-        Node extData1 = Placemark1.getChildNodes().item(0);
+        // First XML child element should be the kml:name one
+        Node kmlName = Placemark1.getChildNodes().item(0);
+        assertTrue(KML.name.getLocalPart().equals(kmlName.getLocalName()));
+
+        // ExtendedData (second XML element)
+        Node extData1 = Placemark1.getChildNodes().item(1);
         assertTrue(KML.ExtendedData.getLocalPart().equals(extData1.getLocalName()));
 
-        Node data1 = extData1.getChildNodes().item(0), data2 = extData1.getChildNodes().item(1);
+        Node data1 = extData1.getChildNodes().item(0),
+                data2 = extData1.getChildNodes().item(1);
         assertTrue(KML.Data.getLocalPart().equals(data1.getLocalName()));
         assertTrue(KML.Data.getLocalPart().equals(data2.getLocalName()));
         // We cannot predict the features order, just check the name of the attribute columns.
         Attr attrName1 = (Attr) data1.getAttributes().getNamedItem(KML.name.getLocalPart());
         Attr attrName2 = (Attr) data2.getAttributes().getNamedItem(KML.name.getLocalPart());
 
-        assertTrue("attr1".equals(attrName1.getValue()));
+        assertTrue("name".equals(attrName1.getValue()));
         assertTrue("attr2".equals(attrName2.getValue()));
 
     }


### PR DESCRIPTION
Following the previous PR 604, this allows the kml:name for each placemark to be also dumped (if the featuretype of the features contains a name property) when generating KML 2.2 documents.

Testing: Unit tests adapted.