### PR TITLE
Speed up initialization of Oracle DataStores

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/EnsureAuthorizationTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/EnsureAuthorizationTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2014, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2014-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -85,6 +85,11 @@ public class EnsureAuthorizationTest {
             };
             calls++;
             return stmt;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql) throws SQLException {
+            return prepareStatement(sql, 0, 0);
         }
 
         @Override


### PR DESCRIPTION
Oracle JDBC DataStore has used SQL queries where parameter values are concatenated into the query. This approach is unsafe (consider strings containing control characters) and causes performance issues. The database needs to create a separate execution plan for each query with different values and in complex database setups, creating the execution plan might take multiple seconds. This patch has been proven to increase GeoServer startup time by a factory of 7x in a configuration where most features (~70 features) are backed by the Oracle JDBC DataStore.