### PR TITLE
Fix issues with dates being coerced into GMT [GEOT-5047]

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDateOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDateOnlineTest.java
@@ -32,7 +32,9 @@ public abstract class JDBCDateOnlineTest extends JDBCTestSupport {
     }
     
     public void testFiltersByDate() throws Exception {
-        FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
+        
+        
+        
         
         FilterFactory ff = dataStore.getFilterFactory();
     
@@ -43,10 +45,17 @@ public abstract class JDBCDateOnlineTest extends JDBCTestSupport {
                 TimeZone.getTimeZone("GMT"), TimeZone.getTimeZone("CET"),
                 TimeZone.getTimeZone("Etc/GMT-12"),
                 TimeZone.getTimeZone("Etc/GMT-14") };
+        
         for (TimeZone zone : zones) {
-            df.setTimeZone(zone);
+           
+            FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
+        
             // set JVM time zone
             TimeZone.setDefault(zone);
+            //regenerate the database table using the new JVM Timezone
+            
+            setup.setUpData();
+            df.setTimeZone(zone);
             // less than
             Filter f = ff.lessOrEqual(ff.property(aname("d")),
                     ff.literal(df.parse("2009-28-06")));
@@ -56,6 +65,7 @@ public abstract class JDBCDateOnlineTest extends JDBCTestSupport {
             f = ff.lessOrEqual(ff.property(aname("d")),
                     ff.literal(df.parse("2009-28-06")));
             assertEquals("wrong number of records for "+zone.getDisplayName(),2, fs.getCount(new DefaultQuery(tname("dates"), f)));
+            
         }
     }
 

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDateOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDateOnlineTest.java
@@ -35,44 +35,57 @@ public abstract class JDBCDateOnlineTest extends JDBCTestSupport {
         FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
         
         FilterFactory ff = dataStore.getFilterFactory();
-        
-        DateFormat df = new SimpleDateFormat("yyyy-dd-MM");
-        df.setTimeZone( TimeZone.getTimeZone("PST"));
-        
-        //less than
-        Filter f = ff.lessOrEqual( ff.property( aname("d") ), ff.literal( df.parse("2009-28-06")
-         ) );
-        assertEquals( 2, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
-        
-        f = ff.lessOrEqual( ff.property( aname("d") ),ff.literal( df.parse("2009-28-06") ) );
-        assertEquals( 2, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
-    }
     
+        DateFormat df = new SimpleDateFormat("yyyy-dd-MM");
+    
+        TimeZone[] zones = { TimeZone.getTimeZone("Etc/GMT+12"),
+                TimeZone.getTimeZone("PST"), TimeZone.getTimeZone("EST"),
+                TimeZone.getTimeZone("GMT"), TimeZone.getTimeZone("CET"),
+                TimeZone.getTimeZone("Etc/GMT-12"),
+                TimeZone.getTimeZone("Etc/GMT-14") };
+        for (TimeZone zone : zones) {
+            df.setTimeZone(zone);
+            // set JVM time zone
+            TimeZone.setDefault(zone);
+            // less than
+            Filter f = ff.lessOrEqual(ff.property(aname("d")),
+                    ff.literal(df.parse("2009-28-06")));
+            System.out.println(f);
+            assertEquals("wrong number of records for "+zone.getDisplayName(), 2, fs.getCount(new DefaultQuery(tname("dates"), f)));
+    
+            f = ff.lessOrEqual(ff.property(aname("d")),
+                    ff.literal(df.parse("2009-28-06")));
+            assertEquals("wrong number of records for "+zone.getDisplayName(),2, fs.getCount(new DefaultQuery(tname("dates"), f)));
+        }
+    }
+
     public void testFilterByTimeStamp() throws Exception {
-        FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
-        
+        FeatureSource fs = dataStore.getFeatureSource(tname("dates"));
+    
         FilterFactory ff = dataStore.getFilterFactory();
-        
-        //equal to
-        Filter f = ff.equals( ff.property( aname("dt") ), ff.literal( "2009-06-28 15:12:41" ) );
-        assertEquals( 1, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
-        
-        f = ff.equals( ff.property( aname("dt") ), 
-                ff.literal( new SimpleDateFormat("HH:mm:ss,dd-yyyy-MM").parse("15:12:41,28-2009-06") ) );
-        assertEquals( 1, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
+    
+        // equal to
+        Filter f = ff.equals(ff.property(aname("dt")),
+                ff.literal("2009-06-28 15:12:41"));
+        assertEquals(1, fs.getCount(new DefaultQuery(tname("dates"), f)));
+    
+        f = ff.equals(ff.property(aname("dt")), ff.literal(new SimpleDateFormat(
+                "HH:mm:ss,dd-yyyy-MM").parse("15:12:41,28-2009-06")));
+        assertEquals(1, fs.getCount(new DefaultQuery(tname("dates"), f)));
     }
     
     public void testFilterByTime() throws Exception {
-        FeatureSource fs = dataStore.getFeatureSource( tname("dates") );
-        
+        FeatureSource fs = dataStore.getFeatureSource(tname("dates"));
+    
         FilterFactory ff = dataStore.getFilterFactory();
-        
+    
         // greather than or equal to
-        Filter f = ff.greaterOrEqual( ff.property( aname("t") ), ff.literal( "13:10:12" ) );
-        assertEquals( 3, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
-        
-        f = ff.greaterOrEqual( ff.property( aname("t") ), 
-                ff.literal( new SimpleDateFormat("ss:HH:mm").parse("12:13:10") ) );
-        assertEquals( 3, fs.getCount( new DefaultQuery(tname("dates"),f ) ) );
+        Filter f = ff.greaterOrEqual(ff.property(aname("t")),
+                ff.literal("13:10:12"));
+        assertEquals(3, fs.getCount(new DefaultQuery(tname("dates"), f)));
+    
+        f = ff.greaterOrEqual(ff.property(aname("t")),
+                ff.literal(new SimpleDateFormat("ss:HH:mm").parse("12:13:10")));
+        assertEquals(3, fs.getCount(new DefaultQuery(tname("dates"), f)));
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/util/TemporalConverterFactory.java
+++ b/modules/library/main/src/main/java/org/geotools/util/TemporalConverterFactory.java
@@ -134,22 +134,7 @@ public class TemporalConverterFactory implements ConverterFactory {
                     }
                 };
             }
-            // if ( String.class.equals( target ) ) {
-            // final DateFormat fFormat;
-            // if ( dateFormat != null ) {
-            // fFormat = dateFormat;
-            // }
-            // else {
-            // //create a default
-            // fFormat = DateFormat.getDateInstance();
-            // }
-            //				
-            // return new Converter() {
-            // public Object convert(Object source, Class target) throws Exception {
-            // return fFormat.format( (Date)source );
-            // }
-            // };
-            // }
+            
         }
 
         // this should handle java.util.Calendar to
@@ -165,7 +150,7 @@ public class TemporalConverterFactory implements ConverterFactory {
                     public Object convert(Object source, Class target) throws Exception {
                         Calendar calendar = (Calendar) source;
 
-                        return timeMillisToDate(calendar.getTimeInMillis(), target);
+                        return timeMillisToDate(calendar.getTimeInMillis(), target, calendar.getTimeZone());
                     }
                 };
             }
@@ -181,23 +166,7 @@ public class TemporalConverterFactory implements ConverterFactory {
                     }
                 };
             }
-            // if ( String.class.equals( target ) ) {
-            // final DateFormat fFormat;
-            // if ( dateTimeFormat != null ) {
-            // fFormat = dateTimeFormat;
-            // }
-            // else {
-            // //create a default
-            // fFormat = DateFormat.getDateTimeInstance();
-            // }
-            //				
-            // return new Converter() {
-            // public Object convert(Object source, Class target) throws Exception {
-            // Date date = ((Calendar)source).getTime();
-            // return fFormat.format( date );
-            // }
-            // };
-            // }
+            
         }
 
         if (XMLGregorianCalendar.class.isAssignableFrom(source)) {
@@ -262,18 +231,21 @@ public class TemporalConverterFactory implements ConverterFactory {
      * @return
      */
     Date timeMillisToDate(long time, Class target) {
+        return timeMillisToDate(time, target, TimeZone.getDefault());
+    }
+    Date timeMillisToDate(long time, Class target, TimeZone zone) {
     	if(Timestamp.class.isAssignableFrom(target)) {
         	return new Timestamp(time);
         } else if(java.sql.Date.class.isAssignableFrom(target)) {
-        	Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        	Calendar cal = Calendar.getInstance(zone);
         	cal.setTimeInMillis(time);
-        	cal.set(Calendar.HOUR_OF_DAY, 0);
+        	cal.set(Calendar.HOUR, 0);
         	cal.set(Calendar.MINUTE, 0);
         	cal.set(Calendar.SECOND, 0);
         	cal.set(Calendar.MILLISECOND, 0);
          	return new java.sql.Date(cal.getTimeInMillis());
         } else if(java.sql.Time.class.isAssignableFrom(target)) {
-        	Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        	Calendar cal = Calendar.getInstance(zone);
         	cal.setTimeInMillis(time);
         	cal.set(Calendar.YEAR, 0);
         	cal.set(Calendar.MONTH, 0);

--- a/modules/library/main/src/test/java/org/geotools/util/TemporalConverterFactoryTest.java
+++ b/modules/library/main/src/test/java/org/geotools/util/TemporalConverterFactoryTest.java
@@ -103,7 +103,7 @@ public class TemporalConverterFactoryTest extends TestCase {
 	}
 	
 	public void testCalendarToTime() throws Exception {
-		Calendar calendar = Calendar.getInstance( TimeZone.getTimeZone("GMT") );
+		Calendar calendar = Calendar.getInstance( /*TimeZone.getTimeZone("GMT")*/ );
 		calendar.clear();
 		calendar.set(Calendar.HOUR_OF_DAY, 17);
 		calendar.set(Calendar.MINUTE, 0);
@@ -171,8 +171,8 @@ public class TemporalConverterFactoryTest extends TestCase {
 		Time time = (Time) factory.createConverter( Date.class, Time.class, null )
 			.convert( date, Time.class );
 		assertNotNull( time );
-		// need to remove the date part, use GMT as Date.getTime() is always GMT
-		Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+		// need to remove the date part
+		Calendar cal = Calendar.getInstance(/*TimeZone.getTimeZone("GMT")*/);
 		cal.setTime(date);
     	cal.set(Calendar.YEAR, 0);
     	cal.set(Calendar.MONTH, 0);

--- a/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2FilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2FilterToSQL.java
@@ -20,9 +20,11 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.logging.Logger;
 
 import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.filter.FilterCapabilities;
+import org.geotools.util.logging.Logging;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
@@ -50,7 +52,7 @@ import com.vividsolutions.jts.geom.LinearRing;
  * @source $URL$
  */
 public class H2FilterToSQL extends FilterToSQL {
-
+    private static final Logger LOGGER = Logging.getLogger(H2FilterToSQL.class);
     @Override
     protected FilterCapabilities createFilterCapabilities() {
         FilterCapabilities caps = super.createFilterCapabilities();
@@ -205,15 +207,18 @@ public class H2FilterToSQL extends FilterToSQL {
     }
 
     static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
-    static{
-        // Set DATE_FORMAT time zone to GMT, as Date's are always in GMT internaly. Otherwise we'll
-        // get a local timezone encoding regardless of the actual Date value        
-        DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
-    }
+    
     static SimpleDateFormat DATETIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
     
     @Override
     protected void writeLiteral(Object literal) throws IOException {
+        if(TimeZone.getDefault()!=DATE_FORMAT.getTimeZone()) {
+            //if someone changes the JVM time zone we need to rebuild these formatters so that
+            //they use the new TimeZone or bad things will happen.
+            DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+            DATETIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
+        }
+
         if (literal instanceof Date) {
             out.write("PARSEDATETIME(");
             if (literal instanceof java.sql.Date) {

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DateTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DateTestSetup.java
@@ -38,7 +38,7 @@ public class H2DateTestSetup extends JDBCDateTestSetup {
 
     @Override
     protected void dropDateTable() throws Exception {
-        run( "DROP TABLE \"geotools\".\"dates\"" );
+        runSafe( "DROP TABLE \"geotools\".\"dates\"" );
     }
 
 }


### PR DESCRIPTION
This PR adds improved JDBC tests to make sure we can add and filter by dates regardless of the TimeZone we are in. It also modifies the temporal convertor to keep track of the TimeZone of the source object (if it has one) so that the GML code can continue to be fixed in GMT(at least in the tests).