### PR TITLE
GEOT-5047: Make sure we have stable date/time literal conversion to sql.

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDateOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDateOnlineTest.java
@@ -35,7 +35,7 @@ public abstract class JDBCDateOnlineTest extends JDBCTestSupport {
         FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
         
         FilterFactory ff = dataStore.getFilterFactory();
-    
+        
         DateFormat df = new SimpleDateFormat("yyyy-dd-MM");
     
         TimeZone[] zones = { TimeZone.getTimeZone("Etc/GMT+12"),
@@ -60,32 +60,32 @@ public abstract class JDBCDateOnlineTest extends JDBCTestSupport {
     }
 
     public void testFilterByTimeStamp() throws Exception {
-        FeatureSource fs = dataStore.getFeatureSource(tname("dates"));
+        FeatureSource fs = dataStore.getFeatureSource( tname("dates"));
     
         FilterFactory ff = dataStore.getFilterFactory();
     
         // equal to
-        Filter f = ff.equals(ff.property(aname("dt")),
+        Filter f = ff.equals( ff.property(aname("dt")),
                 ff.literal("2009-06-28 15:12:41"));
-        assertEquals(1, fs.getCount(new DefaultQuery(tname("dates"), f)));
+        assertEquals(1, fs.getCount(new DefaultQuery( tname("dates"), f)));
     
         f = ff.equals(ff.property(aname("dt")), ff.literal(new SimpleDateFormat(
                 "HH:mm:ss,dd-yyyy-MM").parse("15:12:41,28-2009-06")));
-        assertEquals(1, fs.getCount(new DefaultQuery(tname("dates"), f)));
+        assertEquals( 1, fs.getCount(new DefaultQuery( tname("dates"), f)));
     }
     
     public void testFilterByTime() throws Exception {
-        FeatureSource fs = dataStore.getFeatureSource(tname("dates"));
+        FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
     
         FilterFactory ff = dataStore.getFilterFactory();
     
         // greather than or equal to
         Filter f = ff.greaterOrEqual(ff.property(aname("t")),
                 ff.literal("13:10:12"));
-        assertEquals(3, fs.getCount(new DefaultQuery(tname("dates"), f)));
+        assertEquals(3, fs.getCount(new DefaultQuery( tname("dates"), f)));
     
-        f = ff.greaterOrEqual(ff.property(aname("t")),
-                ff.literal(new SimpleDateFormat("ss:HH:mm").parse("12:13:10")));
-        assertEquals(3, fs.getCount(new DefaultQuery(tname("dates"), f)));
+        f = ff.greaterOrEqual( ff.property(aname("t")),
+                ff.literal( new SimpleDateFormat("ss:HH:mm").parse("12:13:10")));
+        assertEquals(3, fs.getCount(new DefaultQuery( tname("dates"), f)));
     }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDateOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDateOnlineTest.java
@@ -35,44 +35,57 @@ public abstract class JDBCDateOnlineTest extends JDBCTestSupport {
         FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
         
         FilterFactory ff = dataStore.getFilterFactory();
-        
-        DateFormat df = new SimpleDateFormat("yyyy-dd-MM");
-        df.setTimeZone( TimeZone.getTimeZone("PST"));
-        
-        //less than
-        Filter f = ff.lessOrEqual( ff.property( aname("d") ), ff.literal( df.parse("2009-28-06")
-         ) );
-        assertEquals( 2, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
-        
-        f = ff.lessOrEqual( ff.property( aname("d") ),ff.literal( df.parse("2009-28-06") ) );
-        assertEquals( 2, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
-    }
     
+        DateFormat df = new SimpleDateFormat("yyyy-dd-MM");
+    
+        TimeZone[] zones = { TimeZone.getTimeZone("Etc/GMT+12"),
+                TimeZone.getTimeZone("PST"), TimeZone.getTimeZone("EST"),
+                TimeZone.getTimeZone("GMT"), TimeZone.getTimeZone("CET"),
+                TimeZone.getTimeZone("Etc/GMT-12"),
+                TimeZone.getTimeZone("Etc/GMT-14") };
+        for (TimeZone zone : zones) {
+            System.out.println(zone.getDisplayName());
+            df.setTimeZone(zone);
+            TimeZone.setDefault(zone);
+            // less than
+            Filter f = ff.lessOrEqual(ff.property(aname("d")),
+                    ff.literal(df.parse("2009-28-06")));
+            System.out.println(f);
+            assertEquals(2, fs.getCount(new DefaultQuery(tname("dates"), f)));
+    
+            f = ff.lessOrEqual(ff.property(aname("d")),
+                    ff.literal(df.parse("2009-28-06")));
+            assertEquals(2, fs.getCount(new DefaultQuery(tname("dates"), f)));
+        }
+    }
+
     public void testFilterByTimeStamp() throws Exception {
-        FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
-        
+        FeatureSource fs = dataStore.getFeatureSource(tname("dates"));
+    
         FilterFactory ff = dataStore.getFilterFactory();
-        
-        //equal to
-        Filter f = ff.equals( ff.property( aname("dt") ), ff.literal( "2009-06-28 15:12:41" ) );
-        assertEquals( 1, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
-        
-        f = ff.equals( ff.property( aname("dt") ), 
-                ff.literal( new SimpleDateFormat("HH:mm:ss,dd-yyyy-MM").parse("15:12:41,28-2009-06") ) );
-        assertEquals( 1, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
+    
+        // equal to
+        Filter f = ff.equals(ff.property(aname("dt")),
+                ff.literal("2009-06-28 15:12:41"));
+        assertEquals(1, fs.getCount(new DefaultQuery(tname("dates"), f)));
+    
+        f = ff.equals(ff.property(aname("dt")), ff.literal(new SimpleDateFormat(
+                "HH:mm:ss,dd-yyyy-MM").parse("15:12:41,28-2009-06")));
+        assertEquals(1, fs.getCount(new DefaultQuery(tname("dates"), f)));
     }
     
     public void testFilterByTime() throws Exception {
-        FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
-        
+        FeatureSource fs = dataStore.getFeatureSource(tname("dates"));
+    
         FilterFactory ff = dataStore.getFilterFactory();
-        
+    
         // greather than or equal to
-        Filter f = ff.greaterOrEqual( ff.property( aname("t") ), ff.literal( "13:10:12" ) );
-        assertEquals( 3, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
-        
-        f = ff.greaterOrEqual( ff.property( aname("t") ), 
-                ff.literal( new SimpleDateFormat("ss:HH:mm").parse("12:13:10") ) );
-        assertEquals( 3, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
+        Filter f = ff.greaterOrEqual(ff.property(aname("t")),
+                ff.literal("13:10:12"));
+        assertEquals(3, fs.getCount(new DefaultQuery(tname("dates"), f)));
+    
+        f = ff.greaterOrEqual(ff.property(aname("t")),
+                ff.literal(new SimpleDateFormat("ss:HH:mm").parse("12:13:10")));
+        assertEquals(3, fs.getCount(new DefaultQuery(tname("dates"), f)));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/util/TemporalConverterFactoryTest.java
+++ b/modules/library/main/src/test/java/org/geotools/util/TemporalConverterFactoryTest.java
@@ -18,11 +18,12 @@ package org.geotools.util;
 
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
-
 import java.util.TimeZone;
+
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -291,5 +292,29 @@ public class TemporalConverterFactoryTest extends TestCase {
 
         assertEquals(TimeZone.getDefault().getID(), converter.convert(TimeZone.getDefault(), String.class));
         assertNull(converter.convert(null,String.class));
+    }
+    
+    public void testDatetoSQLDate() throws Exception {
+        Converter converter = factory.createConverter(Date.class,
+                java.sql.Date.class, null);
+        assertNotNull(converter);
+        TimeZone[] zones = { TimeZone.getTimeZone("Etc/GMT+12"),
+                TimeZone.getTimeZone("PST"), TimeZone.getTimeZone("EST"),
+                TimeZone.getTimeZone("GMT"), TimeZone.getTimeZone("CET"),
+                TimeZone.getTimeZone("Etc/GMT-12"),
+                TimeZone.getTimeZone("Etc/GMT-14") };
+    
+        for (TimeZone zone : zones) {
+            System.out.println(zone.getDisplayName());
+            TimeZone.setDefault(zone);
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-dd-MM");
+            simpleDateFormat.setTimeZone(zone);
+            Date date = simpleDateFormat.parse("2009-28-06");
+    
+            java.sql.Date output = (java.sql.Date) converter.convert(date,
+                    java.sql.Date.class);
+            System.out.println(output.toGMTString());
+            assertEquals("28 Jun 2009 00:00:00 GMT", output.toGMTString());
+        }
     }
 }

--- a/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2FilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2FilterToSQL.java
@@ -19,6 +19,7 @@ package org.geotools.data.h2;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.geotools.data.jdbc.FilterToSQL;
@@ -217,7 +218,7 @@ public class H2FilterToSQL extends FilterToSQL {
         if (literal instanceof Date) {
             out.write("PARSEDATETIME(");
             if (literal instanceof java.sql.Date) {
-                out.write("'" + DATE_FORMAT.format(literal) + "', 'yyyy-MM-dd'");
+                out.write("'" + DATE_FORMAT.format(literal) + "', 'yyyy-MM-dd', '"+Locale.getDefault()+"', 'GMT'");
             }
             else {
                 out.write("'" + DATETIME_FORMAT.format(literal) + "', 'yyyy-MM-dd HH:mm:ss.SSSZ'");


### PR DESCRIPTION
First attempt to fix GEOT-5047 Make sure we have stable date/time literal conversion to sql.

I now know far too much about how broken Java.util.Date and Java.sql.Date are :-( it seems that the only place we can fix this is at the database level. This PR currently improves the tests to try out a variety of timezones across the world (so that we see time zone related failures) and applies a fix to the H2 db by adding an explicit GMT/UTC timezone to the dateformat statement generated for date filters in the SQL dialect. 