### PR TITLE
fast bounds using SDO_GEOM_METADATA

### DIFF
--- a/docs/user/library/jdbc/oracle.rst
+++ b/docs/user/library/jdbc/oracle.rst
@@ -61,7 +61,14 @@ Advanced
 | "Geometry metadata  | An alternative table where geometry            |
 | table"              | metadata information can be looked up          |
 +---------------------+------------------------------------------------+
-
+| "Metadata bbox"     | Flag controlling the use of                    |
+|                     | MDSYS.USER_SDO_GEOM_METADATA or                |
+|                     | MDSYS.ALL_SDO_GEOM_METADATA table for bounding |
+|                     | box calculations, this brings a better         |
+|                     | performance if the views access is fast and    |
+|                     | the bounds are configured right in the tables  |
+|                     | default is false                               |
++---------------------+------------------------------------------------+
 
 Example use::
   
@@ -100,7 +107,7 @@ The table has the following structure (the table name is free, just indicate the
 	   UNIQUE(F_TABLE_SCHEMA, F_TABLE_NAME, F_GEOMETRY_COLUMN),
 	   CHECK(TYPE IN ('POINT','LINE', 'POLYGON', 'COLLECTION', 'MULTIPOINT', 'MULTILINE', 'MULTIPOLYGON', 'GEOMETRY') ));
 	   
-When the table is present the store wil first search it for information about each geometry column
+When the table is present the store will first search it for information about each geometry column
 to be classified, and fall back on the MDSYS views only if such table does not contain any information.
 
 Setup

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGDataStoreFactory.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import oracle.jdbc.OracleConnection;
 
 import org.geotools.data.Transaction;
+import org.geotools.data.DataAccessFactory.Param;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
@@ -33,7 +34,7 @@ import org.geotools.jdbc.SQLDialect;
  * 
  * @author Justin Deoliveira, OpenGEO
  * @author Andrea Aime, OpenGEO
- *
+ * @author Hendrik Peilke
  *
  *
  * @source $URL$
@@ -62,6 +63,9 @@ public class OracleNGDataStoreFactory extends JDBCDataStoreFactory {
     /** Metadata table providing information about primary keys **/
     public static final Param GEOMETRY_METADATA_TABLE = new Param("Geometry metadata table", String.class,
             "The optional table containing geometry metadata (geometry type and srid). Can be expressed as 'schema.name' or just 'name'", false);
+    
+    /** parameter for getting bbox from MDSYS.USER_SDO_GEOM_METADATA or MDSYS.ALL_SDO_GEOM_METADATA table */
+    public static final Param METADATA_BBOX = new Param("Metadata bbox", Boolean.class, "Get data bounds quickly from MDSYS.USER_SDO_GEOM_METADATA or MDSYS.ALL_SDO_GEOM_METADATA table", false, Boolean.FALSE);
     
     @Override
     protected SQLDialect createSQLDialect(JDBCDataStore dataStore) {
@@ -129,6 +133,10 @@ public class OracleNGDataStoreFactory extends JDBCDataStoreFactory {
         String metadataTable = (String) GEOMETRY_METADATA_TABLE.lookUp(params);
         dialect.setGeometryMetadataTable(metadataTable);
         
+        // check the metadata bbox option
+        Boolean metadateBbox = (Boolean) METADATA_BBOX.lookUp(params);
+        dialect.setMetadataBboxEnabled(Boolean.TRUE.equals(metadateBbox));
+        
         if (dataStore.getFetchSize() <= 0) {
             // Oracle is dead slow with the fetch size at 0, let's have a sane default
             dataStore.setFetchSize(200);
@@ -182,6 +190,7 @@ public class OracleNGDataStoreFactory extends JDBCDataStoreFactory {
         parameters.put(DATABASE.key, DATABASE);
         parameters.put(DBTYPE.key, DBTYPE);
         parameters.put(GEOMETRY_METADATA_TABLE.key, GEOMETRY_METADATA_TABLE);
+        parameters.put(METADATA_BBOX.key, METADATA_BBOX);
     }
     
     @Override

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGJNDIDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGJNDIDataStoreFactory.java
@@ -43,5 +43,6 @@ public class OracleNGJNDIDataStoreFactory extends JDBCJNDIDataStoreFactory {
         parameters.put(OracleNGDataStoreFactory.LOOSEBBOX.key, OracleNGDataStoreFactory.LOOSEBBOX);
         parameters.put(OracleNGDataStoreFactory.ESTIMATED_EXTENTS.key, OracleNGDataStoreFactory.ESTIMATED_EXTENTS);
         parameters.put(OracleNGDataStoreFactory.GEOMETRY_METADATA_TABLE.key, OracleNGDataStoreFactory.GEOMETRY_METADATA_TABLE);
+        parameters.put(OracleNGDataStoreFactory.METADATA_BBOX.key, OracleNGDataStoreFactory.METADATA_BBOX);
     }
 }

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGOCIDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGOCIDataStoreFactory.java
@@ -89,6 +89,7 @@ public class OracleNGOCIDataStoreFactory extends OracleNGDataStoreFactory {
         
         parameters.put(OracleNGDataStoreFactory.ESTIMATED_EXTENTS.key, OracleNGDataStoreFactory.ESTIMATED_EXTENTS);
         parameters.put(OracleNGDataStoreFactory.GEOMETRY_METADATA_TABLE.key, OracleNGDataStoreFactory.GEOMETRY_METADATA_TABLE);
+        parameters.put(METADATA_BBOX.key, METADATA_BBOX);
 
     }
 }


### PR DESCRIPTION
As discussed about two years ago in the geotools users mailing list (see http://sourceforge.net/p/geotools/mailman/message/30415309/) this enables fast bounds calculation for oracle database layers containing a lot of data (assumption: the access to the SDO_GEOM_METADATA views is not slower than SDO.TUNE). We integrated this into our applications and would like to share it.

The pull request includes:
- updated source code: A switch, as Andrea suggested, to turn the behaviour on (off by default)
- a test case
- updated documentation