### PR TITLE
GEOT-4998 improved check on empty intersection 

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/CachingDataStoreGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/CachingDataStoreGranuleCatalog.java
@@ -212,7 +212,7 @@ class CachingDataStoreGranuleCatalog extends GranuleCatalog {
             private boolean polygonOverlap(Geometry g1, Geometry g2) {
                 // TODO: try to use relate instead
                 Geometry intersection = g1.intersection(g2);
-                return intersection != null && intersection.getDimension() == 2;
+                return intersection != null && intersection.getDimension() == 2 && !intersection.isEmpty();
             }
         }, listener);
         


### PR DESCRIPTION
Fix for GEOT-4998 to actually filter out empty intersections. The current code did not manage to filter out a 'POLYGON EMPTY' geometry in JTS.
I did not use the relate() or intersects() method provided by JTS as I was not sure of the performance impact. I did do some local benchmarking, which showed that the relate() method was definetly not faster, perhaps even a bit slower. Of course, anyone with more knowledge of JTS might contradict this, as my benchmark setup was not very scientific.