### PR TITLE
Use reflection to configure JAI logging [GEOT-5016]

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/logging/Logging.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/logging/Logging.java
@@ -122,14 +122,14 @@ public final class Logging {
                     Class<?> imagingListenerClass = Class.forName("javax.media.jai.util.ImagingListener");
                     Method setImagingListener = jaiClass.getMethod("setImagingListener", new Class[]{ imagingListenerClass } );
                     setImagingListener.invoke(defaultInstance, new Object[]{ new LoggingImagingListener()} );
-                    System.out.println("Logging JAI messages: javax.media.jai logger redirected");
+                    // System.out.println("Logging JAI messages: javax.media.jai logger redirected");
                 } else {
-                    System.out.println("Logging JAI messages: ImagingListener already in use: "+ imagingListener);
+                    // System.out.println("Logging JAI messages: ImagingListener already in use: "+ imagingListener);
                 }
             }
         } catch (Throwable ignore) {
             // JAI not available so no need to redirect logging messages
-            System.out.println("Logging JAI messages: Unable to redirect to javax.media.jai");
+            // System.out.println("Logging JAI messages: Unable to redirect to javax.media.jai");
         }
     }
     /**

--- a/modules/library/metadata/src/main/java/org/geotools/util/logging/LoggingImagingListener.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/logging/LoggingImagingListener.java
@@ -1,0 +1,25 @@
+package org.geotools.util.logging;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.media.jai.util.ImagingListener;
+
+final class LoggingImagingListener implements ImagingListener {
+    @Override
+    public boolean errorOccurred(String message, Throwable thrown, Object where,
+            boolean isRetryable) throws RuntimeException {
+        Logger log = Logging.getLogger("javax.media.jai");
+        if (message.contains("Continuing in pure Java mode")) {
+            log.log(Level.FINER, message, thrown);
+        } else {
+            log.log(Level.INFO, message, thrown);
+        }
+        return false; // we are not trying to recover
+    }
+
+    @Override
+    public String toString() {
+        return "LoggingImagingListener";
+    }
+}


### PR DESCRIPTION
Use reflection to redirect JAI ImageListener to our logging system without tripping up when running in environments where JAI is not available.

See https://jira.codehaus.org/browse/GEOT-5016