### PR TITLE
Added support for Nvarchar filtering in SQL Server [GEOT-5587]

### DIFF
--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerFilterToSQL.java
@@ -17,12 +17,15 @@
 package org.geotools.data.sqlserver;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.geotools.data.jdbc.FilterToSQL;
+import org.geotools.data.jdbc.FilterToSQLException;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.jdbc.SQLDialect;
+import org.opengis.filter.Filter;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
@@ -66,6 +69,14 @@ public class SQLServerFilterToSQL extends FilterToSQL {
         caps.addType(DWithin.class);
         caps.addType(Beyond.class);
         return caps;
+    }
+
+	@Override
+    public String encodeToString(Filter filter) throws FilterToSQLException {
+        StringWriter out = new StringWriter();
+        this.out = out;
+        this.encode(filter);
+        return out.getBuffer().toString().replaceAll("= '", "= N'");
     }
     
     @Override


### PR DESCRIPTION
See - https://osgeo-org.atlassian.net/browse/GEOT-5587

Change made because there was no option to filter SQL Server columns that contains special/national characters as a query generated by this SQL Server jdbc plugin was not using nvarchar type comparison with N' prefix. I think it is necesary to have nvarchar type of comparison because when using geotools in geoserver there is need to create complicated shapes, layers with different type of data and characters. Without this change GeoServer is useless for national data sets
