### PR TITLE
[GEOT-5145] ContentDataStore inefficient verification of available co…

### DIFF
--- a/modules/library/data/src/test/java/org/geotools/data/store/ContentDataStoreTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/store/ContentDataStoreTest.java
@@ -1,14 +1,19 @@
 package org.geotools.data.store;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.geotools.feature.NameImpl;
 import org.junit.Test;
+import org.opengis.feature.type.Name;
 
 public class ContentDataStoreTest extends AbstractContentTest {
     
+    protected static final Name TYPENAME2 = new NameImpl("http://www.geotools.org", "Mock2");
+
     @Test
     public void testRepeatedTypeListCreation() throws IOException {
         // setup a store in which we can count how many times we call createTypeNames()
@@ -24,8 +29,28 @@ public class ContentDataStoreTest extends AbstractContentTest {
         store.getFeatureSource(TYPENAME.getLocalPart());
         assertEquals(1, creationCounter.get());
 
-        // we used to keep no calling createTypeNames
+        // we used to keep on calling createTypeNames
         store.getFeatureSource(TYPENAME.getLocalPart());
+        assertEquals(1, creationCounter.get());
+    }
+
+    @Test
+    public void testCallCreateTypeNamesOnce() throws IOException {
+        // setup a store in which we can count how many times we call createTypeNames()
+        final AtomicInteger creationCounter = new AtomicInteger(0);
+        MockContentDataStore store = new MockContentDataStore() {
+            protected java.util.List<org.opengis.feature.type.Name> createTypeNames()
+                    throws java.io.IOException {
+                creationCounter.incrementAndGet();
+                return Arrays.asList(TYPENAME, TYPENAME2);
+            };
+        };
+
+        store.getFeatureSource(TYPENAME.getLocalPart());
+        assertEquals(1, creationCounter.get());
+
+        // we used to keep on calling createTypeNames
+        store.getFeatureSource(TYPENAME2.getLocalPart());
         assertEquals(1, creationCounter.get());
     }
 


### PR DESCRIPTION
From the original discussion about this one on the ml:

> Would caching getTypeNames() alleviate this performance issue?

Yes, it would, but would have side effects too, the method would stop returning fresh information (and
we don't have a quick way to determine is something changed in a database), and the change
Ben reverted had issues in the filesystem cases, where it seemed like we had a fast way instead so...
not sure how we can effectively bring it back?

The change I'm proposing has less side effects, createTypeNames() would still return fresh values,
ensureEntry() may be fooled by the cache we setup at the first time we cannot find an entry in
case a table got removed, but the feature source created that way would fail at the first data access attempt... so, it just ends up failing a bit later down the road.
And it would not fail in case a table got added, which would instead be another failure case for createTypeNames() caching.

> Yep, please proceed and I can review.

See: https://osgeo-org.atlassian.net/browse/GEOT-5145