### PR TITLE
Resolved issue [GEOT-5021](https://jira.codehaus.org/browse/GEOT-5021);

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/WKTReader2.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/WKTReader2.java
@@ -397,7 +397,7 @@ public class WKTReader2 extends WKTReader {
             return null;
         }
 
-        if (type.equals("POINT")) {
+        if (type.equalsIgnoreCase("POINT")) {
             return readPointText();
         } else if (type.equalsIgnoreCase("LINESTRING")) {
             return readLineStringText();

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/WKTReader2Test.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/WKTReader2Test.java
@@ -187,4 +187,14 @@ public class WKTReader2Test {
         assertTrue(ml.getGeometryN(0).getClass() == LineString.class);
         assertTrue(ml.getGeometryN(1) instanceof CompoundRing);
     }
+
+    @Test
+    public void testCaseInsensitive() throws Exception {
+        WKTReader reader = new WKTReader2();
+        assertNotNull( reader.read("POINT(1 2)") );
+        assertNotNull( reader.read("Point(1 2)") );
+
+        assertNotNull( reader.read("LINESTRING(0 2, 2 0, 8 6)") );
+        assertNotNull( reader.read("LineString(0 2, 2 0, 8 6)") );
+    }
 }


### PR DESCRIPTION
For some reason readGeometryTaggedText in WKT2Reader used equals() instead of equalsIgnoreCase for evaluating "POINT". All other evaluations use equalsIgnoreCase ("LINESTRING", "LINEARRING", etc).

Added a simple test case to test case insensitivity in WKTReader2Test.