### PR TITLE
Updated SQLServer example fixture to use the default port of 1433

### DIFF
--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerTestSetup.java
@@ -39,10 +39,10 @@ public class SQLServerTestSetup extends JDBCTestSetup {
     protected Properties createExampleFixture() {
         Properties fixture = new Properties();
         fixture.put("driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
-        fixture.put("url", "jdbc:sqlserver://192.168.150.138:4866");
+        fixture.put("url", "jdbc:sqlserver://192.168.150.138:1433");
         fixture.put("host", "192.168.150.138");
         fixture.put("database", "geotools");
-        fixture.put("port", "4866");
+        fixture.put("port", "1433");
         fixture.put("user", "geotools");
         fixture.put("password", "geotools");
         return fixture;

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/resources/org/geotools/data/sqlserver/db.properties
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/resources/org/geotools/data/sqlserver/db.properties
@@ -1,4 +1,4 @@
 driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
-url=jdbc:sqlserver://192.168.150.138:4866
+url=jdbc:sqlserver://192.168.150.138:1433
 username=geotools
 password=geotools

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/resources/org/geotools/data/sqlserver/factory.properties
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/resources/org/geotools/data/sqlserver/factory.properties
@@ -1,6 +1,6 @@
 driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
 host=192.168.123.130
-port=4866
+port=1433
 user=geotools
 passwd=geotools
 database=geotools


### PR DESCRIPTION
Changed from the previous, seemingly arbitrary, value of 4866.