### PR TITLE
Fixed events implementation for ContentFeatureSource

### DIFF
--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentState.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentState.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2006-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -401,25 +401,25 @@ public class ContentState {
         if (batchFeatureEvent == null) {
             return;
         }
-        if (listeners.isEmpty()) {
-            return;
-        }
         if (isCommit) {
             batchFeatureEvent.setType(Type.COMMIT);
+            
+            // This state already knows about the changes, let others know a modifications was made
+            this.entry.notifiyFeatureEvent(this, batchFeatureEvent);
         } else {
             batchFeatureEvent.setType(Type.ROLLBACK);
-        }
-        for (FeatureListener listener : listeners) {
-            try {
-                listener.changed(batchFeatureEvent);
-            } catch (Throwable t) {
-                this.entry.dataStore.LOGGER.log(Level.WARNING,
-                        "Problem issuing batch feature event " + batchFeatureEvent, t);
+            
+            // Notify this state about the rollback, other transactions see no change
+            for (FeatureListener listener : listeners) {
+                try {
+                    listener.changed(batchFeatureEvent);
+                } catch (Throwable t) {
+                    this.entry.dataStore.LOGGER.log(Level.WARNING,
+                            "Problem issuing batch feature event " + batchFeatureEvent, t);
+                }
             }
         }
-        // Let others know a modifications was made
-        this.entry.notifiyFeatureEvent(this, batchFeatureEvent);
-
+        
         batchFeatureEvent = null;
     }
 

--- a/modules/library/data/src/test/java/org/geotools/data/memory/MemoryDataStoreTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/memory/MemoryDataStoreTest.java
@@ -1251,7 +1251,7 @@ public class MemoryDataStoreTest extends DataTestCase {
 
         store1.getTransaction().commit();
 
-        assertEquals(1, listener1.events.size()); //This is wrong (expect 0)
+        assertEquals(0, listener1.events.size());
 
         assertEquals(1, listener2.events.size());
         event = listener2.getEvent(0);
@@ -1281,7 +1281,7 @@ public class MemoryDataStoreTest extends DataTestCase {
         assertEquals(feature.getBounds(), event.getBounds());
         assertEquals(FeatureEvent.Type.ROLLBACK, event.getType());
 
-        assertEquals(1, listener2.events.size()); //this is wrong (expect 0)
+        assertEquals(0, listener2.events.size());
 
         // this is how Auto_commit is supposed to work
         listener1.events.clear();
@@ -1292,7 +1292,7 @@ public class MemoryDataStoreTest extends DataTestCase {
         event = listener1.getEvent(0);
         assertEquals(feature.getBounds(), event.getBounds());
         assertEquals(FeatureEvent.Type.ADDED, event.getType());
-        assertEquals(1, listener2.events.size()); //this is wrong (expect 0)
+        assertEquals(1, listener2.events.size());
     }
 
     //

--- a/modules/library/data/src/test/java/org/geotools/data/store/ContentFeatureSourceEventsTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/store/ContentFeatureSourceEventsTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2012, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2012-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.geotools.data.BatchFeatureEvent;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.DefaultTransaction;
@@ -29,10 +30,18 @@ import org.geotools.data.FeatureEvent;
 import org.geotools.data.FeatureListener;
 import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.NameImpl;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
-import org.opengis.filter.Id;
+
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.io.WKTReader;
 
 /**
  * Tests events in autocommit and with transactions
@@ -64,48 +73,72 @@ public class ContentFeatureSourceEventsTest extends AbstractContentTest {
     @Test
     public void testFeatureEventsAutoCommit() throws Exception {
         DataStore store = new MockContentDataStore();
-        
         SimpleFeatureStore store1 = (SimpleFeatureStore) store.getFeatureSource(TYPENAME);
         SimpleFeatureStore store2 = (SimpleFeatureStore) store.getFeatureSource(TYPENAME);        
-
+        
         Listener listener1 = new Listener("one");
         Listener listener2 = new Listener("two");
-
         store1.addFeatureListener(listener1);
         store2.addFeatureListener(listener2);
-
+        
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
-
-        // test that both listeners get the event.
+        
         final SimpleFeature feature = FEATURES.get(0);
-        Id fidFilter = ff.id(feature.getIdentifier());
-
-        store1.removeFeatures(fidFilter);
-
+        Filter fidFilter = ff.id(feature.getIdentifier());
+        
+        // test change
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory( null );
+        WKTReader reader = new WKTReader( geometryFactory );
+        Polygon geom = (Polygon) reader.read("POLYGON ((0 2, 1 0, 1 1, 0 1, 0 2))");
+        
+        ReferencedEnvelope bounds = new ReferencedEnvelope();
+        bounds.include(feature.getBounds());
+        bounds.expandToInclude(geom.getEnvelopeInternal());
+        
+        store1.modifyFeatures(new Name[]{new NameImpl("geom")}, 
+                new Object[]{geom}, fidFilter);
+        
+        // test that both listeners get the event.
         assertEquals(1, listener1.events.size());
         assertEquals(1, listener2.events.size());
         
         FeatureEvent event = listener1.getEvent(0);
+        assertEquals(bounds, event.getBounds());
+        assertEquals(FeatureEvent.Type.CHANGED, event.getType());
+        assertEquals(event, listener2.getEvent(0));
+        
+        listener1.events.clear();
+        listener2.events.clear();
+        
+        // test remove
+        store1.removeFeatures(fidFilter);
+        
+        assertEquals(1, listener1.events.size());
+        assertEquals(1, listener2.events.size());
+        
+        event = listener1.getEvent(0);
         assertEquals(feature.getBounds(), event.getBounds());
         assertEquals(FeatureEvent.Type.REMOVED, event.getType());
+        assertEquals(event, listener2.getEvent(0));
         
         // test add
         listener1.events.clear();
-        listener2.events.clear();        
-
+        listener2.events.clear();
+        
         store1.addFeatures(DataUtilities.collection(feature));
-
+        
         assertEquals(1, listener1.events.size());
+        assertEquals(1, listener2.events.size());
+        
         event = listener1.getEvent(0);
         assertEquals(feature.getBounds(), event.getBounds());
         assertEquals(FeatureEvent.Type.ADDED, event.getType());
-        assertEquals(1, listener2.events.size());
+        assertEquals(event, listener2.getEvent(0));
     }
-
+    
     @Test
     public void testFeatureEventsWithTransaction() throws Exception {
         DataStore store = new MockContentDataStore();
-        
         SimpleFeatureStore store1 = (SimpleFeatureStore) store.getFeatureSource(TYPENAME);
         SimpleFeatureStore store2 = (SimpleFeatureStore) store.getFeatureSource(TYPENAME);
         store1.setTransaction(new DefaultTransaction());
@@ -113,64 +146,154 @@ public class ContentFeatureSourceEventsTest extends AbstractContentTest {
         
         Listener listener1 = new Listener("one");
         Listener listener2 = new Listener("two");
-
         store1.addFeatureListener(listener1);
         store2.addFeatureListener(listener2);
-
+        
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
-
-        // test that only the listener listening with the current transaction gets the event.
+        
         final SimpleFeature feature = FEATURES.get(0);
-        Id fidFilter = ff.id(feature.getIdentifier());
-
-        store1.removeFeatures(fidFilter);
-
+        Filter fidFilter = ff.id(feature.getIdentifier());
+        
+        // test change
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory( null );
+        WKTReader reader = new WKTReader( geometryFactory );
+        Polygon geom = (Polygon) reader.read("POLYGON ((0 2, 1 0, 1 1, 0 1, 0 2))");
+        
+        ReferencedEnvelope bounds = new ReferencedEnvelope();
+        bounds.include(feature.getBounds());
+        bounds.expandToInclude(geom.getEnvelopeInternal());
+        
+        store1.modifyFeatures(new Name[]{new NameImpl("geom")}, 
+                new Object[]{geom}, fidFilter);
+        
+        // test that only the listener listening with the current transaction gets the event.
         assertEquals(1, listener1.events.size());
         assertEquals(0, listener2.events.size());
-
+        
         FeatureEvent event = listener1.getEvent(0);
-        assertEquals(feature.getBounds(), event.getBounds());
-        assertEquals(FeatureEvent.Type.REMOVED, event.getType());
-
+        assertEquals(bounds, event.getBounds());
+        assertEquals(FeatureEvent.Type.CHANGED, event.getType());
+        
         listener1.events.clear();
         listener2.events.clear();
         
-        // test that commit sends events to both listeners.
-
-        store1.getTransaction().commit();
-
+        // test that rollback sends events to
+        // only the listener listening with the current transaction.
+        store1.getTransaction().rollback();
+        
         assertEquals(1, listener1.events.size());
+        assertEquals(0, listener2.events.size());
+        
+        event = listener1.getEvent(0);
+        assertEquals(bounds, event.getBounds());
+        assertEquals(FeatureEvent.Type.ROLLBACK, event.getType());
+        
+        listener1.events.clear();
+        listener2.events.clear();
+        
+        //test remove
+        store1.removeFeatures(fidFilter);
+        
+        assertEquals(1, listener1.events.size());
+        assertEquals(0, listener2.events.size());
+        
+        event = listener1.getEvent(0);
+        assertEquals(feature.getBounds(), event.getBounds());
+        assertEquals(FeatureEvent.Type.REMOVED, event.getType());
+        
+        listener1.events.clear();
+        listener2.events.clear();
+        
+        // test that commit sends events to all listeners
+        // except the listener listening with the current transaction.
+        store1.getTransaction().commit();
+        
+        assertEquals(0, listener1.events.size());
         assertEquals(1, listener2.events.size());
-
+        
         event = listener2.getEvent(0);
         assertEquals(feature.getBounds(), event.getBounds());
         assertEquals(FeatureEvent.Type.COMMIT, event.getType());
-
-        // test add 
+        
         listener1.events.clear();
         listener2.events.clear();
-
+        
+        // test add
         store1.addFeatures(DataUtilities.collection(feature));
-
+        
         assertEquals(1, listener1.events.size());
         event = listener1.getEvent(0);
         assertEquals(feature.getBounds(), event.getBounds());
         assertEquals(FeatureEvent.Type.ADDED, event.getType());
         assertEquals(0, listener2.events.size());
-
-        // test that rollback sends events to both listeners.
+        
         listener1.events.clear();
         listener2.events.clear();
-
+        
+        // test that rollback sends events to
+        // only the listener listening with the current transaction.
         store1.getTransaction().rollback();
-
+        
         assertEquals(1, listener1.events.size());
+        assertEquals(0, listener2.events.size());
         event = listener1.getEvent(0);
         assertEquals(FeatureEvent.Type.ROLLBACK, event.getType());
-
-        assertEquals(1, listener2.events.size());
     }
-
     
-
+    @Test
+    public void testBatchFeatureEvents() throws Exception {
+        DataStore store = new MockContentDataStore();
+        SimpleFeatureStore store1 = (SimpleFeatureStore) store.getFeatureSource(TYPENAME);
+        SimpleFeatureStore store2 = (SimpleFeatureStore) store.getFeatureSource(TYPENAME);
+        store1.setTransaction(new DefaultTransaction());
+        
+        Listener listener1 = new Listener("one");
+        Listener listener2 = new Listener("two");
+        store1.addFeatureListener(listener1);
+        store2.addFeatureListener(listener2);
+        
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        
+        final SimpleFeature feature0 = FEATURES.get(0);
+        final SimpleFeature feature1 = FEATURES.get(1);
+        Filter fidFilter0 = ff.id(feature0.getIdentifier());
+        Filter fidFilter1 = ff.id(feature1.getIdentifier());
+        
+        //remove a feature
+        store1.removeFeatures(fidFilter0);
+        
+        assertEquals(1, listener1.events.size());
+        assertEquals(0, listener2.events.size());
+        
+        FeatureEvent event = listener1.getEvent(0);
+        assertEquals(feature0.getBounds(), event.getBounds());
+        assertEquals(FeatureEvent.Type.REMOVED, event.getType());
+        
+        //remove another feature
+        store1.removeFeatures(fidFilter1);
+        
+        assertEquals(2, listener1.events.size());
+        assertEquals(0, listener2.events.size());
+        
+        event = listener1.getEvent(1);
+        assertEquals(feature1.getBounds(), event.getBounds());
+        assertEquals(FeatureEvent.Type.REMOVED, event.getType());
+        
+        // commit the changes
+        store1.getTransaction().commit();
+        
+        // test that multiple changes are contained within a single batch feature event
+        assertEquals(2, listener1.events.size());
+        assertEquals(1, listener2.events.size());
+        
+        event = listener2.getEvent(0);
+        
+        assertTrue(event instanceof BatchFeatureEvent);
+        ReferencedEnvelope bounds = new ReferencedEnvelope();
+        bounds.include(feature0.getBounds());
+        bounds.include(feature1.getBounds());
+        
+        assertEquals(bounds, event.getBounds());
+        assertEquals(FeatureEvent.Type.COMMIT, event.getType());
+    }
 }


### PR DESCRIPTION
Changed ContentState to issue events to only the current transaction on ROLLBACK, and only other transactions on COMMIT.

Fixed and improved ContentFeatureSourceEventsTest.java to test events properly. Added tests for CHANGED events and multiple changes in a batch event.

Fixed event tests for MemoryDataStore.
