### PR TITLE
General Oblique Transform (Rotated Pole Coordinates) [GEOT-5190]

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeneralOblique.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeneralOblique.java
@@ -1,0 +1,192 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 1999-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ *    This package contains formulas from the PROJ package of USGS.
+ *    USGS's work is fully acknowledged here. This derived work has
+ *    been relicensed under LGPL with Frank Warmerdam's permission.
+ */
+package org.geotools.referencing.operation.projection;
+
+import java.awt.geom.Point2D;
+import org.opengis.parameter.ParameterValueGroup;
+import org.opengis.parameter.ParameterDescriptor;
+import org.opengis.parameter.ParameterDescriptorGroup;
+import org.opengis.parameter.ParameterNotFoundException;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.operation.MathTransform;
+//import org.geotools.resources.i18n.ErrorKeys;
+//import org.geotools.resources.i18n.Errors;
+import org.geotools.referencing.NamedIdentifier;
+import org.geotools.metadata.iso.citation.Citations;
+
+import static java.lang.Math.*;
+
+/**
+ * General Oblique Transformation projection useful for rotated spherical coordinates ("Rotated Pole"), 
+ * commonly used in numerical weather forecasting models.
+ * 
+ * Based on the code provided by Jürgen Seib (Deutscher Wetterdienst), adopted to follow "+proj=ob_tran" behaviour.
+ * 
+ * For examples see "GeneralOblique.txt" file in tests directory
+ * 
+ * @see <a href="http://www.cosmo-model.org/content/model/documentation/core/default.htm#p1"> COSMO User Manual, Part 1</a>
+ * @see <a href="https://github.com/OSGeo/proj.4/blob/master/src/PJ_ob_tran.c">proj.4</a>
+ *  
+ * @since 13.1
+ * 
+ * @source $URL$
+ * @version $Id$
+ * @author Maciej Filocha (ICM)
+ */
+public class GeneralOblique extends MapProjection {
+
+    /** serialVersionUID */
+    private static final long serialVersionUID = 9008485425176368580L;
+
+    /**
+     * Constructs a rotated latitude/longitude projection.
+     * 
+     * @param parameters The group of parameter values.
+     * @throws ParameterNotFoundException if a required parameter was not found.
+     */
+    protected GeneralOblique(final ParameterValueGroup parameters)
+            throws ParameterNotFoundException {
+        super(parameters);
+    }
+
+    /**
+     * Transforms the specified (<var>&lambda;</var>,<var>&phi;</var>) coordinates (units in radians) and stores the result in {@code ptDst} (linear
+     * distance on a unit sphere).
+     * 
+     * @param x The longitude of the coordinate, in <strong>radians</strong>.
+     * @param y The latitude of the coordinate, in <strong>radians</strong>.
+     */
+    protected Point2D transformNormalized(double x, double y, Point2D ptDst)
+            throws ProjectionException {
+        final double sinlat = sin(y);
+        final double coslat = cos(y);
+        final double sinlatP = sin(latitudeOfOrigin);
+        final double coslatP = cos(latitudeOfOrigin);
+        final double sinlon1 = sin(x);
+        final double coslon1 = cos(x);
+
+        x = toDegrees(atan((coslat * sinlon1) / (coslat * sinlatP * coslon1 + sinlat * coslatP)))
+                / globalScale;
+        y = toDegrees(asin(sinlat * sinlatP - coslat * coslatP * coslon1)) / globalScale;
+
+        if (ptDst != null) {
+            ptDst.setLocation(x, y);
+            return ptDst;
+        }
+        return new Point2D.Double(x, y);
+    }
+
+    /**
+     * Transforms the specified (<var>x</var>,<var>y</var>) coordinates (units in radians) and stores the result in {@code ptDst} (linear distance on
+     * a unit sphere).
+     */
+    protected Point2D inverseTransformNormalized(double x, double y, Point2D ptDst)
+            throws ProjectionException {
+        final double scalePI = globalScale * PI / 180;
+        final double sinlat = sin(y * scalePI);
+        final double coslat = cos(y * scalePI);
+        final double sinlon = sin(x * scalePI);
+        final double coslon = cos(x * scalePI);
+        final double sinlatP = sin(latitudeOfOrigin);
+        final double coslatP = cos(latitudeOfOrigin);
+
+        x = -atan((coslat * sinlon) / (sinlat * coslatP - sinlatP * coslat * coslon));
+        y = asin(sinlat * sinlatP + coslat * coslon * coslatP);
+
+        if (ptDst != null) {
+            ptDst.setLocation(x, y);
+            return ptDst;
+        }
+        return new Point2D.Double(x, y);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ParameterDescriptorGroup getParameterDescriptors() {
+        return Provider.PARAMETERS;
+    }
+
+    // ////////////////////////////////////////////////////////////////////////////////////////
+    // ////////////////////////////////////////////////////////////////////////////////////////
+    // ////// ////////
+    // ////// PROVIDERS ////////
+    // ////// ////////
+    // ////////////////////////////////////////////////////////////////////////////////////////
+    // ////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * The {@linkplain org.geotools.referencing.operation.MathTransformProvider math transform provider} for an
+     * {@linkplain org.geotools.referencing.operation.projection.GeneralOblique General Oblique Transformation} projection.
+     * 
+     * @since 2.8
+     * @version $Id$
+     * @author Maciej Filocha (ICM)
+     * 
+     * @see org.geotools.referencing.operation.DefaultMathTransformFactory
+     */
+    public static class Provider extends AbstractProvider {
+
+        /** serialVersionUID */
+        private static final long serialVersionUID = 8452425384927757022L;
+
+        /**
+         * The parameters group.
+         */
+        static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
+                new NamedIdentifier[] { new NamedIdentifier(Citations.AUTO, "General_Oblique"), },
+                new ParameterDescriptor[] { SEMI_MAJOR, SEMI_MINOR, CENTRAL_MERIDIAN,
+                        LATITUDE_OF_ORIGIN, SCALE_FACTOR, FALSE_EASTING, FALSE_NORTHING });
+
+        /**
+         * Constructs a new provider.
+         */
+        public Provider() {
+            super(PARAMETERS);
+        }
+
+        /**
+         * Creates a transform from the specified group of parameter values.
+         * 
+         * @param parameters The group of parameter values.
+         * @return The created math transform.
+         * @throws ParameterNotFoundException if a required parameter was not found.
+         */
+        protected MathTransform createMathTransform(final ParameterValueGroup parameters)
+                throws ParameterNotFoundException, FactoryException {
+            if (isSpherical(parameters)) {
+                return new GeneralOblique(parameters);
+            } else {
+                /*
+                 * "Use of the general oblique transformation is limited to projections assuming a spherical earth. Oblique or transverse projections
+                 * on a elliptical earth present complex problem that requires specific analysis of each projection and cannot be applied in a general
+                 * manner." (see http://download.osgeo.org/proj/proj.4.3.I2.pdf)
+                 *
+                 * However, enabling this dirty hack below allows to convert to and from WGS84 coordinates with much better accuracy. One possible
+                 * reason is that Geotools omits additional transformation between spherical and ellipsoidal coordinates which is not really needed here.
+                 */
+                // throw new FactoryException(Errors.format(ErrorKeys.ELLIPTICAL_NOT_SUPPORTED));
+                return new GeneralOblique(parameters);
+            }
+        }
+    }
+}

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeneralOblique.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeneralOblique.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 1999-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 1999-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -21,14 +21,13 @@
 package org.geotools.referencing.operation.projection;
 
 import java.awt.geom.Point2D;
+import java.util.logging.Level;
 import org.opengis.parameter.ParameterValueGroup;
 import org.opengis.parameter.ParameterDescriptor;
 import org.opengis.parameter.ParameterDescriptorGroup;
 import org.opengis.parameter.ParameterNotFoundException;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.MathTransform;
-//import org.geotools.resources.i18n.ErrorKeys;
-//import org.geotools.resources.i18n.Errors;
 import org.geotools.referencing.NamedIdentifier;
 import org.geotools.metadata.iso.citation.Citations;
 
@@ -184,7 +183,8 @@ public class GeneralOblique extends MapProjection {
                  * However, enabling this dirty hack below allows to convert to and from WGS84 coordinates with much better accuracy. One possible
                  * reason is that Geotools omits additional transformation between spherical and ellipsoidal coordinates which is not really needed here.
                  */
-                // throw new FactoryException(Errors.format(ErrorKeys.ELLIPTICAL_NOT_SUPPORTED));
+            	LOGGER.log(Level.FINE, "GeoTools GeneralOblique transformation is defined only on the sphere, " +
+                        "we're going to use spherical equations even if the projection is using an ellipsoid");
                 return new GeneralOblique(parameters);
             }
         }

--- a/modules/library/referencing/src/main/resources/META-INF/services/org.geotools.referencing.operation.MathTransformProvider
+++ b/modules/library/referencing/src/main/resources/META-INF/services/org.geotools.referencing.operation.MathTransformProvider
@@ -51,3 +51,4 @@ org.geotools.referencing.operation.projection.Mollweide$WagnerIVProvider
 org.geotools.referencing.operation.projection.Gnomonic$Provider
 org.geotools.referencing.operation.projection.WorldVanDerGrintenI$Provider
 org.geotools.referencing.operation.projection.Sinusoidal$Provider
+org.geotools.referencing.operation.projection.GeneralOblique$Provider

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/ScriptTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/ScriptTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/ScriptTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/ScriptTest.java
@@ -268,7 +268,16 @@ public final class ScriptTest {
     public void testWagnerIV() throws Exception {
         runScript("scripts/WagnerIV.txt");
     }
-    
+
+    /**
+     * Run "GeneralOblique.txt"
+     * @throws Exception
+     */
+    @Test
+    public void testGeneralOblique() throws Exception {
+        runScript("scripts/GeneralOblique.txt");
+    }    
+
     /**
      * Run "WorldVanDerGrintenI.txt"
      *

--- a/modules/library/referencing/src/test/resources/org/geotools/referencing/test-data/scripts/GeneralOblique.txt
+++ b/modules/library/referencing/src/test/resources/org/geotools/referencing/test-data/scripts/GeneralOblique.txt
@@ -1,6 +1,6 @@
 // Test points for the GeneralOblique projection
 //
-// (C) 2014, Open Source Geospatial Foundation (OSGeo)
+// (C) 2015, Open Source Geospatial Foundation (OSGeo)
 //
 // The following test points were calculated with eqtoll and proj.4 tools.
 // "eqtoll" is a part of the MetOffice Unified Model suite 

--- a/modules/library/referencing/src/test/resources/org/geotools/referencing/test-data/scripts/GeneralOblique.txt
+++ b/modules/library/referencing/src/test/resources/org/geotools/referencing/test-data/scripts/GeneralOblique.txt
@@ -1,0 +1,77 @@
+// Test points for the GeneralOblique projection
+//
+// (C) 2014, Open Source Geospatial Foundation (OSGeo)
+//
+// The following test points were calculated with eqtoll and proj.4 tools.
+// "eqtoll" is a part of the MetOffice Unified Model suite 
+// 
+//
+// Maciej Filocha (ICM) - May 2015
+//
+// --------------------------------------------------------------------------
+// How to run this script:
+//
+//    java -cp target/classes:target/test-classes:_CLASS_PATH_ -ea org.geotools.referencing.ScriptRunner src/test/resources/org/geotools/referencing/test-data/scripts/GeneralOblique.txt
+//
+// the _CLASS_PATH_ can be generated with
+//
+//    mvn dependency:build-classpath
+//
+// A test is performed every time a "target pt" statement occurs. If the target point computed
+// by Geotools is different from the target point declared in this script by an amount greater
+// than the value specified in the last "test tolerance" statement, then a failure is reported.
+// Inverse transforms are tested if java assertions are enabled.
+// If some test fails, "print" statements can be added in this script for debugging purpose:
+//
+//    print crs            (prints the source and target CRS, and the transform between them)
+//    print pts            (prints the source and target points, and their transformed points)
+
+
+
+// CRS used for the test 
+set _WGS84_  = GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563 ] ], PRIMEM["Greenwich",0.0], UNIT["degree",0.01745329251994328 ]]
+set _WebM_ = PROJCS["WGS84 / Google Mercator", GEOGCS["WGS 84", DATUM["World Geodetic System 1984", SPHEROID["WGS 84", 6378137.0, 298.257223563, AUTHORITY["EPSG","7030"]], AUTHORITY["EPSG","6326"]], PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], UNIT["degree", 0.017453292519943295], AUTHORITY["EPSG","4326"]], PROJECTION["Mercator (1SP)", AUTHORITY["EPSG","9804"]], PARAMETER["semi_major", 6378137.0], PARAMETER["semi_minor", 6378137.0], PARAMETER["latitude_of_origin", 0.0], PARAMETER["central_meridian", 0.0], PARAMETER["scale_factor", 1.0], PARAMETER["false_easting", 0.0], PARAMETER["false_northing", 0.0], UNIT["m", 1.0]]
+set _UM_ = PROJCS["UM", GEOGCS["UM GeogCS",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563],TOWGS84[0,0,0]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9108"]],AXIS["Longitude", EAST],AXIS["Latitude", NORTH]],PROJECTION["General_Oblique"],PARAMETER["central_meridian", 19.3],PARAMETER["latitude_of_origin", 37.5],PARAMETER["scale_factor", 1.0],PARAMETER["false_easting", 0.0],PARAMETER["false_northing", 0.0],UNIT["degree", 1.0]]
+
+//
+// Rough tolerance, but acceptable for intended usage - NWP models grids have typical horizontal
+// resolution on the order of kilometers   
+test tolerance = (1.5, 1.5)
+
+
+//  
+// First part test points are taken from output of the "eqtoll" tool
+// 
+source crs = _UM_
+target crs = _WGS84_
+//print crs
+
+source pt = (0, 0)
+target pt = (19.300000,52.500000)
+//print pts
+
+source pt = (-7.9700, -7.840000)
+target pt = (8.281982 ,44.05167)
+//print pts
+
+source pt = (8.1220, 14.30000)
+target pt = (38.73398 ,65.70290)
+//print pts
+
+//
+// proj ob_tran conversion
+// echo -7.97 -7.84 |  cs2cs -f %.6f +proj=ob_tran +o_proj=longlat +to_meter=0.0174533 +lon_0=19.3 +o_lat_p=37.5 +a=6378137 +b=6378137 +no_defs +to  +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs
+// 921947.603732   5473440.829158 0.000000 
+//
+source crs = _UM_
+target crs = _WebM_
+//print crs
+
+source pt = (-7.97, -7.84)
+target pt = (921947.603732, 5473440.829158)
+//print pts
+
+source pt = (8.122, 14.30)
+target pt = (4311848.341418, 9796005.730920)
+//print pts
+


### PR DESCRIPTION
Add new transformation used quite often by Numerical Weather Forecasting community to support "Rotated Pole" coordinates. That transformation is also available in proj.4 as "+proj=ob_tran".

For initial idea of this pull request, see:
http://sourceforge.net/p/geoserver/mailman/message/34095134/