### PR TITLE
tone down wfs-ng use of system.err, warnings and info messages

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/AttributeEncodeExecutor.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/AttributeEncodeExecutor.java
@@ -63,7 +63,7 @@ public class AttributeEncodeExecutor implements BindingWalker.Visitor {
     public void visit(Binding binding) {
         //ensure the object type matches the type declared on the bindign
         if (binding.getType() == null) {
-            logger.warning("Binding: " + binding.getTarget() + " does not declare a target type");
+            logger.fine("Binding: " + binding.getTarget() + " does not declare a target type");
 
             return;
         }
@@ -75,7 +75,7 @@ public class AttributeEncodeExecutor implements BindingWalker.Visitor {
             if (converted != null) {
                 object = converted;
             } else {
-                logger.warning(object + "[ " + object.getClass() + " ] is not of type "
+                logger.fine(object + "[ " + object.getClass() + " ] is not of type "
                     + binding.getType());
 
                 return;

--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/bindings/GML2ParsingUtils.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/bindings/GML2ParsingUtils.java
@@ -277,7 +277,7 @@ public class GML2ParsingUtils {
 
             if (bindings.isEmpty()) {
                 // could not find a binding, use the defaults
-                LOGGER.warning( "Could not find binding for " + property.getQName() + ", using XSAnyTypeBinding." );
+                LOGGER.fine( "Could not find binding for " + property.getQName() + ", using XSAnyTypeBinding." );
                 bindings.add( new XSAnyTypeBinding() );
             }
 

--- a/modules/library/api/src/main/java/org/geotools/data/Transaction.java
+++ b/modules/library/api/src/main/java/org/geotools/data/Transaction.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.data;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Set;
 
@@ -122,7 +123,7 @@ import org.opengis.feature.type.Name;
  * @source $URL$
  * @version $Id$
  */
-public interface Transaction {
+public interface Transaction extends Closeable {
     /** 
      * Represents AUTO_COMMIT mode as opposed to operations with commit/rollback
      * control under a user-supplied transaction.

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSRemoteTransactionState.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSRemoteTransactionState.java
@@ -16,7 +16,7 @@
  */
 package org.geotools.data.wfs;
 
-import static org.geotools.data.wfs.internal.Loggers.info;
+import static org.geotools.data.wfs.internal.Loggers.trace;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -129,7 +129,7 @@ class WFSRemoteTransactionState implements State {
         List<FeatureId> insertedFids = transactionResponse.getInsertedFids();
         int deleteCount = transactionResponse.getDeleteCount();
         int updatedCount = transactionResponse.getUpdatedCount();
-        info(getClass().getSimpleName(), "::commit(): Updated: ", updatedCount, ", Deleted: ",
+        trace(getClass().getSimpleName(), "::commit(): Updated: ", updatedCount, ", Deleted: ",
                 deleteCount, ", Inserted: ", insertedFids);
 
         if (requestedInsertFids.size() != insertedFids.size()) {

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/Loggers.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/Loggers.java
@@ -21,6 +21,10 @@ import java.util.logging.Logger;
 
 import org.geotools.util.logging.Logging;
 
+/**
+ * Internal utility class providing static constants for
+ * Loggers used during WFSDataStore operation.
+ */
 public final class Loggers {
 
     private Loggers() {
@@ -39,15 +43,15 @@ public final class Loggers {
 
     public static final Level MODULE_INFO_LEVEL = Level.INFO;
 
-    public static final Level REQUEST_TRACE_LEVEL = Level.INFO;// TODO: lower this
+    public static final Level REQUEST_TRACE_LEVEL = Level.FINE;
 
-    public static final Level REQUEST_DEBUG_LEVEL = Level.INFO;// TODO: lower this
+    public static final Level REQUEST_DEBUG_LEVEL = Level.FINER;
 
     public static final Level REQUEST_INFO_LEVEL = Level.INFO;
 
-    public static final Level RESPONSES_TRACE_LEVEL = Level.INFO;// TODO: lower this
+    public static final Level RESPONSES_TRACE_LEVEL = Level.FINE;
 
-    public static final Level RESPONSES_DEBUG_LEVEL = Level.INFO;// TODO: lower this
+    public static final Level RESPONSES_DEBUG_LEVEL = Level.FINER;
 
     public static void trace(Object... message) {
         log(MODULE, MODULE_TRACE_LEVEL, message);

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
@@ -211,8 +211,7 @@ public class WFSClient extends AbstractOpenWebService<WFSGetCapabilities, QName>
                 throw new IllegalArgumentException("Unsupported version: " + capsVersion);
             }
         }
-        LOGGER.info("Using WFS Strategy: " + strategy.getClass().getName());
-        
+        LOGGER.finer("Using WFS Strategy: " + strategy.getClass().getName());
         strategy.setConfig(config);
         
         return strategy;

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/IntegrationTestWFSClient.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/IntegrationTestWFSClient.java
@@ -374,7 +374,7 @@ public class IntegrationTestWFSClient extends WFSClient {
         String encodedTransactionResponse = enc.encodeAsString(tr, 
                 "1.0.0".equals(getStrategy().getVersion()) ? org.geotools.wfs.v1_0.WFS.WFS_TransactionResponse :
                     WFS.TransactionResponse);
-        System.err.println(encodedTransactionResponse);
+        // System.err.println(encodedTransactionResponse);
         return encodedTransactionResponse;
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v1_1/DataStoreTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v1_1/DataStoreTest.java
@@ -45,6 +45,8 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
+import com.vividsolutions.jts.geom.Polygon;
+
 /**
  * Unit test suite for WFSContentDataStore
  * 
@@ -129,7 +131,9 @@ public class DataStoreTest {
         featureReader = ds.getFeatureReader(query, Transaction.AUTO_COMMIT);
         while(featureReader.hasNext()) {
             SimpleFeature feature = featureReader.next();
-            System.out.println(feature.getDefaultGeometry());
+            Object geometry = feature.getDefaultGeometry();
+            assertNotNull( geometry );
+            assertTrue( geometry instanceof Polygon);
         }
         GetFeatureRequest request = wfs.getRequest();
         assertEquals("text/xml; subtype=gml/2.1.2", request.getOutputFormat());


### PR DESCRIPTION
Reducing the logs during our unit tests:

* downgrade common xml binding warnings to level fine
* makes Transaction AutoClosable (GEOT-5129), and closes transactions used during unit testing
* Clean up use of System.err and System.out.
