### PR TITLE
[GEOT-5189] getNames() and getFeatureSource() incosistency in AppSchemaDataAccess

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/DataAccessRegistry.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/DataAccessRegistry.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2009-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2009-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -220,7 +220,7 @@ public class DataAccessRegistry implements Repository {
        for (DataAccess<FeatureType, Feature> dataAccess : registry) {
             if (dataAccess instanceof AppSchemaDataAccess) {
                 if (((AppSchemaDataAccess) dataAccess).hasElement(name)) {
-                    return ((AppSchemaDataAccess) dataAccess).getMappingByElement(name);
+                    return ((AppSchemaDataAccess) dataAccess).getMappingByNameOrElement(name);
                 }
             }
         }

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/GeologicUnitTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/GeologicUnitTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2009-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2009-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -41,6 +42,7 @@ import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.test.AppSchemaTestSupport;
 import org.geotools.xml.SchemaIndex;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.feature.Feature;
@@ -76,6 +78,11 @@ public class GeologicUnitTest extends AppSchemaTestSupport {
     @BeforeClass
     public static void oneTimeSetUp() throws Exception {
         reader = EmfComplexFeatureReader.newInstance();
+    }
+
+    @After
+    public void cleanUpDataAccessRegistry() {
+        DataAccessRegistry.unregisterAndDisposeAll();
     }
 
     /**
@@ -137,6 +144,31 @@ public class GeologicUnitTest extends AppSchemaTestSupport {
 
         assertNotNull(mappings);
         assertEquals(1, mappings.size());
+    }
+
+    /**
+     * Tests that a {@link FeatureSource} can be obtained for all names returned by {@link AppSchemaDataAccess#getNames()}.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testGetNamesAndFeatureSources() throws Exception {
+        /*
+         * Initiate data accesses and make sure they have the mappings
+         */
+        final Map<String, Serializable> dsParams = new HashMap<String, Serializable>();
+        URL url = getClass().getResource(schemaBase + "GeologicUnit.xml");
+        assertNotNull(url);
+        dsParams.put("dbtype", "app-schema");
+        dsParams.put("url", url.toExternalForm());
+
+        DataAccess<?, ?> guDataStore = DataAccessFinder.getDataStore(dsParams);
+        assertNotNull(guDataStore);
+
+        for (Name name: guDataStore.getNames()) {
+            FeatureSource<?, ?>  fs = guDataStore.getFeatureSource(name);
+            assertNotNull(fs);
+        }
     }
 
     /**

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/filter/UnmappingFilterVisitorTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/filter/UnmappingFilterVisitorTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2007-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2007-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -383,7 +383,7 @@ public class UnmappingFilterVisitorTest extends AppSchemaTestSupport {
         
         AppSchemaDataAccess complexDs = (AppSchemaDataAccess) mappingDataStore;
         
-        mapping = complexDs.getMappingByElement(typeName);
+        mapping = complexDs.getMappingByNameOrElement(typeName);
 
         NamespaceSupport namespaces = new NamespaceSupport();
         namespaces.declarePrefix("gml", GML.NAMESPACE);
@@ -415,7 +415,7 @@ public class UnmappingFilterVisitorTest extends AppSchemaTestSupport {
 
         AppSchemaDataAccess complexDs = (AppSchemaDataAccess) mappingDataStore;
 
-        mapping = complexDs.getMappingByElement(typeName);
+        mapping = complexDs.getMappingByNameOrElement(typeName);
 
         NamespaceSupport namespaces = new NamespaceSupport();
         namespaces.declarePrefix("gml", GML.NAMESPACE);
@@ -517,7 +517,7 @@ public class UnmappingFilterVisitorTest extends AppSchemaTestSupport {
         final Name typeName = new NameImpl(XMMLNS, "Borehole");
         
         AppSchemaDataAccess complexDs = (AppSchemaDataAccess) mappingDataStore;
-        mapping = complexDs.getMappingByElement(typeName);
+        mapping = complexDs.getMappingByNameOrElement(typeName);
 
         NamespaceSupport namespaces = new NamespaceSupport();
         namespaces.declarePrefix("gml", GML.NAMESPACE);


### PR DESCRIPTION
Basically, I merged the logic from `getMappingByName()` into `getMappingByElement()`, and renamed it to `getMappingElementByNameOrElement()`.

Technically, this is an API change, because the `getMappingByElement()` method is public; however, the JavaDocs state _"this method is public just for unit testing purposes"_, so I guess it's safe to rename it. Also, the `getMappingByName()` method is now redundant and could be removed, but I didn't want to go that far (it's also public _"for unit testing purposes"_).
