### PR TITLE
Fixed FeatureWriter next() and hasNext() implementations to conform to standard file handle behavior

### DIFF
--- a/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
+++ b/docs/src/main/java/org/geotools/tutorial/csv2/CSVFeatureWriter.java
@@ -80,7 +80,7 @@ public class CSVFeatureWriter implements FeatureWriter<SimpleFeatureType, Simple
     @Override
     public boolean hasNext() throws IOException {
         if( csvWriter == null ){
-            throw new IOException("Writer has been closed");
+            return false;
         }
         if (this.appending) {
             return false; // reader has no more contents
@@ -94,7 +94,7 @@ public class CSVFeatureWriter implements FeatureWriter<SimpleFeatureType, Simple
     public SimpleFeature next() throws IOException, IllegalArgumentException,
             NoSuchElementException {
         if( csvWriter == null ){
-            throw new IOException("Writer has been closed");
+            throw new IOException("FeatureWriter has been closed");
         }
         if (this.currentFeature != null) {
             this.write(); // the previous one was not written, so do it now.

--- a/modules/library/api/src/main/java/org/geotools/data/FeatureWriter.java
+++ b/modules/library/api/src/main/java/org/geotools/data/FeatureWriter.java
@@ -83,7 +83,8 @@ public interface FeatureWriter<T extends FeatureType, F extends Feature> extends
      *
      * @return Feature from Query, or newly appended Feature
      *
-     * @throws IOException DOCUMENT ME!
+     * @throws IOException if the writer has been closed or an I/O error occurs reading the next 
+     * <code>Feature</code>.
      */
     F next() throws IOException;
 
@@ -159,14 +160,14 @@ public interface FeatureWriter<T extends FeatureType, F extends Feature> extends
      * </p>
      *
      * <p>
-     * FeatureWriters that support append opperations will allow calls to next,
-     * even when haveNext() returns <code>false</code>.
+     * FeatureWriters that support append operations will allow calls to next,
+     * even when hasNext() returns <code>false</code>.
      * </p>
      *
      * @return <code>true</code> if an additional <code>Feature</code> is
-     *         available.
+     *         available, <code>false</code> if not.
      *
-     * @throws IOException DOCUMENT ME!
+     * @throws IOException if an I/O error occurs.
      */
     boolean hasNext() throws IOException;
 

--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryDataStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryDataStore.java
@@ -468,6 +468,9 @@ public class MemoryDataStore extends AbstractDataStore {
                 }
 
                 public SimpleFeature next() throws IOException, NoSuchElementException {
+                    if (contents == null) {
+                        throw new IOException("FeatureWriter has been closed");
+                    }
                     if (hasNext()) {
                         // existing content
                         live = iterator.next();
@@ -560,7 +563,7 @@ public class MemoryDataStore extends AbstractDataStore {
 
                 public boolean hasNext() throws IOException {
                     if (contents == null) {
-                        throw new IOException("FeatureWriter has been closed");
+                        return false; //writer has been closed
                     }
 
                     return (iterator != null) && iterator.hasNext();

--- a/modules/library/data/src/main/java/org/geotools/data/store/DiffContentFeatureWriter.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/DiffContentFeatureWriter.java
@@ -118,6 +118,9 @@ public class DiffContentFeatureWriter implements FeatureWriter<SimpleFeatureType
 
             return current;
         } else {
+            if (diff == null) {
+                throw new IOException("FeatureWriter has been closed");
+            }
             // Create new content
             // created with an empty ID
             // (The real writer will supply a FID later)
@@ -200,6 +203,9 @@ public class DiffContentFeatureWriter implements FeatureWriter<SimpleFeatureType
         live = null;
         current = null;
 
+        if (reader == null) {
+            return false;
+        }
         if (reader.hasNext()) {
             try {
                 next = reader.next();

--- a/modules/library/data/src/main/java/org/geotools/data/store/EventContentFeatureWriter.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/EventContentFeatureWriter.java
@@ -93,6 +93,9 @@ public class EventContentFeatureWriter implements FeatureWriter<SimpleFeatureTyp
      * @see org.geotools.data.FeatureWriter#next()
      */
     public SimpleFeature next() throws IOException {
+        if (writer == null) {
+            throw new IOException("FeatureWriter has been closed");
+        }
         feature = writer.next();
         return feature;
     }
@@ -101,6 +104,9 @@ public class EventContentFeatureWriter implements FeatureWriter<SimpleFeatureTyp
      * @see org.geotools.data.FeatureWriter#remove()
      */
     public void remove() throws IOException {
+        if (writer == null) {
+            throw new IOException("FeatureWriter has been closed");
+        }
         state.fireFeatureRemoved(store, feature);
         writer.remove();
     }
@@ -113,6 +119,9 @@ public class EventContentFeatureWriter implements FeatureWriter<SimpleFeatureTyp
      * @see org.geotools.data.FeatureWriter#write()
      */
     public void write() throws IOException {
+        if (writer == null) {
+            throw new IOException("FeatureWriter has been closed");
+        }
         writer.write();
         if (feature == null) {
             throw new IOException("No feature available to write");
@@ -134,6 +143,9 @@ public class EventContentFeatureWriter implements FeatureWriter<SimpleFeatureTyp
      * @see org.geotools.data.FeatureWriter#hasNext()
      */
     public boolean hasNext() throws IOException {
+        if (writer == null) {
+            return false;
+        }
         return writer.hasNext();
     }
 

--- a/modules/library/data/src/test/java/org/geotools/data/memory/MemoryDataStoreTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/memory/MemoryDataStoreTest.java
@@ -601,13 +601,9 @@ public class MemoryDataStoreTest extends DataTestCase {
             IllegalAttributeException {
         FeatureWriter<SimpleFeatureType, SimpleFeature> writer = data.getFeatureWriter("road", Transaction.AUTO_COMMIT);
         assertEquals(roadFeatures.length, count(writer));
-
-        try {
-            writer.hasNext();
-            fail("Should not be able to use a closed writer");
-        } catch (IOException expected) {
-        }
-
+        
+        assertFalse(writer.hasNext());
+        
         try {
             writer.next();
             fail("Should not be able to use a closed writer");

--- a/modules/library/main/src/main/java/org/geotools/data/DiffFeatureWriter.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DiffFeatureWriter.java
@@ -107,6 +107,9 @@ public abstract class DiffFeatureWriter implements FeatureWriter<SimpleFeatureTy
                 throw (IOException) new IOException("Could not modify content").initCause( e );
             }
         } else {
+            if (diff == null) {
+                throw new IOException("FeatureWriter has been closed");
+            }
             // Create new content
             // created with an empty ID
             // (The real writer will supply a FID later) 
@@ -197,6 +200,10 @@ public abstract class DiffFeatureWriter implements FeatureWriter<SimpleFeatureTy
 	
 	    live = null;
 	    current = null;
+	    
+	    if (reader == null) {
+	            throw new IOException("FeatureWriter has been closed");
+	    }
 	
 	    if (reader.hasNext()) {
 	        try {

--- a/modules/library/main/src/main/java/org/geotools/data/FilteringFeatureWriter.java
+++ b/modules/library/main/src/main/java/org/geotools/data/FilteringFeatureWriter.java
@@ -65,6 +65,9 @@ public class FilteringFeatureWriter implements FeatureWriter<SimpleFeatureType, 
 
             return current;
         }
+        if (writer == null) {
+            throw new IOException("FeatureWriter has been closed");
+        }
             // FilteringFeatureWriter Does not support the creation
             // of new content
             throw new NoSuchElementException(

--- a/modules/plugin/property/src/main/java/org/geotools/data/property/PropertyFeatureWriter.java
+++ b/modules/plugin/property/src/main/java/org/geotools/data/property/PropertyFeatureWriter.java
@@ -94,7 +94,7 @@ public class PropertyFeatureWriter implements FeatureWriter<SimpleFeatureType, S
     // hasNext start
     public boolean hasNext() throws IOException {
         if (writer == null) {
-            throw new IOException("Writer has been closed");
+            return false; //writer has been closed
         }
         if (live != null && origional != null) {
             // we have returned something to the user,

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureWriter.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureWriter.java
@@ -281,7 +281,7 @@ class ShapefileFeatureWriter implements FeatureWriter<SimpleFeatureType, SimpleF
 
     public boolean hasNext() throws IOException {
         if (featureReader == null) {
-            throw new IOException("Writer closed");
+            return false; //writer has been closed
         }
 
         return featureReader.hasNext();

--- a/modules/unsupported/efeature/src/main/java/org/geotools/data/efeature/EFeatureWriter.java
+++ b/modules/unsupported/efeature/src/main/java/org/geotools/data/efeature/EFeatureWriter.java
@@ -183,7 +183,7 @@ public class EFeatureWriter implements SimpleFeatureWriter {
     @Override
     public boolean hasNext() throws IOException {
         if (eReader == null) {
-            throw new IOException("Writer has been closed");
+            return false; //writer has been closed
         }
         if (isModified()) {
             write();

--- a/modules/unsupported/property-old/src/main/java/org/geotools/data/property/old/PropertyFeatureWriter.java
+++ b/modules/unsupported/property-old/src/main/java/org/geotools/data/property/old/PropertyFeatureWriter.java
@@ -73,7 +73,7 @@ public class PropertyFeatureWriter implements
     // hasNext start
     public boolean hasNext() throws IOException {
         if (writer == null) {
-            throw new IOException("Writer has been closed");
+            return false; //writer has been closed
         }
         if (live != null && origional != null) {
             // we have returned something to the user,


### PR DESCRIPTION
QA consistency check:

* hasNext() returns false if the writer is closed
* next() throws an IOException if the writer is closed

A number of implementaitons set their internal reader/writer to null, then did not test this in next() or hasNext(), leading to NPEs. I have added checks for this.
Some other implementaitons would throw an IOException on hasNext() if the writer was closed. I have changed this to return false, for consistency.

The javadoc for the FeatureWriter interface has been updated to reflect these changes.
Test case(s) updated where applicable.