### PR TITLE
fix remaining timezone issues

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTemporalFilterOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTemporalFilterOnlineTest.java
@@ -81,7 +81,7 @@ public abstract class JDBCTemporalFilterOnlineTest extends JDBCTestSupport {
         try {
             while(it.hasNext()) {
                 SimpleFeature f = it.next();
-                Date expected = FORMAT.parse(dates[i++]);
+                Date expected = date(dates[i++]);
 
                 assertEquals(Converters.convert(expected, Timestamp.class), f.getAttribute(aname("dt")));
             }
@@ -196,9 +196,10 @@ public abstract class JDBCTemporalFilterOnlineTest extends JDBCTestSupport {
         assertDatesMatch(q, "2009-06-28 15:12:41", "2009-09-29 17:54:23", "2009-09-29 17:54:23");
     }
 
-    static DateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    DateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     protected Date date(String date) throws ParseException {
+        //System.out.println("Format timezone "+FORMAT.getTimeZone().getDisplayName());
         return FORMAT.parse(date);
     }
 

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTimeZoneDateOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTimeZoneDateOnlineTest.java
@@ -20,14 +20,15 @@ public abstract class JDBCTimeZoneDateOnlineTest extends JDBCTestSupport {
     
     @Override
     protected abstract JDBCDateTestSetup createTestSetup();
-    
+    TimeZone originalTimeZone;
     public void setTimeZone(TimeZone zone) {
+        originalTimeZone = TimeZone.getDefault();
         // set JVM time zone
         TimeZone.setDefault(zone);
     }
     
     public void testFiltersByDate() throws Exception {
-    
+        setup.setUpData();
         FilterFactory ff = dataStore.getFilterFactory();
     
         DateFormat df = new SimpleDateFormat("yyyy-dd-MM");
@@ -38,6 +39,7 @@ public abstract class JDBCTimeZoneDateOnlineTest extends JDBCTestSupport {
         assertEquals("wrong number of records for "
                 + TimeZone.getDefault().getDisplayName(), 2,
                 fs.getCount(new DefaultQuery(tname("dates"), f)));
-    
+        TimeZone.setDefault(originalTimeZone);
+        setup.setUpData();
     }
 }


### PR DESCRIPTION
reset the dates table to original timezone after timezone tests
removed static DateFormat from Temporal Tests