### PR TITLE
[GEOT-4990] DataUtilities.urlToFile relative paths on Windows

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -356,8 +356,13 @@ public class DataUtilities {
         String standardPrefix = "file://";
 
         if (IS_WINDOWS_OS && string.startsWith(standardPrefix)) {
-            // win32: host/share reference
+            // win32: host/share reference. Keep the host slashes.
             path3 = string.substring(standardPrefix.length() - 2);
+            File f = new File(path3);
+            if (!f.exists()) {
+            	// Make path relative to be backwards compatible.
+            	path3 = path3.substring(2, path3.length());
+            }
         } else if (string.startsWith(standardPrefix)) {
             path3 = string.substring(standardPrefix.length());
         } else if (string.startsWith(simplePrefix)) {

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -209,6 +209,15 @@ public class DataUtilitiesTest extends DataTestCase {
             handleFile("C:\\one\\two");
             handleFile("C:\\one\\two\\and three");
             handleFile("D:\\");
+            
+            // Single slash keeps rooted path
+            assertURL("\\one", "file:/one");
+            assertURL("\\.\\one", "file:/./one");
+            
+            // Double slash makes it relative if non existent.
+            assertURL("one", "file://one");
+            assertURL("./one", "file://./one");
+            
             if (TestData.isExtensiveTest()){
                 handleFile("\\\\host\\share\\file");
                 // from GEOT-3300 DataUtilities.urlToFile doesn't handle network paths correctly

--- a/modules/library/main/src/test/java/org/geotools/styling/DefaultResourceLocatorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/styling/DefaultResourceLocatorTest.java
@@ -15,6 +15,8 @@ public class DefaultResourceLocatorTest extends TestCase {
 
         checkURL(locator.locateResource("blob.gif"));
         checkURL(locator.locateResource("file:blob.gif"));
+        checkURL(locator.locateResource("file://blob.gif"));
+        checkURL(locator.locateResource("file://./blob.gif"));
     }
 
     void checkURL(URL url) {


### PR DESCRIPTION
DataUtilities.urlToFile now handles relative paths on Windows for the standard file:// prefix.
A test has been added that checks if the file exists at the absolute path. If not, the path is handled as relative in the same way as for the simple prefix and the standard prefix on other platforms.