### PR TITLE
[GEOT-5194] types defined in imported schemas not found

### DIFF
--- a/modules/extension/xsd/xsd-core/src/test/resources/org/geotools/xml/importFacetsEmpty.xsd
+++ b/modules/extension/xsd/xsd-core/src/test/resources/org/geotools/xml/importFacetsEmpty.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://geotools.org/test/importFacets"
+    elementFormDefault="qualified">
+    <import namespace="http://geotools.org/test" schemaLocation="facets.xsd" />
+</schema>

--- a/modules/extension/xsd/xsd-core/src/test/resources/org/geotools/xml/importFacetsNotEmpty.xsd
+++ b/modules/extension/xsd/xsd-core/src/test/resources/org/geotools/xml/importFacetsNotEmpty.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://geotools.org/test/importFacets"
+    elementFormDefault="qualified">
+    <import namespace="http://geotools.org/test" schemaLocation="facets.xsd" />
+
+    <complexType name="stringCollection">
+        <sequence>
+            <element name="s" type="string" minOccurs="1" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+</schema>


### PR DESCRIPTION
Forces parsing of imported schemas (if any) when importing schema has no element / type declaration.

See [related JIRA ticket](https://osgeo-org.atlassian.net/browse/GEOT-5194) for a description of the issue fixed by this PR.