### PR TITLE
[GEOT-5172] Backport of fix for date comparison filters in MongoDB datastore

### DIFF
--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
@@ -245,7 +245,10 @@ public class MongoFeatureSource extends ContentFeatureSource {
             return new BasicDBObject();
         }
 
-        return (DBObject) f.accept(new FilterToMongo(mapper), null);
+        FilterToMongo v = new FilterToMongo(mapper);
+        v.setFeatureType(getSchema());
+
+        return (DBObject) f.accept(v, null);
     }
 
     boolean isAll(Filter f) {

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
@@ -18,6 +18,7 @@
 package org.geotools.data.mongodb;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import org.geotools.data.FeatureWriter;
@@ -25,8 +26,6 @@ import org.geotools.data.Query;
 import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureReader;
 import org.geotools.data.simple.SimpleFeatureSource;
-import org.geotools.data.simple.SimpleFeatureWriter;
-import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.GeometryBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -94,6 +93,7 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
         f.setAttribute("properties.intProperty", 3);
         f.setAttribute("properties.doubleProperty", 3.3);
         f.setAttribute("properties.stringProperty", "three");
+        f.setAttribute("properties.dateProperty", MongoTestSetup.parseDate("2015-01-24T14:28:16.000+01:00"));
         w.write();
         w.close();
     }
@@ -106,6 +106,7 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
         tb.add("intProperty", Integer.class);
         tb.add("doubleProperty", Double.class);
         tb.add("stringProperty", String.class);
+        tb.add("dateProperty", Date.class);
 
         List<String> typeNames = Arrays.asList(dataStore.getTypeNames());
         assertFalse(typeNames.contains("ft2"));

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSetup.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSetup.java
@@ -18,6 +18,8 @@
 package org.geotools.data.mongodb;
 
 import java.io.IOException;
+import java.text.ParseException;
+import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
 
@@ -29,6 +31,8 @@ public abstract class MongoTestSetup {
     public abstract void setUp(DB db);
 
     protected abstract void setUpDataStore(MongoDataStore dataStore);
+
+    protected abstract Date getDateProperty(int featureIdx);
 
     public MongoDataStore createDataStore(Properties fixture) throws IOException {
         MongoDataStore dataStore = new MongoDataStoreFactory().createDataStore((Map)fixture);
@@ -43,4 +47,17 @@ public abstract class MongoTestSetup {
         }
         return list;
     }
+
+    /**
+     * @param dateAsString ISO-8601 formatted date
+     * @return the parsed date
+     */
+    protected static Date parseDate(String dateAsString) {
+        try {
+            return FilterToMongo.ISO8601_SDF.parse(dateAsString);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Failed to parse string as ISO-8601 formatted date", e);
+        }
+    }
+
 }

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSupport.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSupport.java
@@ -17,16 +17,15 @@
  */
 package org.geotools.data.mongodb;
 
+import java.util.Properties;
+
+import org.geotools.test.OnlineTestCase;
+import org.opengis.feature.simple.SimpleFeature;
+
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.vividsolutions.jts.geom.Point;
-
-import java.util.Properties;
-import java.util.Set;
-
-import org.geotools.test.OnlineTestCase;
-import org.opengis.feature.simple.SimpleFeature;
 
 public abstract class MongoTestSupport extends OnlineTestCase {
 
@@ -103,6 +102,9 @@ public abstract class MongoTestSupport extends OnlineTestCase {
 
             assertNotNull(f.getAttribute("properties.stringProperty"));
             assertEquals(toString(i), (String)f.getAttribute("properties.stringProperty"));
+
+            assertNotNull(f.getAttribute("properties.dateProperty"));
+            assertEquals(testSetup.getDateProperty(i), f.getAttribute("properties.dateProperty"));
         }
     }
 

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -17,6 +17,9 @@
  */
 package org.geotools.data.mongodb.geojson;
 
+import java.util.Date;
+
+import org.geotools.data.mongodb.FilterToMongo;
 import org.geotools.data.mongodb.MongoDataStore;
 import org.geotools.data.mongodb.MongoTestSetup;
 
@@ -26,6 +29,12 @@ import com.mongodb.DB;
 import com.mongodb.DBCollection;
 
 public class GeoJSONMongoTestSetup extends MongoTestSetup {
+
+    static Date[] dateValues = new Date[] {
+        parseDate("2015-01-01T00:00:00.000Z"),
+        parseDate("2015-01-01T16:30:00.000Z"),
+        parseDate("0000-00-00T16:30:00.000Z")
+    };
 
     @Override
     protected void setUpDataStore(MongoDataStore dataStore) {
@@ -48,6 +57,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                 .add("doubleProperty", 0.0)
                 .add("stringProperty", "zero")
                 .add("listProperty", list(new BasicDBObject("value", 0.1),new BasicDBObject("value", 0.2)))
+                .add("dateProperty", getDateProperty(0))
             .pop()
         .get());
         ft1.save(BasicDBObjectBuilder.start()
@@ -61,6 +71,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                 .add("doubleProperty", 1.1)
                 .add("stringProperty", "one")
                 .add("listProperty", list(new BasicDBObject("value", 1.1),new BasicDBObject("value", 1.2)))
+                .add("dateProperty", getDateProperty(1))
             .pop()
         .get());
         ft1.save(BasicDBObjectBuilder.start()
@@ -74,6 +85,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                 .add("doubleProperty", 2.2)
                 .add("stringProperty", "two")
                 .add("listProperty", list(new BasicDBObject("value", 2.1),new BasicDBObject("value", 2.2)))
+                .add("dateProperty", getDateProperty(2))
             .pop()
         .get());
 
@@ -85,4 +97,12 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
         
     }
 
+    @Override
+    protected Date getDateProperty(int featureIdx) {
+        if (featureIdx < dateValues.length) {
+            return dateValues[featureIdx];
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
See [related discussion](http://osgeo-org.1560.x6.nabble.com/WMS-Date-filters-not-working-with-MongoDB-td5216793.html) on mailing list.
