### PR TITLE
GEOT-5040 - Apply default timeouts to HTTPURIHandler

### DIFF
--- a/modules/extension/xsd/xsd-core/pom.xml
+++ b/modules/extension/xsd/xsd-core/pom.xml
@@ -143,6 +143,16 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymockclassextension</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/HTTPURIHandler.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/HTTPURIHandler.java
@@ -19,6 +19,7 @@ package org.geotools.xml.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 import java.util.logging.Level;
@@ -49,13 +50,13 @@ public class HTTPURIHandler extends URIHandlerImpl {
     
     static final Logger LOGGER = Logging.getLogger(HTTPURIHandler.class);
 
-    int connectionTimeout;
+    int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
 
-    int readTimeout;
+    int readTimeout = DEFAULT_READ_TIMEOUT;
 
     @Override
     public boolean canHandle(URI uri) {
-        return "http".equals(uri.scheme()) || "https".equals(uri.scheme());
+    return "http".equals(uri.scheme()) || "https".equals(uri.scheme());
     }
 
     /**
@@ -68,10 +69,7 @@ public class HTTPURIHandler extends URIHandlerImpl {
     public InputStream createInputStream(URI uri, Map<?, ?> options) throws IOException {
         try {
             
-            String s = uri.toString();
-            LOGGER.log(Level.INFO, s);
-            URL url = new URL(s);
-            final HttpURLConnection httpConnection = (HttpURLConnection) url.openConnection();
+            final HttpURLConnection httpConnection = getConnection(uri);
             httpConnection.setConnectTimeout(connectionTimeout);
             httpConnection.setReadTimeout(readTimeout);
 
@@ -85,6 +83,13 @@ public class HTTPURIHandler extends URIHandlerImpl {
         } catch (RuntimeException exception) {
             throw new Resource.IOWrappedException(exception);
         }
+    }
+
+    protected HttpURLConnection getConnection(URI uri) throws IOException {
+        String s = uri.toString();
+        LOGGER.log(Level.INFO, s);
+        URL url = new URL(s);
+        return (HttpURLConnection) url.openConnection();
     }
 
     /**

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xml/impl/HTTPURIHandlerTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xml/impl/HTTPURIHandlerTest.java
@@ -1,0 +1,142 @@
+package org.geotools.xml.impl;
+
+import static org.easymock.classextension.EasyMock.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+
+import org.eclipse.emf.common.util.URI;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class HTTPURIHandlerTest {
+    HttpURLConnection conn;
+    InputStream is;
+    HTTPURIHandler handler;
+    
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    
+    @Before
+    public void setUp() throws Exception {
+        conn = createMock(HttpURLConnection.class);
+        is = createMock(InputStream.class);
+        
+        conn.setConnectTimeout(anyInt()); expectLastCall().asStub();
+        conn.setReadTimeout(anyInt()); expectLastCall().asStub();
+        expect(conn.getInputStream()).andStubReturn(is);
+        
+        handler = new HTTPURIHandler() {
+    
+            @Override
+            protected HttpURLConnection getConnection(URI uri)
+                    throws IOException {
+                // TODO Auto-generated method stub
+                return conn;
+            }
+            
+        };
+        
+        replay(conn, is);
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        verify(conn, is);
+    }
+    
+    @Test
+    public void testCanHandleHttp() throws Exception {
+        URI uri = URI.createURI("http://example.com");
+        
+        assertThat(handler.canHandle(uri), is(true));
+        
+        handler.createInputStream(uri, Collections.EMPTY_MAP);
+    }
+    
+    @Test
+    public void testCanHandleHttps() throws Exception {
+        URI uri = URI.createURI("https://example.com");
+        
+        assertThat(handler.canHandle(uri), is(true));
+        
+        handler.createInputStream(uri, Collections.EMPTY_MAP);
+    }
+    
+    @Test
+    public void testCantHandleFtp() throws Exception {
+        URI uri = URI.createURI("ftp://example.com");
+        
+        assertThat(handler.canHandle(uri), is(false));
+    }
+    
+    @Test
+    public void testDefaultTimeouts() throws Exception {
+        
+        reset(conn); {
+            conn.setConnectTimeout(HTTPURIHandler.DEFAULT_CONNECTION_TIMEOUT); expectLastCall();
+            conn.setReadTimeout(HTTPURIHandler.DEFAULT_READ_TIMEOUT); expectLastCall();
+            expect(conn.getInputStream()).andStubReturn(is);
+        } replay(conn);
+        
+        URI uri = URI.createURI("http://example.com");
+        
+        handler.createInputStream(uri, Collections.EMPTY_MAP);
+    }
+    @Test
+    public void testCustomConnectTimeout() throws Exception {
+        final int testValue = 42;
+        
+        reset(conn); {
+            conn.setConnectTimeout(testValue); expectLastCall();
+            conn.setReadTimeout(HTTPURIHandler.DEFAULT_READ_TIMEOUT); expectLastCall();
+            expect(conn.getInputStream()).andReturn(is);
+        } replay(conn);
+        
+        handler.setConnectionTimeout(testValue);
+        
+        URI uri = URI.createURI("http://example.com");
+        
+        handler.createInputStream(uri, Collections.EMPTY_MAP);
+    }
+    
+    @Test
+    public void testCustomReadTimeout() throws Exception {
+        final int testValue = 42;
+        
+        reset(conn); {
+            conn.setConnectTimeout(HTTPURIHandler.DEFAULT_CONNECTION_TIMEOUT); expectLastCall();
+            conn.setReadTimeout(testValue); expectLastCall();
+            expect(conn.getInputStream()).andStubReturn(is);
+        } replay(conn);
+        
+        handler.setReadTimeout(testValue);
+        
+        URI uri = URI.createURI("http://example.com");
+        
+        handler.createInputStream(uri, Collections.EMPTY_MAP);
+        
+    }
+    
+    @Test
+    public void testTimeout() throws Exception {
+        reset(conn); {
+            conn.setConnectTimeout(anyInt()); expectLastCall();
+            conn.setReadTimeout(anyInt()); expectLastCall();
+            expect(conn.getInputStream()).andThrow(new IOException());
+        } replay(conn);
+        
+        URI uri = URI.createURI("http://example.com");
+        
+        exception.expect(IOException.class);
+        handler.createInputStream(uri, Collections.EMPTY_MAP);
+        
+    }
+}


### PR DESCRIPTION
Fix for http://jira.codehaus.org/browse/GEOT-5040

Added unit tests.  The XSD module didn't have any mocking libraries so I pulled in EasyMock from the root POM.  I can drop the unit tests if this is a problem.

I noticed an oddity in the POM, while adding EasyMock , the JUnit dependancy is a different version from the root POM and has a different scope (compile rather than test)