### PR TITLE
Remove @Deprecated from MemoryDataStore

### DIFF
--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryDataStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryDataStore.java
@@ -55,10 +55,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 
-@Deprecated
 /**
- * AbstractDataStore is deprecated. Migrate to ContentDataStore.
- * 
  * This is an example implementation of a DataStore used for testing.
  * 
  * <p>


### PR DESCRIPTION
When updating MemoryDataStore to use ContentDataStore instead of AbstractDataStore, forgot to remove @Deprecated. Fixed here.