### PR TITLE
Fix test failure on Windows

### DIFF
--- a/modules/unsupported/csv/src/test/java/org/geotools/data/csv/CSVWriteTest.java
+++ b/modules/unsupported/csv/src/test/java/org/geotools/data/csv/CSVWriteTest.java
@@ -250,7 +250,9 @@ public class CSVWriteTest {
         SimpleFeatureStore featureStore = (SimpleFeatureStore) store.getFeatureSource("locations");
         assertEquals("featureStore should only have the one feature we created", 
                 1, featureStore.getFeatures().size());
-        String contents = "LAT,LON,CITY,NUMBER,YEAR\nPOINT (45.52 -122.681944),Portland,800,2014,";
+        final String newline = System.lineSeparator();
+        String contents = "LAT,LON,CITY,NUMBER,YEAR" + newline + 
+        		"POINT (45.52 -122.681944),Portland,800,2014,";
         assertEquals("Ensure the file has only the one feature we created", 
                 contents.trim(), checkFileContents(file).trim());
     }


### PR DESCRIPTION
I don't know if my way of checking the OS is the correct way to go about it, but I believe this fixes it. We only care to change the test when the OS is Windows, in which case we need \r\n instead of just \n.