### PR TITLE
Updated Oracle JDBC version

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/pom.xml
+++ b/modules/plugin/jdbc/jdbc-oracle/pom.xml
@@ -71,11 +71,11 @@
 
     <!--                                                           -->
     <!-- To use for real:                                          -->
-    <!--   Download the ojdbc14.jar driver from oracle and install -->
+    <!--   Download the ojdbc7.jar driver from oracle and install -->
     <!--   into maven:                                             
-            mvn install:install-file -Dfile=ojdbc14.jar \
-                -DgroupId=com.oracle -DartifactId=ojdbc14 \
-                -Dversion=10.2.0.3.0 -Dpackaging=jar -DgeneratePom=true
+            mvn install:install-file -Dfile=ojdbc7.jar \
+                -DgroupId=com.oracle -DartifactId=ojdbc7 \
+                -Dversion=12.1.0.2 -Dpackaging=jar -DgeneratePom=true
                                                                    -->
     <!--   You can then supply -Doracle=true on the command line   -->
     <profile>
@@ -87,7 +87,7 @@
         </activation>
         <dependencies>
           <dependency>
-            <artifactId>ojdbc14</artifactId>
+            <artifactId>ojdbc7</artifactId>
             <groupId>com.oracle</groupId>
             <!-- version specified in root pom -->
           </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <!--                        modules or example code used by the  -->
   <!--                        build box.                           -->
   <!--                                                             -->
-  <!--    -Djdbc.oracle=true  Indicate that the real oracle driver -->
+  <!--    -Doracle=true       Indicate that the real oracle driver -->
   <!--                        has been installed into the local    -->
   <!--                        repository and should be used.       -->
   <!--                                                             -->
@@ -66,7 +66,7 @@
   <!--       mvn -P extensive.tests install                        -->
   <!--       mvn -P online,stress install                          -->
   <!--       mvn -P site.build site                                -->
-  <!--       mvn eclipse:eclipse -Djdbc.oracle=true -P pending     -->
+  <!--       mvn eclipse:eclipse -Doracle=true -P pending          -->
   <!--                                                             -->
   <!--     While you can specify properties one at a time on the   -->
   <!--     command line, for properties describing your            -->
@@ -937,9 +937,9 @@
       <!-- ORACLE -->
       <!-- Download and install into your own repo -->
       <dependency>
-        <artifactId>ojdbc14</artifactId>
+        <artifactId>ojdbc7</artifactId>
         <groupId>com.oracle</groupId>
-        <version>10.2.0.3.0</version>
+        <version>12.1.0.2</version>
       </dependency>
       <dependency>
         <artifactId>sdoapi</artifactId>


### PR DESCRIPTION
As with #794 this is primarily intended to support online tests. However, a version update is probably a good idea anyways.
Also fixes some outdated documentation in the root pom. `-Djdbc.oracle` doesn't actually do anything, changed to `-Doracle` instead to match jdbc-oracle pom.