### PR TITLE
[GEOT-5054] 13.x Fixed IllegalArgumentException painting a GraphicLegend with a negative scale.

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StyledShapePainter.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StyledShapePainter.java
@@ -362,7 +362,7 @@ public final class StyledShapePainter {
                     iter.currentSegment(coords);
                     try {
                         BufferedImage image = ImageIO.read(graphic.getOnlineResource().getLinkage().toURL());
-                        if (symbolScale != 1.0){
+                        if ((symbolScale > 0.0) && (symbolScale != 1.0)) {
                             int w = (int) (image.getWidth() / symbolScale);
                             int h = (int) (image.getHeight() / symbolScale);
                             int imageType = image.getType() == 0 ? BufferedImage.TYPE_4BYTE_ABGR : image.getType();

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StyledShapePainter.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StyledShapePainter.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/StyledShapePainterTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/StyledShapePainterTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2013, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2013-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/StyledShapePainterTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/StyledShapePainterTest.java
@@ -100,6 +100,42 @@ public class StyledShapePainterTest extends TestCase {
         // Ensure painted legend matches image from file
         Assert.assertTrue(imagesIdentical(paintedImage, testImage));
     }
+
+    @Test
+    public void testGraphicLegendNegativeScale() throws Exception {
+
+        // Load image directly from file, for comparison with painter output
+        final URL imageURL = TestData.getResource(this, "icon64.png");
+        final BufferedImage testImage = ImageIO.read(imageURL);
+        final int width = testImage.getWidth();
+        final int height = testImage.getHeight();
+
+        // Get graphic legend from style
+        final Style style = RendererBaseTest.loadStyle(
+                this, "testGraphicLegend.sld");
+        final Rule rule = style.featureTypeStyles().get(0).rules().get(0);
+        final GraphicLegend legend = (GraphicLegend) rule.getLegend();
+
+        // Paint legend using StyledShapePainter
+        final Point point = new GeometryFactory().createPoint(
+                new Coordinate(width / 2, height / 2));
+        final LiteShape2 shape = new LiteShape2(point, null, null, false);
+
+        int imageType = testImage.getType();
+        if(imageType == BufferedImage.TYPE_CUSTOM) {
+            imageType = BufferedImage.TYPE_INT_RGB;
+        }
+        final BufferedImage paintedImage =
+                new BufferedImage(width, height, imageType);
+        final Graphics2D graphics = paintedImage.createGraphics();
+        final StyledShapePainter painter = new StyledShapePainter();
+        painter.paint(graphics, shape, legend, -1, false);
+        graphics.dispose();
+
+        // Ensure painted legend matches image from file
+        Assert.assertTrue(imagesIdentical(paintedImage, testImage));
+    }
+
     public void testGraphicLegendRotation() throws Exception {
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
         GeometryFactory gf = JTSFactoryFinder.getGeometryFactory();


### PR DESCRIPTION
Attempting to backport this bug fix to 13.x.
[GEOT-5054] Fixed IllegalArgumentException painting a GraphicLegend with a negative scale.