### PR TITLE
Fixed: mongodb LIKE filter partial match

### DIFF
--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
@@ -284,6 +284,8 @@ public class FilterToMongo implements FilterVisitor, ExpressionVisitor {
         int flags = (filter.isMatchingCase()) ? 0 : Pattern.CASE_INSENSITIVE;
 
         String regex = filter.getLiteral().replace(multi, ".*").replace(single, ".");
+        // force full string match
+        regex = "^" + regex + "$";
         Pattern p = Pattern.compile(regex, flags);
         output.put((String) expr, p);
 

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -97,6 +97,15 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
         finally {
             it.close();
         }
+
+        // check full string match
+        f = ff.like(ff.property("properties.stringProperty"), "n%", "%", "_", "\\");
+
+        source = dataStore.getFeatureSource("ft1");
+        q = new Query("ft1", f);
+
+        // no feature should match
+        assertEquals(0, source.getCount(q));
     }
 
     public void testLikePostFilter() throws Exception {


### PR DESCRIPTION
A LIKE pattern is supposed to match the full string it is tested against (e.g. `'Central Park'` matches pattern `'Central%'` but NOT pattern `'tral%'`); the fix makes sure that LIKE filters translated to regular expressions by  the `FilterToMongo` class behave the same way.