### PR TITLE
[GEOT-4946] Fixes null geom when reading schema

### DIFF
--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureHandler.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureHandler.java
@@ -75,7 +75,7 @@ public class FeatureHandler extends DelegatingHandler<SimpleFeature> {
     }
     
     public boolean startObjectEntry(String key) throws ParseException, IOException {
-        if ("id".equals(key)) {
+        if ("id".equals(key) && properties == null) {
             id = "";
             return true;
         }

--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureTypeHandler.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureTypeHandler.java
@@ -154,9 +154,9 @@ public class FeatureTypeHandler extends DelegatingHandler<SimpleFeatureType>
             return false;
           }
         } else if (knownType != newType) {
-          throw new IllegalStateException("Found conflicting types "
-              + knownType.getSimpleName() + " and " + newType.getSimpleName()
-              + " for property " + currentProp);
+          if (Number.class.isAssignableFrom(knownType) && newType == Double.class) {
+            propertyTypes.put(currentProp, Double.class);
+          }
         }
       }
     }
@@ -212,7 +212,9 @@ public class FeatureTypeHandler extends DelegatingHandler<SimpleFeatureType>
     typeBuilder.setName("feature");
     typeBuilder.setNamespaceURI("http://geotools.org");
 
-    typeBuilder.add(geom.getLocalName(), geom.getType().getBinding(), crs);
+    if (geom != null) {
+      typeBuilder.add(geom.getLocalName(), geom.getType().getBinding(), crs);
+    }
 
     if (propertyTypes != null) {
       Set<Entry<String, Class<?>>> entrySet = propertyTypes.entrySet();

--- a/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
+++ b/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
@@ -30,6 +30,7 @@ import org.geotools.geojson.feature.FeatureJSON;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.junit.Test;
+import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -760,6 +761,7 @@ public class FeatureJSONTest extends GeoJSONTestSupport {
           "  'features': [" +
           "    {" +
           "      'type': 'Feature'," +
+          "      'geometry': null," +
           "      'properties': {" +
           "      }," +
           "      'id': 'xyz.1'" +
@@ -769,6 +771,34 @@ public class FeatureJSONTest extends GeoJSONTestSupport {
 
       SimpleFeatureType type = fjson.readFeatureCollectionSchema(json, true);
       assertNull(type.getGeometryDescriptor());
+    }
+    
+    public void testFeatureCollectionWithIdPropertyReadWrite() throws Exception {
+     
+      String json = strip(
+          "{" +
+          "  'type': 'FeatureCollection'," +
+          "  'features': [" +
+          "    {" +
+          "      'type': 'Feature'," +
+          "      'properties': {" +
+          "         'id': 'one'" +
+          "      }," +
+          "      'id': 'xyz.1'" +
+          "    }" +
+          "  ]" +
+          "}");
+      
+      FeatureCollection fc = fjson.readFeatureCollection(json);
+      assertNotNull(fc.getSchema().getDescriptor("id"));
+      Feature feat = fc.features().next();
+      assertEquals("one", feat.getProperty("id").getValue());
+      assertEquals("xyz.1", feat.getIdentifier().getID());
+      
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      fjson.writeFeatureCollection(fc, os);
+
+      assertEquals(json, os.toString());
     }
 
     String crsText() {

--- a/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
+++ b/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
@@ -733,6 +733,43 @@ public class FeatureJSONTest extends GeoJSONTestSupport {
         String json = fjson.toString(features);
 
     }
+    
+    public void testFeatureCollectionWithNullGeometrySchemaRead() throws Exception {
+      String json = strip(
+          "{" +
+          "  'type': 'FeatureCollection'," +
+          "  'features': [" +
+          "    {" +
+          "      'type': 'Feature'," +
+          "      'geometry': null," +
+          "      'properties': {" +
+          "      }," +
+          "      'id': 'xyz.1'" +
+          "    }" +
+          "  ]" +
+          "}");
+
+      SimpleFeatureType type = fjson.readFeatureCollectionSchema(json, true);
+      assertNull(type.getGeometryDescriptor());
+    }
+
+    public void testFeatureCollectionWithoutGeometrySchemaRead() throws Exception {
+      String json = strip(
+          "{" +
+          "  'type': 'FeatureCollection'," +
+          "  'features': [" +
+          "    {" +
+          "      'type': 'Feature'," +
+          "      'properties': {" +
+          "      }," +
+          "      'id': 'xyz.1'" +
+          "    }" +
+          "  ]" +
+          "}");
+
+      SimpleFeatureType type = fjson.readFeatureCollectionSchema(json, true);
+      assertNull(type.getGeometryDescriptor());
+    }
 
     String crsText() {
         return 


### PR DESCRIPTION
FeatureJSON#readFeatureCollectionSchema does not support null geometry.
It now checks if the geometry is null.
Also removed check that forced primite types to be always the same when parsing entire JSON.