### PR TITLE
Add dependency to "batik-codec" artifact

### DIFF
--- a/modules/plugin/svg/pom.xml
+++ b/modules/plugin/svg/pom.xml
@@ -85,6 +85,10 @@
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-transcoder</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-codec</artifactId>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.geotools</groupId>


### PR DESCRIPTION
Adding "batik-codec" to the classpath automatically makes Batik support raster images in SVG output (through Base64 encoding).
Tested in GeoServer.