### PR TITLE
GEOT-5191: Use GeographicLib-Java for geodesic calculations.

### DIFF
--- a/modules/library/referencing/pom.xml
+++ b/modules/library/referencing/pom.xml
@@ -194,6 +194,11 @@
       <artifactId>jgridshift</artifactId>
       <version>1.0</version>
     </dependency>
+   <dependency>
+     <groupId>net.sf.geographiclib</groupId>
+     <artifactId>GeographicLib-Java</artifactId>
+     <version>1.44</version>
+   </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/GeodeticCalculatorTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/GeodeticCalculatorTest.java
@@ -63,7 +63,7 @@ public final class GeodeticCalculatorTest {
         calculator.setDestinationGeographicPoint(13, 20);  assertEquals("East",   90, calculator.getAzimuth(), EPS);
         calculator.setDestinationGeographicPoint(12, 21);  assertEquals("North",   0, calculator.getAzimuth(), EPS);
         calculator.setDestinationGeographicPoint(11, 20);  assertEquals("West",  -90, calculator.getAzimuth(), EPS);
-        calculator.setDestinationGeographicPoint(12, 19);  assertEquals("South", 180, calculator.getAzimuth(), EPS);
+        calculator.setDestinationGeographicPoint(12, 19);  assertEquals("South",-180, calculator.getAzimuth(), EPS);
     }
 
     /**
@@ -179,11 +179,11 @@ public final class GeodeticCalculatorTest {
             calculator.setDestinationGeographicPoint(x, 0);
             final double distance = calculator.getOrthodromicDistance() / 1000; // In kilometers
             /*
-             * Checks that the increment is constant. It is not for x>179 unless
-             * GeodeticCalculator switch to DefaultEllipsoid algorithm, which is
-             * what we want to ensure with this test.
+             * Checks that the increment is constant and then tapers off.
              */
-            assertFalse(Math.abs(Math.abs(distance - last) - 13.914935) > 2E-6);
+            assertTrue(x == 0 ? (distance == 0) :
+                       (x < 179.5 ? (Math.abs(distance - last - 13.914936) < 2E-6)
+                        : (distance - last < 13)));
             last = distance;
         }
     }

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/GeocentricTransformTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/GeocentricTransformTest.java
@@ -151,7 +151,7 @@ public final class GeocentricTransformTest extends TransformTestBase {
         array0[6]=  0; array0[ 7]=0.0; array0[ 8]=0;
         array0[9]=180; array0[10]=0.0; array0[11]=0; // Antipodes; distance should be 2*6378.137 km
         cartesianDistance  [1] = ellipsoid.getSemiMajorAxis() * 2;
-        orthodromicDistance[1] = ellipsoid.getSemiMajorAxis() * Math.PI;
+        orthodromicDistance[1] = 20003931.46;
 
         array0[12]=  0; array0[13]=-90; array0[14]=0;
         array0[15]=180; array0[16]=+90; array0[17]=0; // Antipodes; distance should be 2*6356.752 km
@@ -161,7 +161,7 @@ public final class GeocentricTransformTest extends TransformTestBase {
         array0[18]= 95; array0[19]=-38; array0[20]=0;
         array0[21]=-85; array0[22]=+38; array0[23]=0; // Antipodes
         cartesianDistance  [3] = 12740147.19;
-        orthodromicDistance[3] = 20003867.86;
+        orthodromicDistance[3] = 20003931.46;
         /*
          * Transform all points, and then inverse transform then. The resulting
          * <code>array2</code> array should be equals to <code>array0</code>


### PR DESCRIPTION
The affected classes are GeodeticCalculator and DefaultEllipsoid.  Some
of the tests were wrong and these needed to be fixed.  Now you can
calculate the distance between Wellington, 41.32S 174.81E, and
Salamanca, 40.96N 5.50W.

The latitude must lie in [-90,90] as before.  But now, any finite
longitude, azimuth, and distance is accepted by the GeodeticCalculator.
The calculated longitude and azimuth is in the range [-180,180), except
that the longitudes returned by getGeodeticPath are "unrolled" and so
vary continuously (this is governed by the GeodesicMask.LONG_UNROLL
flag).