### PR TITLE
GEOT-4999: Adding support for bbox types to solr datastore.

### DIFF
--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrAttribute.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrAttribute.java
@@ -52,6 +52,8 @@ public class SolrAttribute implements Serializable {
 
     private Boolean defaultGeometry = false;
 
+    private String solrType;
+
     public SolrAttribute(String name, Class<?> type) {
         super();
         this.name = name;
@@ -129,6 +131,14 @@ public class SolrAttribute implements Serializable {
         return multivalued;
     }
 
+    public String getSolrType() {
+        return solrType;
+    }
+
+    public void setSolrType(String solrType) {
+        this.solrType = solrType;
+    }
+
     @Override
     public String toString() {
         return "SolrAttribute [name=" + name + ", type=" + type + ", pk=" + pk + ", use=" + use
@@ -148,6 +158,7 @@ public class SolrAttribute implements Serializable {
         result = prime * result + ((srid == null) ? 0 : srid.hashCode());
         result = prime * result + ((type == null) ? 0 : type.hashCode());
         result = prime * result + ((use == null) ? 0 : use.hashCode());
+        result = prime * result + ((solrType == null) ? 0 : solrType.hashCode());
         return result;
     }
 
@@ -199,6 +210,11 @@ public class SolrAttribute implements Serializable {
             if (other.use != null)
                 return false;
         } else if (!use.equals(other.use))
+            return false;
+        if (solrType == null) {
+            if (other.solrType != null)
+                return false;
+        } else if (!solrType.equals(other.solrType))
             return false;
         return true;
     }

--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrDataStore.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrDataStore.java
@@ -151,11 +151,13 @@ public class SolrDataStore extends ContentDataStore {
 
                     FieldTypeInfo fty = processSchema.getFieldTypeInfo(type);
                     if (fty != null) {
-                        Class<?> objType = SolrUtils.decodeSolrFieldType(fty.getClassName());
+                        String solrTypeName = fty.getClassName();
+                        Class<?> objType = SolrUtils.decodeSolrFieldType(solrTypeName);
                         if (objType != null) {
                             ExtendedFieldSchemaInfo extendedFieldSchemaInfo = new SolrUtils.ExtendedFieldSchemaInfo(
                                     processSchema, processField, name);
                             SolrAttribute at = new SolrAttribute(name, objType);
+                            at.setSolrType(solrTypeName);
                             if (extendedFieldSchemaInfo.getUniqueKey()) {
                                 at.setPk(true);
                                 at.setUse(true);
@@ -233,7 +235,7 @@ public class SolrDataStore extends ContentDataStore {
      * @return The filter capabilities, never <code>null</code>.
      */
     public FilterCapabilities getFilterCapabilities() {
-        FilterToSolr f2s = new FilterToSolr();
+        FilterToSolr f2s = new FilterToSolr(null);
         return f2s.getCapabilities();
     }
 
@@ -402,9 +404,10 @@ public class SolrDataStore extends ContentDataStore {
      * Set parameters for OGC filter encoder
      */
     private FilterToSolr initializeFilterToSolr(SimpleFeatureType featureType) {
-        FilterToSolr f2s = new FilterToSolr();
+        FilterToSolr f2s = new FilterToSolr(featureType);
         f2s.setPrimaryKey(this.getPrimaryKey(featureType.getName().getLocalPart()));
         f2s.setFeatureTypeName(featureType.getName().getLocalPart());
+
         return f2s;
     }
 

--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrFeatureSource.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrFeatureSource.java
@@ -54,6 +54,11 @@ import com.vividsolutions.jts.geom.Geometry;
 public class SolrFeatureSource extends ContentFeatureSource {
 
     /**
+     * Used to store native solr type for geometry attributes
+     */
+    static final String KEY_SOLR_TYPE = "solr_type";
+
+    /**
      * Creates the new SOLR feature store.
      * 
      * @param entry the datastore entry.
@@ -238,7 +243,12 @@ public class SolrFeatureSource extends ContentFeatureSource {
                         ab.setBinding(attribute.getType());
                         att = ab.buildDescriptor(attribute.getName(), ab.buildType());
                     }
-                    tb.add(att);
+
+                    if (att != null) {
+                        // store the native solr type
+                        att.getUserData().put(KEY_SOLR_TYPE, attribute.getSolrType());
+                        tb.add(att);
+                    }
                 }
             }
             if (defaultGeometryName != null) {

--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrSpatialStrategy.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrSpatialStrategy.java
@@ -30,15 +30,21 @@ import static java.lang.Double.parseDouble;
 
 /**
  * Strategy interface for interacting with solr spatial types.
+ * <p>
+ *  Instances of this interface must be thread safe.
+ * </p>
  */
 public abstract class SolrSpatialStrategy {
+
+    static final SolrSpatialStrategy DEFAULT = new DefaultStrategy();
+    static final SolrSpatialStrategy BBOX = new DefaultStrategy();
 
     static SolrSpatialStrategy createStrategy(GeometryDescriptor att) {
         String solrType = (String) att.getUserData().get(SolrFeatureSource.KEY_SOLR_TYPE);
         if (solrType != null && solrType.endsWith("BBoxField")) {
-            return new BBoxStrategy();
+            return BBOX;
         }
-        return new DefaultStrategy();
+        return DEFAULT;
     }
 
     public abstract String encode(Geometry geometry);

--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrSpatialStrategy.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrSpatialStrategy.java
@@ -1,0 +1,82 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.solr;
+
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+import org.geotools.geometry.jts.JTS;
+import org.opengis.feature.type.GeometryDescriptor;
+
+import java.io.IOException;
+
+import static java.lang.Double.parseDouble;
+
+/**
+ * Strategy interface for interacting with solr spatial types.
+ */
+public abstract class SolrSpatialStrategy {
+
+    static SolrSpatialStrategy createStrategy(GeometryDescriptor att) {
+        String solrType = (String) att.getUserData().get(SolrFeatureSource.KEY_SOLR_TYPE);
+        if (solrType != null && solrType.endsWith("BBoxField")) {
+            return new BBoxStrategy();
+        }
+        return new DefaultStrategy();
+    }
+
+    public abstract String encode(Geometry geometry);
+
+    public abstract Geometry decode(String str) throws ParseException;
+
+    public static class DefaultStrategy extends SolrSpatialStrategy {
+
+        @Override
+        public String encode(Geometry geometry) {
+            WKTWriter writer = new WKTWriter();
+            return writer.write(geometry);
+        }
+
+        @Override
+        public Geometry decode(String str) throws ParseException {
+            return new WKTReader().read(str);
+        }
+    }
+
+    public static class BBoxStrategy extends SolrSpatialStrategy {
+
+        @Override
+        public String encode(Geometry geometry) {
+            Envelope env = geometry.getEnvelopeInternal();
+            return String.format("%f %f %f %f", env.getMinX(), env.getMinY(), env.getMaxX(), env.getMaxY());
+        }
+
+        @Override
+        public Geometry decode(String str) throws ParseException {
+            String[] bbox = str.split("\\s+");
+            if (bbox.length != 4) {
+                throw new ParseException("Illegal bounding box: " + str);
+            }
+
+            Envelope env = new Envelope(parseDouble(bbox[0]), parseDouble(bbox[2]),
+                parseDouble(bbox[1]), parseDouble(bbox[3]));
+            return JTS.toGeometry(env);
+        }
+    }
+}

--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrUtils.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrUtils.java
@@ -44,7 +44,8 @@ public class SolrUtils {
         if (className.equals("org.apache.solr.schema.BoolField"))
             return Boolean.class;
         if (className.equals("org.apache.solr.schema.SpatialRecursivePrefixTreeFieldType")
-                || className.equals("org.apache.solr.schema.LatLonType"))
+                || className.equals("org.apache.solr.schema.LatLonType")
+                || className.equals("org.apache.solr.schema.BBoxField"))
             return Geometry.class;
         if (className.equals("org.apache.solr.schema.DateField")
                 || className.equals("org.apache.solr.schema.TrieDateField"))

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/SolrGeometryTest.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/SolrGeometryTest.java
@@ -237,7 +237,7 @@ public class SolrGeometryTest extends SolrTestSupport {
         assertEquals("geo2", gd.getLocalName());
 
         FilterFactory2 ff = (FilterFactory2) dataStore.getFilterFactory();
-        BBOX bbox = ff.bbox("", 6.5, 23.5, 7.5, 24.5, "EPSG:4326");
+        BBOX bbox = ff.bbox("geo2", 6.5, 23.5, 7.5, 24.5, "EPSG:4326");
         SimpleFeatureCollection features = featureSource.getFeatures(bbox);
         assertEquals(1, features.size());
         SimpleFeatureIterator fsi = features.features();

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/SolrSpatialStrategyTest.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/SolrSpatialStrategyTest.java
@@ -1,0 +1,85 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.solr;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
+import org.geotools.data.solr.SolrSpatialStrategy.BBoxStrategy;
+import org.geotools.data.solr.SolrSpatialStrategy.DefaultStrategy;
+import org.geotools.feature.NameImpl;
+import org.geotools.feature.type.FeatureTypeFactoryImpl;
+import org.junit.Test;
+import org.opengis.feature.type.FeatureTypeFactory;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.GeometryType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SolrSpatialStrategyTest {
+
+    @Test
+    public void testCreate() throws Exception {
+
+        assertTrue(SolrSpatialStrategy.createStrategy(newDescriptor(null)) instanceof DefaultStrategy);
+        assertTrue(SolrSpatialStrategy.createStrategy(newDescriptor(
+            "org.apache.solr.schema.SpatialRecursivePrefixTreeFieldType")) instanceof DefaultStrategy);
+        assertTrue(SolrSpatialStrategy.createStrategy(newDescriptor(
+            "org.apache.solr.schema.LatLonType")) instanceof DefaultStrategy);
+        assertTrue(SolrSpatialStrategy.createStrategy(newDescriptor(
+            "org.apache.solr.schema.BBoxField")) instanceof BBoxStrategy);
+    }
+
+    @Test
+    public void testDefaultStrategy() throws Exception {
+        SolrSpatialStrategy ss = new DefaultStrategy();
+
+        Geometry g = ss.decode("POINT (0 0)");
+        assertNotNull(g);
+        assertTrue(g instanceof Point);
+
+        assertEquals("POINT (0 0)", ss.encode(g));
+    }
+
+    @Test
+    public void testBBoxStrategy() throws Exception {
+        SolrSpatialStrategy ss = new BBoxStrategy();
+
+        Geometry g = ss.decode("1 2 3 4");
+        assertNotNull(g);
+        assertTrue(g instanceof Polygon);
+
+        String[] bbox = ss.encode(g).split("\\s+");
+        assertEquals(1.0, Double.parseDouble(bbox[0]), 0.1);
+        assertEquals(2.0, Double.parseDouble(bbox[1]), 0.1);
+        assertEquals(3.0, Double.parseDouble(bbox[2]), 0.1);
+        assertEquals(4.0, Double.parseDouble(bbox[3]), 0.1);
+    }
+
+    GeometryDescriptor newDescriptor(String solrTypeValue) {
+        FeatureTypeFactory ftf = new FeatureTypeFactoryImpl();
+        GeometryType type =
+            ftf.createGeometryType(new NameImpl("fooType"), Geometry.class, null, false, false, null, null, null);
+        GeometryDescriptor att = ftf
+            .createGeometryDescriptor(type, new NameImpl("foo"), 1, 1, true, null);
+
+        att.getUserData().put(SolrFeatureSource.KEY_SOLR_TYPE, solrTypeValue);
+        return att;
+    }
+}

--- a/modules/unsupported/solr/src/test/resources/TestGeotoolsCore/conf/custom_schema.xml
+++ b/modules/unsupported/solr/src/test/resources/TestGeotoolsCore/conf/custom_schema.xml
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <field name="geo" type="location_rpt" indexed="true" stored="true" multiValued="true" />  
 <field name="geo2" type="location_rpt" indexed="true" stored="true" multiValued="true" />
+<field name="geo3" type="bbox" indexed="true" stored="true" multiValued="true" />

--- a/modules/unsupported/solr/src/test/resources/TestGeotoolsCore/conf/schema.xml
+++ b/modules/unsupported/solr/src/test/resources/TestGeotoolsCore/conf/schema.xml
@@ -637,6 +637,14 @@
     		   spatialContextFactory="com.spatial4j.core.context.jts.JtsSpatialContextFactory"
                geo="true" distErrPct="0.025" maxDistErr="0.000009" units="degrees" />
 
+     <!-- Spatial rectangle (bounding box) field. It supports most spatial predicates, and has
+     special relevancy modes: score=overlapRatio|area|area2D (local-param to the query).  DocValues is required for
+     relevancy. -->
+    <fieldType name="bbox" class="solr.BBoxField"
+        geo="true" units="degrees" numberType="_bbox_coord" />
+    <fieldType name="_bbox_coord" class="solr.TrieDoubleField" precisionStep="8" docValues="true" stored="false"/>
+
+
     <!-- Money/currency field type. See http://wiki.apache.org/solr/MoneyFieldType
         Parameters:
           defaultCurrency: Specifies the default currency if none specified. Defaults to "USD"

--- a/modules/unsupported/solr/src/test/resources/wifiAccessPoint.xml
+++ b/modules/unsupported/solr/src/test/resources/wifiAccessPoint.xml
@@ -13,6 +13,7 @@
 		<field name="geo">POINT (0 0)</field>
         <field name="geo2">LINESTRING (0 0, 0 1)</field>
 		<field name="installed_tdt">2011-05-20T17:33:18Z</field>
+		<field name="geo3">0 0 1 1</field>
 	</doc>
 	<doc>
 		<field name="id">2</field>
@@ -26,6 +27,7 @@
 		<field name="geo">POINT (10 15)</field>
         <field name="geo2">LINESTRING (10 15, 10 16)</field>
 		<field name="installed_tdt">2012-01-10T07:43:58Z</field>
+		<field name="geo3">10 10 16 16</field>
 	</doc>
 	<doc>
 		<field name="id">3</field>
@@ -38,6 +40,7 @@
 		<field name="geo">POINT (5 7)</field>
         <field name="geo2">LINESTRING (5 7, 5 8)</field>
 		<field name="installed_tdt">2013-10-01T00:13:11Z</field>
+		<field name="geo3">5 5 8 8</field>
 	</doc>
 	<doc>
 		<field name="id">4</field>
@@ -52,6 +55,7 @@
 		<field name="geo">POINT (24 2)</field>
         <field name="geo2">LINESTRING (24 2, 24 3)</field>
 		<field name="installed_tdt">2013-12-01T00:16:21Z</field>
+		<field name="geo3">22 2 24 3</field>
 	</doc>
 	<doc>
 		<field name="id">5</field>
@@ -64,6 +68,7 @@
 		<field name="geo">POINT (12 17)</field>
         <field name="geo2">LINESTRING (12 17, 12 18)</field>
 		<field name="installed_tdt">2000-11-11T11:16:21Z</field>
+		<field name="geo3">12 17 13 18</field>
 	</doc>
 	<doc>
 		<field name="id">6</field>
@@ -77,6 +82,7 @@
 		<field name="geo">POINT (13 9)</field>
         <field name="geo2">LINESTRING (13 9, 13 10)</field>
 		<field name="installed_tdt">2001-04-28T23:23:21Z</field>
+		<field name="geo3">13 9 14 10</field>
 	</doc>
 	<doc>
 		<field name="id">7</field>
@@ -89,6 +95,7 @@
 		<field name="geo">POINT (22 27)</field>
         <field name="geo2">LINESTRING (22 27, 22 28)</field>
 		<field name="installed_tdt">2004-06-20T03:44:56Z</field>
+		<field name="geo3">22 27 23 28</field>
 	</doc>
 	<doc>
 		<field name="id">8</field>
@@ -101,6 +108,7 @@
 		<field name="geo">POINT (2 3)</field>
         <field name="geo2">LINESTRING (2 3, 2 4)</field>
 		<field name="installed_tdt">2014-02-12T06:37:48Z</field>
+		<field name="geo3">2 3 3 4</field>
 	</doc>
 	<doc>
 		<field name="id">9</field>
@@ -114,6 +122,7 @@
 		<field name="geo">POINT (7 23)</field>
         <field name="geo2">LINESTRING (7 23, 7 24)</field>
 		<field name="installed_tdt">2008-09-23T16:43:23Z</field>
+		<field name="geo3">7 23 8 24</field>
 	</doc>
 	<doc>
 		<field name="id">10</field>
@@ -127,6 +136,7 @@
 		<field name="security_ss">WPA</field>
 		<field name="geo">POINT (0 0)</field>
         <field name="geo2">LINESTRING (0 0, 0 1)</field>
+		<field name="geo3">0 0 1 1</field>
 	</doc>
 	<doc>
 		<field name="id">11</field>
@@ -137,6 +147,7 @@
 		<field name="modem_b">true</field>
 		<field name="geo">POINT (1 43)</field>
         <field name="geo2">LINESTRING (1 43, 1 44)</field>
+		<field name="geo3">1 43 2 44</field>
 	</doc>
 	<doc>
 		<field name="id">12</field>
@@ -149,6 +160,7 @@
 		<field name="security_ss">WPA</field>
 		<field name="geo">POLYGON((1 1,5 1,5 5,1 5,1 1))</field>
         <field name="geo2">LINESTRING (1 1, 1 2)</field>
+		<field name="geo3">1 5 2 6</field>
 	</doc>
 		<doc>
 		<field name="id">13</field>
@@ -160,6 +172,7 @@
 		<field name="modem_b">true</field>
 		<field name="geo">POLYGON((3 2,6 2,6 7,3 7,3 2))</field>
         <field name="geo2">LINESTRING (3 2, 3 3)</field>
+		<field name="geo3">2 3 4 6</field>
 	</doc>
 </add>
 


### PR DESCRIPTION
Includes introducing the abstraction called "SpatialStrategy" to encapsulate
the handling of different geometry types.