### PR TITLE
[GEOT-4885] GeoTools stops rendering valid geometry elements after an invalid geometry element

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/SDO.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/SDO.java
@@ -37,6 +37,7 @@ import com.vividsolutions.jts.algorithm.RobustCGAlgorithms;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.CoordinateSequence;
 import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
+import com.vividsolutions.jts.geom.CoordinateSequences;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryCollection;
@@ -2767,8 +2768,12 @@ public final class SDO {
             }
             ring = (LinearRing) gf.createCurvedGeometry(components);
         } else if (INTERPRETATION == 1) {
-            ring = gf.createLinearRing(subList(gf.getCoordinateSequenceFactory(), coords, GTYPE,
-                    elemInfo, triplet, false));
+            CoordinateSequence coordSeq = subList(
+                    gf.getCoordinateSequenceFactory(), coords, GTYPE, elemInfo,
+                    triplet, false);
+            coordSeq = CoordinateSequences.ensureValidRing(
+                    gf.getCoordinateSequenceFactory(), coordSeq);
+            ring = gf.createLinearRing(coordSeq);
         } else if (INTERPRETATION == 3) {
             // rectangle does not maintain measures
             //

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/sdo/SDOCreateTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/sdo/SDOCreateTest.java
@@ -128,6 +128,49 @@ public class SDOCreateTest {
     }
 
     @Test
+    public void testXY_Polygon_With_Unclosed_Ring() throws Exception {
+        SDO_GEOMETRY oraGeom = MDSYS.SDO_GEOMETRY(2003, NULL, NULL,
+                MDSYS.SDO_ELEM_INFO_ARRAY(1, 1003, 1),
+                MDSYS.SDO_ORDINATE_ARRAY(0, 0, 50, 0, 50, 50, 0, 50));
+        // geometry will be automatically fixed by appending one copy
+        // of the start point
+        checkValue(oraGeom, "POLYGON ((0 0, 50 0, 50 50, 0 50, 0 0))");
+    }
+
+    @Test
+    public void testXY_Polygon_With_Single_Point_Ring() throws Exception {
+        // geometries will be automatically fixed by appending three copies
+        // of the start point
+        SDO_GEOMETRY onePointOraGeom = MDSYS.SDO_GEOMETRY(2003, NULL, NULL,
+                MDSYS.SDO_ELEM_INFO_ARRAY(1, 1003, 1),
+                MDSYS.SDO_ORDINATE_ARRAY(0, 0));
+
+        checkValue(onePointOraGeom, "POLYGON ((0 0, 0 0, 0 0, 0 0))");
+    }
+
+    @Test
+    public void testXY_Polygon_With_Closed_Two_Points_Ring() throws Exception {
+        // geometries will be automatically fixed by appending two copies
+        // of the start point
+        SDO_GEOMETRY twoPointsOraGeom = MDSYS.SDO_GEOMETRY(2003, NULL, NULL,
+                MDSYS.SDO_ELEM_INFO_ARRAY(1, 1003, 1),
+                MDSYS.SDO_ORDINATE_ARRAY(0, 0, 0, 0));
+
+        checkValue(twoPointsOraGeom, "POLYGON ((0 0, 0 0, 0 0, 0 0))");
+    }
+
+    @Test
+    public void testXY_Polygon_With_Closed_Three_Points_Ring() throws Exception {
+        // geometries will be automatically fixed by appending one copy
+        // of the start point
+        SDO_GEOMETRY threePointsOraGeom = MDSYS.SDO_GEOMETRY(2003, NULL, NULL,
+                MDSYS.SDO_ELEM_INFO_ARRAY(1, 1003, 1),
+                MDSYS.SDO_ORDINATE_ARRAY(0, 0, 50, 0, 0, 0));
+
+        checkValue(threePointsOraGeom, "POLYGON ((0 0, 50 0, 0 0, 0 0))");
+    }
+
+    @Test
     public void testXYZ_Polygon() throws Exception {
         SDO_GEOMETRY oraGeom = MDSYS.SDO_GEOMETRY(3003, NULL, NULL,
                 MDSYS.SDO_ELEM_INFO_ARRAY(1, 1003, 1),


### PR DESCRIPTION
The issue involved malformed polygons containing either unclosed rings or rings with less than 4 points. Code in class `org.geotools.data.oracle.sdo.SDO` has been amended to make sure a `CoordinateSequence` forms a valid linear ring, before invoking `LinearRing`'s constructor.