### PR TITLE
Added reprojection and forced CRS handling to ContentFeatureSource

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/data/Query.java
+++ b/modules/library/api/src/main/java/org/geotools/data/Query.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2008-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/api/src/main/java/org/geotools/data/Query.java
+++ b/modules/library/api/src/main/java/org/geotools/data/Query.java
@@ -749,9 +749,7 @@ public class Query {
     }
     
     /**
-     * Get the coordinate system that applies to features retrieved by this Query.
-     * By default this is the coordinate system of the features in the data source
-     * but this can be overriden via {@linkplain #setCoordinateSystem( CoordinateReferenceSystem )}.
+     * Get the coordinate system to use as an override for features retrieved by this Query.
      *
      * @return The coordinate system to be returned for Features from this
      *         Query (override the set coordinate system).
@@ -761,7 +759,7 @@ public class Query {
     }
 
     /**
-     * Set the coordinate system to apply to features retrieved by this Query.
+     * Provide an override coordinate system to apply to features retrieved by this Query.
      * <p>
      * This denotes a request to <b>temporarily</b> override the coordinate system
      * contained in the feature data source being queried. The same coordinate
@@ -769,7 +767,7 @@ public class Query {
      * Coordinate System.
      *
      * <p>
-     * This change is not persistant and only applies to the features
+     * This change is not persistent and only applies to the features
      * returned by this Query. If used in conjunction with {@link #getCoordinateSystemReproject()}
      * the reprojection will occur from {@link #getCoordinateSystem()} to
      * {@link #getCoordinateSystemReproject()}.

--- a/modules/library/data/pom.xml
+++ b/modules/library/data/pom.xml
@@ -91,6 +91,12 @@
       <artifactId>gt-main</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-epsg-hsql</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -432,6 +432,7 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
             CoordinateReferenceSystem sourceCRS = query.getCoordinateSystem();
             CoordinateReferenceSystem targetCRS = query.getCoordinateSystemReproject();
             CoordinateReferenceSystem nativeCRS = getSchema().getCoordinateReferenceSystem();
+            
             if (sourceCRS != null && !sourceCRS.equals(nativeCRS)) {
                 //override native crs
                 bounds = new ReferencedEnvelope(bounds, sourceCRS);
@@ -670,7 +671,6 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
             CoordinateReferenceSystem sourceCRS = query.getCoordinateSystem();
             CoordinateReferenceSystem targetCRS = query.getCoordinateSystemReproject();
             CoordinateReferenceSystem nativeCRS = reader.getFeatureType().getCoordinateReferenceSystem();
-
             
             if (sourceCRS != null && !sourceCRS.equals(nativeCRS)) {
                 //override the nativeCRS


### PR DESCRIPTION
API Clarifications to Query javadoc.
Added forced CRS handling to ContentFeatureSource getBounds and getReader.
Added reprojection handling to getBounds.
Added test cases for forced CRS handling and reprojection to MemoryDataStore (the ContentFeatureSource test mocks are insufficient to test the changes to ContentFeatureSource). Also updated DataTestCase to use EPSG:4326 for the the river data set, to allow for testing tranformations and pre-assigned CRSs (Verified that this does not break any other test cases).