### PR TITLE
(GEOS-6868) Upstream upgrade of commons-lang to 2.6 to support geoserver upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -849,7 +849,7 @@
       <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
-        <version>2.3</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>


### PR DESCRIPTION
Ensure geotools and geoserver are using the same version of commons-lang. Tested full build; no failures.
https://jira.codehaus.org/browse/GEOS-6868

See also: https://github.com/geoserver/geoserver/pull/914