### PR TITLE
Fixed issue: CQL LIKE filter not working on MongoDB DataStore

### DIFF
--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
@@ -262,13 +262,13 @@ public class FilterToMongo implements FilterVisitor, ExpressionVisitor {
     @Override
     public Object visit(PropertyIsLike filter, Object extraData) {
         BasicDBObject output = asDBObject(extraData);
-        String expr = convert(filter.accept(this, null), String.class);
+        String expr = convert(filter.getExpression().accept(this, null), String.class);
 
         String multi = filter.getWildCard();
         String single = filter.getSingleChar();
         int flags = (filter.isMatchingCase()) ? 0 : Pattern.CASE_INSENSITIVE;
 
-        String regex = filter.getLiteral().replaceAll(multi, ".*").replaceAll(single, ".");
+        String regex = filter.getLiteral().replace(multi, ".*").replace(single, ".");
         Pattern p = Pattern.compile(regex, flags);
         output.put((String) expr, p);
 

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoDBObjectFeature.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoDBObjectFeature.java
@@ -100,8 +100,7 @@ public class MongoDBObjectFeature implements SimpleFeature {
 
     @Override
     public Object getDefaultGeometry() {
-        Object o = getDBOValue(mapper.getGeometryPath());
-        return o instanceof DBObject ? mapper.getGeometry((DBObject)o) : null;
+        return mapper.getGeometry(featureDBO);
     }
 
     @Override

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
@@ -53,6 +53,7 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.Id;
 import org.opengis.filter.Not;
 import org.opengis.filter.PropertyIsBetween;
+import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.spatial.BBOX;
 import org.opengis.filter.spatial.Intersects;
@@ -160,6 +161,7 @@ public class MongoDataStore extends ContentDataStore {
         capabilities.addAll(FilterCapabilities.SIMPLE_COMPARISONS_OPENGIS);
         capabilities.addType(PropertyIsNull.class);
         capabilities.addType(PropertyIsBetween.class);
+        capabilities.addType(PropertyIsLike.class);
        
         capabilities.addType(BBOX.class);
         capabilities.addType(Intersects.class);

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.Query;
 import org.geotools.data.simple.FilteringSimpleFeatureReader;
@@ -181,6 +182,15 @@ public class MongoFeatureSource extends ContentFeatureSource {
             BasicDBObject keys = new BasicDBObject();
             for (String p : q.getPropertyNames()) {
                 keys.put(mapper.getPropertyPath(p), 1);
+            }
+            // add properties from post filters
+            for (Filter filter: postFilter) {
+                String[] postFilterAttributes = DataUtilities.attributeNames(filter);
+                for (String attrName: postFilterAttributes) {
+                    if (attrName != null && !attrName.isEmpty() && !keys.containsField(attrName)) {
+                        keys.put(mapper.getPropertyPath(attrName), 1);
+                    }
+                }
             }
             if (!keys.containsField(mapper.getGeometryPath())) {
                 keys.put(mapper.getGeometryPath(), 1);

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
@@ -25,11 +25,12 @@ import java.util.logging.Logger;
 
 import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureReader;
+import org.geotools.data.FilteringFeatureReader;
 import org.geotools.data.Query;
-import org.geotools.data.simple.FilteringSimpleFeatureReader;
-import org.geotools.data.simple.SimpleFeatureReader;
+import org.geotools.data.ReTypeFeatureReader;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.filter.visitor.PostPreProcessFilterSplittingVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.logging.Logging;
@@ -116,7 +117,9 @@ public class MongoFeatureSource extends ContentFeatureSource {
 
         Filter[] split = splitFilter(f);
         if (!isAll(split[1])) {
-            return -1;
+            // calculate manually, don't use datastore optimization
+            return countManually(query);
+            //return -1;
         }
 
         DBObject q = toQuery(f);
@@ -126,16 +129,45 @@ public class MongoFeatureSource extends ContentFeatureSource {
         return (int) collection.count(q);
     }
 
+    private int countManually(Query query) throws IOException {
+        getDataStore().getLogger().fine("Calculating size manually");
+
+        int count = 0;
+        //grab a reader
+         FeatureReader<SimpleFeatureType, SimpleFeature> reader = getReader( query );
+        try {
+            while (reader.hasNext()) {
+                reader.next();
+                count++;
+            }
+        } finally {
+            reader.close();
+        }
+
+        return count;
+    }
+
     @Override
     protected FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(Query query)
             throws IOException {
 
-        List<Filter> postFilter = new ArrayList<Filter>();
-        DBCursor cursor = toCursor(query, postFilter);
-        SimpleFeatureReader r = new MongoFeatureReader(cursor, this);
+        List<Filter> postFilterList = new ArrayList<Filter>();
+        List<String> postFilterAttributes = new ArrayList<String>();
+        DBCursor cursor = toCursor(query, postFilterList, postFilterAttributes);
+        FeatureReader<SimpleFeatureType, SimpleFeature> r = new MongoFeatureReader(cursor, this);
 
-        if (!postFilter.isEmpty()) {
-            r = new FilteringSimpleFeatureReader(r, postFilter.get(0));
+        if (!postFilterList.isEmpty() && !isAll(postFilterList.get(0))) {
+            r = new FilteringFeatureReader<SimpleFeatureType, SimpleFeature>(r, postFilterList.get(0));
+
+            // check whether attributes not present in the original query have been
+            // added to the set of retrieved attributes for the sake of
+            // post-filters; if so, wrap the FeatureReader in a ReTypeFeatureReader
+            if (!postFilterAttributes.isEmpty()) {
+                // build the feature type returned by this query
+                SimpleFeatureType returnedSchema = SimpleFeatureTypeBuilder.retype(
+                        getSchema(), query.getPropertyNames());
+                r = new ReTypeFeatureReader(r, returnedSchema);
+            }
         }
         return r;
     }
@@ -165,7 +197,7 @@ public class MongoFeatureSource extends ContentFeatureSource {
         return true;
     }
 
-    DBCursor toCursor(Query q, List<Filter> postFilter) {
+    DBCursor toCursor(Query q, List<Filter> postFilter, List<String> postFilterAttrs) {
         DBObject query = new BasicDBObject();
 
         Filter f = q.getFilter();
@@ -185,10 +217,11 @@ public class MongoFeatureSource extends ContentFeatureSource {
             }
             // add properties from post filters
             for (Filter filter: postFilter) {
-                String[] postFilterAttributes = DataUtilities.attributeNames(filter);
-                for (String attrName: postFilterAttributes) {
+                String[] attributeNames = DataUtilities.attributeNames(filter);
+                for (String attrName: attributeNames) {
                     if (attrName != null && !attrName.isEmpty() && !keys.containsField(attrName)) {
                         keys.put(mapper.getPropertyPath(attrName), 1);
+                        postFilterAttrs.add(attrName);
                     }
                 }
             }

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
@@ -22,6 +22,7 @@ import junit.framework.TestCase;
 import org.geotools.factory.CommonFactoryFinder;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.spatial.BBOX;
 
 import com.mongodb.BasicDBObject;
@@ -54,4 +55,13 @@ public class FilterToMongoTest extends TestCase {
         assertNotNull(obj);
         System.out.println(obj);
     }
+
+    public void testLike() throws Exception {
+        PropertyIsLike like = ff.like(ff.property("stringProperty"), "on%", "%", "_", "\\");
+        BasicDBObject obj = (BasicDBObject) like.accept(filterToMongo, null);
+
+        assertNotNull(obj);
+        System.out.println(obj);
+    }
+
 }

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
@@ -53,7 +53,6 @@ public class FilterToMongoTest extends TestCase {
         BasicDBObject obj = (BasicDBObject) bbox.accept(filterToMongo, null);
         
         assertNotNull(obj);
-        System.out.println(obj);
     }
 
     public void testLike() throws Exception {
@@ -61,7 +60,27 @@ public class FilterToMongoTest extends TestCase {
         BasicDBObject obj = (BasicDBObject) like.accept(filterToMongo, null);
 
         assertNotNull(obj);
-        System.out.println(obj);
+    }
+
+    public void testLikeUnsupported() throws Exception {
+        PropertyIsLike likeLiteral = ff.like(ff.literal("once upon a time"), "on%", "%", "_", "\\");
+        PropertyIsLike likeFunction = ff.like(
+                ff.function("Concatenate", ff.property("stringProperty"),
+                        ff.literal("test")), "on%", "%", "_", "\\");
+
+        try {
+            likeLiteral.accept(filterToMongo, null);
+            fail("Expected UnsupportedOperationException not thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof UnsupportedOperationException);
+        }
+
+        try {
+            likeFunction.accept(filterToMongo, null);
+            fail("Expected UnsupportedOperationException not thrown");
+        } catch (Exception e) {
+            assertTrue(e instanceof UnsupportedOperationException);
+        }
     }
 
 }

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
@@ -28,7 +28,7 @@ import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.GeometryBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
@@ -99,9 +99,11 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
     public void testCreateSchema() throws Exception {
         SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
         tb.setName("ft2");
-        tb.setCRS(CRS.decode("EPSG:4326", true));
+        tb.setCRS(DefaultGeographicCRS.WGS84);
         tb.add("geometry", Point.class);
         tb.add("intProperty", Integer.class);
+        tb.add("doubleProperty", Double.class);
+        tb.add("stringProperty", String.class);
 
         List<String> typeNames = Arrays.asList(dataStore.getTypeNames());
         assertFalse(typeNames.contains("ft2"));

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
@@ -25,11 +25,10 @@ import org.geotools.data.Query;
 import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureReader;
 import org.geotools.data.simple.SimpleFeatureSource;
-import org.geotools.data.simple.SimpleFeatureWriter;
-import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.GeometryBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
@@ -90,9 +89,9 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
 
         GeometryBuilder gb = new GeometryBuilder();
         f.setDefaultGeometry(gb.point(3, 3));
-        f.setAttribute("intProperty", 3);
-        f.setAttribute("doubleProperty", 3.3);
-        f.setAttribute("stringProperty", "three");
+        f.setAttribute("properties.intProperty", 3);
+        f.setAttribute("properties.doubleProperty", 3.3);
+        f.setAttribute("properties.stringProperty", "three");
         w.write();
         w.close();
     }
@@ -100,6 +99,9 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
     public void testCreateSchema() throws Exception {
         SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
         tb.setName("ft2");
+        tb.setCRS(CRS.decode("EPSG:4326", true));
+        tb.add("geometry", Point.class);
+        tb.add("intProperty", Integer.class);
 
         List<String> typeNames = Arrays.asList(dataStore.getTypeNames());
         assertFalse(typeNames.contains("ft2"));
@@ -120,6 +122,5 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
 
         source = dataStore.getFeatureSource("ft2");
         assertEquals(1, source.getCount(new Query("ft2")));
-        
     }
 }

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -23,7 +23,7 @@ import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsLike;
@@ -43,7 +43,7 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
       Query q = new Query("ft1", f);
       assertEquals(1, source.getCount(q));
-      assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,CRS.decode("EPSG:4326", true)), source.getBounds(q));
+      assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,DefaultGeographicCRS.WGS84), source.getBounds(q));
 
       SimpleFeatureCollection features = source.getFeatures(q);
       SimpleFeatureIterator it = features.features();
@@ -64,7 +64,7 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
         Query q = new Query("ft1", f);
         
         assertEquals(1, source.getCount(q));
-        assertEquals(new ReferencedEnvelope(2d,2d,2d,2d,CRS.decode("EPSG:4326", true)), source.getBounds(q));
+        assertEquals(new ReferencedEnvelope(2d,2d,2d,2d,DefaultGeographicCRS.WGS84), source.getBounds(q));
 
         SimpleFeatureCollection features = source.getFeatures(q);
         SimpleFeatureIterator it = features.features();
@@ -85,7 +85,7 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
         Query q = new Query("ft1", f);
 
         assertEquals(1, source.getCount(q));
-        assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,CRS.decode("EPSG:4326", true)), source.getBounds(q));
+        assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,DefaultGeographicCRS.WGS84), source.getBounds(q));
 
         SimpleFeatureCollection features = source.getFeatures(q);
         SimpleFeatureIterator it = features.features();

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -23,8 +23,10 @@ import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.spatial.BBOX;
 
 public abstract class MongoFeatureSourceTest extends MongoTestSupport {
@@ -41,7 +43,7 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
       Query q = new Query("ft1", f);
       assertEquals(1, source.getCount(q));
-      assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,null), source.getBounds(q));
+      assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,CRS.decode("EPSG:4326", true)), source.getBounds(q));
 
       SimpleFeatureCollection features = source.getFeatures(q);
       SimpleFeatureIterator it = features.features();
@@ -56,13 +58,13 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
     public void testEqualToFilter() throws Exception {
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
-        PropertyIsEqualTo f = ff.equals(ff.property("stringProperty"), ff.literal("two"));
+        PropertyIsEqualTo f = ff.equals(ff.property("properties.stringProperty"), ff.literal("two"));
 
         SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
         Query q = new Query("ft1", f);
         
         assertEquals(1, source.getCount(q));
-        assertEquals(new ReferencedEnvelope(2d,2d,2d,2d,null), source.getBounds(q));
+        assertEquals(new ReferencedEnvelope(2d,2d,2d,2d,CRS.decode("EPSG:4326", true)), source.getBounds(q));
 
         SimpleFeatureCollection features = source.getFeatures(q);
         SimpleFeatureIterator it = features.features();
@@ -74,4 +76,26 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
             it.close();
         }
     }
+
+    public void testLikeFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyIsLike f = ff.like(ff.property("properties.stringProperty"), "on%", "%", "?", "\\");
+
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", f);
+
+        assertEquals(1, source.getCount(q));
+        assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,CRS.decode("EPSG:4326", true)), source.getBounds(q));
+
+        SimpleFeatureCollection features = source.getFeatures(q);
+        SimpleFeatureIterator it = features.features();
+        try {
+            assertTrue(it.hasNext());
+            assertFeature(it.next(), 1);
+        }
+        finally {
+            it.close();
+        }
+    }
+
 }

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -24,6 +24,7 @@ import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsLike;
@@ -79,7 +80,7 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
     public void testLikeFilter() throws Exception {
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
-        PropertyIsLike f = ff.like(ff.property("properties.stringProperty"), "on%", "%", "?", "\\");
+        PropertyIsLike f = ff.like(ff.property("properties.stringProperty"), "on%", "%", "_", "\\");
 
         SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
         Query q = new Query("ft1", f);
@@ -92,6 +93,37 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
         try {
             assertTrue(it.hasNext());
             assertFeature(it.next(), 1);
+        }
+        finally {
+            it.close();
+        }
+    }
+
+    public void testLikePostFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        // wrapping the property name in a function that is not declared as
+        // supported in the filter capabilities (i.e. Concatenate) will make the
+        // filter a post-filter
+        PropertyIsLike f = ff.like(ff.function("Concatenate",
+                ff.property("properties.stringProperty"), ff.literal("test")),
+                "on%", "%", "_", "\\");
+
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", f, new String[] { "geometry" });
+
+        // filter should match just one feature
+        assertEquals(1, source.getCount(q));
+        assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,DefaultGeographicCRS.WGS84), source.getBounds(q));
+
+        SimpleFeatureCollection features = source.getFeatures(q);
+        SimpleFeatureIterator it = features.features();
+        try {
+            assertTrue(it.hasNext());
+            SimpleFeature feature =  it.next();
+            assertFeature(feature, 1, false);
+            // the stringProperty attribute should not be returned, since it was
+            // used in the post-filter, but was not listed among the properties to fetch
+            assertNull(feature.getAttribute("properties.stringProperty"));
         }
         finally {
             it.close();

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSupport.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSupport.java
@@ -82,19 +82,25 @@ public abstract class MongoTestSupport extends OnlineTestCase {
     }
     
     protected void assertFeature(SimpleFeature f, int i) {
+        assertFeature(f, i, true);
+    }
+
+    protected void assertFeature(SimpleFeature f, int i, boolean checkAttributes) {
         assertNotNull(f.getDefaultGeometry());
+
         Point p = (Point) f.getDefaultGeometry();
-
-        assertNotNull(f.getAttribute("properties.intProperty"));
-
         assertEquals((double)i, p.getX(), 0.1);
         assertEquals((double)i, p.getY(), 0.1);
 
-        assertNotNull(f.getAttribute("properties.doubleProperty"));
-        assertEquals(i + i*0.1, (Double)f.getAttribute("properties.doubleProperty"), 0.1);
+        if (checkAttributes) {
+            assertNotNull(f.getAttribute("properties.intProperty"));
 
-        assertNotNull(f.getAttribute("properties.stringProperty"));
-        assertEquals(toString(i), (String)f.getAttribute("properties.stringProperty"));
+            assertNotNull(f.getAttribute("properties.doubleProperty"));
+            assertEquals(i + i*0.1, (Double)f.getAttribute("properties.doubleProperty"), 0.1);
+
+            assertNotNull(f.getAttribute("properties.stringProperty"));
+            assertEquals(toString(i), (String)f.getAttribute("properties.stringProperty"));
+        }
     }
 
     protected String toString(int i) {

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSupport.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSupport.java
@@ -77,7 +77,7 @@ public abstract class MongoTestSupport extends OnlineTestCase {
     }
 
     protected void assertFeature(SimpleFeature f) {
-        int i = (Integer) f.getAttribute("intProperty");
+        int i = (Integer) f.getAttribute("properties.intProperty");
         assertFeature(f, i);
     }
     
@@ -85,16 +85,16 @@ public abstract class MongoTestSupport extends OnlineTestCase {
         assertNotNull(f.getDefaultGeometry());
         Point p = (Point) f.getDefaultGeometry();
 
-        assertNotNull(f.getAttribute("intProperty"));
+        assertNotNull(f.getAttribute("properties.intProperty"));
 
         assertEquals((double)i, p.getX(), 0.1);
         assertEquals((double)i, p.getY(), 0.1);
 
-        assertNotNull(f.getAttribute("doubleProperty"));
-        assertEquals(i + i*0.1, (Double)f.getAttribute("doubleProperty"), 0.1);
+        assertNotNull(f.getAttribute("properties.doubleProperty"));
+        assertEquals(i + i*0.1, (Double)f.getAttribute("properties.doubleProperty"), 0.1);
 
-        assertNotNull(f.getAttribute("stringProperty"));
-        assertEquals(toString(i), (String)f.getAttribute("stringProperty"));
+        assertNotNull(f.getAttribute("properties.stringProperty"));
+        assertEquals(toString(i), (String)f.getAttribute("properties.stringProperty"));
     }
 
     protected String toString(int i) {

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -17,12 +17,13 @@
  */
 package org.geotools.data.mongodb.geojson;
 
+import org.geotools.data.mongodb.MongoDataStore;
+import org.geotools.data.mongodb.MongoTestSetup;
+
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
-import org.geotools.data.mongodb.MongoDataStore;
-import org.geotools.data.mongodb.MongoTestSetup;
 
 public class GeoJSONMongoTestSetup extends MongoTestSetup {
 
@@ -73,7 +74,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
             .pop()
         .get());
 
-        ft1.ensureIndex(new BasicDBObject("geometry.coordinates", "2d"));
+        ft1.ensureIndex(new BasicDBObject("geometry", "2dsphere"));
 
         DBCollection ft2 = db.getCollection("ft2");
         ft2.drop();


### PR DESCRIPTION
In general, POST filters require that attributes they operate on be retrieved from the datastore and this was fixed in MongoFeatureSource.toCursor() method. However, a PropertyIsLike filter can actually be processed server-side by MongoDB itself, so it was added to the FilterCapabilities instance created by MongoDataStore.
Other changes are small fixes needed to make the online tests run (tested on Mongo v. 2.6.10 and 3.0.4).