### PR TITLE
Safe envelope conversion

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope3D.java
+++ b/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope3D.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope3D.java
+++ b/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope3D.java
@@ -719,6 +719,11 @@ public class ReferencedEnvelope3D extends ReferencedEnvelope implements Bounding
 
     /**
      * Creates a new envelope from an existing bounding box.
+     * 
+     * <p> NOTE: if the bounding box is empty, the resulting ReferencedEnvelope will not be. In 
+     *           case this is needed use {@link #create(org.opengis.geometry.Envelope, 
+     *           CoordinateReferenceSystem) ReferencedEnvelope.create(bbox,
+     *           bbox.getCoordinateReferenceSystem())}
      *
      * @param bbox The bounding box to initialize from.
      * @throws MismatchedDimensionException if the CRS dimension is not valid.
@@ -747,6 +752,11 @@ public class ReferencedEnvelope3D extends ReferencedEnvelope implements Bounding
     
     /**
      * Creates a new envelope from an existing OGC envelope.
+     *
+     * <p> NOTE: if the envelope is empty, the resulting ReferencedEnvelope will not be. In 
+     *           case this is needed use {@link #create(org.opengis.geometry.Envelope, 
+     *           CoordinateReferenceSystem) ReferencedEnvelope.create(envelope,
+     *           envelope.getCoordinateReferenceSystem())}
      *
      * @param envelope The envelope to initialize from.
      * @throws MismatchedDimensionException if the CRS dimension is not valid.

--- a/modules/library/api/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
+++ b/modules/library/api/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
@@ -1,7 +1,17 @@
 package org.geotools.geometry.jts;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.awt.geom.Rectangle2D;
+
+import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
@@ -10,7 +20,6 @@ import org.opengis.geometry.MismatchedReferenceSystemException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Coordinate;
-import java.awt.geom.Rectangle2D;
 
 /**
  * 
@@ -142,7 +151,7 @@ public class ReferencedEnvelopeTest {
     @Test
     public void testFactoryMethod() throws Exception {
         try {
-            ReferencedEnvelope bounds = new ReferencedEnvelope( DefaultGeographicCRS.WGS84_3D );
+            new ReferencedEnvelope( DefaultGeographicCRS.WGS84_3D );
             fail("ReferencedEnvelope should not be able to represent 3D CRS such as GDA94");
         }
         catch (Exception expected){
@@ -187,5 +196,34 @@ public class ReferencedEnvelopeTest {
         assertTrue(r2.isNull());
         r1.expandToInclude(r2);
         assertTrue(r1.isNull());
+    }
+    
+    /**
+     * Tests that the conversion of different bound types to ReferencedEnvelope does not lose
+     * the emptiness property 
+     * @throws Exception
+     */
+    @Test
+    public void testEmptyEnvelopeConversion() throws Exception {
+        // conversion of an empty OGC envelope should stay empty
+        GeneralEnvelope ge = new GeneralEnvelope(new double[]{0,0}, new double[]{-1,-1});
+        assertTrue(ge.isEmpty());
+        assertTrue(ReferencedEnvelope.create(ge, ge.getCoordinateReferenceSystem()).isEmpty());
+        assertTrue(ReferencedEnvelope.reference(ge).isEmpty());
+        
+        // conversion of an empty Java Rectangle 2D should stay empty
+        Rectangle2D r2d = new Rectangle2D.Double(0, 0, -1, -1);
+        assertTrue(r2d.isEmpty());
+        assertTrue(ReferencedEnvelope.create(r2d,null).isEmpty());
+        
+        // conversion of an empty ReferencedEnvelope should stay empty
+        ReferencedEnvelope re = new ReferencedEnvelope();
+        assertTrue(re.isEmpty());
+        assertTrue(ReferencedEnvelope.create(re).isEmpty());
+        assertTrue(ReferencedEnvelope.create(re, re.getCoordinateReferenceSystem()).isEmpty());
+        assertTrue(ReferencedEnvelope.reference(re).isEmpty());
+        
+        
+        
     }
 }


### PR DESCRIPTION
As discussed on the geotools-devel mailing list (topic "Envelope conversion loses emptyness"), this pull request tries to extend ReferencedEvenlope implementation, such that emptiness property survives the conversion between different envelope formats.

This pull request includes:
- the changed source code
- some minor fixes in source code (spelling mistakes, elimination of doubly defined methods, unused variables)
- a test

GeoTools and GeoServer build fine on my machine