### PR TITLE
wfs-ng Cascaded Stored Query improvements

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/DescribeStoredQueriesResponseFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/DescribeStoredQueriesResponseFactory.java
@@ -50,8 +50,7 @@ public class DescribeStoredQueriesResponseFactory implements WFSResponseFactory 
 
     @Override
     public List<String> getSupportedOutputFormats() {
-        return Arrays.asList("", "text/xml", "text/xml; subtype=gml/3.1.1",
-                "text/xml; subtype=gml/3.2", "XMLSCHEMA", "text/gml; subtype=gml/3.1.1");
+        return Arrays.asList("text/xml");
     }
 
     @Override

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/DescribeStoredQueriesResponseFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/DescribeStoredQueriesResponseFactory.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2014, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2014-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/ListStoredQueriesResponseFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/ListStoredQueriesResponseFactory.java
@@ -50,8 +50,7 @@ public class ListStoredQueriesResponseFactory implements WFSResponseFactory {
 
     @Override
     public List<String> getSupportedOutputFormats() {
-        return Arrays.asList("", "text/xml", "text/xml; subtype=gml/3.1.1",
-                "text/xml; subtype=gml/3.2", "XMLSCHEMA", "text/gml; subtype=gml/3.1.1");
+        return Arrays.asList("text/xml");
     }
 
     @Override

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/ListStoredQueriesResponseFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/ListStoredQueriesResponseFactory.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2014, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2014-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -506,6 +506,10 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
         case TRANSACTION:
             parameterName = "inputFormat";
             break;
+        case LIST_STORED_QUERIES:
+        case DESCRIBE_STORED_QUERIES:
+            // These return XML as specified in WFS 2.0.0
+            return Collections.singleton("text/xml");
         default:
             throw new UnsupportedOperationException("not yet implemented for " + operation);
         }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2014, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/storedquery/ParameterCQLExpressionFilterFactoryImpl.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/storedquery/ParameterCQLExpressionFilterFactoryImpl.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2014, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2014-2105, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v2_0/storedquery/ParameterTypeFactoryTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v2_0/storedquery/ParameterTypeFactoryTest.java
@@ -307,7 +307,7 @@ public class ParameterTypeFactoryTest {
         ParameterMappingExpressionValue paramMapping = new ParameterMappingExpressionValue();
         paramMapping.setParameterName("foo");
         paramMapping.setExpressionLanguage("CQL");
-        paramMapping.setExpression("numberFormat('0.0', 1+1*2) + ',10'");
+        paramMapping.setExpression("concatenate(numberFormat('0.0', 1+1*2), ',10')");
 
         config.getStoredQueryParameterMappings().add(paramMapping);
 


### PR DESCRIPTION
Adjustments to the Cascaded Stored Query support:
- Removed specialized + operator in favor of using concatenate()
- More efficient property name matching (hashmap instead of if equals() else if equals() else ..)
- Fixed outputformat handling for WFS 2.0.0 operations ListStoredQueries and DescribeStoredQueries