### PR TITLE
ProjectiveTransform2D.inverse() throws class cast exception.

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/GeocentricTranslation.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/GeocentricTranslation.java
@@ -17,10 +17,18 @@
 package org.geotools.referencing.operation.transform;
 
 import java.util.Collections;
-
-import javax.measure.unit.NonSI;
 import javax.measure.unit.SI;
+import javax.measure.unit.NonSI;
 
+import org.opengis.parameter.ParameterDescriptor;
+import org.opengis.parameter.ParameterDescriptorGroup;
+import org.opengis.parameter.ParameterNotFoundException;
+import org.opengis.parameter.ParameterValueGroup;
+import org.opengis.referencing.operation.Matrix;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.Transformation;
+
+import org.geotools.util.Utilities;
 import org.geotools.measure.Units;
 import org.geotools.metadata.iso.citation.Citations;
 import org.geotools.parameter.DefaultParameterDescriptor;
@@ -29,57 +37,33 @@ import org.geotools.parameter.ParameterGroup;
 import org.geotools.referencing.NamedIdentifier;
 import org.geotools.referencing.datum.BursaWolfParameters;
 import org.geotools.referencing.operation.MathTransformProvider;
-import org.geotools.resources.i18n.ErrorKeys;
 import org.geotools.resources.i18n.Errors;
-import org.geotools.util.Utilities;
-import org.opengis.parameter.ParameterDescriptor;
-import org.opengis.parameter.ParameterDescriptorGroup;
-import org.opengis.parameter.ParameterNotFoundException;
-import org.opengis.parameter.ParameterValueGroup;
-import org.opengis.referencing.operation.MathTransform;
-import org.opengis.referencing.operation.Matrix;
-import org.opengis.referencing.operation.Transformation;
+import org.geotools.resources.i18n.ErrorKeys;
+
 
 /**
- * An affine transform applied on
- * {@linkplain org.opengis.referencing.crs.GeocentricCRS geocentric}
- * coordinates. While "geocentric translation" is a little bit more restrictive
- * name, it describes the part which is common to all instances of this class. A
- * rotation may also be performed in addition of the translation, but the
- * rotation sign is operation-dependent (EPSG 9606 and 9607 have opposite sign).
- * This transform is used for the following operations:
+ * An affine transform applied on {@linkplain org.opengis.referencing.crs.GeocentricCRS geocentric}
+ * coordinates. While "geocentric translation" is a little bit more restrictive name, it describes
+ * the part which is common to all instances of this class. A rotation may also be performed in
+ * addition of the translation, but the rotation sign is operation-dependent (EPSG 9606 and 9607
+ * have opposite sign). This transform is used for the following operations:
  * <p>
  * <table border="1">
- * <tr>
- * <th>EPSG name</th>
- * <th>EPSG code</th>
- * </tr>
- * <tr>
- * <td>Geocentric translations</td>
- * <td>9603</td>
- * </tr>
- * <tr>
- * <td>Position Vector 7-param. transformation</td>
- * <td>9606</td>
- * </tr>
- * <tr>
- * <td>Coordinate Frame rotation</td>
- * <td>9607</td>
- * </tr>
+ *   <tr><th>EPSG name</th>                               <th>EPSG code</th></tr>
+ *   <tr><td>Geocentric translations</td>                 <td>9603</td></tr>
+ *   <tr><td>Position Vector 7-param. transformation</td> <td>9606</td></tr>
+ *   <tr><td>Coordinate Frame rotation</td>               <td>9607</td></tr>
  * </table>
  * <p>
- * The conversion between geographic and geocentric coordinates is usually
- * <strong>not</strong> part of this transform. However, the Geotools
- * implementation of the {@linkplain GeocentricTranslation.Provider provider}
- * accepts the following extensions:
+ * The conversion between geographic and geocentric coordinates is usually <strong>not</strong>
+ * part of this transform. However, the Geotools implementation of the
+ * {@linkplain GeocentricTranslation.Provider provider} accepts the following extensions:
  * <p>
  * <ul>
- * <li>If {@code "src_semi_major"} and {@code "src_semi_minor"} parameters are
- * provided, then a {@code "Ellipsoid_To_Geocentric"} transform is concatenated
- * before this transform.</li>
- * <li>If {@code "tgt_semi_major"} and {@code "tgt_semi_minor"} parameters are
- * provided, then a {@code "Geocentric_To_Ellipsoid"} transform is concatenated
- * after this transform.</li>
+ *   <li>If {@code "src_semi_major"} and {@code "src_semi_minor"} parameters are provided, then
+ *       a {@code "Ellipsoid_To_Geocentric"} transform is concatenated before this transform.</li>
+ *   <li>If {@code "tgt_semi_major"} and {@code "tgt_semi_minor"} parameters are provided, then
+ *       a {@code "Geocentric_To_Ellipsoid"} transform is concatenated after this transform.</li>
  * </ul>
  *
  * @since 2.2
@@ -90,522 +74,498 @@ import org.opengis.referencing.operation.Transformation;
  * @author Martin Desruisseaux (IRD)
  */
 public class GeocentricTranslation extends ProjectiveTransform {
-	/**
-	 * Serial number for interoperability with different versions.
-	 */
-	private static final long serialVersionUID = -168669443433018655L;
+    /**
+     * Serial number for interoperability with different versions.
+     */
+    private static final long serialVersionUID = -168669443433018655L;
 
-	/**
-	 * The parameter descriptor group.
-	 */
-	private final ParameterDescriptorGroup descriptor;
+    /**
+     * The parameter descriptor group.
+     */
+    private final ParameterDescriptorGroup descriptor;
 
-	/**
-	 * Creates a new geocentric affine transform. If the parameters don't
-	 * contain rotation terms, then this transform will be of kind
-	 * "<cite>Geocentric translations</cite>". Otherwise, it will be of kind
-	 * "<cite>Position Vector 7-param. transformation</cite>".
-	 *
-	 * @param parameters
-	 *            The Bursa-Wolf parameters to use for initializing the
-	 *            transformation.
-	 */
-	public GeocentricTranslation(final BursaWolfParameters parameters) {
-		this(parameters, parameters.isTranslation() ? Provider.PARAMETERS
-				: ProviderSevenParam.PARAMETERS);
-	}
+    /**
+     * Creates a new geocentric affine transform. If the parameters don't contain rotation terms,
+     * then this transform will be of kind "<cite>Geocentric translations</cite>". Otherwise, it
+     * will be of kind "<cite>Position Vector 7-param. transformation</cite>".
+     *
+     * @param parameters The Bursa-Wolf parameters to use for initializing the transformation.
+     */
+    public GeocentricTranslation(final BursaWolfParameters parameters) {
+        this(parameters, parameters.isTranslation() ?
+                         Provider.PARAMETERS : ProviderSevenParam.PARAMETERS);
+    }
 
-	/**
-	 * Creates a new geocentric affine transform using the specified parameter
-	 * descriptor.
-	 */
-	GeocentricTranslation(final BursaWolfParameters parameters,
-			final ParameterDescriptorGroup descriptor) {
-		super(parameters.getAffineTransform());
-		this.descriptor = descriptor;
-	}
+    /**
+     * Creates a new geocentric affine transform using the specified parameter descriptor.
+     */
+    GeocentricTranslation(final BursaWolfParameters      parameters,
+                          final ParameterDescriptorGroup descriptor)
+    {
+        super(parameters.getAffineTransform());
+        this.descriptor = descriptor;
+    }
 
-	/**
-	 * Creates a new geocentric affine transform using the specified parameter
-	 * descriptor.
-	 */
-	private GeocentricTranslation(final Matrix matrix,
-			final ParameterDescriptorGroup descriptor) {
-		super(matrix);
-		this.descriptor = descriptor;
-	}
+    /**
+     * Creates a new geocentric affine transform using the specified parameter descriptor.
+     */
+    private GeocentricTranslation(final Matrix matrix,
+                                  final ParameterDescriptorGroup descriptor)
+    {
+        super(matrix);
+        this.descriptor = descriptor;
+    }
 
-	/**
-	 * Returns the parameter descriptors for this math transform.
-	 */
-	@Override
-	public ParameterDescriptorGroup getParameterDescriptors() {
-		return descriptor;
-	}
+    /**
+     * Returns the parameter descriptors for this math transform.
+     */
+    @Override
+    public ParameterDescriptorGroup getParameterDescriptors() {
+        return descriptor;
+    }
 
-	/**
-	 * Returns the parameters for this math transform.
-	 */
-	@Override
-	public ParameterValueGroup getParameterValues() {
-		final BursaWolfParameters parameters = new BursaWolfParameters(null);
-		parameters.setAffineTransform(getMatrix(), Double.POSITIVE_INFINITY);
-		if (ProviderFrameRotation.PARAMETERS.equals(descriptor)) {
-			parameters.ex = -parameters.ex;
-			parameters.ey = -parameters.ey;
-			parameters.ez = -parameters.ez;
-		}
-		final boolean isTranslation = Provider.PARAMETERS.equals(descriptor);
-		final FloatParameter[] param = new FloatParameter[isTranslation ? 3 : 7];
-		param[0] = new FloatParameter(Provider.DX, parameters.dx);
-		param[1] = new FloatParameter(Provider.DY, parameters.dy);
-		param[2] = new FloatParameter(Provider.DZ, parameters.dz);
-		if (!isTranslation) {
-			param[3] = new FloatParameter(ProviderSevenParam.EX, parameters.ex);
-			param[4] = new FloatParameter(ProviderSevenParam.EY, parameters.ey);
-			param[5] = new FloatParameter(ProviderSevenParam.EZ, parameters.ez);
-			param[6] = new FloatParameter(ProviderSevenParam.PPM,
-					parameters.ppm);
-		}
-		return new ParameterGroup(getParameterDescriptors(), param);
-	}
+    /**
+     * Returns the parameters for this math transform.
+     */
+    @Override
+    public ParameterValueGroup getParameterValues() {
+        final BursaWolfParameters parameters = new BursaWolfParameters(null);
+        parameters.setAffineTransform(getMatrix(), Double.POSITIVE_INFINITY);
+        if (ProviderFrameRotation.PARAMETERS.equals(descriptor)) {
+            parameters.ex = -parameters.ex;
+            parameters.ey = -parameters.ey;
+            parameters.ez = -parameters.ez;
+        }
+        final boolean isTranslation = Provider.PARAMETERS.equals(descriptor);
+        final FloatParameter[] param = new FloatParameter[isTranslation ? 3 : 7];
+        param[0] = new FloatParameter(Provider.DX,  parameters.dx);
+        param[1] = new FloatParameter(Provider.DY,  parameters.dy);
+        param[2] = new FloatParameter(Provider.DZ,  parameters.dz);
+        if (!isTranslation) {
+            param[3] = new FloatParameter(ProviderSevenParam.EX,  parameters.ex);
+            param[4] = new FloatParameter(ProviderSevenParam.EY,  parameters.ey);
+            param[5] = new FloatParameter(ProviderSevenParam.EZ,  parameters.ez);
+            param[6] = new FloatParameter(ProviderSevenParam.PPM, parameters.ppm);
+        }
+        return new ParameterGroup(getParameterDescriptors(), param);
+    }
 
-	/**
-	 * Creates an inverse transform using the specified matrix.
-	 */
-	@Override
-	GeocentricTranslation createInverse(final Matrix matrix) {
-		return new GeocentricTranslation(matrix, descriptor);
-	}
+    /**
+     * Creates an inverse transform using the specified matrix.
+     */
+    @Override
+    GeocentricTranslation createInverse(final Matrix matrix) {
+        return new GeocentricTranslation(matrix, descriptor);
+    }
 
-	/**
-	 * Returns a hash value for this transform. This value need not remain
-	 * consistent between different implementations of the same class.
-	 */
-	@Override
-	public int hashCode() {
-		return super.hashCode() ^ descriptor.hashCode();
-	}
+    /**
+     * Returns a hash value for this transform.
+     * This value need not remain consistent between
+     * different implementations of the same class.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ descriptor.hashCode();
+    }
 
-	/**
-	 * Compares the specified object with this math transform for equality.
-	 */
-	@Override
-	public boolean equals(final Object object) {
-		if (super.equals(object)) {
-			final GeocentricTranslation that = (GeocentricTranslation) object;
-			return Utilities.equals(this.descriptor, that.descriptor);
-		}
-		return false;
-	}
+    /**
+     * Compares the specified object with this math transform for equality.
+     */
+    @Override
+    public boolean equals(final Object object) {
+        if (super.equals(object)) {
+            final GeocentricTranslation that = (GeocentricTranslation) object;
+            return Utilities.equals(this.descriptor, that.descriptor);
+        }
+        return false;
+    }
 
-	/**
-	 * Base class for {@linkplain GeocentricTranslation geocentric affine
-	 * transform} providers. This base class is the provider for the
-	 * "<cite>Geocentric translations</cite>" operation (EPSG code 9603). The
-	 * translation terms are the same for the 2 derived operations,
-	 * "<cite>Position Vector 7-param. transformation</cite>" and
-	 * "<cite>Coordinate Frame rotation</cite>".
-	 *
-	 * @version $Id$
-	 * @author Martin Desruisseaux (IRD)
-	 *
-	 * @since 2.2
-	 */
-	public static class Provider extends MathTransformProvider {
-		/**
-		 * Serial number for interoperability with different versions.
-		 */
-		private static final long serialVersionUID = -7160250630666911608L;
+    /**
+     * Base class for {@linkplain GeocentricTranslation geocentric affine transform} providers.
+     * This base class is the provider for the "<cite>Geocentric translations</cite>" operation
+     * (EPSG code 9603). The translation terms are the same for the 2 derived operations,
+     * "<cite>Position Vector 7-param. transformation</cite>" and
+     * "<cite>Coordinate Frame rotation</cite>".
+     *
+     * @version $Id$
+     * @author Martin Desruisseaux (IRD)
+     *
+     * @since 2.2
+     */
+    public static class Provider extends MathTransformProvider {
+        /**
+         * Serial number for interoperability with different versions.
+         */
+        private static final long serialVersionUID = -7160250630666911608L;
 
-		/**
-		 * The default value for geographic source and target dimensions, which
-		 * is 2. NOTE: If this default value is modified, then the handling of
-		 * the 3D cases in {@link MolodenskiTransform} must be adjusted.
-		 */
-		static final int DEFAULT_DIMENSION = 2;
+        /**
+         * The default value for geographic source and target dimensions, which is 2.
+         * NOTE: If this default value is modified, then the handling of the 3D cases
+         * in {@link MolodenskiTransform} must be adjusted.
+         */
+        static final int DEFAULT_DIMENSION = 2;
 
-		/**
-		 * The number of source geographic dimension (2 or 3). This is a
-		 * Geotools-specific argument. If presents, an
-		 * {@code "Ellipsoid_To_Geocentric"} transform will be concatenated
-		 * before the geocentric translation.
-		 */
-		public static final ParameterDescriptor<Integer> SRC_DIM = DefaultParameterDescriptor
-				.create(Collections.singletonMap(NAME_KEY, new NamedIdentifier(
-						Citations.GEOTOOLS, "src_dim")), DEFAULT_DIMENSION, 2,
-						3, false);
+        /**
+         * The number of source geographic dimension (2 or 3).
+         * This is a Geotools-specific argument. If presents, an {@code "Ellipsoid_To_Geocentric"}
+         * transform will be concatenated before the geocentric translation.
+         */
+        public static final ParameterDescriptor<Integer> SRC_DIM = DefaultParameterDescriptor.create(
+                    Collections.singletonMap(NAME_KEY,
+                        new NamedIdentifier(Citations.GEOTOOLS, "src_dim")),
+                    DEFAULT_DIMENSION, 2, 3, false);
 
-		/**
-		 * The number of target geographic dimension (2 or 3). This is a
-		 * Geotools-specific argument. If presents, a
-		 * {@code "Geocentric_To_Ellipsoid"} transform will be concatenated
-		 * after the geocentric translation.
-		 */
-		public static final ParameterDescriptor<Integer> TGT_DIM = DefaultParameterDescriptor
-				.create(Collections.singletonMap(NAME_KEY, new NamedIdentifier(
-						Citations.GEOTOOLS, "tgt_dim")), DEFAULT_DIMENSION, 2,
-						3, false);
+        /**
+         * The number of target geographic dimension (2 or 3).
+         * This is a Geotools-specific argument. If presents, a {@code "Geocentric_To_Ellipsoid"}
+         * transform will be concatenated after the geocentric translation.
+         */
+        public static final ParameterDescriptor<Integer> TGT_DIM = DefaultParameterDescriptor.create(
+                    Collections.singletonMap(NAME_KEY,
+                        new NamedIdentifier(Citations.GEOTOOLS, "tgt_dim")),
+                    DEFAULT_DIMENSION, 2, 3, false);
 
-		/**
-		 * The operation parameter descriptor for the "src_semi_major" optional
-		 * parameter value. This is a Geotools-specific argument. If presents,
-		 * an {@code "Ellipsoid_To_Geocentric"} transform will be concatenated
-		 * before the geocentric translation. Valid values range from 0 to
-		 * infinity.
-		 */
-		public static final ParameterDescriptor<Double> SRC_SEMI_MAJOR = createOptionalDescriptor(
-				new NamedIdentifier[] { new NamedIdentifier(Citations.OGC,
-						"src_semi_major") }, 0.0, Double.POSITIVE_INFINITY,
-				SI.METER);
+        /**
+         * The operation parameter descriptor for the "src_semi_major" optional parameter value.
+         * This is a Geotools-specific argument. If presents, an {@code "Ellipsoid_To_Geocentric"}
+         * transform will be concatenated before the geocentric translation. Valid values range
+         * from 0 to infinity.
+         */
+        public static final ParameterDescriptor<Double> SRC_SEMI_MAJOR = createOptionalDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC, "src_semi_major")
+                },
+                0.0, Double.POSITIVE_INFINITY, SI.METER);
 
-		/**
-		 * The operation parameter descriptor for the "src_semi_minor" optional
-		 * parameter value. This is a Geotools-specific argument. If presents,
-		 * an {@code "Ellipsoid_To_Geocentric"} transform will be concatenated
-		 * before the geocentric translation. Valid values range from 0 to
-		 * infinity.
-		 */
-		public static final ParameterDescriptor<Double> SRC_SEMI_MINOR = createOptionalDescriptor(
-				new NamedIdentifier[] { new NamedIdentifier(Citations.OGC,
-						"src_semi_minor"), }, 0.0, Double.POSITIVE_INFINITY,
-				SI.METER);
+        /**
+         * The operation parameter descriptor for the "src_semi_minor" optional parameter value.
+         * This is a Geotools-specific argument. If presents, an {@code "Ellipsoid_To_Geocentric"}
+         * transform will be concatenated before the geocentric translation. Valid values range
+         * from 0 to infinity.
+         */
+         public static final ParameterDescriptor<Double> SRC_SEMI_MINOR = createOptionalDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC, "src_semi_minor"),
+                },
+                0.0, Double.POSITIVE_INFINITY, SI.METER);
 
-		/**
-		 * The operation parameter descriptor for the "tgt_semi_major" optional
-		 * parameter value. This is a Geotools-specific argument. If presents, a
-		 * {@code "Geocentric_To_Ellipsoid"} transform will be concatenated
-		 * after the geocentric translation. Valid values range from 0 to
-		 * infinity.
-		 */
-		public static final ParameterDescriptor<Double> TGT_SEMI_MAJOR = createOptionalDescriptor(
-				new NamedIdentifier[] { new NamedIdentifier(Citations.OGC,
-						"tgt_semi_major") }, 0.0, Double.POSITIVE_INFINITY,
-				SI.METER);
+        /**
+         * The operation parameter descriptor for the "tgt_semi_major" optional parameter value.
+         * This is a Geotools-specific argument. If presents, a {@code "Geocentric_To_Ellipsoid"}
+         * transform will be concatenated after the geocentric translation. Valid values range
+         * from 0 to infinity.
+         */
+        public static final ParameterDescriptor<Double> TGT_SEMI_MAJOR = createOptionalDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC, "tgt_semi_major")
+                },
+                0.0, Double.POSITIVE_INFINITY, SI.METER);
 
-		/**
-		 * The operation parameter descriptor for the "tgt_semi_minor" optional
-		 * parameter value. This is a Geotools-specific argument. If presents, a
-		 * {@code "Geocentric_To_Ellipsoid"} transform will be concatenated
-		 * after the geocentric translation. Valid values range from 0 to
-		 * infinity.
-		 */
-		public static final ParameterDescriptor<Double> TGT_SEMI_MINOR = createOptionalDescriptor(
-				new NamedIdentifier[] { new NamedIdentifier(Citations.OGC,
-						"tgt_semi_minor") }, 0.0, Double.POSITIVE_INFINITY,
-				SI.METER);
+        /**
+         * The operation parameter descriptor for the "tgt_semi_minor" optional parameter value.
+         * This is a Geotools-specific argument. If presents, a {@code "Geocentric_To_Ellipsoid"}
+         * transform will be concatenated after the geocentric translation. Valid values range
+         * from 0 to infinity.
+         */
+        public static final ParameterDescriptor<Double> TGT_SEMI_MINOR = createOptionalDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC, "tgt_semi_minor")
+                },
+                0.0, Double.POSITIVE_INFINITY, SI.METER);
 
-		/**
-		 * The operation parameter descriptor for the <cite>X-axis
-		 * translation</cite> ("dx") parameter value. Valid values range from
-		 * -infinity to infinity. Units are meters.
-		 */
-		public static final ParameterDescriptor<Double> DX = createDescriptor(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.OGC, "dx"),
-						new NamedIdentifier(Citations.EPSG,
-								"X-axis translation") }, 0.0,
-				Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
+        /**
+         * The operation parameter descriptor for the <cite>X-axis translation</cite> ("dx")
+         * parameter value. Valid values range from -infinity to infinity. Units are meters.
+         */
+        public static final ParameterDescriptor<Double> DX = createDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC,  "dx"),
+                    new NamedIdentifier(Citations.EPSG, "X-axis translation")
+                },
+                0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
 
-		/**
-		 * The operation parameter descriptor for the <cite>Y-axis
-		 * translation</cite> ("dy") parameter value. Valid values range from
-		 * -infinity to infinity. Units are meters.
-		 */
-		public static final ParameterDescriptor<Double> DY = createDescriptor(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.OGC, "dy"),
-						new NamedIdentifier(Citations.EPSG,
-								"Y-axis translation") }, 0.0,
-				Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
+        /**
+         * The operation parameter descriptor for the <cite>Y-axis translation</cite> ("dy")
+         * parameter value. Valid values range from -infinity to infinity. Units are meters.
+         */
+        public static final ParameterDescriptor<Double> DY = createDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC,  "dy"),
+                    new NamedIdentifier(Citations.EPSG, "Y-axis translation")
+                },
+                0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
 
-		/**
-		 * The operation parameter descriptor for the <cite>Z-axis
-		 * translation</cite> ("dz") parameter value. Valid values range from
-		 * -infinity to infinity. Units are meters.
-		 */
-		public static final ParameterDescriptor<Double> DZ = createDescriptor(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.OGC, "dz"),
-						new NamedIdentifier(Citations.EPSG,
-								"Z-axis translation") }, 0.0,
-				Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
+        /**
+         * The operation parameter descriptor for the <cite>Z-axis translation</cite> ("dz")
+         * parameter value. Valid values range from -infinity to infinity. Units are meters.
+         */
+        public static final ParameterDescriptor<Double> DZ = createDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC,  "dz"),
+                    new NamedIdentifier(Citations.EPSG, "Z-axis translation")
+                },
+                0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
 
-		/**
-		 * The parameters group.
-		 */
-		static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.EPSG,
-								"Geocentric translations (geog2D domain)"),
-						new NamedIdentifier(Citations.EPSG, "9603") },
-				new ParameterDescriptor[] { DX, DY, DZ, SRC_SEMI_MAJOR,
-						SRC_SEMI_MINOR, TGT_SEMI_MAJOR, TGT_SEMI_MINOR,
-						SRC_DIM, TGT_DIM });
+        /**
+         * The parameters group.
+         */
+        static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(new NamedIdentifier[] {
+                new NamedIdentifier(Citations.EPSG, "Geocentric translations (geog2D domain)"),
+                new NamedIdentifier(Citations.EPSG, "9603")
+            }, new ParameterDescriptor[] {
+                DX, DY, DZ,
+                SRC_SEMI_MAJOR, SRC_SEMI_MINOR,
+                TGT_SEMI_MAJOR, TGT_SEMI_MINOR,
+                SRC_DIM, TGT_DIM
+            });
 
-		/**
-		 * Constructs a default provider.
-		 */
-		public Provider() {
-			this(PARAMETERS);
-		}
+        /**
+         * Constructs a default provider.
+         */
+        public Provider() {
+            this(PARAMETERS);
+        }
 
-		/**
-		 * Constructs a provider with the specified parameters.
-		 */
-		Provider(final ParameterDescriptorGroup parameters) {
-			super(3, 3, parameters);
-		}
+        /**
+         * Constructs a provider with the specified parameters.
+         */
+        Provider(final ParameterDescriptorGroup parameters) {
+            super(3, 3, parameters);
+        }
 
-		/**
-		 * Returns the operation type.
-		 */
-		@Override
-		public Class<Transformation> getOperationType() {
-			return Transformation.class;
-		}
+        /**
+         * Returns the operation type.
+         */
+        @Override
+        public Class<Transformation> getOperationType() {
+            return Transformation.class;
+        }
 
-		/**
-		 * Creates a math transform from the specified group of parameter
-		 * values.
-		 *
-		 * @param values
-		 *            The group of parameter values.
-		 * @return The created math transform.
-		 * @throws ParameterNotFoundException
-		 *             if a required parameter was not found.
-		 */
-		protected MathTransform createMathTransform(
-				final ParameterValueGroup values)
-				throws ParameterNotFoundException {
-			final BursaWolfParameters parameters = new BursaWolfParameters(null);
-			fill(parameters, values);
-			return concatenate(
-					concatenate(new GeocentricTranslation(parameters,
-							getParameters()), values, SRC_SEMI_MAJOR,
-							SRC_SEMI_MINOR, SRC_DIM), values, TGT_SEMI_MAJOR,
-					TGT_SEMI_MINOR, TGT_DIM);
-		}
+        /**
+         * Creates a math transform from the specified group of parameter values.
+         *
+         * @param  values The group of parameter values.
+         * @return The created math transform.
+         * @throws ParameterNotFoundException if a required parameter was not found.
+         */
+        protected MathTransform createMathTransform(final ParameterValueGroup values)
+                throws ParameterNotFoundException
+        {
+            final BursaWolfParameters parameters = new BursaWolfParameters(null);
+            fill(parameters, values);
+            return concatenate(concatenate(new GeocentricTranslation(parameters, getParameters()),
+                               values, SRC_SEMI_MAJOR, SRC_SEMI_MINOR, SRC_DIM),
+                               values, TGT_SEMI_MAJOR, TGT_SEMI_MINOR, TGT_DIM);
+        }
 
-		/**
-		 * Fill the specified Bursa-Wolf parameters according the specified
-		 * values. This method is invoked automatically by
-		 * {@link #createMathTransform}.
-		 *
-		 * @param parameters
-		 *            The Bursa-Wold parameters to set.
-		 * @param values
-		 *            The parameter values to read. Those parameters will not be
-		 *            modified.
-		 */
-		protected void fill(final BursaWolfParameters parameters,
-				final ParameterValueGroup values) {
-			parameters.dx = doubleValue(DX, values);
-			parameters.dy = doubleValue(DY, values);
-			parameters.dz = doubleValue(DZ, values);
-		}
+        /**
+         * Fill the specified Bursa-Wolf parameters according the specified values.
+         * This method is invoked automatically by {@link #createMathTransform}.
+         *
+         * @param parameters The Bursa-Wold parameters to set.
+         * @param values The parameter values to read. Those parameters will not be modified.
+         */
+        protected void fill(final BursaWolfParameters parameters, final ParameterValueGroup values) {
+            parameters.dx = doubleValue(DX, values);
+            parameters.dy = doubleValue(DY, values);
+            parameters.dz = doubleValue(DZ, values);
+        }
 
-		/**
-		 * Concatenates the supplied transform with an "ellipsoid to geocentric"
-		 * or a "geocentric to ellipsod" step, if needed.
-		 */
-		@SuppressWarnings("fallthrough")
-		private static MathTransform concatenate(final MathTransform transform,
-				final ParameterValueGroup values,
-				final ParameterDescriptor major,
-				final ParameterDescriptor minor, final ParameterDescriptor dim) {
-			double semiMajor = doubleValue(major, values);
-			double semiMinor = doubleValue(minor, values);
-			int dimension = intValue(dim, values);
-			switch (dimension) {
-			case 0:
-				if (Double.isNaN(semiMajor) && Double.isNaN(semiMinor))
-					return transform;
-			case 2: // Fall through for 0 and 2 cases.
-			case 3:
-				break; // The dimension is a valid value.
-			default:
-				throw new IllegalArgumentException(Errors.format(
-						ErrorKeys.ILLEGAL_ARGUMENT_$2, dim.getName().getCode(),
-						dimension));
-			}
-			ensureValid(major, semiMajor);
-			ensureValid(minor, semiMinor);
-			final GeocentricTransform step;
-			step = new GeocentricTransform(semiMajor, semiMinor, SI.METER,
-					dimension == 3);
-			// Note: dimension may be 0 if not user-provided, which is treated
-			// as 2.
-			if (dim == SRC_DIM) {
-				return ConcatenatedTransform.create(step, transform);
-			} else {
-				return ConcatenatedTransform.create(transform, step.inverse());
-			}
-		}
+        /**
+         * Concatenates the supplied transform with an "ellipsoid to geocentric" or a
+         * "geocentric to ellipsod" step, if needed.
+         */
+        @SuppressWarnings("fallthrough")
+        private static MathTransform concatenate(final MathTransform    transform,
+                                                 final ParameterValueGroup values,
+                                                 final ParameterDescriptor major,
+                                                 final ParameterDescriptor minor,
+                                                 final ParameterDescriptor dim)
+        {
+            double semiMajor = doubleValue(major, values);
+            double semiMinor = doubleValue(minor, values);
+            int    dimension =    intValue(dim,   values);
+            switch (dimension) {
+                case 0: if (Double.isNaN(semiMajor) && Double.isNaN(semiMinor)) return transform;
+                case 2:        // Fall through for 0 and 2 cases.
+                case 3: break; // The dimension is a valid value.
+                default: throw new IllegalArgumentException(Errors.format(
+                               ErrorKeys.ILLEGAL_ARGUMENT_$2, dim.getName().getCode(), dimension));
+            }
+            ensureValid(major, semiMajor);
+            ensureValid(minor, semiMinor);
+            final GeocentricTransform step;
+            step = new GeocentricTransform(semiMajor, semiMinor, SI.METER, dimension==3);
+            // Note: dimension may be 0 if not user-provided, which is treated as 2.
+            if (dim == SRC_DIM) {
+                return ConcatenatedTransform.create(step, transform);
+            } else {
+                return ConcatenatedTransform.create(transform, step.inverse());
+            }
+        }
 
-		/**
-		 * Ensures the the specified parameter is valid.
-		 */
-		private static void ensureValid(final ParameterDescriptor param,
-				double value) {
-			if (!(value > 0)) {
-				throw new IllegalStateException(Errors.format(
-						ErrorKeys.MISSING_PARAMETER_$1, param.getName()
-								.getCode()));
-			}
-		}
-	}
+        /**
+         * Ensures the the specified parameter is valid.
+         */
+        private static void ensureValid(final ParameterDescriptor param, double value) {
+            if (!(value > 0)) {
+                throw new IllegalStateException(Errors.format(ErrorKeys.MISSING_PARAMETER_$1,
+                                                param.getName().getCode()));
+            }
+        }
+    }
 
-	/**
-	 * Base class for {@linkplain GeocentricTranslation geocentric affine
-	 * transform} providers with rotation terms. This base class is the provider
-	 * for the "<cite>Position Vector 7-param. transformation</cite>".
-	 *
-	 * @version $Id$
-	 * @author Martin Desruisseaux (IRD)
-	 *
-	 * @since 2.2
-	 */
-	public static class ProviderSevenParam extends Provider {
-		/**
-		 * Serial number for interoperability with different versions.
-		 */
-		private static final long serialVersionUID = -6398226638364450229L;
+    /**
+     * Base class for {@linkplain GeocentricTranslation geocentric affine transform} providers
+     * with rotation terms. This base class is the provider for the "<cite>Position Vector 7-param.
+     * transformation</cite>".
+     *
+     * @version $Id$
+     * @author Martin Desruisseaux (IRD)
+     *
+     * @since 2.2
+     */
+    public static class ProviderSevenParam extends Provider {
+        /**
+         * Serial number for interoperability with different versions.
+         */
+        private static final long serialVersionUID = -6398226638364450229L;
 
-		/**
-		 * The maximal value for a rotation, in arc-second.
-		 */
-		private static final double MAX_ROTATION = 180 * 60 * 60;
+        /**
+         * The maximal value for a rotation, in arc-second.
+         */
+        private static final double MAX_ROTATION = 180*60*60;
 
-		/**
-		 * The operation parameter descriptor for the <cite>X-axis
-		 * rotation</cite> ("ex") parameter value. Units are arc-seconds.
-		 */
-		public static final ParameterDescriptor EX = createDescriptor(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.OGC, "ex"),
-						new NamedIdentifier(Citations.EPSG, "X-axis rotation") },
-				0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
+        /**
+         * The operation parameter descriptor for the <cite>X-axis rotation</cite> ("ex")
+         * parameter value. Units are arc-seconds.
+         */
+        public static final ParameterDescriptor EX = createDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC,  "ex"),
+                    new NamedIdentifier(Citations.EPSG, "X-axis rotation")
+                },
+                0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
 
-		/**
-		 * The operation parameter descriptor for the <cite>Y-axis
-		 * rotation</cite> ("ey") parameter value. Units are arc-seconds.
-		 */
-		public static final ParameterDescriptor EY = createDescriptor(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.OGC, "ey"),
-						new NamedIdentifier(Citations.EPSG, "Y-axis rotation") },
-				0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
+        /**
+         * The operation parameter descriptor for the <cite>Y-axis rotation</cite> ("ey")
+         * parameter value. Units are arc-seconds.
+         */
+        public static final ParameterDescriptor EY = createDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC,  "ey"),
+                    new NamedIdentifier(Citations.EPSG, "Y-axis rotation")
+                },
+                0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
 
-		/**
-		 * The operation parameter descriptor for the <cite>Z-axis
-		 * rotation</cite> ("ez") parameter value. Units are arc-seconds.
-		 */
-		public static final ParameterDescriptor EZ = createDescriptor(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.OGC, "ez"),
-						new NamedIdentifier(Citations.EPSG, "Z-axis rotation") },
-				0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
+        /**
+         * The operation parameter descriptor for the <cite>Z-axis rotation</cite> ("ez")
+         * parameter value. Units are arc-seconds.
+         */
+        public static final ParameterDescriptor EZ = createDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC,  "ez"),
+                    new NamedIdentifier(Citations.EPSG, "Z-axis rotation")
+                },
+                0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
 
-		/**
-		 * The operation parameter descriptor for the <cite>Scale
-		 * difference</cite> ("ppm") parameter value. Valid values range from
-		 * -infinity to infinity. Units are parts per million.
-		 */
-		public static final ParameterDescriptor PPM = createDescriptor(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.OGC, "ppm"),
-						new NamedIdentifier(Citations.EPSG, "Scale difference") },
-				0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
-				Units.PPM);
+        /**
+         * The operation parameter descriptor for the <cite>Scale difference</cite> ("ppm")
+         * parameter value. Valid values range from -infinity to infinity. Units are parts
+         * per million.
+         */
+        public static final ParameterDescriptor PPM = createDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.OGC,  "ppm"),
+                    new NamedIdentifier(Citations.EPSG, "Scale difference")
+                },
+                0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Units.PPM);
 
-		/**
-		 * The parameters group.
-		 */
-		static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
-				"Position Vector transformation (geog2D domain)", "9606");
+        /**
+         * The parameters group.
+         */
+        static final ParameterDescriptorGroup PARAMETERS =
+                        createDescriptorGroup("Position Vector transformation (geog2D domain)", "9606");
 
-		/**
-		 * Creates a parameters group.
-		 */
-		static ParameterDescriptorGroup createDescriptorGroup(
-				final String name, final String code) {
-			return createDescriptorGroup(new NamedIdentifier[] {
-					new NamedIdentifier(Citations.EPSG, name),
-					new NamedIdentifier(Citations.EPSG, code) },
-					new ParameterDescriptor[] { DX, DY, DZ, EX, EY, EZ, PPM,
-							SRC_SEMI_MAJOR, SRC_SEMI_MINOR, TGT_SEMI_MAJOR,
-							TGT_SEMI_MINOR, SRC_DIM, TGT_DIM });
-		}
+        /**
+         * Creates a parameters group.
+         */
+        static ParameterDescriptorGroup createDescriptorGroup(final String name, final String code) {
+            return createDescriptorGroup(new NamedIdentifier[] {
+                new NamedIdentifier(Citations.EPSG, name),
+                new NamedIdentifier(Citations.EPSG, code)
+            }, new ParameterDescriptor[] {
+                DX, DY, DZ, EX, EY, EZ, PPM,
+                SRC_SEMI_MAJOR, SRC_SEMI_MINOR,
+                TGT_SEMI_MAJOR, TGT_SEMI_MINOR,
+                SRC_DIM, TGT_DIM
+            });
+        }
 
-		/**
-		 * Constructs a default provider.
-		 */
-		public ProviderSevenParam() {
-			super(PARAMETERS);
-		}
+        /**
+         * Constructs a default provider.
+         */
+        public ProviderSevenParam() {
+            super(PARAMETERS);
+        }
 
-		/**
-		 * Constructs a provider with the specified parameters.
-		 */
-		ProviderSevenParam(final ParameterDescriptorGroup parameters) {
-			super(parameters);
-		}
+        /**
+         * Constructs a provider with the specified parameters.
+         */
+        ProviderSevenParam(final ParameterDescriptorGroup parameters) {
+            super(parameters);
+        }
 
-		/**
-		 * Fills the specified Bursa-Wolf parameters according the specified
-		 * values.
-		 */
-		@Override
-		protected void fill(final BursaWolfParameters parameters,
-				final ParameterValueGroup values) {
-			super.fill(parameters, values);
-			parameters.ppm = doubleValue(PPM, values);
-			parameters.ex = doubleValue(EX, values);
-			parameters.ey = doubleValue(EY, values);
-			parameters.ez = doubleValue(EZ, values);
-		}
-	}
+        /**
+         * Fills the specified Bursa-Wolf parameters according the specified values.
+         */
+        @Override
+        protected void fill(final BursaWolfParameters parameters, final ParameterValueGroup values) {
+            super.fill(parameters, values);
+            parameters.ppm = doubleValue(PPM, values);
+            parameters.ex  = doubleValue(EX, values);
+            parameters.ey  = doubleValue(EY, values);
+            parameters.ez  = doubleValue(EZ, values);
+        }
+    }
 
-	/**
-	 * {@linkplain GeocentricTranslation Geocentric affine transform} provider
-	 * for "<cite>Coordinate Frame rotation</cite>".
-	 *
-	 * @version $Id$
-	 * @author Martin Desruisseaux (IRD)
-	 *
-	 * @since 2.2
-	 */
-	public static class ProviderFrameRotation extends ProviderSevenParam {
-		/**
-		 * Serial number for interoperability with different versions.
-		 */
-		private static final long serialVersionUID = 5513675854809530038L;
+    /**
+     * {@linkplain GeocentricTranslation Geocentric affine transform} provider for
+     * "<cite>Coordinate Frame rotation</cite>".
+     *
+     * @version $Id$
+     * @author Martin Desruisseaux (IRD)
+     *
+     * @since 2.2
+     */
+    public static class ProviderFrameRotation extends ProviderSevenParam {
+        /**
+         * Serial number for interoperability with different versions.
+         */
+        private static final long serialVersionUID =  5513675854809530038L;
 
-		/**
-		 * The parameters group.
-		 */
-		static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
-				"Coordinate Frame Rotation (geog2D domain)", "9607");
+        /**
+         * The parameters group.
+         */
+        static final ParameterDescriptorGroup PARAMETERS =
+                        createDescriptorGroup("Coordinate Frame Rotation (geog2D domain)", "9607");
 
-		/**
-		 * Constructs a default provider.
-		 */
-		public ProviderFrameRotation() {
-			super(PARAMETERS);
-		}
+        /**
+         * Constructs a default provider.
+         */
+        public ProviderFrameRotation() {
+            super(PARAMETERS);
+        }
 
-		/**
-		 * Fills the specified Bursa-Wolf parameters according the specified
-		 * values.
-		 */
-		@Override
-		protected void fill(final BursaWolfParameters parameters,
-				final ParameterValueGroup values) {
-			super.fill(parameters, values);
-			parameters.ex = -parameters.ex;
-			parameters.ey = -parameters.ey;
-			parameters.ez = -parameters.ez;
-		}
-	}
+        /**
+         * Fills the specified Bursa-Wolf parameters according the specified values.
+         */
+        @Override
+        protected void fill(final BursaWolfParameters parameters, final ParameterValueGroup values) {
+            super.fill(parameters, values);
+            parameters.ex = -parameters.ex;
+            parameters.ey = -parameters.ey;
+            parameters.ez = -parameters.ez;
+        }
+    }
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/GeocentricTranslation.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/GeocentricTranslation.java
@@ -17,18 +17,10 @@
 package org.geotools.referencing.operation.transform;
 
 import java.util.Collections;
-import javax.measure.unit.SI;
+
 import javax.measure.unit.NonSI;
+import javax.measure.unit.SI;
 
-import org.opengis.parameter.ParameterDescriptor;
-import org.opengis.parameter.ParameterDescriptorGroup;
-import org.opengis.parameter.ParameterNotFoundException;
-import org.opengis.parameter.ParameterValueGroup;
-import org.opengis.referencing.operation.Matrix;
-import org.opengis.referencing.operation.MathTransform;
-import org.opengis.referencing.operation.Transformation;
-
-import org.geotools.util.Utilities;
 import org.geotools.measure.Units;
 import org.geotools.metadata.iso.citation.Citations;
 import org.geotools.parameter.DefaultParameterDescriptor;
@@ -37,33 +29,57 @@ import org.geotools.parameter.ParameterGroup;
 import org.geotools.referencing.NamedIdentifier;
 import org.geotools.referencing.datum.BursaWolfParameters;
 import org.geotools.referencing.operation.MathTransformProvider;
-import org.geotools.resources.i18n.Errors;
 import org.geotools.resources.i18n.ErrorKeys;
-
+import org.geotools.resources.i18n.Errors;
+import org.geotools.util.Utilities;
+import org.opengis.parameter.ParameterDescriptor;
+import org.opengis.parameter.ParameterDescriptorGroup;
+import org.opengis.parameter.ParameterNotFoundException;
+import org.opengis.parameter.ParameterValueGroup;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.Matrix;
+import org.opengis.referencing.operation.Transformation;
 
 /**
- * An affine transform applied on {@linkplain org.opengis.referencing.crs.GeocentricCRS geocentric}
- * coordinates. While "geocentric translation" is a little bit more restrictive name, it describes
- * the part which is common to all instances of this class. A rotation may also be performed in
- * addition of the translation, but the rotation sign is operation-dependent (EPSG 9606 and 9607
- * have opposite sign). This transform is used for the following operations:
+ * An affine transform applied on
+ * {@linkplain org.opengis.referencing.crs.GeocentricCRS geocentric}
+ * coordinates. While "geocentric translation" is a little bit more restrictive
+ * name, it describes the part which is common to all instances of this class. A
+ * rotation may also be performed in addition of the translation, but the
+ * rotation sign is operation-dependent (EPSG 9606 and 9607 have opposite sign).
+ * This transform is used for the following operations:
  * <p>
  * <table border="1">
- *   <tr><th>EPSG name</th>                               <th>EPSG code</th></tr>
- *   <tr><td>Geocentric translations</td>                 <td>9603</td></tr>
- *   <tr><td>Position Vector 7-param. transformation</td> <td>9606</td></tr>
- *   <tr><td>Coordinate Frame rotation</td>               <td>9607</td></tr>
+ * <tr>
+ * <th>EPSG name</th>
+ * <th>EPSG code</th>
+ * </tr>
+ * <tr>
+ * <td>Geocentric translations</td>
+ * <td>9603</td>
+ * </tr>
+ * <tr>
+ * <td>Position Vector 7-param. transformation</td>
+ * <td>9606</td>
+ * </tr>
+ * <tr>
+ * <td>Coordinate Frame rotation</td>
+ * <td>9607</td>
+ * </tr>
  * </table>
  * <p>
- * The conversion between geographic and geocentric coordinates is usually <strong>not</strong>
- * part of this transform. However, the Geotools implementation of the
- * {@linkplain GeocentricTranslation.Provider provider} accepts the following extensions:
+ * The conversion between geographic and geocentric coordinates is usually
+ * <strong>not</strong> part of this transform. However, the Geotools
+ * implementation of the {@linkplain GeocentricTranslation.Provider provider}
+ * accepts the following extensions:
  * <p>
  * <ul>
- *   <li>If {@code "src_semi_major"} and {@code "src_semi_minor"} parameters are provided, then
- *       a {@code "Ellipsoid_To_Geocentric"} transform is concatenated before this transform.</li>
- *   <li>If {@code "tgt_semi_major"} and {@code "tgt_semi_minor"} parameters are provided, then
- *       a {@code "Geocentric_To_Ellipsoid"} transform is concatenated after this transform.</li>
+ * <li>If {@code "src_semi_major"} and {@code "src_semi_minor"} parameters are
+ * provided, then a {@code "Ellipsoid_To_Geocentric"} transform is concatenated
+ * before this transform.</li>
+ * <li>If {@code "tgt_semi_major"} and {@code "tgt_semi_minor"} parameters are
+ * provided, then a {@code "Geocentric_To_Ellipsoid"} transform is concatenated
+ * after this transform.</li>
  * </ul>
  *
  * @since 2.2
@@ -74,498 +90,522 @@ import org.geotools.resources.i18n.ErrorKeys;
  * @author Martin Desruisseaux (IRD)
  */
 public class GeocentricTranslation extends ProjectiveTransform {
-    /**
-     * Serial number for interoperability with different versions.
-     */
-    private static final long serialVersionUID = -168669443433018655L;
+	/**
+	 * Serial number for interoperability with different versions.
+	 */
+	private static final long serialVersionUID = -168669443433018655L;
 
-    /**
-     * The parameter descriptor group.
-     */
-    private final ParameterDescriptorGroup descriptor;
+	/**
+	 * The parameter descriptor group.
+	 */
+	private final ParameterDescriptorGroup descriptor;
 
-    /**
-     * Creates a new geocentric affine transform. If the parameters don't contain rotation terms,
-     * then this transform will be of kind "<cite>Geocentric translations</cite>". Otherwise, it
-     * will be of kind "<cite>Position Vector 7-param. transformation</cite>".
-     *
-     * @param parameters The Bursa-Wolf parameters to use for initializing the transformation.
-     */
-    public GeocentricTranslation(final BursaWolfParameters parameters) {
-        this(parameters, parameters.isTranslation() ?
-                         Provider.PARAMETERS : ProviderSevenParam.PARAMETERS);
-    }
+	/**
+	 * Creates a new geocentric affine transform. If the parameters don't
+	 * contain rotation terms, then this transform will be of kind
+	 * "<cite>Geocentric translations</cite>". Otherwise, it will be of kind
+	 * "<cite>Position Vector 7-param. transformation</cite>".
+	 *
+	 * @param parameters
+	 *            The Bursa-Wolf parameters to use for initializing the
+	 *            transformation.
+	 */
+	public GeocentricTranslation(final BursaWolfParameters parameters) {
+		this(parameters, parameters.isTranslation() ? Provider.PARAMETERS
+				: ProviderSevenParam.PARAMETERS);
+	}
 
-    /**
-     * Creates a new geocentric affine transform using the specified parameter descriptor.
-     */
-    GeocentricTranslation(final BursaWolfParameters      parameters,
-                          final ParameterDescriptorGroup descriptor)
-    {
-        super(parameters.getAffineTransform());
-        this.descriptor = descriptor;
-    }
+	/**
+	 * Creates a new geocentric affine transform using the specified parameter
+	 * descriptor.
+	 */
+	GeocentricTranslation(final BursaWolfParameters parameters,
+			final ParameterDescriptorGroup descriptor) {
+		super(parameters.getAffineTransform());
+		this.descriptor = descriptor;
+	}
 
-    /**
-     * Creates a new geocentric affine transform using the specified parameter descriptor.
-     */
-    private GeocentricTranslation(final Matrix matrix,
-                                  final ParameterDescriptorGroup descriptor)
-    {
-        super(matrix);
-        this.descriptor = descriptor;
-    }
+	/**
+	 * Creates a new geocentric affine transform using the specified parameter
+	 * descriptor.
+	 */
+	private GeocentricTranslation(final Matrix matrix,
+			final ParameterDescriptorGroup descriptor) {
+		super(matrix);
+		this.descriptor = descriptor;
+	}
 
-    /**
-     * Returns the parameter descriptors for this math transform.
-     */
-    @Override
-    public ParameterDescriptorGroup getParameterDescriptors() {
-        return descriptor;
-    }
+	/**
+	 * Returns the parameter descriptors for this math transform.
+	 */
+	@Override
+	public ParameterDescriptorGroup getParameterDescriptors() {
+		return descriptor;
+	}
 
-    /**
-     * Returns the parameters for this math transform.
-     */
-    @Override
-    public ParameterValueGroup getParameterValues() {
-        final BursaWolfParameters parameters = new BursaWolfParameters(null);
-        parameters.setAffineTransform(getMatrix(), Double.POSITIVE_INFINITY);
-        if (ProviderFrameRotation.PARAMETERS.equals(descriptor)) {
-            parameters.ex = -parameters.ex;
-            parameters.ey = -parameters.ey;
-            parameters.ez = -parameters.ez;
-        }
-        final boolean isTranslation = Provider.PARAMETERS.equals(descriptor);
-        final FloatParameter[] param = new FloatParameter[isTranslation ? 3 : 7];
-        param[0] = new FloatParameter(Provider.DX,  parameters.dx);
-        param[1] = new FloatParameter(Provider.DY,  parameters.dy);
-        param[2] = new FloatParameter(Provider.DZ,  parameters.dz);
-        if (!isTranslation) {
-            param[3] = new FloatParameter(ProviderSevenParam.EX,  parameters.ex);
-            param[4] = new FloatParameter(ProviderSevenParam.EY,  parameters.ey);
-            param[5] = new FloatParameter(ProviderSevenParam.EZ,  parameters.ez);
-            param[6] = new FloatParameter(ProviderSevenParam.PPM, parameters.ppm);
-        }
-        return new ParameterGroup(getParameterDescriptors(), param);
-    }
+	/**
+	 * Returns the parameters for this math transform.
+	 */
+	@Override
+	public ParameterValueGroup getParameterValues() {
+		final BursaWolfParameters parameters = new BursaWolfParameters(null);
+		parameters.setAffineTransform(getMatrix(), Double.POSITIVE_INFINITY);
+		if (ProviderFrameRotation.PARAMETERS.equals(descriptor)) {
+			parameters.ex = -parameters.ex;
+			parameters.ey = -parameters.ey;
+			parameters.ez = -parameters.ez;
+		}
+		final boolean isTranslation = Provider.PARAMETERS.equals(descriptor);
+		final FloatParameter[] param = new FloatParameter[isTranslation ? 3 : 7];
+		param[0] = new FloatParameter(Provider.DX, parameters.dx);
+		param[1] = new FloatParameter(Provider.DY, parameters.dy);
+		param[2] = new FloatParameter(Provider.DZ, parameters.dz);
+		if (!isTranslation) {
+			param[3] = new FloatParameter(ProviderSevenParam.EX, parameters.ex);
+			param[4] = new FloatParameter(ProviderSevenParam.EY, parameters.ey);
+			param[5] = new FloatParameter(ProviderSevenParam.EZ, parameters.ez);
+			param[6] = new FloatParameter(ProviderSevenParam.PPM,
+					parameters.ppm);
+		}
+		return new ParameterGroup(getParameterDescriptors(), param);
+	}
 
-    /**
-     * Creates an inverse transform using the specified matrix.
-     */
-    @Override
-    MathTransform createInverse(final Matrix matrix) {
-        return new GeocentricTranslation(matrix, descriptor);
-    }
+	/**
+	 * Creates an inverse transform using the specified matrix.
+	 */
+	@Override
+	GeocentricTranslation createInverse(final Matrix matrix) {
+		return new GeocentricTranslation(matrix, descriptor);
+	}
 
-    /**
-     * Returns a hash value for this transform.
-     * This value need not remain consistent between
-     * different implementations of the same class.
-     */
-    @Override
-    public int hashCode() {
-        return super.hashCode() ^ descriptor.hashCode();
-    }
+	/**
+	 * Returns a hash value for this transform. This value need not remain
+	 * consistent between different implementations of the same class.
+	 */
+	@Override
+	public int hashCode() {
+		return super.hashCode() ^ descriptor.hashCode();
+	}
 
-    /**
-     * Compares the specified object with this math transform for equality.
-     */
-    @Override
-    public boolean equals(final Object object) {
-        if (super.equals(object)) {
-            final GeocentricTranslation that = (GeocentricTranslation) object;
-            return Utilities.equals(this.descriptor, that.descriptor);
-        }
-        return false;
-    }
+	/**
+	 * Compares the specified object with this math transform for equality.
+	 */
+	@Override
+	public boolean equals(final Object object) {
+		if (super.equals(object)) {
+			final GeocentricTranslation that = (GeocentricTranslation) object;
+			return Utilities.equals(this.descriptor, that.descriptor);
+		}
+		return false;
+	}
 
-    /**
-     * Base class for {@linkplain GeocentricTranslation geocentric affine transform} providers.
-     * This base class is the provider for the "<cite>Geocentric translations</cite>" operation
-     * (EPSG code 9603). The translation terms are the same for the 2 derived operations,
-     * "<cite>Position Vector 7-param. transformation</cite>" and
-     * "<cite>Coordinate Frame rotation</cite>".
-     *
-     * @version $Id$
-     * @author Martin Desruisseaux (IRD)
-     *
-     * @since 2.2
-     */
-    public static class Provider extends MathTransformProvider {
-        /**
-         * Serial number for interoperability with different versions.
-         */
-        private static final long serialVersionUID = -7160250630666911608L;
+	/**
+	 * Base class for {@linkplain GeocentricTranslation geocentric affine
+	 * transform} providers. This base class is the provider for the
+	 * "<cite>Geocentric translations</cite>" operation (EPSG code 9603). The
+	 * translation terms are the same for the 2 derived operations,
+	 * "<cite>Position Vector 7-param. transformation</cite>" and
+	 * "<cite>Coordinate Frame rotation</cite>".
+	 *
+	 * @version $Id$
+	 * @author Martin Desruisseaux (IRD)
+	 *
+	 * @since 2.2
+	 */
+	public static class Provider extends MathTransformProvider {
+		/**
+		 * Serial number for interoperability with different versions.
+		 */
+		private static final long serialVersionUID = -7160250630666911608L;
 
-        /**
-         * The default value for geographic source and target dimensions, which is 2.
-         * NOTE: If this default value is modified, then the handling of the 3D cases
-         * in {@link MolodenskiTransform} must be adjusted.
-         */
-        static final int DEFAULT_DIMENSION = 2;
+		/**
+		 * The default value for geographic source and target dimensions, which
+		 * is 2. NOTE: If this default value is modified, then the handling of
+		 * the 3D cases in {@link MolodenskiTransform} must be adjusted.
+		 */
+		static final int DEFAULT_DIMENSION = 2;
 
-        /**
-         * The number of source geographic dimension (2 or 3).
-         * This is a Geotools-specific argument. If presents, an {@code "Ellipsoid_To_Geocentric"}
-         * transform will be concatenated before the geocentric translation.
-         */
-        public static final ParameterDescriptor<Integer> SRC_DIM = DefaultParameterDescriptor.create(
-                    Collections.singletonMap(NAME_KEY,
-                        new NamedIdentifier(Citations.GEOTOOLS, "src_dim")),
-                    DEFAULT_DIMENSION, 2, 3, false);
+		/**
+		 * The number of source geographic dimension (2 or 3). This is a
+		 * Geotools-specific argument. If presents, an
+		 * {@code "Ellipsoid_To_Geocentric"} transform will be concatenated
+		 * before the geocentric translation.
+		 */
+		public static final ParameterDescriptor<Integer> SRC_DIM = DefaultParameterDescriptor
+				.create(Collections.singletonMap(NAME_KEY, new NamedIdentifier(
+						Citations.GEOTOOLS, "src_dim")), DEFAULT_DIMENSION, 2,
+						3, false);
 
-        /**
-         * The number of target geographic dimension (2 or 3).
-         * This is a Geotools-specific argument. If presents, a {@code "Geocentric_To_Ellipsoid"}
-         * transform will be concatenated after the geocentric translation.
-         */
-        public static final ParameterDescriptor<Integer> TGT_DIM = DefaultParameterDescriptor.create(
-                    Collections.singletonMap(NAME_KEY,
-                        new NamedIdentifier(Citations.GEOTOOLS, "tgt_dim")),
-                    DEFAULT_DIMENSION, 2, 3, false);
+		/**
+		 * The number of target geographic dimension (2 or 3). This is a
+		 * Geotools-specific argument. If presents, a
+		 * {@code "Geocentric_To_Ellipsoid"} transform will be concatenated
+		 * after the geocentric translation.
+		 */
+		public static final ParameterDescriptor<Integer> TGT_DIM = DefaultParameterDescriptor
+				.create(Collections.singletonMap(NAME_KEY, new NamedIdentifier(
+						Citations.GEOTOOLS, "tgt_dim")), DEFAULT_DIMENSION, 2,
+						3, false);
 
-        /**
-         * The operation parameter descriptor for the "src_semi_major" optional parameter value.
-         * This is a Geotools-specific argument. If presents, an {@code "Ellipsoid_To_Geocentric"}
-         * transform will be concatenated before the geocentric translation. Valid values range
-         * from 0 to infinity.
-         */
-        public static final ParameterDescriptor<Double> SRC_SEMI_MAJOR = createOptionalDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC, "src_semi_major")
-                },
-                0.0, Double.POSITIVE_INFINITY, SI.METER);
+		/**
+		 * The operation parameter descriptor for the "src_semi_major" optional
+		 * parameter value. This is a Geotools-specific argument. If presents,
+		 * an {@code "Ellipsoid_To_Geocentric"} transform will be concatenated
+		 * before the geocentric translation. Valid values range from 0 to
+		 * infinity.
+		 */
+		public static final ParameterDescriptor<Double> SRC_SEMI_MAJOR = createOptionalDescriptor(
+				new NamedIdentifier[] { new NamedIdentifier(Citations.OGC,
+						"src_semi_major") }, 0.0, Double.POSITIVE_INFINITY,
+				SI.METER);
 
-        /**
-         * The operation parameter descriptor for the "src_semi_minor" optional parameter value.
-         * This is a Geotools-specific argument. If presents, an {@code "Ellipsoid_To_Geocentric"}
-         * transform will be concatenated before the geocentric translation. Valid values range
-         * from 0 to infinity.
-         */
-         public static final ParameterDescriptor<Double> SRC_SEMI_MINOR = createOptionalDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC, "src_semi_minor"),
-                },
-                0.0, Double.POSITIVE_INFINITY, SI.METER);
+		/**
+		 * The operation parameter descriptor for the "src_semi_minor" optional
+		 * parameter value. This is a Geotools-specific argument. If presents,
+		 * an {@code "Ellipsoid_To_Geocentric"} transform will be concatenated
+		 * before the geocentric translation. Valid values range from 0 to
+		 * infinity.
+		 */
+		public static final ParameterDescriptor<Double> SRC_SEMI_MINOR = createOptionalDescriptor(
+				new NamedIdentifier[] { new NamedIdentifier(Citations.OGC,
+						"src_semi_minor"), }, 0.0, Double.POSITIVE_INFINITY,
+				SI.METER);
 
-        /**
-         * The operation parameter descriptor for the "tgt_semi_major" optional parameter value.
-         * This is a Geotools-specific argument. If presents, a {@code "Geocentric_To_Ellipsoid"}
-         * transform will be concatenated after the geocentric translation. Valid values range
-         * from 0 to infinity.
-         */
-        public static final ParameterDescriptor<Double> TGT_SEMI_MAJOR = createOptionalDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC, "tgt_semi_major")
-                },
-                0.0, Double.POSITIVE_INFINITY, SI.METER);
+		/**
+		 * The operation parameter descriptor for the "tgt_semi_major" optional
+		 * parameter value. This is a Geotools-specific argument. If presents, a
+		 * {@code "Geocentric_To_Ellipsoid"} transform will be concatenated
+		 * after the geocentric translation. Valid values range from 0 to
+		 * infinity.
+		 */
+		public static final ParameterDescriptor<Double> TGT_SEMI_MAJOR = createOptionalDescriptor(
+				new NamedIdentifier[] { new NamedIdentifier(Citations.OGC,
+						"tgt_semi_major") }, 0.0, Double.POSITIVE_INFINITY,
+				SI.METER);
 
-        /**
-         * The operation parameter descriptor for the "tgt_semi_minor" optional parameter value.
-         * This is a Geotools-specific argument. If presents, a {@code "Geocentric_To_Ellipsoid"}
-         * transform will be concatenated after the geocentric translation. Valid values range
-         * from 0 to infinity.
-         */
-        public static final ParameterDescriptor<Double> TGT_SEMI_MINOR = createOptionalDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC, "tgt_semi_minor")
-                },
-                0.0, Double.POSITIVE_INFINITY, SI.METER);
+		/**
+		 * The operation parameter descriptor for the "tgt_semi_minor" optional
+		 * parameter value. This is a Geotools-specific argument. If presents, a
+		 * {@code "Geocentric_To_Ellipsoid"} transform will be concatenated
+		 * after the geocentric translation. Valid values range from 0 to
+		 * infinity.
+		 */
+		public static final ParameterDescriptor<Double> TGT_SEMI_MINOR = createOptionalDescriptor(
+				new NamedIdentifier[] { new NamedIdentifier(Citations.OGC,
+						"tgt_semi_minor") }, 0.0, Double.POSITIVE_INFINITY,
+				SI.METER);
 
-        /**
-         * The operation parameter descriptor for the <cite>X-axis translation</cite> ("dx")
-         * parameter value. Valid values range from -infinity to infinity. Units are meters.
-         */
-        public static final ParameterDescriptor<Double> DX = createDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC,  "dx"),
-                    new NamedIdentifier(Citations.EPSG, "X-axis translation")
-                },
-                0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
+		/**
+		 * The operation parameter descriptor for the <cite>X-axis
+		 * translation</cite> ("dx") parameter value. Valid values range from
+		 * -infinity to infinity. Units are meters.
+		 */
+		public static final ParameterDescriptor<Double> DX = createDescriptor(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.OGC, "dx"),
+						new NamedIdentifier(Citations.EPSG,
+								"X-axis translation") }, 0.0,
+				Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
 
-        /**
-         * The operation parameter descriptor for the <cite>Y-axis translation</cite> ("dy")
-         * parameter value. Valid values range from -infinity to infinity. Units are meters.
-         */
-        public static final ParameterDescriptor<Double> DY = createDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC,  "dy"),
-                    new NamedIdentifier(Citations.EPSG, "Y-axis translation")
-                },
-                0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
+		/**
+		 * The operation parameter descriptor for the <cite>Y-axis
+		 * translation</cite> ("dy") parameter value. Valid values range from
+		 * -infinity to infinity. Units are meters.
+		 */
+		public static final ParameterDescriptor<Double> DY = createDescriptor(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.OGC, "dy"),
+						new NamedIdentifier(Citations.EPSG,
+								"Y-axis translation") }, 0.0,
+				Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
 
-        /**
-         * The operation parameter descriptor for the <cite>Z-axis translation</cite> ("dz")
-         * parameter value. Valid values range from -infinity to infinity. Units are meters.
-         */
-        public static final ParameterDescriptor<Double> DZ = createDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC,  "dz"),
-                    new NamedIdentifier(Citations.EPSG, "Z-axis translation")
-                },
-                0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
+		/**
+		 * The operation parameter descriptor for the <cite>Z-axis
+		 * translation</cite> ("dz") parameter value. Valid values range from
+		 * -infinity to infinity. Units are meters.
+		 */
+		public static final ParameterDescriptor<Double> DZ = createDescriptor(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.OGC, "dz"),
+						new NamedIdentifier(Citations.EPSG,
+								"Z-axis translation") }, 0.0,
+				Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, SI.METER);
 
-        /**
-         * The parameters group.
-         */
-        static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(new NamedIdentifier[] {
-                new NamedIdentifier(Citations.EPSG, "Geocentric translations (geog2D domain)"),
-                new NamedIdentifier(Citations.EPSG, "9603")
-            }, new ParameterDescriptor[] {
-                DX, DY, DZ,
-                SRC_SEMI_MAJOR, SRC_SEMI_MINOR,
-                TGT_SEMI_MAJOR, TGT_SEMI_MINOR,
-                SRC_DIM, TGT_DIM
-            });
+		/**
+		 * The parameters group.
+		 */
+		static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.EPSG,
+								"Geocentric translations (geog2D domain)"),
+						new NamedIdentifier(Citations.EPSG, "9603") },
+				new ParameterDescriptor[] { DX, DY, DZ, SRC_SEMI_MAJOR,
+						SRC_SEMI_MINOR, TGT_SEMI_MAJOR, TGT_SEMI_MINOR,
+						SRC_DIM, TGT_DIM });
 
-        /**
-         * Constructs a default provider.
-         */
-        public Provider() {
-            this(PARAMETERS);
-        }
+		/**
+		 * Constructs a default provider.
+		 */
+		public Provider() {
+			this(PARAMETERS);
+		}
 
-        /**
-         * Constructs a provider with the specified parameters.
-         */
-        Provider(final ParameterDescriptorGroup parameters) {
-            super(3, 3, parameters);
-        }
+		/**
+		 * Constructs a provider with the specified parameters.
+		 */
+		Provider(final ParameterDescriptorGroup parameters) {
+			super(3, 3, parameters);
+		}
 
-        /**
-         * Returns the operation type.
-         */
-        @Override
-        public Class<Transformation> getOperationType() {
-            return Transformation.class;
-        }
+		/**
+		 * Returns the operation type.
+		 */
+		@Override
+		public Class<Transformation> getOperationType() {
+			return Transformation.class;
+		}
 
-        /**
-         * Creates a math transform from the specified group of parameter values.
-         *
-         * @param  values The group of parameter values.
-         * @return The created math transform.
-         * @throws ParameterNotFoundException if a required parameter was not found.
-         */
-        protected MathTransform createMathTransform(final ParameterValueGroup values)
-                throws ParameterNotFoundException
-        {
-            final BursaWolfParameters parameters = new BursaWolfParameters(null);
-            fill(parameters, values);
-            return concatenate(concatenate(new GeocentricTranslation(parameters, getParameters()),
-                               values, SRC_SEMI_MAJOR, SRC_SEMI_MINOR, SRC_DIM),
-                               values, TGT_SEMI_MAJOR, TGT_SEMI_MINOR, TGT_DIM);
-        }
+		/**
+		 * Creates a math transform from the specified group of parameter
+		 * values.
+		 *
+		 * @param values
+		 *            The group of parameter values.
+		 * @return The created math transform.
+		 * @throws ParameterNotFoundException
+		 *             if a required parameter was not found.
+		 */
+		protected MathTransform createMathTransform(
+				final ParameterValueGroup values)
+				throws ParameterNotFoundException {
+			final BursaWolfParameters parameters = new BursaWolfParameters(null);
+			fill(parameters, values);
+			return concatenate(
+					concatenate(new GeocentricTranslation(parameters,
+							getParameters()), values, SRC_SEMI_MAJOR,
+							SRC_SEMI_MINOR, SRC_DIM), values, TGT_SEMI_MAJOR,
+					TGT_SEMI_MINOR, TGT_DIM);
+		}
 
-        /**
-         * Fill the specified Bursa-Wolf parameters according the specified values.
-         * This method is invoked automatically by {@link #createMathTransform}.
-         *
-         * @param parameters The Bursa-Wold parameters to set.
-         * @param values The parameter values to read. Those parameters will not be modified.
-         */
-        protected void fill(final BursaWolfParameters parameters, final ParameterValueGroup values) {
-            parameters.dx = doubleValue(DX, values);
-            parameters.dy = doubleValue(DY, values);
-            parameters.dz = doubleValue(DZ, values);
-        }
+		/**
+		 * Fill the specified Bursa-Wolf parameters according the specified
+		 * values. This method is invoked automatically by
+		 * {@link #createMathTransform}.
+		 *
+		 * @param parameters
+		 *            The Bursa-Wold parameters to set.
+		 * @param values
+		 *            The parameter values to read. Those parameters will not be
+		 *            modified.
+		 */
+		protected void fill(final BursaWolfParameters parameters,
+				final ParameterValueGroup values) {
+			parameters.dx = doubleValue(DX, values);
+			parameters.dy = doubleValue(DY, values);
+			parameters.dz = doubleValue(DZ, values);
+		}
 
-        /**
-         * Concatenates the supplied transform with an "ellipsoid to geocentric" or a
-         * "geocentric to ellipsod" step, if needed.
-         */
-        @SuppressWarnings("fallthrough")
-        private static MathTransform concatenate(final MathTransform    transform,
-                                                 final ParameterValueGroup values,
-                                                 final ParameterDescriptor major,
-                                                 final ParameterDescriptor minor,
-                                                 final ParameterDescriptor dim)
-        {
-            double semiMajor = doubleValue(major, values);
-            double semiMinor = doubleValue(minor, values);
-            int    dimension =    intValue(dim,   values);
-            switch (dimension) {
-                case 0: if (Double.isNaN(semiMajor) && Double.isNaN(semiMinor)) return transform;
-                case 2:        // Fall through for 0 and 2 cases.
-                case 3: break; // The dimension is a valid value.
-                default: throw new IllegalArgumentException(Errors.format(
-                               ErrorKeys.ILLEGAL_ARGUMENT_$2, dim.getName().getCode(), dimension));
-            }
-            ensureValid(major, semiMajor);
-            ensureValid(minor, semiMinor);
-            final GeocentricTransform step;
-            step = new GeocentricTransform(semiMajor, semiMinor, SI.METER, dimension==3);
-            // Note: dimension may be 0 if not user-provided, which is treated as 2.
-            if (dim == SRC_DIM) {
-                return ConcatenatedTransform.create(step, transform);
-            } else {
-                return ConcatenatedTransform.create(transform, step.inverse());
-            }
-        }
+		/**
+		 * Concatenates the supplied transform with an "ellipsoid to geocentric"
+		 * or a "geocentric to ellipsod" step, if needed.
+		 */
+		@SuppressWarnings("fallthrough")
+		private static MathTransform concatenate(final MathTransform transform,
+				final ParameterValueGroup values,
+				final ParameterDescriptor major,
+				final ParameterDescriptor minor, final ParameterDescriptor dim) {
+			double semiMajor = doubleValue(major, values);
+			double semiMinor = doubleValue(minor, values);
+			int dimension = intValue(dim, values);
+			switch (dimension) {
+			case 0:
+				if (Double.isNaN(semiMajor) && Double.isNaN(semiMinor))
+					return transform;
+			case 2: // Fall through for 0 and 2 cases.
+			case 3:
+				break; // The dimension is a valid value.
+			default:
+				throw new IllegalArgumentException(Errors.format(
+						ErrorKeys.ILLEGAL_ARGUMENT_$2, dim.getName().getCode(),
+						dimension));
+			}
+			ensureValid(major, semiMajor);
+			ensureValid(minor, semiMinor);
+			final GeocentricTransform step;
+			step = new GeocentricTransform(semiMajor, semiMinor, SI.METER,
+					dimension == 3);
+			// Note: dimension may be 0 if not user-provided, which is treated
+			// as 2.
+			if (dim == SRC_DIM) {
+				return ConcatenatedTransform.create(step, transform);
+			} else {
+				return ConcatenatedTransform.create(transform, step.inverse());
+			}
+		}
 
-        /**
-         * Ensures the the specified parameter is valid.
-         */
-        private static void ensureValid(final ParameterDescriptor param, double value) {
-            if (!(value > 0)) {
-                throw new IllegalStateException(Errors.format(ErrorKeys.MISSING_PARAMETER_$1,
-                                                param.getName().getCode()));
-            }
-        }
-    }
+		/**
+		 * Ensures the the specified parameter is valid.
+		 */
+		private static void ensureValid(final ParameterDescriptor param,
+				double value) {
+			if (!(value > 0)) {
+				throw new IllegalStateException(Errors.format(
+						ErrorKeys.MISSING_PARAMETER_$1, param.getName()
+								.getCode()));
+			}
+		}
+	}
 
-    /**
-     * Base class for {@linkplain GeocentricTranslation geocentric affine transform} providers
-     * with rotation terms. This base class is the provider for the "<cite>Position Vector 7-param.
-     * transformation</cite>".
-     *
-     * @version $Id$
-     * @author Martin Desruisseaux (IRD)
-     *
-     * @since 2.2
-     */
-    public static class ProviderSevenParam extends Provider {
-        /**
-         * Serial number for interoperability with different versions.
-         */
-        private static final long serialVersionUID = -6398226638364450229L;
+	/**
+	 * Base class for {@linkplain GeocentricTranslation geocentric affine
+	 * transform} providers with rotation terms. This base class is the provider
+	 * for the "<cite>Position Vector 7-param. transformation</cite>".
+	 *
+	 * @version $Id$
+	 * @author Martin Desruisseaux (IRD)
+	 *
+	 * @since 2.2
+	 */
+	public static class ProviderSevenParam extends Provider {
+		/**
+		 * Serial number for interoperability with different versions.
+		 */
+		private static final long serialVersionUID = -6398226638364450229L;
 
-        /**
-         * The maximal value for a rotation, in arc-second.
-         */
-        private static final double MAX_ROTATION = 180*60*60;
+		/**
+		 * The maximal value for a rotation, in arc-second.
+		 */
+		private static final double MAX_ROTATION = 180 * 60 * 60;
 
-        /**
-         * The operation parameter descriptor for the <cite>X-axis rotation</cite> ("ex")
-         * parameter value. Units are arc-seconds.
-         */
-        public static final ParameterDescriptor EX = createDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC,  "ex"),
-                    new NamedIdentifier(Citations.EPSG, "X-axis rotation")
-                },
-                0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
+		/**
+		 * The operation parameter descriptor for the <cite>X-axis
+		 * rotation</cite> ("ex") parameter value. Units are arc-seconds.
+		 */
+		public static final ParameterDescriptor EX = createDescriptor(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.OGC, "ex"),
+						new NamedIdentifier(Citations.EPSG, "X-axis rotation") },
+				0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
 
-        /**
-         * The operation parameter descriptor for the <cite>Y-axis rotation</cite> ("ey")
-         * parameter value. Units are arc-seconds.
-         */
-        public static final ParameterDescriptor EY = createDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC,  "ey"),
-                    new NamedIdentifier(Citations.EPSG, "Y-axis rotation")
-                },
-                0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
+		/**
+		 * The operation parameter descriptor for the <cite>Y-axis
+		 * rotation</cite> ("ey") parameter value. Units are arc-seconds.
+		 */
+		public static final ParameterDescriptor EY = createDescriptor(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.OGC, "ey"),
+						new NamedIdentifier(Citations.EPSG, "Y-axis rotation") },
+				0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
 
-        /**
-         * The operation parameter descriptor for the <cite>Z-axis rotation</cite> ("ez")
-         * parameter value. Units are arc-seconds.
-         */
-        public static final ParameterDescriptor EZ = createDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC,  "ez"),
-                    new NamedIdentifier(Citations.EPSG, "Z-axis rotation")
-                },
-                0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
+		/**
+		 * The operation parameter descriptor for the <cite>Z-axis
+		 * rotation</cite> ("ez") parameter value. Units are arc-seconds.
+		 */
+		public static final ParameterDescriptor EZ = createDescriptor(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.OGC, "ez"),
+						new NamedIdentifier(Citations.EPSG, "Z-axis rotation") },
+				0.0, -MAX_ROTATION, MAX_ROTATION, NonSI.SECOND_ANGLE);
 
-        /**
-         * The operation parameter descriptor for the <cite>Scale difference</cite> ("ppm")
-         * parameter value. Valid values range from -infinity to infinity. Units are parts
-         * per million.
-         */
-        public static final ParameterDescriptor PPM = createDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.OGC,  "ppm"),
-                    new NamedIdentifier(Citations.EPSG, "Scale difference")
-                },
-                0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Units.PPM);
+		/**
+		 * The operation parameter descriptor for the <cite>Scale
+		 * difference</cite> ("ppm") parameter value. Valid values range from
+		 * -infinity to infinity. Units are parts per million.
+		 */
+		public static final ParameterDescriptor PPM = createDescriptor(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.OGC, "ppm"),
+						new NamedIdentifier(Citations.EPSG, "Scale difference") },
+				0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+				Units.PPM);
 
-        /**
-         * The parameters group.
-         */
-        static final ParameterDescriptorGroup PARAMETERS =
-                        createDescriptorGroup("Position Vector transformation (geog2D domain)", "9606");
+		/**
+		 * The parameters group.
+		 */
+		static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
+				"Position Vector transformation (geog2D domain)", "9606");
 
-        /**
-         * Creates a parameters group.
-         */
-        static ParameterDescriptorGroup createDescriptorGroup(final String name, final String code) {
-            return createDescriptorGroup(new NamedIdentifier[] {
-                new NamedIdentifier(Citations.EPSG, name),
-                new NamedIdentifier(Citations.EPSG, code)
-            }, new ParameterDescriptor[] {
-                DX, DY, DZ, EX, EY, EZ, PPM,
-                SRC_SEMI_MAJOR, SRC_SEMI_MINOR,
-                TGT_SEMI_MAJOR, TGT_SEMI_MINOR,
-                SRC_DIM, TGT_DIM
-            });
-        }
+		/**
+		 * Creates a parameters group.
+		 */
+		static ParameterDescriptorGroup createDescriptorGroup(
+				final String name, final String code) {
+			return createDescriptorGroup(new NamedIdentifier[] {
+					new NamedIdentifier(Citations.EPSG, name),
+					new NamedIdentifier(Citations.EPSG, code) },
+					new ParameterDescriptor[] { DX, DY, DZ, EX, EY, EZ, PPM,
+							SRC_SEMI_MAJOR, SRC_SEMI_MINOR, TGT_SEMI_MAJOR,
+							TGT_SEMI_MINOR, SRC_DIM, TGT_DIM });
+		}
 
-        /**
-         * Constructs a default provider.
-         */
-        public ProviderSevenParam() {
-            super(PARAMETERS);
-        }
+		/**
+		 * Constructs a default provider.
+		 */
+		public ProviderSevenParam() {
+			super(PARAMETERS);
+		}
 
-        /**
-         * Constructs a provider with the specified parameters.
-         */
-        ProviderSevenParam(final ParameterDescriptorGroup parameters) {
-            super(parameters);
-        }
+		/**
+		 * Constructs a provider with the specified parameters.
+		 */
+		ProviderSevenParam(final ParameterDescriptorGroup parameters) {
+			super(parameters);
+		}
 
-        /**
-         * Fills the specified Bursa-Wolf parameters according the specified values.
-         */
-        @Override
-        protected void fill(final BursaWolfParameters parameters, final ParameterValueGroup values) {
-            super.fill(parameters, values);
-            parameters.ppm = doubleValue(PPM, values);
-            parameters.ex  = doubleValue(EX, values);
-            parameters.ey  = doubleValue(EY, values);
-            parameters.ez  = doubleValue(EZ, values);
-        }
-    }
+		/**
+		 * Fills the specified Bursa-Wolf parameters according the specified
+		 * values.
+		 */
+		@Override
+		protected void fill(final BursaWolfParameters parameters,
+				final ParameterValueGroup values) {
+			super.fill(parameters, values);
+			parameters.ppm = doubleValue(PPM, values);
+			parameters.ex = doubleValue(EX, values);
+			parameters.ey = doubleValue(EY, values);
+			parameters.ez = doubleValue(EZ, values);
+		}
+	}
 
-    /**
-     * {@linkplain GeocentricTranslation Geocentric affine transform} provider for
-     * "<cite>Coordinate Frame rotation</cite>".
-     *
-     * @version $Id$
-     * @author Martin Desruisseaux (IRD)
-     *
-     * @since 2.2
-     */
-    public static class ProviderFrameRotation extends ProviderSevenParam {
-        /**
-         * Serial number for interoperability with different versions.
-         */
-        private static final long serialVersionUID =  5513675854809530038L;
+	/**
+	 * {@linkplain GeocentricTranslation Geocentric affine transform} provider
+	 * for "<cite>Coordinate Frame rotation</cite>".
+	 *
+	 * @version $Id$
+	 * @author Martin Desruisseaux (IRD)
+	 *
+	 * @since 2.2
+	 */
+	public static class ProviderFrameRotation extends ProviderSevenParam {
+		/**
+		 * Serial number for interoperability with different versions.
+		 */
+		private static final long serialVersionUID = 5513675854809530038L;
 
-        /**
-         * The parameters group.
-         */
-        static final ParameterDescriptorGroup PARAMETERS =
-                        createDescriptorGroup("Coordinate Frame Rotation (geog2D domain)", "9607");
+		/**
+		 * The parameters group.
+		 */
+		static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
+				"Coordinate Frame Rotation (geog2D domain)", "9607");
 
-        /**
-         * Constructs a default provider.
-         */
-        public ProviderFrameRotation() {
-            super(PARAMETERS);
-        }
+		/**
+		 * Constructs a default provider.
+		 */
+		public ProviderFrameRotation() {
+			super(PARAMETERS);
+		}
 
-        /**
-         * Fills the specified Bursa-Wolf parameters according the specified values.
-         */
-        @Override
-        protected void fill(final BursaWolfParameters parameters, final ParameterValueGroup values) {
-            super.fill(parameters, values);
-            parameters.ex = -parameters.ex;
-            parameters.ey = -parameters.ey;
-            parameters.ez = -parameters.ez;
-        }
-    }
+		/**
+		 * Fills the specified Bursa-Wolf parameters according the specified
+		 * values.
+		 */
+		@Override
+		protected void fill(final BursaWolfParameters parameters,
+				final ParameterValueGroup values) {
+			super.fill(parameters, values);
+			parameters.ex = -parameters.ex;
+			parameters.ey = -parameters.ey;
+			parameters.ez = -parameters.ez;
+		}
+	}
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform.java
@@ -28,21 +28,6 @@ import java.util.Map;
 
 import javax.measure.unit.NonSI;
 
-import org.geotools.metadata.iso.citation.Citations;
-import org.geotools.parameter.MatrixParameterDescriptors;
-import org.geotools.parameter.MatrixParameters;
-import org.geotools.referencing.NamedIdentifier;
-import org.geotools.referencing.operation.LinearTransform;
-import org.geotools.referencing.operation.MathTransformProvider;
-import org.geotools.referencing.operation.matrix.GeneralMatrix;
-import org.geotools.referencing.operation.matrix.MatrixFactory;
-import org.geotools.referencing.operation.matrix.SingularMatrixException;
-import org.geotools.referencing.operation.matrix.XMatrix;
-import org.geotools.resources.i18n.ErrorKeys;
-import org.geotools.resources.i18n.Errors;
-import org.geotools.resources.i18n.Vocabulary;
-import org.geotools.resources.i18n.VocabularyKeys;
-import org.opengis.geometry.DirectPosition;
 import org.opengis.parameter.ParameterDescriptor;
 import org.opengis.parameter.ParameterDescriptorGroup;
 import org.opengis.parameter.ParameterNotFoundException;
@@ -51,37 +36,46 @@ import org.opengis.referencing.operation.Conversion;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.Matrix;
 import org.opengis.referencing.operation.NoninvertibleTransformException;
+import org.opengis.geometry.DirectPosition;
+import org.geotools.metadata.iso.citation.Citations;
+import org.geotools.parameter.MatrixParameterDescriptors;
+import org.geotools.parameter.MatrixParameters;
+import org.geotools.referencing.NamedIdentifier;
+import org.geotools.referencing.operation.LinearTransform;
+import org.geotools.referencing.operation.MathTransformProvider;
+import org.geotools.referencing.operation.matrix.MatrixFactory;
+import org.geotools.referencing.operation.matrix.GeneralMatrix;
+import org.geotools.referencing.operation.matrix.SingularMatrixException;
+import org.geotools.referencing.operation.matrix.XMatrix;
+import org.geotools.resources.i18n.VocabularyKeys;
+import org.geotools.resources.i18n.Vocabulary;
+import org.geotools.resources.i18n.ErrorKeys;
+import org.geotools.resources.i18n.Errors;
+
 
 /**
- * A usually affine, or otherwise a projective transform. A projective transform
- * is capable of mapping an arbitrary quadrilateral into another arbitrary
- * quadrilateral, while preserving the straightness of lines. In the special
- * case where the transform is affine, the parallelism of lines in the source is
- * preserved in the output.
+ * A usually affine, or otherwise a projective transform. A projective transform is capable of
+ * mapping an arbitrary quadrilateral into another arbitrary quadrilateral, while preserving the
+ * straightness of lines. In the special case where the transform is affine, the parallelism of
+ * lines in the source is preserved in the output.
  * <p>
- * Such a coordinate transformation can be represented by a square
- * {@linkplain GeneralMatrix matrix} of an arbitrary size. Point coordinates
- * must have a dimension equals to <code>{@linkplain Matrix#getNumCol}-1</code>.
- * For example, for square matrix of size 4&times;4, coordinate points are
- * three-dimensional. The transformed points <code>(x',y',z')</code> are
+ * Such a coordinate transformation can be represented by a square {@linkplain GeneralMatrix matrix}
+ * of an arbitrary size. Point coordinates must have a dimension equals to
+ * <code>{@linkplain Matrix#getNumCol}-1</code>. For example, for square matrix of size 4&times;4,
+ * coordinate points are three-dimensional. The transformed points <code>(x',y',z')</code> are
  * computed as below (note that this computation is similar to
- * {@link javax.media.jai.PerspectiveTransform} in <cite>Java Advanced
- * Imaging</cite>):
+ * {@link javax.media.jai.PerspectiveTransform} in <cite>Java Advanced Imaging</cite>):
  *
- * <blockquote>
- * 
- * <pre>
+ * <blockquote><pre>
  * [ u ]     [ m<sub>00</sub>  m<sub>01</sub>  m<sub>02</sub>  m<sub>03</sub> ] [ x ]
  * [ v ]  =  [ m<sub>10</sub>  m<sub>11</sub>  m<sub>12</sub>  m<sub>13</sub> ] [ y ]
  * [ w ]     [ m<sub>20</sub>  m<sub>21</sub>  m<sub>22</sub>  m<sub>23</sub> ] [ z ]
  * [ t ]     [ m<sub>30</sub>  m<sub>31</sub>  m<sub>32</sub>  m<sub>33</sub> ] [ 1 ]
- * 
+ *
  *   x' = u/t
  *   y' = v/t
  *   y' = w/t
- * </pre>
- * 
- * </blockquote>
+ * </pre></blockquote>
  *
  * In the special case of an affine transform, the last row contains only zero
  * values except in the last column, which contains 1.
@@ -95,698 +89,636 @@ import org.opengis.referencing.operation.NoninvertibleTransformException;
  *
  * @see javax.media.jai.PerspectiveTransform
  * @see java.awt.geom.AffineTransform
- * @see <A HREF="http://mathworld.wolfram.com/AffineTransformation.html">Affine
- *      transformation on MathWorld</A>
+ * @see <A HREF="http://mathworld.wolfram.com/AffineTransformation.html">Affine transformation on MathWorld</A>
  */
-public class ProjectiveTransform extends AbstractMathTransform implements
-		LinearTransform, Serializable {
-	/**
-	 * Serial number for interoperability with different versions.
-	 */
-	private static final long serialVersionUID = -2104496465933824935L;
+public class ProjectiveTransform extends AbstractMathTransform implements LinearTransform, Serializable {
+    /**
+     * Serial number for interoperability with different versions.
+     */
+    private static final long serialVersionUID = -2104496465933824935L;
 
-	/**
-	 * The number of rows.
-	 */
-	private final int numRow;
+    /**
+     * The number of rows.
+     */
+    private final int numRow;
 
-	/**
-	 * The number of columns.
-	 */
-	private final int numCol;
+    /**
+     * The number of columns.
+     */
+    private final int numCol;
 
-	/**
-	 * Elements of the matrix. Column indice vary fastest.
-	 */
-	private final double[] elt;
+    /**
+     * Elements of the matrix. Column indice vary fastest.
+     */
+    private final double[] elt;
 
-	/**
-	 * The inverse transform. Will be created only when first needed.
-	 */
-	private transient ProjectiveTransform inverse;
+    /**
+     * The inverse transform. Will be created only when first needed.
+     */
+    private transient ProjectiveTransform inverse;
 
-	/**
-	 * Constructs a transform from the specified matrix. The matrix should be
-	 * affine, but it will not be verified.
-	 *
-	 * @param matrix
-	 *            The matrix.
-	 */
-	protected ProjectiveTransform(final Matrix matrix) {
-		numRow = matrix.getNumRow();
-		numCol = matrix.getNumCol();
-		elt = new double[numRow * numCol];
-		int index = 0;
-		for (int j = 0; j < numRow; j++) {
-			for (int i = 0; i < numCol; i++) {
-				elt[index++] = matrix.getElement(j, i);
-			}
-		}
-	}
+    /**
+     * Constructs a transform from the specified matrix.
+     * The matrix should be affine, but it will not be verified.
+     *
+     * @param matrix The matrix.
+     */
+    protected ProjectiveTransform(final Matrix matrix) {
+        numRow = matrix.getNumRow();
+        numCol = matrix.getNumCol();
+        elt = new double[numRow*numCol];
+        int index = 0;
+        for (int j=0; j<numRow; j++) {
+            for (int i=0; i<numCol; i++) {
+                elt[index++] = matrix.getElement(j,i);
+            }
+        }
+    }
 
-	/**
-	 * Creates a transform for the specified matrix. The matrix should be
-	 * affine, but it is not be verified.
-	 *
-	 * @param matrix
-	 *            The affine transform as a matrix.
-	 * @return The transform for the given matrix.
-	 */
-	public static LinearTransform create(final Matrix matrix) {
-		final int dimension = matrix.getNumRow() - 1;
-		if (dimension == matrix.getNumCol() - 1) {
-			if (matrix.isIdentity()) {
-				return IdentityTransform.create(dimension);
-			}
-			final GeneralMatrix m = toGMatrix(matrix);
-			if (m.isAffine()) {
-				switch (dimension) {
-				case 1:
-					return LinearTransform1D.create(m.getElement(0, 0),
-							m.getElement(0, 1));
-				case 2:
-					return create(m.toAffineTransform2D());
-				}
-			}
-		}
-		switch (dimension) {
-		case 2:
-			return new ProjectiveTransform2D(matrix);
-		default:
-			return new ProjectiveTransform(matrix);
-		}
-	}
+    /**
+     * Creates a transform for the specified matrix.
+     * The matrix should be affine, but it is not be verified.
+     *
+     * @param matrix The affine transform as a matrix.
+     * @return The transform for the given matrix.
+     */
+    public static LinearTransform create(final Matrix matrix) {
+        final int dimension = matrix.getNumRow()-1;
+        if (dimension == matrix.getNumCol()-1) {
+            if (matrix.isIdentity()) {
+                return IdentityTransform.create(dimension);
+            }
+            final GeneralMatrix m = toGMatrix(matrix);
+            if (m.isAffine()) {
+                switch (dimension) {
+                    case 1: return LinearTransform1D.create(m.getElement(0,0), m.getElement(0,1));
+                    case 2: return create(m.toAffineTransform2D());
+                }
+            }
+        }
+        switch (dimension) {
+            case 2:  return new ProjectiveTransform2D(matrix);
+            default: return new ProjectiveTransform  (matrix);
+        }
+    }
 
-	/**
-	 * Creates a transform for the specified matrix as a Java2D object. This
-	 * method is provided for interoperability with <A
-	 * HREF="http://java.sun.com/products/java-media/2D/index.jsp">Java2D</A>.
-	 *
-	 * @param matrix
-	 *            The affine transform as a matrix.
-	 * @return The transform for the given matrix.
-	 */
-	public static LinearTransform create(final AffineTransform matrix) {
-		if (matrix.isIdentity()) {
-			return IdentityTransform.create(2);
-		}
-		return new AffineTransform2D(matrix);
-	}
+    /**
+     * Creates a transform for the specified matrix as a Java2D object.
+     * This method is provided for interoperability with
+     * <A HREF="http://java.sun.com/products/java-media/2D/index.jsp">Java2D</A>.
+     *
+     * @param matrix The affine transform as a matrix.
+     * @return The transform for the given matrix.
+     */
+    public static LinearTransform create(final AffineTransform matrix) {
+        if (matrix.isIdentity()) {
+            return IdentityTransform.create(2);
+        }
+        return new AffineTransform2D(matrix);
+    }
 
-	/**
-	 * Creates a transform that apply a uniform scale along all axis.
-	 *
-	 * @param dimension
-	 *            The input and output dimensions.
-	 * @param scale
-	 *            The scale factor.
-	 * @return The scale transform.
-	 *
-	 * @since 2.3
-	 */
-	public static LinearTransform createScale(final int dimension,
-			final double scale) {
-		if (scale == 1) {
-			return IdentityTransform.create(dimension);
-		}
-		final Matrix matrix = new GeneralMatrix(dimension + 1);
-		for (int i = 0; i < dimension; i++) {
-			matrix.setElement(i, i, scale);
-		}
-		return create(matrix);
-	}
+    /**
+     * Creates a transform that apply a uniform scale along all axis.
+     *
+     * @param dimension The input and output dimensions.
+     * @param scale The scale factor.
+     * @return The scale transform.
+     *
+     * @since 2.3
+     */
+    public static LinearTransform createScale(final int dimension, final double scale) {
+        if (scale == 1) {
+            return IdentityTransform.create(dimension);
+        }
+        final Matrix matrix = new GeneralMatrix(dimension + 1);
+        for (int i=0; i<dimension; i++) {
+            matrix.setElement(i, i, scale);
+        }
+        return create(matrix);
+    }
 
-	/**
-	 * Creates a transform that apply the same translation along all axis.
-	 *
-	 * @param dimension
-	 *            The input and output dimensions.
-	 * @param offset
-	 *            The translation.
-	 * @return The offset transform.
-	 *
-	 * @since 2.3
-	 */
-	public static LinearTransform createTranslation(final int dimension,
-			final double offset) {
-		if (offset == 0) {
-			return IdentityTransform.create(dimension);
-		}
-		final Matrix matrix = new GeneralMatrix(dimension + 1);
-		for (int i = 0; i < dimension; i++) {
-			matrix.setElement(i, dimension, offset);
-		}
-		return create(matrix);
-	}
+    /**
+     * Creates a transform that apply the same translation along all axis.
+     *
+     * @param dimension The input and output dimensions.
+     * @param offset The translation.
+     * @return The offset transform.
+     *
+     * @since 2.3
+     */
+    public static LinearTransform createTranslation(final int dimension, final double offset) {
+        if (offset == 0) {
+            return IdentityTransform.create(dimension);
+        }
+        final Matrix matrix = new GeneralMatrix(dimension + 1);
+        for (int i=0; i<dimension; i++) {
+            matrix.setElement(i, dimension, offset);
+        }
+        return create(matrix);
+    }
 
-	/**
-	 * Creates a matrix that keep only a subset of the ordinate values. The
-	 * dimension of source coordinates is {@code sourceDim} and the dimension of
-	 * target coordinates is {@code toKeep.length}.
-	 *
-	 * @param sourceDim
-	 *            the dimension of source coordinates.
-	 * @param toKeep
-	 *            the indices of ordinate values to keep.
-	 * @return The matrix to give to the {@link #create(Matrix)} method in order
-	 *         to create the transform.
-	 * @throws IndexOutOfBoundsException
-	 *             if a value of {@code toKeep} is lower than 0 or not smaller
-	 *             than {@code sourceDim}.
-	 */
-	public static Matrix createSelectMatrix(final int sourceDim,
-			final int[] toKeep) throws IndexOutOfBoundsException {
-		final int targetDim = toKeep.length;
-		final XMatrix matrix = MatrixFactory.create(targetDim + 1,
-				sourceDim + 1);
-		matrix.setZero();
-		for (int j = 0; j < targetDim; j++) {
-			matrix.setElement(j, toKeep[j], 1);
-		}
-		matrix.setElement(targetDim, sourceDim, 1);
-		return matrix;
-	}
+    /**
+     * Creates a matrix that keep only a subset of the ordinate values.
+     * The dimension of source coordinates is {@code sourceDim} and
+     * the dimension of target coordinates is {@code toKeep.length}.
+     *
+     * @param  sourceDim the dimension of source coordinates.
+     * @param  toKeep the indices of ordinate values to keep.
+     * @return The matrix to give to the {@link #create(Matrix)}
+     *         method in order to create the transform.
+     * @throws IndexOutOfBoundsException if a value of {@code toKeep}
+     *         is lower than 0 or not smaller than {@code sourceDim}.
+     */
+    public static Matrix createSelectMatrix(final int sourceDim, final int[] toKeep)
+            throws IndexOutOfBoundsException
+    {
+        final int targetDim = toKeep.length;
+        final XMatrix matrix = MatrixFactory.create(targetDim+1, sourceDim+1);
+        matrix.setZero();
+        for (int j=0; j<targetDim; j++) {
+            matrix.setElement(j, toKeep[j], 1);
+        }
+        matrix.setElement(targetDim, sourceDim, 1);
+        return matrix;
+    }
 
-	/**
-	 * Returns the parameter descriptors for this math transform.
-	 */
-	@Override
-	public ParameterDescriptorGroup getParameterDescriptors() {
-		return ProviderAffine.PARAMETERS;
-	}
+    /**
+     * Returns the parameter descriptors for this math transform.
+     */
+    @Override
+    public ParameterDescriptorGroup getParameterDescriptors() {
+        return ProviderAffine.PARAMETERS;
+    }
 
-	/**
-	 * Returns the matrix elements as a group of parameters values. The number
-	 * of parameters depends on the matrix size. Only matrix elements different
-	 * from their default value will be included in this group.
-	 *
-	 * @param matrix
-	 *            The matrix to returns as a group of parameters.
-	 * @return A copy of the parameter values for this math transform.
-	 */
-	static ParameterValueGroup getParameterValues(final Matrix matrix) {
-		final MatrixParameters values;
-		values = (MatrixParameters) ProviderAffine.PARAMETERS.createValue();
-		values.setMatrix(matrix);
-		return values;
-	}
+    /**
+     * Returns the matrix elements as a group of parameters values. The number of parameters
+     * depends on the matrix size. Only matrix elements different from their default value
+     * will be included in this group.
+     *
+     * @param  matrix The matrix to returns as a group of parameters.
+     * @return A copy of the parameter values for this math transform.
+     */
+    static ParameterValueGroup getParameterValues(final Matrix matrix) {
+        final MatrixParameters values;
+        values = (MatrixParameters) ProviderAffine.PARAMETERS.createValue();
+        values.setMatrix(matrix);
+        return values;
+    }
 
-	/**
-	 * Returns the matrix elements as a group of parameters values. The number
-	 * of parameters depends on the matrix size. Only matrix elements different
-	 * from their default value will be included in this group.
-	 *
-	 * @return A copy of the parameter values for this math transform.
-	 */
-	@Override
-	public ParameterValueGroup getParameterValues() {
-		return getParameterValues(getMatrix());
-	}
+    /**
+     * Returns the matrix elements as a group of parameters values. The number of parameters
+     * depends on the matrix size. Only matrix elements different from their default value
+     * will be included in this group.
+     *
+     * @return A copy of the parameter values for this math transform.
+     */
+    @Override
+    public ParameterValueGroup getParameterValues() {
+        return getParameterValues(getMatrix());
+    }
 
-	/**
-	 * Transforms an array of floating point coordinates by this matrix. Point
-	 * coordinates must have a dimension equals to
-	 * <code>{@link Matrix#getNumCol}-1</code>. For example, for square matrix
-	 * of size 4&times;4, coordinate points are three-dimensional and stored in
-	 * the arrays starting at the specified offset ({@code srcOff}) in the order
-	 * <code>[x<sub>0</sub>, y<sub>0</sub>, z<sub>0</sub>,
-	 *        x<sub>1</sub>, y<sub>1</sub>, z<sub>1</sub>...,
-	 *        x<sub>n</sub>, y<sub>n</sub>, z<sub>n</sub>]</code>.
-	 *
-	 * @param srcPts
-	 *            The array containing the source point coordinates.
-	 * @param srcOff
-	 *            The offset to the first point to be transformed in the source
-	 *            array.
-	 * @param dstPts
-	 *            The array into which the transformed point coordinates are
-	 *            returned.
-	 * @param dstOff
-	 *            The offset to the location of the first transformed point that
-	 *            is stored in the destination array. The source and destination
-	 *            array sections can be overlaps.
-	 * @param numPts
-	 *            The number of points to be transformed
-	 */
-	@Override
-	public void transform(float[] srcPts, int srcOff, final float[] dstPts,
-			int dstOff, int numPts) {
-		final int inputDimension = numCol - 1; // The last ordinate will be
-												// assumed equals to 1.
-		final int outputDimension = numRow - 1;
-		final double[] buffer = new double[numRow];
-		if (srcPts == dstPts) {
-			// We are going to write in the source array. Checks if
-			// source and destination sections are going to clash.
-			final int upperSrc = srcOff + numPts * inputDimension;
-			if (upperSrc > dstOff) {
-				if (inputDimension >= outputDimension ? dstOff > srcOff
-						: dstOff + numPts * outputDimension > upperSrc) {
-					// If source overlaps destination, then the easiest
-					// workaround is
-					// to copy source data. This is not the most efficient
-					// however...
-					srcPts = new float[numPts * inputDimension];
-					System.arraycopy(dstPts, srcOff, srcPts, 0, srcPts.length);
-					srcOff = 0;
-				}
-			}
-		}
-		while (--numPts >= 0) {
-			int mix = 0;
-			for (int j = 0; j < numRow; j++) {
-				double sum = elt[mix + inputDimension];
-				for (int i = 0; i < inputDimension; i++) {
-					sum += srcPts[srcOff + i] * elt[mix++];
-				}
-				buffer[j] = sum;
-				mix++;
-			}
-			final double w = buffer[outputDimension];
-			for (int j = 0; j < outputDimension; j++) {
-				// 'w' is equals to 1 if the transform is affine.
-				dstPts[dstOff++] = (float) (buffer[j] / w);
-			}
-			srcOff += inputDimension;
-		}
-	}
+    /**
+     * Transforms an array of floating point coordinates by this matrix. Point coordinates
+     * must have a dimension equals to <code>{@link Matrix#getNumCol}-1</code>. For example,
+     * for square matrix of size 4&times;4, coordinate points are three-dimensional and
+     * stored in the arrays starting at the specified offset ({@code srcOff}) in the order
+     * <code>[x<sub>0</sub>, y<sub>0</sub>, z<sub>0</sub>,
+     *        x<sub>1</sub>, y<sub>1</sub>, z<sub>1</sub>...,
+     *        x<sub>n</sub>, y<sub>n</sub>, z<sub>n</sub>]</code>.
+     *
+     * @param srcPts The array containing the source point coordinates.
+     * @param srcOff The offset to the first point to be transformed in the source array.
+     * @param dstPts The array into which the transformed point coordinates are returned.
+     * @param dstOff The offset to the location of the first transformed point that is stored
+     *               in the destination array. The source and destination array sections can
+     *               be overlaps.
+     * @param numPts The number of points to be transformed
+     */
+    @Override
+    public void transform(float[] srcPts, int srcOff,
+                          final float[] dstPts, int dstOff, int numPts)
+    {
+        final int  inputDimension = numCol-1; // The last ordinate will be assumed equals to 1.
+        final int outputDimension = numRow-1;
+        final double[]     buffer = new double[numRow];
+        if (srcPts == dstPts) {
+            // We are going to write in the source array. Checks if
+            // source and destination sections are going to clash.
+            final int upperSrc = srcOff + numPts*inputDimension;
+            if (upperSrc > dstOff) {
+                if (inputDimension >= outputDimension ? dstOff > srcOff :
+                            dstOff + numPts*outputDimension > upperSrc) {
+                    // If source overlaps destination, then the easiest workaround is
+                    // to copy source data. This is not the most efficient however...
+                    srcPts = new float[numPts*inputDimension];
+                    System.arraycopy(dstPts, srcOff, srcPts, 0, srcPts.length);
+                    srcOff = 0;
+                }
+            }
+        }
+        while (--numPts >= 0) {
+            int mix = 0;
+            for (int j=0; j<numRow; j++) {
+                double sum=elt[mix + inputDimension];
+                for (int i=0; i<inputDimension; i++) {
+                    sum += srcPts[srcOff+i]*elt[mix++];
+                }
+                buffer[j] = sum;
+                mix++;
+            }
+            final double w = buffer[outputDimension];
+            for (int j=0; j<outputDimension; j++) {
+                // 'w' is equals to 1 if the transform is affine.
+                dstPts[dstOff++] = (float) (buffer[j]/w);
+            }
+            srcOff += inputDimension;
+        }
+    }
 
-	/**
-	 * Transforms an array of floating point coordinates by this matrix. Point
-	 * coordinates must have a dimension equals to
-	 * <code>{@link Matrix#getNumCol}-1</code>. For example, for square matrix
-	 * of size 4&times;4, coordinate points are three-dimensional and stored in
-	 * the arrays starting at the specified offset ({@code srcOff}) in the order
-	 * <code>[x<sub>0</sub>, y<sub>0</sub>, z<sub>0</sub>,
-	 *        x<sub>1</sub>, y<sub>1</sub>, z<sub>1</sub>...,
-	 *        x<sub>n</sub>, y<sub>n</sub>, z<sub>n</sub>]</code>.
-	 *
-	 * @param srcPts
-	 *            The array containing the source point coordinates.
-	 * @param srcOff
-	 *            The offset to the first point to be transformed in the source
-	 *            array.
-	 * @param dstPts
-	 *            The array into which the transformed point coordinates are
-	 *            returned.
-	 * @param dstOff
-	 *            The offset to the location of the first transformed point that
-	 *            is stored in the destination array. The source and destination
-	 *            array sections can be overlaps.
-	 * @param numPts
-	 *            The number of points to be transformed
-	 */
-	public void transform(double[] srcPts, int srcOff, final double[] dstPts,
-			int dstOff, int numPts) {
-		final int inputDimension = numCol - 1; // The last ordinate will be
-												// assumed equals to 1.
-		final int outputDimension = numRow - 1;
-		final double[] buffer = new double[numRow];
-		if (srcPts == dstPts) {
-			// We are going to write in the source array. Checks if
-			// source and destination sections are going to clash.
-			final int upperSrc = srcOff + numPts * inputDimension;
-			if (upperSrc > dstOff) {
-				if (inputDimension >= outputDimension ? dstOff > srcOff
-						: dstOff + numPts * outputDimension > upperSrc) {
-					// If source overlaps destination, then the easiest
-					// workaround is
-					// to copy source data. This is not the most efficient
-					// however...
-					srcPts = new double[numPts * inputDimension];
-					System.arraycopy(dstPts, srcOff, srcPts, 0, srcPts.length);
-					srcOff = 0;
-				}
-			}
-		}
-		while (--numPts >= 0) {
-			int mix = 0;
-			for (int j = 0; j < numRow; j++) {
-				double sum = elt[mix + inputDimension];
-				for (int i = 0; i < inputDimension; i++) {
-					sum += srcPts[srcOff + i] * elt[mix++];
-				}
-				buffer[j] = sum;
-				mix++;
-			}
-			final double w = buffer[outputDimension];
-			for (int j = 0; j < outputDimension; j++) {
-				// 'w' is equals to 1 if the transform is affine.
-				dstPts[dstOff++] = buffer[j] / w;
-			}
-			srcOff += inputDimension;
-		}
-	}
+    /**
+     * Transforms an array of floating point coordinates by this matrix. Point coordinates
+     * must have a dimension equals to <code>{@link Matrix#getNumCol}-1</code>. For example,
+     * for square matrix of size 4&times;4, coordinate points are three-dimensional and
+     * stored in the arrays starting at the specified offset ({@code srcOff}) in the order
+     * <code>[x<sub>0</sub>, y<sub>0</sub>, z<sub>0</sub>,
+     *        x<sub>1</sub>, y<sub>1</sub>, z<sub>1</sub>...,
+     *        x<sub>n</sub>, y<sub>n</sub>, z<sub>n</sub>]</code>.
+     *
+     * @param srcPts The array containing the source point coordinates.
+     * @param srcOff The offset to the first point to be transformed in the source array.
+     * @param dstPts The array into which the transformed point coordinates are returned.
+     * @param dstOff The offset to the location of the first transformed point that is stored
+     *               in the destination array. The source and destination array sections can
+     *               be overlaps.
+     * @param numPts The number of points to be transformed
+     */
+    public void transform(double[] srcPts, int srcOff,
+                          final double[] dstPts, int dstOff, int numPts)
+    {
+        final int  inputDimension = numCol-1; // The last ordinate will be assumed equals to 1.
+        final int outputDimension = numRow-1;
+        final double[]     buffer = new double[numRow];
+        if (srcPts == dstPts) {
+            // We are going to write in the source array. Checks if
+            // source and destination sections are going to clash.
+            final int upperSrc = srcOff + numPts*inputDimension;
+            if (upperSrc > dstOff) {
+                if (inputDimension >= outputDimension ? dstOff > srcOff :
+                            dstOff + numPts*outputDimension > upperSrc) {
+                    // If source overlaps destination, then the easiest workaround is
+                    // to copy source data. This is not the most efficient however...
+                    srcPts = new double[numPts*inputDimension];
+                    System.arraycopy(dstPts, srcOff, srcPts, 0, srcPts.length);
+                    srcOff = 0;
+                }
+            }
+        }
+        while (--numPts >= 0) {
+            int mix = 0;
+            for (int j=0; j<numRow; j++) {
+                double sum=elt[mix + inputDimension];
+                for (int i=0; i<inputDimension; i++) {
+                    sum += srcPts[srcOff+i]*elt[mix++];
+                }
+                buffer[j] = sum;
+                mix++;
+            }
+            final double w = buffer[outputDimension];
+            for (int j=0; j<outputDimension; j++) {
+                // 'w' is equals to 1 if the transform is affine.
+                dstPts[dstOff++] = buffer[j]/w;
+            }
+            srcOff += inputDimension;
+        }
+    }
 
-	/**
-	 * Gets the derivative of this transform at a point. For a matrix transform,
-	 * the derivative is the same everywhere.
-	 */
-	@Override
-	public Matrix derivative(final Point2D point) {
-		return derivative((DirectPosition) null);
-	}
+    /**
+     * Gets the derivative of this transform at a point.
+     * For a matrix transform, the derivative is the
+     * same everywhere.
+     */
+    @Override
+    public Matrix derivative(final Point2D point) {
+        return derivative((DirectPosition)null);
+    }
 
-	/**
-	 * Gets the derivative of this transform at a point. For a matrix transform,
-	 * the derivative is the same everywhere.
-	 */
-	@Override
-	public Matrix derivative(final DirectPosition point) {
-		final GeneralMatrix matrix = getGeneralMatrix();
-		matrix.setSize(numRow - 1, numCol - 1);
-		return matrix;
-	}
+    /**
+     * Gets the derivative of this transform at a point.
+     * For a matrix transform, the derivative is the
+     * same everywhere.
+     */
+    @Override
+    public Matrix derivative(final DirectPosition point) {
+        final GeneralMatrix matrix = getGeneralMatrix();
+        matrix.setSize(numRow-1, numCol-1);
+        return matrix;
+    }
 
-	/**
-	 * Returns a copy of the matrix.
-	 */
-	public Matrix getMatrix() {
-		return getGeneralMatrix();
-	}
+    /**
+     * Returns a copy of the matrix.
+     */
+    public Matrix getMatrix() {
+        return getGeneralMatrix();
+    }
 
-	/**
-	 * Returns a copy of the matrix.
-	 */
-	private GeneralMatrix getGeneralMatrix() {
-		return new GeneralMatrix(numRow, numCol, elt);
-	}
+    /**
+     * Returns a copy of the matrix.
+     */
+    private GeneralMatrix getGeneralMatrix() {
+        return new GeneralMatrix(numRow, numCol, elt);
+    }
 
-	/**
-	 * Gets the dimension of input points.
-	 */
-	public int getSourceDimensions() {
-		return numCol - 1;
-	}
+    /**
+     * Gets the dimension of input points.
+     */
+    public int getSourceDimensions() {
+        return numCol - 1;
+    }
 
-	/**
-	 * Gets the dimension of output points.
-	 */
-	public int getTargetDimensions() {
-		return numRow - 1;
-	}
+    /**
+     * Gets the dimension of output points.
+     */
+    public int getTargetDimensions() {
+        return numRow - 1;
+    }
 
-	/**
-	 * Tests whether this transform does not move any points.
-	 */
-	@Override
-	public boolean isIdentity() {
-		if (numRow != numCol) {
-			return false;
-		}
-		int index = 0;
-		for (int j = 0; j < numRow; j++) {
-			for (int i = 0; i < numCol; i++) {
-				if (elt[index++] != (i == j ? 1 : 0)) {
-					return false;
-				}
-			}
-		}
-		assert isIdentity(0);
-		return true;
-	}
+    /**
+     * Tests whether this transform does not move any points.
+     */
+    @Override
+    public boolean isIdentity() {
+        if (numRow != numCol) {
+            return false;
+        }
+        int index=0;
+        for (int j=0; j<numRow; j++) {
+            for (int i=0; i<numCol; i++) {
+                if (elt[index++] != (i==j ? 1 : 0)) {
+                    return false;
+                }
+            }
+        }
+        assert isIdentity(0);
+        return true;
+    }
 
-	/**
-	 * Tests whether this transform does not move any points by using the
-	 * provided tolerance. This method work in the same way than
-	 * {@link org.geotools.referencing.operation.matrix.XMatrix#isIdentity(double)}
-	 * .
-	 *
-	 * @since 2.4
-	 */
-	public boolean isIdentity(double tolerance) {
-		tolerance = Math.abs(tolerance);
-		if (numRow != numCol) {
-			return false;
-		}
-		int index = 0;
-		for (int j = 0; j < numRow; j++) {
-			for (int i = 0; i < numCol; i++) {
-				double e = elt[index++];
-				if (i == j) {
-					e--;
-				}
-				// Uses '!' in order to catch NaN values.
-				if (!(Math.abs(e) <= tolerance)) {
-					return false;
-				}
-			}
-		}
-		return true;
-	}
+    /**
+     * Tests whether this transform does not move any points by using the provided tolerance.
+     * This method work in the same way than
+     * {@link org.geotools.referencing.operation.matrix.XMatrix#isIdentity(double)}.
+     *
+     * @since 2.4
+     */
+    public boolean isIdentity(double tolerance) {
+        tolerance = Math.abs(tolerance);
+        if (numRow != numCol) {
+            return false;
+        }
+        int index=0;
+        for (int j=0; j<numRow; j++) {
+            for (int i=0; i<numCol; i++) {
+                double e = elt[index++];
+                if (i == j) {
+                    e--;
+                }
+                // Uses '!' in order to catch NaN values.
+                if (!(Math.abs(e) <= tolerance)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 
-	/**
-	 * Creates the inverse transform of this object.
-	 */
-	@Override
-	public synchronized MathTransform inverse()
-			throws NoninvertibleTransformException {
-		if (inverse == null) {
-			if (isIdentity()) {
-				inverse = this;
-			} else {
-				final XMatrix matrix = getGeneralMatrix();
-				try {
-					matrix.invert();
-				} catch (SingularMatrixException | IllegalArgumentException exception) {
-					throw new NoninvertibleTransformException(
-							Errors.format(ErrorKeys.NONINVERTIBLE_TRANSFORM),
-							exception);
-				}
-				inverse = createInverse(matrix);
-				inverse.inverse = this;
-			}
-		}
-		return inverse;
-	}
+    /**
+     * Creates the inverse transform of this object.
+     */
+    @Override
+    public synchronized MathTransform inverse() throws NoninvertibleTransformException {
+        if (inverse == null) {
+            if (isIdentity()) {
+                inverse = this;
+            } else {
+                final XMatrix matrix = getGeneralMatrix();
+                try {
+                    matrix.invert();
+                } catch (SingularMatrixException|IllegalArgumentException exception) {
+                    throw new NoninvertibleTransformException(Errors.format(
+                              ErrorKeys.NONINVERTIBLE_TRANSFORM), exception);
+                }
+                inverse = createInverse(matrix);
+                inverse.inverse = this;
+            }
+        }
+        return inverse;
+    }
 
-	/**
-	 * Creates an inverse transform using the specified matrix. To be overridden
-	 * by {@link GeocentricTranslation}.
-	 */
-	ProjectiveTransform createInverse(final Matrix matrix) {
-		return new ProjectiveTransform(matrix);
-	}
+    /**
+     * Creates an inverse transform using the specified matrix.
+     * To be overridden by {@link GeocentricTranslation}.
+     */
+    ProjectiveTransform createInverse(final Matrix matrix) {
+        return new ProjectiveTransform(matrix);
+    }
 
-	/**
-	 * Returns a hash value for this transform. This value need not remain
-	 * consistent between different implementations of the same class.
-	 */
-	@Override
-	public int hashCode() {
-		long code = serialVersionUID;
-		for (int i = elt.length; --i >= 0;) {
-			code = code * 37 + Double.doubleToLongBits(elt[i]);
-		}
-		return (int) (code >>> 32) ^ (int) code;
-	}
+    /**
+     * Returns a hash value for this transform.
+     * This value need not remain consistent between
+     * different implementations of the same class.
+     */
+    @Override
+    public int hashCode() {
+        long code = serialVersionUID;
+        for (int i=elt.length; --i>=0;) {
+            code = code*37 + Double.doubleToLongBits(elt[i]);
+        }
+        return (int)(code >>> 32) ^ (int)code;
+    }
 
-	/**
-	 * Compares the specified object with this math transform for equality.
-	 */
-	@Override
-	public boolean equals(final Object object) {
-		if (object == this) {
-			// Slight optimization
-			return true;
-		}
-		if (super.equals(object)) {
-			final ProjectiveTransform that = (ProjectiveTransform) object;
-			return this.numRow == that.numRow && this.numCol == that.numCol
-					&& Arrays.equals(this.elt, that.elt);
-		}
-		return false;
-	}
+    /**
+     * Compares the specified object with
+     * this math transform for equality.
+     */
+    @Override
+    public boolean equals(final Object object) {
+        if (object == this) {
+            // Slight optimization
+            return true;
+        }
+        if (super.equals(object)) {
+            final ProjectiveTransform that = (ProjectiveTransform) object;
+            return this.numRow == that.numRow &&
+                   this.numCol == that.numCol &&
+                   Arrays.equals(this.elt, that.elt);
+        }
+        return false;
+    }
 
-	/**
-	 * The provider for the
-	 * "<cite>Affine general parametric transformation</cite>" (EPSG 9624). The
-	 * OGC's name is {@code "Affine"}. The default matrix size is
-	 * {@value org.geotools.parameter.MatrixParameterDescriptors#DEFAULT_MATRIX_SIZE}
-	 * &times;
-	 * {@value org.geotools.parameter.MatrixParameterDescriptors#DEFAULT_MATRIX_SIZE}
-	 * .
-	 * <p>
-	 * Note that affine transform is a special case of projective transform.
-	 *
-	 * @version $Id$
-	 * @author Martin Desruisseaux (IRD)
-	 */
-	public static final class ProviderAffine extends MathTransformProvider {
-		/**
-		 * Serial number for interoperability with different versions.
-		 */
-		private static final long serialVersionUID = 649555815622129472L;
+    /**
+     * The provider for the "<cite>Affine general parametric transformation</cite>" (EPSG 9624).
+     * The OGC's name is {@code "Affine"}. The default matrix size is
+     * {@value org.geotools.parameter.MatrixParameterDescriptors#DEFAULT_MATRIX_SIZE}&times;{@value
+     * org.geotools.parameter.MatrixParameterDescriptors#DEFAULT_MATRIX_SIZE}.
+     * <p>
+     * Note that affine transform is a special case of projective transform.
+     *
+     * @version $Id$
+     * @author Martin Desruisseaux (IRD)
+     */
+    public static final class ProviderAffine extends MathTransformProvider {
+        /**
+         * Serial number for interoperability with different versions.
+         */
+        private static final long serialVersionUID = 649555815622129472L;
 
-		/**
-		 * The set of predefined providers.
-		 */
-		private static final ProviderAffine[] methods = new ProviderAffine[8];
+        /**
+         * The set of predefined providers.
+         */
+        private static final ProviderAffine[] methods = new ProviderAffine[8];
 
-		/**
-		 * The parameters group.
-		 *
-		 * @todo We should register EPSG parameter identifiers (A0, A1, A2, B0,
-		 *       B1, B2) as well.
-		 */
-		static final ParameterDescriptorGroup PARAMETERS;
-		static {
-			final NamedIdentifier name = new NamedIdentifier(Citations.OGC,
-					"Affine");
-			final Map<String, Object> properties = new HashMap<String, Object>(
-					4, 0.8f);
-			properties.put(NAME_KEY, name);
-			properties.put(IDENTIFIERS_KEY, name);
-			properties
-					.put(ALIAS_KEY,
-							new NamedIdentifier[] {
-									name,
-									new NamedIdentifier(Citations.EPSG,
-											"Affine general parametric transformation"),
-									new NamedIdentifier(Citations.EPSG, "9624"),
-									new NamedIdentifier(
-											Citations.GEOTOOLS,
-											Vocabulary
-													.formatInternational(VocabularyKeys.AFFINE_TRANSFORM)) });
-			PARAMETERS = new MatrixParameterDescriptors(properties);
-		}
+        /**
+         * The parameters group.
+         *
+         * @todo We should register EPSG parameter identifiers (A0, A1, A2, B0, B1, B2) as well.
+         */
+        static final ParameterDescriptorGroup PARAMETERS;
+        static {
+            final NamedIdentifier name = new NamedIdentifier(Citations.OGC, "Affine");
+            final Map<String,Object> properties = new HashMap<String,Object>(4, 0.8f);
+            properties.put(NAME_KEY,        name);
+            properties.put(IDENTIFIERS_KEY, name);
+            properties.put(ALIAS_KEY, new NamedIdentifier[] {name,
+                new NamedIdentifier(Citations.EPSG, "Affine general parametric transformation"),
+                new NamedIdentifier(Citations.EPSG, "9624"),
+                new NamedIdentifier(Citations.GEOTOOLS,
+                    Vocabulary.formatInternational(VocabularyKeys.AFFINE_TRANSFORM))
+            });
+            PARAMETERS = new MatrixParameterDescriptors(properties);
+        }
 
-		/**
-		 * Creates a provider for affine transform with a default matrix size.
-		 */
-		public ProviderAffine() {
-			this(MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE - 1,
-					MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE - 1);
-			methods[MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE - 2] = this;
-		}
+        /**
+         * Creates a provider for affine transform with a default matrix size.
+         */
+        public ProviderAffine() {
+            this(MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE-1,
+                 MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE-1);
+            methods[MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE-2] = this;
+        }
 
-		/**
-		 * Creates a provider for affine transform with the specified
-		 * dimensions.
-		 */
-		private ProviderAffine(final int sourceDimensions,
-				final int targetDimensions) {
-			super(sourceDimensions, targetDimensions, PARAMETERS);
-		}
+        /**
+         * Creates a provider for affine transform with the specified dimensions.
+         */
+        private ProviderAffine(final int sourceDimensions, final int targetDimensions) {
+            super(sourceDimensions, targetDimensions, PARAMETERS);
+        }
 
-		/**
-		 * Returns the operation type.
-		 */
-		@Override
-		public Class<Conversion> getOperationType() {
-			return Conversion.class;
-		}
+        /**
+         * Returns the operation type.
+         */
+        @Override
+        public Class<Conversion> getOperationType() {
+            return Conversion.class;
+        }
 
-		/**
-		 * Creates a projective transform from the specified group of parameter
-		 * values.
-		 *
-		 * @param values
-		 *            The group of parameter values.
-		 * @return The created math transform.
-		 * @throws ParameterNotFoundException
-		 *             if a required parameter was not found.
-		 */
-		protected MathTransform createMathTransform(
-				final ParameterValueGroup values)
-				throws ParameterNotFoundException {
-			final MathTransform transform;
-			transform = create(((MatrixParameterDescriptors) getParameters())
-					.getMatrix(values));
-			return new Delegate(transform, getProvider(
-					transform.getSourceDimensions(),
-					transform.getTargetDimensions()));
-		}
+        /**
+         * Creates a projective transform from the specified group of parameter values.
+         *
+         * @param  values The group of parameter values.
+         * @return The created math transform.
+         * @throws ParameterNotFoundException if a required parameter was not found.
+         */
+        protected MathTransform createMathTransform(final ParameterValueGroup values)
+                throws ParameterNotFoundException
+        {
+            final MathTransform transform;
+            transform = create(((MatrixParameterDescriptors) getParameters()).getMatrix(values));
+            return new Delegate(transform, getProvider(transform.getSourceDimensions(),
+                                                       transform.getTargetDimensions()));
+        }
 
-		/**
-		 * Returns the operation method for the specified source and target
-		 * dimensions. This method provides different methods for different
-		 * matrix sizes.
-		 *
-		 * @param sourceDimensions
-		 *            The number of source dimensions.
-		 * @param targetDimensions
-		 *            The number of target dimensions.
-		 * @return The provider for transforms of the given source and target
-		 *         dimensions.
-		 */
-		public static ProviderAffine getProvider(final int sourceDimensions,
-				final int targetDimensions) {
-			if (sourceDimensions == targetDimensions) {
-				final int i = sourceDimensions - 1;
-				if (i >= 0 && i < methods.length) {
-					ProviderAffine method = methods[i];
-					if (method == null) {
-						methods[i] = method = new ProviderAffine(
-								sourceDimensions, targetDimensions);
-					}
-					return method;
-				}
-			}
-			return new ProviderAffine(sourceDimensions, targetDimensions);
-		}
-	}
+        /**
+         * Returns the operation method for the specified source and target dimensions.
+         * This method provides different methods for different matrix sizes.
+         *
+         * @param sourceDimensions The number of source dimensions.
+         * @param targetDimensions The number of target dimensions.
+         * @return The provider for transforms of the given source and target dimensions.
+         */
+        public static ProviderAffine getProvider(final int sourceDimensions,
+                                                 final int targetDimensions)
+        {
+            if (sourceDimensions == targetDimensions) {
+                final int i = sourceDimensions - 1;
+                if (i>=0 && i<methods.length) {
+                    ProviderAffine method = methods[i];
+                    if (method == null) {
+                        methods[i] = method = new ProviderAffine(sourceDimensions, targetDimensions);
+                    }
+                    return method;
+                }
+            }
+            return new ProviderAffine(sourceDimensions, targetDimensions);
+        }
+    }
 
-	/**
-	 * The provider for the "<cite>Longitude rotation</cite>" (EPSG 9601).
-	 *
-	 * @version $Id$
-	 * @author Martin Desruisseaux (IRD)
-	 */
-	public static final class ProviderLongitudeRotation extends
-			MathTransformProvider {
-		/**
-		 * Serial number for interoperability with different versions.
-		 */
-		private static final long serialVersionUID = -2104496465933824935L;
+    /**
+     * The provider for the "<cite>Longitude rotation</cite>" (EPSG 9601).
+     *
+     * @version $Id$
+     * @author Martin Desruisseaux (IRD)
+     */
+    public static final class ProviderLongitudeRotation extends MathTransformProvider {
+        /**
+         * Serial number for interoperability with different versions.
+         */
+        private static final long serialVersionUID = -2104496465933824935L;
 
-		/**
-		 * The longitude offset.
-		 */
-		public static final ParameterDescriptor OFFSET = createDescriptor(
-				new NamedIdentifier[] { new NamedIdentifier(Citations.EPSG,
-						"Longitude offset") }, Double.NaN, -180, +180,
-				NonSI.DEGREE_ANGLE);
+        /**
+         * The longitude offset.
+         */
+        public static final ParameterDescriptor OFFSET = createDescriptor(
+                new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.EPSG, "Longitude offset")
+                },
+                Double.NaN, -180, +180, NonSI.DEGREE_ANGLE);
 
-		/**
-		 * The parameters group.
-		 */
-		static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
-				new NamedIdentifier[] {
-						new NamedIdentifier(Citations.EPSG,
-								"Longitude rotation"),
-						new NamedIdentifier(Citations.EPSG, "9601") },
-				new ParameterDescriptor[] { OFFSET });
+        /**
+         * The parameters group.
+         */
+        static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(new NamedIdentifier[] {
+                    new NamedIdentifier(Citations.EPSG, "Longitude rotation"),
+                    new NamedIdentifier(Citations.EPSG, "9601")
+                }, new ParameterDescriptor[] {
+                    OFFSET
+                });
 
-		/**
-		 * Constructs a provider with default parameters.
-		 */
-		public ProviderLongitudeRotation() {
-			super(2, 2, PARAMETERS);
-		}
+        /**
+         * Constructs a provider with default parameters.
+         */
+        public ProviderLongitudeRotation() {
+            super(2, 2, PARAMETERS);
+        }
 
-		/**
-		 * Returns the operation type.
-		 */
-		@Override
-		public Class<Conversion> getOperationType() {
-			return Conversion.class;
-		}
+        /**
+         * Returns the operation type.
+         */
+        @Override
+        public Class<Conversion> getOperationType() {
+            return Conversion.class;
+        }
 
-		/**
-		 * Creates a transform from the specified group of parameter values.
-		 *
-		 * @param values
-		 *            The group of parameter values.
-		 * @return The created math transform.
-		 * @throws ParameterNotFoundException
-		 *             if a required parameter was not found.
-		 */
-		protected MathTransform createMathTransform(
-				final ParameterValueGroup values)
-				throws ParameterNotFoundException {
-			final double offset = doubleValue(OFFSET, values);
-			return create(AffineTransform.getTranslateInstance(offset, 0));
-		}
-	}
+        /**
+         * Creates a transform from the specified group of parameter values.
+         *
+         * @param  values The group of parameter values.
+         * @return The created math transform.
+         * @throws ParameterNotFoundException if a required parameter was not found.
+         */
+        protected MathTransform createMathTransform(final ParameterValueGroup values)
+                throws ParameterNotFoundException
+        {
+            final double offset = doubleValue(OFFSET, values);
+            return create(AffineTransform.getTranslateInstance(offset, 0));
+        }
+    }
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform.java
@@ -28,6 +28,21 @@ import java.util.Map;
 
 import javax.measure.unit.NonSI;
 
+import org.geotools.metadata.iso.citation.Citations;
+import org.geotools.parameter.MatrixParameterDescriptors;
+import org.geotools.parameter.MatrixParameters;
+import org.geotools.referencing.NamedIdentifier;
+import org.geotools.referencing.operation.LinearTransform;
+import org.geotools.referencing.operation.MathTransformProvider;
+import org.geotools.referencing.operation.matrix.GeneralMatrix;
+import org.geotools.referencing.operation.matrix.MatrixFactory;
+import org.geotools.referencing.operation.matrix.SingularMatrixException;
+import org.geotools.referencing.operation.matrix.XMatrix;
+import org.geotools.resources.i18n.ErrorKeys;
+import org.geotools.resources.i18n.Errors;
+import org.geotools.resources.i18n.Vocabulary;
+import org.geotools.resources.i18n.VocabularyKeys;
+import org.opengis.geometry.DirectPosition;
 import org.opengis.parameter.ParameterDescriptor;
 import org.opengis.parameter.ParameterDescriptorGroup;
 import org.opengis.parameter.ParameterNotFoundException;
@@ -36,46 +51,37 @@ import org.opengis.referencing.operation.Conversion;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.Matrix;
 import org.opengis.referencing.operation.NoninvertibleTransformException;
-import org.opengis.geometry.DirectPosition;
-import org.geotools.metadata.iso.citation.Citations;
-import org.geotools.parameter.MatrixParameterDescriptors;
-import org.geotools.parameter.MatrixParameters;
-import org.geotools.referencing.NamedIdentifier;
-import org.geotools.referencing.operation.LinearTransform;
-import org.geotools.referencing.operation.MathTransformProvider;
-import org.geotools.referencing.operation.matrix.MatrixFactory;
-import org.geotools.referencing.operation.matrix.GeneralMatrix;
-import org.geotools.referencing.operation.matrix.SingularMatrixException;
-import org.geotools.referencing.operation.matrix.XMatrix;
-import org.geotools.resources.i18n.VocabularyKeys;
-import org.geotools.resources.i18n.Vocabulary;
-import org.geotools.resources.i18n.ErrorKeys;
-import org.geotools.resources.i18n.Errors;
-
 
 /**
- * A usually affine, or otherwise a projective transform. A projective transform is capable of
- * mapping an arbitrary quadrilateral into another arbitrary quadrilateral, while preserving the
- * straightness of lines. In the special case where the transform is affine, the parallelism of
- * lines in the source is preserved in the output.
+ * A usually affine, or otherwise a projective transform. A projective transform
+ * is capable of mapping an arbitrary quadrilateral into another arbitrary
+ * quadrilateral, while preserving the straightness of lines. In the special
+ * case where the transform is affine, the parallelism of lines in the source is
+ * preserved in the output.
  * <p>
- * Such a coordinate transformation can be represented by a square {@linkplain GeneralMatrix matrix}
- * of an arbitrary size. Point coordinates must have a dimension equals to
- * <code>{@linkplain Matrix#getNumCol}-1</code>. For example, for square matrix of size 4&times;4,
- * coordinate points are three-dimensional. The transformed points <code>(x',y',z')</code> are
+ * Such a coordinate transformation can be represented by a square
+ * {@linkplain GeneralMatrix matrix} of an arbitrary size. Point coordinates
+ * must have a dimension equals to <code>{@linkplain Matrix#getNumCol}-1</code>.
+ * For example, for square matrix of size 4&times;4, coordinate points are
+ * three-dimensional. The transformed points <code>(x',y',z')</code> are
  * computed as below (note that this computation is similar to
- * {@link javax.media.jai.PerspectiveTransform} in <cite>Java Advanced Imaging</cite>):
+ * {@link javax.media.jai.PerspectiveTransform} in <cite>Java Advanced
+ * Imaging</cite>):
  *
- * <blockquote><pre>
+ * <blockquote>
+ * 
+ * <pre>
  * [ u ]     [ m<sub>00</sub>  m<sub>01</sub>  m<sub>02</sub>  m<sub>03</sub> ] [ x ]
  * [ v ]  =  [ m<sub>10</sub>  m<sub>11</sub>  m<sub>12</sub>  m<sub>13</sub> ] [ y ]
  * [ w ]     [ m<sub>20</sub>  m<sub>21</sub>  m<sub>22</sub>  m<sub>23</sub> ] [ z ]
  * [ t ]     [ m<sub>30</sub>  m<sub>31</sub>  m<sub>32</sub>  m<sub>33</sub> ] [ 1 ]
- *
+ * 
  *   x' = u/t
  *   y' = v/t
  *   y' = w/t
- * </pre></blockquote>
+ * </pre>
+ * 
+ * </blockquote>
  *
  * In the special case of an affine transform, the last row contains only zero
  * values except in the last column, which contains 1.
@@ -89,636 +95,698 @@ import org.geotools.resources.i18n.Errors;
  *
  * @see javax.media.jai.PerspectiveTransform
  * @see java.awt.geom.AffineTransform
- * @see <A HREF="http://mathworld.wolfram.com/AffineTransformation.html">Affine transformation on MathWorld</A>
+ * @see <A HREF="http://mathworld.wolfram.com/AffineTransformation.html">Affine
+ *      transformation on MathWorld</A>
  */
-public class ProjectiveTransform extends AbstractMathTransform implements LinearTransform, Serializable {
-    /**
-     * Serial number for interoperability with different versions.
-     */
-    private static final long serialVersionUID = -2104496465933824935L;
+public class ProjectiveTransform extends AbstractMathTransform implements
+		LinearTransform, Serializable {
+	/**
+	 * Serial number for interoperability with different versions.
+	 */
+	private static final long serialVersionUID = -2104496465933824935L;
 
-    /**
-     * The number of rows.
-     */
-    private final int numRow;
+	/**
+	 * The number of rows.
+	 */
+	private final int numRow;
 
-    /**
-     * The number of columns.
-     */
-    private final int numCol;
+	/**
+	 * The number of columns.
+	 */
+	private final int numCol;
 
-    /**
-     * Elements of the matrix. Column indice vary fastest.
-     */
-    private final double[] elt;
+	/**
+	 * Elements of the matrix. Column indice vary fastest.
+	 */
+	private final double[] elt;
 
-    /**
-     * The inverse transform. Will be created only when first needed.
-     */
-    private transient ProjectiveTransform inverse;
+	/**
+	 * The inverse transform. Will be created only when first needed.
+	 */
+	private transient ProjectiveTransform inverse;
 
-    /**
-     * Constructs a transform from the specified matrix.
-     * The matrix should be affine, but it will not be verified.
-     *
-     * @param matrix The matrix.
-     */
-    protected ProjectiveTransform(final Matrix matrix) {
-        numRow = matrix.getNumRow();
-        numCol = matrix.getNumCol();
-        elt = new double[numRow*numCol];
-        int index = 0;
-        for (int j=0; j<numRow; j++) {
-            for (int i=0; i<numCol; i++) {
-                elt[index++] = matrix.getElement(j,i);
-            }
-        }
-    }
+	/**
+	 * Constructs a transform from the specified matrix. The matrix should be
+	 * affine, but it will not be verified.
+	 *
+	 * @param matrix
+	 *            The matrix.
+	 */
+	protected ProjectiveTransform(final Matrix matrix) {
+		numRow = matrix.getNumRow();
+		numCol = matrix.getNumCol();
+		elt = new double[numRow * numCol];
+		int index = 0;
+		for (int j = 0; j < numRow; j++) {
+			for (int i = 0; i < numCol; i++) {
+				elt[index++] = matrix.getElement(j, i);
+			}
+		}
+	}
 
-    /**
-     * Creates a transform for the specified matrix.
-     * The matrix should be affine, but it is not be verified.
-     *
-     * @param matrix The affine transform as a matrix.
-     * @return The transform for the given matrix.
-     */
-    public static LinearTransform create(final Matrix matrix) {
-        final int dimension = matrix.getNumRow()-1;
-        if (dimension == matrix.getNumCol()-1) {
-            if (matrix.isIdentity()) {
-                return IdentityTransform.create(dimension);
-            }
-            final GeneralMatrix m = toGMatrix(matrix);
-            if (m.isAffine()) {
-                switch (dimension) {
-                    case 1: return LinearTransform1D.create(m.getElement(0,0), m.getElement(0,1));
-                    case 2: return create(m.toAffineTransform2D());
-                }
-            }
-        }
-        switch (dimension) {
-            case 2:  return new ProjectiveTransform2D(matrix);
-            default: return new ProjectiveTransform  (matrix);
-        }
-    }
+	/**
+	 * Creates a transform for the specified matrix. The matrix should be
+	 * affine, but it is not be verified.
+	 *
+	 * @param matrix
+	 *            The affine transform as a matrix.
+	 * @return The transform for the given matrix.
+	 */
+	public static LinearTransform create(final Matrix matrix) {
+		final int dimension = matrix.getNumRow() - 1;
+		if (dimension == matrix.getNumCol() - 1) {
+			if (matrix.isIdentity()) {
+				return IdentityTransform.create(dimension);
+			}
+			final GeneralMatrix m = toGMatrix(matrix);
+			if (m.isAffine()) {
+				switch (dimension) {
+				case 1:
+					return LinearTransform1D.create(m.getElement(0, 0),
+							m.getElement(0, 1));
+				case 2:
+					return create(m.toAffineTransform2D());
+				}
+			}
+		}
+		switch (dimension) {
+		case 2:
+			return new ProjectiveTransform2D(matrix);
+		default:
+			return new ProjectiveTransform(matrix);
+		}
+	}
 
-    /**
-     * Creates a transform for the specified matrix as a Java2D object.
-     * This method is provided for interoperability with
-     * <A HREF="http://java.sun.com/products/java-media/2D/index.jsp">Java2D</A>.
-     *
-     * @param matrix The affine transform as a matrix.
-     * @return The transform for the given matrix.
-     */
-    public static LinearTransform create(final AffineTransform matrix) {
-        if (matrix.isIdentity()) {
-            return IdentityTransform.create(2);
-        }
-        return new AffineTransform2D(matrix);
-    }
+	/**
+	 * Creates a transform for the specified matrix as a Java2D object. This
+	 * method is provided for interoperability with <A
+	 * HREF="http://java.sun.com/products/java-media/2D/index.jsp">Java2D</A>.
+	 *
+	 * @param matrix
+	 *            The affine transform as a matrix.
+	 * @return The transform for the given matrix.
+	 */
+	public static LinearTransform create(final AffineTransform matrix) {
+		if (matrix.isIdentity()) {
+			return IdentityTransform.create(2);
+		}
+		return new AffineTransform2D(matrix);
+	}
 
-    /**
-     * Creates a transform that apply a uniform scale along all axis.
-     *
-     * @param dimension The input and output dimensions.
-     * @param scale The scale factor.
-     * @return The scale transform.
-     *
-     * @since 2.3
-     */
-    public static LinearTransform createScale(final int dimension, final double scale) {
-        if (scale == 1) {
-            return IdentityTransform.create(dimension);
-        }
-        final Matrix matrix = new GeneralMatrix(dimension + 1);
-        for (int i=0; i<dimension; i++) {
-            matrix.setElement(i, i, scale);
-        }
-        return create(matrix);
-    }
+	/**
+	 * Creates a transform that apply a uniform scale along all axis.
+	 *
+	 * @param dimension
+	 *            The input and output dimensions.
+	 * @param scale
+	 *            The scale factor.
+	 * @return The scale transform.
+	 *
+	 * @since 2.3
+	 */
+	public static LinearTransform createScale(final int dimension,
+			final double scale) {
+		if (scale == 1) {
+			return IdentityTransform.create(dimension);
+		}
+		final Matrix matrix = new GeneralMatrix(dimension + 1);
+		for (int i = 0; i < dimension; i++) {
+			matrix.setElement(i, i, scale);
+		}
+		return create(matrix);
+	}
 
-    /**
-     * Creates a transform that apply the same translation along all axis.
-     *
-     * @param dimension The input and output dimensions.
-     * @param offset The translation.
-     * @return The offset transform.
-     *
-     * @since 2.3
-     */
-    public static LinearTransform createTranslation(final int dimension, final double offset) {
-        if (offset == 0) {
-            return IdentityTransform.create(dimension);
-        }
-        final Matrix matrix = new GeneralMatrix(dimension + 1);
-        for (int i=0; i<dimension; i++) {
-            matrix.setElement(i, dimension, offset);
-        }
-        return create(matrix);
-    }
+	/**
+	 * Creates a transform that apply the same translation along all axis.
+	 *
+	 * @param dimension
+	 *            The input and output dimensions.
+	 * @param offset
+	 *            The translation.
+	 * @return The offset transform.
+	 *
+	 * @since 2.3
+	 */
+	public static LinearTransform createTranslation(final int dimension,
+			final double offset) {
+		if (offset == 0) {
+			return IdentityTransform.create(dimension);
+		}
+		final Matrix matrix = new GeneralMatrix(dimension + 1);
+		for (int i = 0; i < dimension; i++) {
+			matrix.setElement(i, dimension, offset);
+		}
+		return create(matrix);
+	}
 
-    /**
-     * Creates a matrix that keep only a subset of the ordinate values.
-     * The dimension of source coordinates is {@code sourceDim} and
-     * the dimension of target coordinates is {@code toKeep.length}.
-     *
-     * @param  sourceDim the dimension of source coordinates.
-     * @param  toKeep the indices of ordinate values to keep.
-     * @return The matrix to give to the {@link #create(Matrix)}
-     *         method in order to create the transform.
-     * @throws IndexOutOfBoundsException if a value of {@code toKeep}
-     *         is lower than 0 or not smaller than {@code sourceDim}.
-     */
-    public static Matrix createSelectMatrix(final int sourceDim, final int[] toKeep)
-            throws IndexOutOfBoundsException
-    {
-        final int targetDim = toKeep.length;
-        final XMatrix matrix = MatrixFactory.create(targetDim+1, sourceDim+1);
-        matrix.setZero();
-        for (int j=0; j<targetDim; j++) {
-            matrix.setElement(j, toKeep[j], 1);
-        }
-        matrix.setElement(targetDim, sourceDim, 1);
-        return matrix;
-    }
+	/**
+	 * Creates a matrix that keep only a subset of the ordinate values. The
+	 * dimension of source coordinates is {@code sourceDim} and the dimension of
+	 * target coordinates is {@code toKeep.length}.
+	 *
+	 * @param sourceDim
+	 *            the dimension of source coordinates.
+	 * @param toKeep
+	 *            the indices of ordinate values to keep.
+	 * @return The matrix to give to the {@link #create(Matrix)} method in order
+	 *         to create the transform.
+	 * @throws IndexOutOfBoundsException
+	 *             if a value of {@code toKeep} is lower than 0 or not smaller
+	 *             than {@code sourceDim}.
+	 */
+	public static Matrix createSelectMatrix(final int sourceDim,
+			final int[] toKeep) throws IndexOutOfBoundsException {
+		final int targetDim = toKeep.length;
+		final XMatrix matrix = MatrixFactory.create(targetDim + 1,
+				sourceDim + 1);
+		matrix.setZero();
+		for (int j = 0; j < targetDim; j++) {
+			matrix.setElement(j, toKeep[j], 1);
+		}
+		matrix.setElement(targetDim, sourceDim, 1);
+		return matrix;
+	}
 
-    /**
-     * Returns the parameter descriptors for this math transform.
-     */
-    @Override
-    public ParameterDescriptorGroup getParameterDescriptors() {
-        return ProviderAffine.PARAMETERS;
-    }
+	/**
+	 * Returns the parameter descriptors for this math transform.
+	 */
+	@Override
+	public ParameterDescriptorGroup getParameterDescriptors() {
+		return ProviderAffine.PARAMETERS;
+	}
 
-    /**
-     * Returns the matrix elements as a group of parameters values. The number of parameters
-     * depends on the matrix size. Only matrix elements different from their default value
-     * will be included in this group.
-     *
-     * @param  matrix The matrix to returns as a group of parameters.
-     * @return A copy of the parameter values for this math transform.
-     */
-    static ParameterValueGroup getParameterValues(final Matrix matrix) {
-        final MatrixParameters values;
-        values = (MatrixParameters) ProviderAffine.PARAMETERS.createValue();
-        values.setMatrix(matrix);
-        return values;
-    }
+	/**
+	 * Returns the matrix elements as a group of parameters values. The number
+	 * of parameters depends on the matrix size. Only matrix elements different
+	 * from their default value will be included in this group.
+	 *
+	 * @param matrix
+	 *            The matrix to returns as a group of parameters.
+	 * @return A copy of the parameter values for this math transform.
+	 */
+	static ParameterValueGroup getParameterValues(final Matrix matrix) {
+		final MatrixParameters values;
+		values = (MatrixParameters) ProviderAffine.PARAMETERS.createValue();
+		values.setMatrix(matrix);
+		return values;
+	}
 
-    /**
-     * Returns the matrix elements as a group of parameters values. The number of parameters
-     * depends on the matrix size. Only matrix elements different from their default value
-     * will be included in this group.
-     *
-     * @return A copy of the parameter values for this math transform.
-     */
-    @Override
-    public ParameterValueGroup getParameterValues() {
-        return getParameterValues(getMatrix());
-    }
+	/**
+	 * Returns the matrix elements as a group of parameters values. The number
+	 * of parameters depends on the matrix size. Only matrix elements different
+	 * from their default value will be included in this group.
+	 *
+	 * @return A copy of the parameter values for this math transform.
+	 */
+	@Override
+	public ParameterValueGroup getParameterValues() {
+		return getParameterValues(getMatrix());
+	}
 
-    /**
-     * Transforms an array of floating point coordinates by this matrix. Point coordinates
-     * must have a dimension equals to <code>{@link Matrix#getNumCol}-1</code>. For example,
-     * for square matrix of size 4&times;4, coordinate points are three-dimensional and
-     * stored in the arrays starting at the specified offset ({@code srcOff}) in the order
-     * <code>[x<sub>0</sub>, y<sub>0</sub>, z<sub>0</sub>,
-     *        x<sub>1</sub>, y<sub>1</sub>, z<sub>1</sub>...,
-     *        x<sub>n</sub>, y<sub>n</sub>, z<sub>n</sub>]</code>.
-     *
-     * @param srcPts The array containing the source point coordinates.
-     * @param srcOff The offset to the first point to be transformed in the source array.
-     * @param dstPts The array into which the transformed point coordinates are returned.
-     * @param dstOff The offset to the location of the first transformed point that is stored
-     *               in the destination array. The source and destination array sections can
-     *               be overlaps.
-     * @param numPts The number of points to be transformed
-     */
-    @Override
-    public void transform(float[] srcPts, int srcOff,
-                          final float[] dstPts, int dstOff, int numPts)
-    {
-        final int  inputDimension = numCol-1; // The last ordinate will be assumed equals to 1.
-        final int outputDimension = numRow-1;
-        final double[]     buffer = new double[numRow];
-        if (srcPts == dstPts) {
-            // We are going to write in the source array. Checks if
-            // source and destination sections are going to clash.
-            final int upperSrc = srcOff + numPts*inputDimension;
-            if (upperSrc > dstOff) {
-                if (inputDimension >= outputDimension ? dstOff > srcOff :
-                            dstOff + numPts*outputDimension > upperSrc) {
-                    // If source overlaps destination, then the easiest workaround is
-                    // to copy source data. This is not the most efficient however...
-                    srcPts = new float[numPts*inputDimension];
-                    System.arraycopy(dstPts, srcOff, srcPts, 0, srcPts.length);
-                    srcOff = 0;
-                }
-            }
-        }
-        while (--numPts >= 0) {
-            int mix = 0;
-            for (int j=0; j<numRow; j++) {
-                double sum=elt[mix + inputDimension];
-                for (int i=0; i<inputDimension; i++) {
-                    sum += srcPts[srcOff+i]*elt[mix++];
-                }
-                buffer[j] = sum;
-                mix++;
-            }
-            final double w = buffer[outputDimension];
-            for (int j=0; j<outputDimension; j++) {
-                // 'w' is equals to 1 if the transform is affine.
-                dstPts[dstOff++] = (float) (buffer[j]/w);
-            }
-            srcOff += inputDimension;
-        }
-    }
+	/**
+	 * Transforms an array of floating point coordinates by this matrix. Point
+	 * coordinates must have a dimension equals to
+	 * <code>{@link Matrix#getNumCol}-1</code>. For example, for square matrix
+	 * of size 4&times;4, coordinate points are three-dimensional and stored in
+	 * the arrays starting at the specified offset ({@code srcOff}) in the order
+	 * <code>[x<sub>0</sub>, y<sub>0</sub>, z<sub>0</sub>,
+	 *        x<sub>1</sub>, y<sub>1</sub>, z<sub>1</sub>...,
+	 *        x<sub>n</sub>, y<sub>n</sub>, z<sub>n</sub>]</code>.
+	 *
+	 * @param srcPts
+	 *            The array containing the source point coordinates.
+	 * @param srcOff
+	 *            The offset to the first point to be transformed in the source
+	 *            array.
+	 * @param dstPts
+	 *            The array into which the transformed point coordinates are
+	 *            returned.
+	 * @param dstOff
+	 *            The offset to the location of the first transformed point that
+	 *            is stored in the destination array. The source and destination
+	 *            array sections can be overlaps.
+	 * @param numPts
+	 *            The number of points to be transformed
+	 */
+	@Override
+	public void transform(float[] srcPts, int srcOff, final float[] dstPts,
+			int dstOff, int numPts) {
+		final int inputDimension = numCol - 1; // The last ordinate will be
+												// assumed equals to 1.
+		final int outputDimension = numRow - 1;
+		final double[] buffer = new double[numRow];
+		if (srcPts == dstPts) {
+			// We are going to write in the source array. Checks if
+			// source and destination sections are going to clash.
+			final int upperSrc = srcOff + numPts * inputDimension;
+			if (upperSrc > dstOff) {
+				if (inputDimension >= outputDimension ? dstOff > srcOff
+						: dstOff + numPts * outputDimension > upperSrc) {
+					// If source overlaps destination, then the easiest
+					// workaround is
+					// to copy source data. This is not the most efficient
+					// however...
+					srcPts = new float[numPts * inputDimension];
+					System.arraycopy(dstPts, srcOff, srcPts, 0, srcPts.length);
+					srcOff = 0;
+				}
+			}
+		}
+		while (--numPts >= 0) {
+			int mix = 0;
+			for (int j = 0; j < numRow; j++) {
+				double sum = elt[mix + inputDimension];
+				for (int i = 0; i < inputDimension; i++) {
+					sum += srcPts[srcOff + i] * elt[mix++];
+				}
+				buffer[j] = sum;
+				mix++;
+			}
+			final double w = buffer[outputDimension];
+			for (int j = 0; j < outputDimension; j++) {
+				// 'w' is equals to 1 if the transform is affine.
+				dstPts[dstOff++] = (float) (buffer[j] / w);
+			}
+			srcOff += inputDimension;
+		}
+	}
 
-    /**
-     * Transforms an array of floating point coordinates by this matrix. Point coordinates
-     * must have a dimension equals to <code>{@link Matrix#getNumCol}-1</code>. For example,
-     * for square matrix of size 4&times;4, coordinate points are three-dimensional and
-     * stored in the arrays starting at the specified offset ({@code srcOff}) in the order
-     * <code>[x<sub>0</sub>, y<sub>0</sub>, z<sub>0</sub>,
-     *        x<sub>1</sub>, y<sub>1</sub>, z<sub>1</sub>...,
-     *        x<sub>n</sub>, y<sub>n</sub>, z<sub>n</sub>]</code>.
-     *
-     * @param srcPts The array containing the source point coordinates.
-     * @param srcOff The offset to the first point to be transformed in the source array.
-     * @param dstPts The array into which the transformed point coordinates are returned.
-     * @param dstOff The offset to the location of the first transformed point that is stored
-     *               in the destination array. The source and destination array sections can
-     *               be overlaps.
-     * @param numPts The number of points to be transformed
-     */
-    public void transform(double[] srcPts, int srcOff,
-                          final double[] dstPts, int dstOff, int numPts)
-    {
-        final int  inputDimension = numCol-1; // The last ordinate will be assumed equals to 1.
-        final int outputDimension = numRow-1;
-        final double[]     buffer = new double[numRow];
-        if (srcPts == dstPts) {
-            // We are going to write in the source array. Checks if
-            // source and destination sections are going to clash.
-            final int upperSrc = srcOff + numPts*inputDimension;
-            if (upperSrc > dstOff) {
-                if (inputDimension >= outputDimension ? dstOff > srcOff :
-                            dstOff + numPts*outputDimension > upperSrc) {
-                    // If source overlaps destination, then the easiest workaround is
-                    // to copy source data. This is not the most efficient however...
-                    srcPts = new double[numPts*inputDimension];
-                    System.arraycopy(dstPts, srcOff, srcPts, 0, srcPts.length);
-                    srcOff = 0;
-                }
-            }
-        }
-        while (--numPts >= 0) {
-            int mix = 0;
-            for (int j=0; j<numRow; j++) {
-                double sum=elt[mix + inputDimension];
-                for (int i=0; i<inputDimension; i++) {
-                    sum += srcPts[srcOff+i]*elt[mix++];
-                }
-                buffer[j] = sum;
-                mix++;
-            }
-            final double w = buffer[outputDimension];
-            for (int j=0; j<outputDimension; j++) {
-                // 'w' is equals to 1 if the transform is affine.
-                dstPts[dstOff++] = buffer[j]/w;
-            }
-            srcOff += inputDimension;
-        }
-    }
+	/**
+	 * Transforms an array of floating point coordinates by this matrix. Point
+	 * coordinates must have a dimension equals to
+	 * <code>{@link Matrix#getNumCol}-1</code>. For example, for square matrix
+	 * of size 4&times;4, coordinate points are three-dimensional and stored in
+	 * the arrays starting at the specified offset ({@code srcOff}) in the order
+	 * <code>[x<sub>0</sub>, y<sub>0</sub>, z<sub>0</sub>,
+	 *        x<sub>1</sub>, y<sub>1</sub>, z<sub>1</sub>...,
+	 *        x<sub>n</sub>, y<sub>n</sub>, z<sub>n</sub>]</code>.
+	 *
+	 * @param srcPts
+	 *            The array containing the source point coordinates.
+	 * @param srcOff
+	 *            The offset to the first point to be transformed in the source
+	 *            array.
+	 * @param dstPts
+	 *            The array into which the transformed point coordinates are
+	 *            returned.
+	 * @param dstOff
+	 *            The offset to the location of the first transformed point that
+	 *            is stored in the destination array. The source and destination
+	 *            array sections can be overlaps.
+	 * @param numPts
+	 *            The number of points to be transformed
+	 */
+	public void transform(double[] srcPts, int srcOff, final double[] dstPts,
+			int dstOff, int numPts) {
+		final int inputDimension = numCol - 1; // The last ordinate will be
+												// assumed equals to 1.
+		final int outputDimension = numRow - 1;
+		final double[] buffer = new double[numRow];
+		if (srcPts == dstPts) {
+			// We are going to write in the source array. Checks if
+			// source and destination sections are going to clash.
+			final int upperSrc = srcOff + numPts * inputDimension;
+			if (upperSrc > dstOff) {
+				if (inputDimension >= outputDimension ? dstOff > srcOff
+						: dstOff + numPts * outputDimension > upperSrc) {
+					// If source overlaps destination, then the easiest
+					// workaround is
+					// to copy source data. This is not the most efficient
+					// however...
+					srcPts = new double[numPts * inputDimension];
+					System.arraycopy(dstPts, srcOff, srcPts, 0, srcPts.length);
+					srcOff = 0;
+				}
+			}
+		}
+		while (--numPts >= 0) {
+			int mix = 0;
+			for (int j = 0; j < numRow; j++) {
+				double sum = elt[mix + inputDimension];
+				for (int i = 0; i < inputDimension; i++) {
+					sum += srcPts[srcOff + i] * elt[mix++];
+				}
+				buffer[j] = sum;
+				mix++;
+			}
+			final double w = buffer[outputDimension];
+			for (int j = 0; j < outputDimension; j++) {
+				// 'w' is equals to 1 if the transform is affine.
+				dstPts[dstOff++] = buffer[j] / w;
+			}
+			srcOff += inputDimension;
+		}
+	}
 
-    /**
-     * Gets the derivative of this transform at a point.
-     * For a matrix transform, the derivative is the
-     * same everywhere.
-     */
-    @Override
-    public Matrix derivative(final Point2D point) {
-        return derivative((DirectPosition)null);
-    }
+	/**
+	 * Gets the derivative of this transform at a point. For a matrix transform,
+	 * the derivative is the same everywhere.
+	 */
+	@Override
+	public Matrix derivative(final Point2D point) {
+		return derivative((DirectPosition) null);
+	}
 
-    /**
-     * Gets the derivative of this transform at a point.
-     * For a matrix transform, the derivative is the
-     * same everywhere.
-     */
-    @Override
-    public Matrix derivative(final DirectPosition point) {
-        final GeneralMatrix matrix = getGeneralMatrix();
-        matrix.setSize(numRow-1, numCol-1);
-        return matrix;
-    }
+	/**
+	 * Gets the derivative of this transform at a point. For a matrix transform,
+	 * the derivative is the same everywhere.
+	 */
+	@Override
+	public Matrix derivative(final DirectPosition point) {
+		final GeneralMatrix matrix = getGeneralMatrix();
+		matrix.setSize(numRow - 1, numCol - 1);
+		return matrix;
+	}
 
-    /**
-     * Returns a copy of the matrix.
-     */
-    public Matrix getMatrix() {
-        return getGeneralMatrix();
-    }
+	/**
+	 * Returns a copy of the matrix.
+	 */
+	public Matrix getMatrix() {
+		return getGeneralMatrix();
+	}
 
-    /**
-     * Returns a copy of the matrix.
-     */
-    private GeneralMatrix getGeneralMatrix() {
-        return new GeneralMatrix(numRow, numCol, elt);
-    }
+	/**
+	 * Returns a copy of the matrix.
+	 */
+	private GeneralMatrix getGeneralMatrix() {
+		return new GeneralMatrix(numRow, numCol, elt);
+	}
 
-    /**
-     * Gets the dimension of input points.
-     */
-    public int getSourceDimensions() {
-        return numCol - 1;
-    }
+	/**
+	 * Gets the dimension of input points.
+	 */
+	public int getSourceDimensions() {
+		return numCol - 1;
+	}
 
-    /**
-     * Gets the dimension of output points.
-     */
-    public int getTargetDimensions() {
-        return numRow - 1;
-    }
+	/**
+	 * Gets the dimension of output points.
+	 */
+	public int getTargetDimensions() {
+		return numRow - 1;
+	}
 
-    /**
-     * Tests whether this transform does not move any points.
-     */
-    @Override
-    public boolean isIdentity() {
-        if (numRow != numCol) {
-            return false;
-        }
-        int index=0;
-        for (int j=0; j<numRow; j++) {
-            for (int i=0; i<numCol; i++) {
-                if (elt[index++] != (i==j ? 1 : 0)) {
-                    return false;
-                }
-            }
-        }
-        assert isIdentity(0);
-        return true;
-    }
+	/**
+	 * Tests whether this transform does not move any points.
+	 */
+	@Override
+	public boolean isIdentity() {
+		if (numRow != numCol) {
+			return false;
+		}
+		int index = 0;
+		for (int j = 0; j < numRow; j++) {
+			for (int i = 0; i < numCol; i++) {
+				if (elt[index++] != (i == j ? 1 : 0)) {
+					return false;
+				}
+			}
+		}
+		assert isIdentity(0);
+		return true;
+	}
 
-    /**
-     * Tests whether this transform does not move any points by using the provided tolerance.
-     * This method work in the same way than
-     * {@link org.geotools.referencing.operation.matrix.XMatrix#isIdentity(double)}.
-     *
-     * @since 2.4
-     */
-    public boolean isIdentity(double tolerance) {
-        tolerance = Math.abs(tolerance);
-        if (numRow != numCol) {
-            return false;
-        }
-        int index=0;
-        for (int j=0; j<numRow; j++) {
-            for (int i=0; i<numCol; i++) {
-                double e = elt[index++];
-                if (i == j) {
-                    e--;
-                }
-                // Uses '!' in order to catch NaN values.
-                if (!(Math.abs(e) <= tolerance)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
+	/**
+	 * Tests whether this transform does not move any points by using the
+	 * provided tolerance. This method work in the same way than
+	 * {@link org.geotools.referencing.operation.matrix.XMatrix#isIdentity(double)}
+	 * .
+	 *
+	 * @since 2.4
+	 */
+	public boolean isIdentity(double tolerance) {
+		tolerance = Math.abs(tolerance);
+		if (numRow != numCol) {
+			return false;
+		}
+		int index = 0;
+		for (int j = 0; j < numRow; j++) {
+			for (int i = 0; i < numCol; i++) {
+				double e = elt[index++];
+				if (i == j) {
+					e--;
+				}
+				// Uses '!' in order to catch NaN values.
+				if (!(Math.abs(e) <= tolerance)) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
 
-    /**
-     * Creates the inverse transform of this object.
-     */
-    @Override
-    public synchronized MathTransform inverse() throws NoninvertibleTransformException {
-        if (inverse == null) {
-            if (isIdentity()) {
-                inverse = this;
-            } else {
-                final XMatrix matrix = getGeneralMatrix();
-                try {
-                    matrix.invert();
-                } catch (SingularMatrixException|IllegalArgumentException exception) {
-                    throw new NoninvertibleTransformException(Errors.format(
-                              ErrorKeys.NONINVERTIBLE_TRANSFORM), exception);
-                }
-                inverse = new ProjectiveTransform(matrix);
-                inverse.inverse = this;
-            }
-        }
-        return inverse;
-    }
+	/**
+	 * Creates the inverse transform of this object.
+	 */
+	@Override
+	public synchronized MathTransform inverse()
+			throws NoninvertibleTransformException {
+		if (inverse == null) {
+			if (isIdentity()) {
+				inverse = this;
+			} else {
+				final XMatrix matrix = getGeneralMatrix();
+				try {
+					matrix.invert();
+				} catch (SingularMatrixException | IllegalArgumentException exception) {
+					throw new NoninvertibleTransformException(
+							Errors.format(ErrorKeys.NONINVERTIBLE_TRANSFORM),
+							exception);
+				}
+				inverse = createInverse(matrix);
+				inverse.inverse = this;
+			}
+		}
+		return inverse;
+	}
 
-    /**
-     * Creates an inverse transform using the specified matrix.
-     * To be overridden by {@link GeocentricTranslation}.
-     */
-    MathTransform createInverse(final Matrix matrix) {
-        return new ProjectiveTransform(matrix);
-    }
+	/**
+	 * Creates an inverse transform using the specified matrix. To be overridden
+	 * by {@link GeocentricTranslation}.
+	 */
+	ProjectiveTransform createInverse(final Matrix matrix) {
+		return new ProjectiveTransform(matrix);
+	}
 
-    /**
-     * Returns a hash value for this transform.
-     * This value need not remain consistent between
-     * different implementations of the same class.
-     */
-    @Override
-    public int hashCode() {
-        long code = serialVersionUID;
-        for (int i=elt.length; --i>=0;) {
-            code = code*37 + Double.doubleToLongBits(elt[i]);
-        }
-        return (int)(code >>> 32) ^ (int)code;
-    }
+	/**
+	 * Returns a hash value for this transform. This value need not remain
+	 * consistent between different implementations of the same class.
+	 */
+	@Override
+	public int hashCode() {
+		long code = serialVersionUID;
+		for (int i = elt.length; --i >= 0;) {
+			code = code * 37 + Double.doubleToLongBits(elt[i]);
+		}
+		return (int) (code >>> 32) ^ (int) code;
+	}
 
-    /**
-     * Compares the specified object with
-     * this math transform for equality.
-     */
-    @Override
-    public boolean equals(final Object object) {
-        if (object == this) {
-            // Slight optimization
-            return true;
-        }
-        if (super.equals(object)) {
-            final ProjectiveTransform that = (ProjectiveTransform) object;
-            return this.numRow == that.numRow &&
-                   this.numCol == that.numCol &&
-                   Arrays.equals(this.elt, that.elt);
-        }
-        return false;
-    }
+	/**
+	 * Compares the specified object with this math transform for equality.
+	 */
+	@Override
+	public boolean equals(final Object object) {
+		if (object == this) {
+			// Slight optimization
+			return true;
+		}
+		if (super.equals(object)) {
+			final ProjectiveTransform that = (ProjectiveTransform) object;
+			return this.numRow == that.numRow && this.numCol == that.numCol
+					&& Arrays.equals(this.elt, that.elt);
+		}
+		return false;
+	}
 
-    /**
-     * The provider for the "<cite>Affine general parametric transformation</cite>" (EPSG 9624).
-     * The OGC's name is {@code "Affine"}. The default matrix size is
-     * {@value org.geotools.parameter.MatrixParameterDescriptors#DEFAULT_MATRIX_SIZE}&times;{@value
-     * org.geotools.parameter.MatrixParameterDescriptors#DEFAULT_MATRIX_SIZE}.
-     * <p>
-     * Note that affine transform is a special case of projective transform.
-     *
-     * @version $Id$
-     * @author Martin Desruisseaux (IRD)
-     */
-    public static final class ProviderAffine extends MathTransformProvider {
-        /**
-         * Serial number for interoperability with different versions.
-         */
-        private static final long serialVersionUID = 649555815622129472L;
+	/**
+	 * The provider for the
+	 * "<cite>Affine general parametric transformation</cite>" (EPSG 9624). The
+	 * OGC's name is {@code "Affine"}. The default matrix size is
+	 * {@value org.geotools.parameter.MatrixParameterDescriptors#DEFAULT_MATRIX_SIZE}
+	 * &times;
+	 * {@value org.geotools.parameter.MatrixParameterDescriptors#DEFAULT_MATRIX_SIZE}
+	 * .
+	 * <p>
+	 * Note that affine transform is a special case of projective transform.
+	 *
+	 * @version $Id$
+	 * @author Martin Desruisseaux (IRD)
+	 */
+	public static final class ProviderAffine extends MathTransformProvider {
+		/**
+		 * Serial number for interoperability with different versions.
+		 */
+		private static final long serialVersionUID = 649555815622129472L;
 
-        /**
-         * The set of predefined providers.
-         */
-        private static final ProviderAffine[] methods = new ProviderAffine[8];
+		/**
+		 * The set of predefined providers.
+		 */
+		private static final ProviderAffine[] methods = new ProviderAffine[8];
 
-        /**
-         * The parameters group.
-         *
-         * @todo We should register EPSG parameter identifiers (A0, A1, A2, B0, B1, B2) as well.
-         */
-        static final ParameterDescriptorGroup PARAMETERS;
-        static {
-            final NamedIdentifier name = new NamedIdentifier(Citations.OGC, "Affine");
-            final Map<String,Object> properties = new HashMap<String,Object>(4, 0.8f);
-            properties.put(NAME_KEY,        name);
-            properties.put(IDENTIFIERS_KEY, name);
-            properties.put(ALIAS_KEY, new NamedIdentifier[] {name,
-                new NamedIdentifier(Citations.EPSG, "Affine general parametric transformation"),
-                new NamedIdentifier(Citations.EPSG, "9624"),
-                new NamedIdentifier(Citations.GEOTOOLS,
-                    Vocabulary.formatInternational(VocabularyKeys.AFFINE_TRANSFORM))
-            });
-            PARAMETERS = new MatrixParameterDescriptors(properties);
-        }
+		/**
+		 * The parameters group.
+		 *
+		 * @todo We should register EPSG parameter identifiers (A0, A1, A2, B0,
+		 *       B1, B2) as well.
+		 */
+		static final ParameterDescriptorGroup PARAMETERS;
+		static {
+			final NamedIdentifier name = new NamedIdentifier(Citations.OGC,
+					"Affine");
+			final Map<String, Object> properties = new HashMap<String, Object>(
+					4, 0.8f);
+			properties.put(NAME_KEY, name);
+			properties.put(IDENTIFIERS_KEY, name);
+			properties
+					.put(ALIAS_KEY,
+							new NamedIdentifier[] {
+									name,
+									new NamedIdentifier(Citations.EPSG,
+											"Affine general parametric transformation"),
+									new NamedIdentifier(Citations.EPSG, "9624"),
+									new NamedIdentifier(
+											Citations.GEOTOOLS,
+											Vocabulary
+													.formatInternational(VocabularyKeys.AFFINE_TRANSFORM)) });
+			PARAMETERS = new MatrixParameterDescriptors(properties);
+		}
 
-        /**
-         * Creates a provider for affine transform with a default matrix size.
-         */
-        public ProviderAffine() {
-            this(MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE-1,
-                 MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE-1);
-            methods[MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE-2] = this;
-        }
+		/**
+		 * Creates a provider for affine transform with a default matrix size.
+		 */
+		public ProviderAffine() {
+			this(MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE - 1,
+					MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE - 1);
+			methods[MatrixParameterDescriptors.DEFAULT_MATRIX_SIZE - 2] = this;
+		}
 
-        /**
-         * Creates a provider for affine transform with the specified dimensions.
-         */
-        private ProviderAffine(final int sourceDimensions, final int targetDimensions) {
-            super(sourceDimensions, targetDimensions, PARAMETERS);
-        }
+		/**
+		 * Creates a provider for affine transform with the specified
+		 * dimensions.
+		 */
+		private ProviderAffine(final int sourceDimensions,
+				final int targetDimensions) {
+			super(sourceDimensions, targetDimensions, PARAMETERS);
+		}
 
-        /**
-         * Returns the operation type.
-         */
-        @Override
-        public Class<Conversion> getOperationType() {
-            return Conversion.class;
-        }
+		/**
+		 * Returns the operation type.
+		 */
+		@Override
+		public Class<Conversion> getOperationType() {
+			return Conversion.class;
+		}
 
-        /**
-         * Creates a projective transform from the specified group of parameter values.
-         *
-         * @param  values The group of parameter values.
-         * @return The created math transform.
-         * @throws ParameterNotFoundException if a required parameter was not found.
-         */
-        protected MathTransform createMathTransform(final ParameterValueGroup values)
-                throws ParameterNotFoundException
-        {
-            final MathTransform transform;
-            transform = create(((MatrixParameterDescriptors) getParameters()).getMatrix(values));
-            return new Delegate(transform, getProvider(transform.getSourceDimensions(),
-                                                       transform.getTargetDimensions()));
-        }
+		/**
+		 * Creates a projective transform from the specified group of parameter
+		 * values.
+		 *
+		 * @param values
+		 *            The group of parameter values.
+		 * @return The created math transform.
+		 * @throws ParameterNotFoundException
+		 *             if a required parameter was not found.
+		 */
+		protected MathTransform createMathTransform(
+				final ParameterValueGroup values)
+				throws ParameterNotFoundException {
+			final MathTransform transform;
+			transform = create(((MatrixParameterDescriptors) getParameters())
+					.getMatrix(values));
+			return new Delegate(transform, getProvider(
+					transform.getSourceDimensions(),
+					transform.getTargetDimensions()));
+		}
 
-        /**
-         * Returns the operation method for the specified source and target dimensions.
-         * This method provides different methods for different matrix sizes.
-         *
-         * @param sourceDimensions The number of source dimensions.
-         * @param targetDimensions The number of target dimensions.
-         * @return The provider for transforms of the given source and target dimensions.
-         */
-        public static ProviderAffine getProvider(final int sourceDimensions,
-                                                 final int targetDimensions)
-        {
-            if (sourceDimensions == targetDimensions) {
-                final int i = sourceDimensions - 1;
-                if (i>=0 && i<methods.length) {
-                    ProviderAffine method = methods[i];
-                    if (method == null) {
-                        methods[i] = method = new ProviderAffine(sourceDimensions, targetDimensions);
-                    }
-                    return method;
-                }
-            }
-            return new ProviderAffine(sourceDimensions, targetDimensions);
-        }
-    }
+		/**
+		 * Returns the operation method for the specified source and target
+		 * dimensions. This method provides different methods for different
+		 * matrix sizes.
+		 *
+		 * @param sourceDimensions
+		 *            The number of source dimensions.
+		 * @param targetDimensions
+		 *            The number of target dimensions.
+		 * @return The provider for transforms of the given source and target
+		 *         dimensions.
+		 */
+		public static ProviderAffine getProvider(final int sourceDimensions,
+				final int targetDimensions) {
+			if (sourceDimensions == targetDimensions) {
+				final int i = sourceDimensions - 1;
+				if (i >= 0 && i < methods.length) {
+					ProviderAffine method = methods[i];
+					if (method == null) {
+						methods[i] = method = new ProviderAffine(
+								sourceDimensions, targetDimensions);
+					}
+					return method;
+				}
+			}
+			return new ProviderAffine(sourceDimensions, targetDimensions);
+		}
+	}
 
-    /**
-     * The provider for the "<cite>Longitude rotation</cite>" (EPSG 9601).
-     *
-     * @version $Id$
-     * @author Martin Desruisseaux (IRD)
-     */
-    public static final class ProviderLongitudeRotation extends MathTransformProvider {
-        /**
-         * Serial number for interoperability with different versions.
-         */
-        private static final long serialVersionUID = -2104496465933824935L;
+	/**
+	 * The provider for the "<cite>Longitude rotation</cite>" (EPSG 9601).
+	 *
+	 * @version $Id$
+	 * @author Martin Desruisseaux (IRD)
+	 */
+	public static final class ProviderLongitudeRotation extends
+			MathTransformProvider {
+		/**
+		 * Serial number for interoperability with different versions.
+		 */
+		private static final long serialVersionUID = -2104496465933824935L;
 
-        /**
-         * The longitude offset.
-         */
-        public static final ParameterDescriptor OFFSET = createDescriptor(
-                new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.EPSG, "Longitude offset")
-                },
-                Double.NaN, -180, +180, NonSI.DEGREE_ANGLE);
+		/**
+		 * The longitude offset.
+		 */
+		public static final ParameterDescriptor OFFSET = createDescriptor(
+				new NamedIdentifier[] { new NamedIdentifier(Citations.EPSG,
+						"Longitude offset") }, Double.NaN, -180, +180,
+				NonSI.DEGREE_ANGLE);
 
-        /**
-         * The parameters group.
-         */
-        static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(new NamedIdentifier[] {
-                    new NamedIdentifier(Citations.EPSG, "Longitude rotation"),
-                    new NamedIdentifier(Citations.EPSG, "9601")
-                }, new ParameterDescriptor[] {
-                    OFFSET
-                });
+		/**
+		 * The parameters group.
+		 */
+		static final ParameterDescriptorGroup PARAMETERS = createDescriptorGroup(
+				new NamedIdentifier[] {
+						new NamedIdentifier(Citations.EPSG,
+								"Longitude rotation"),
+						new NamedIdentifier(Citations.EPSG, "9601") },
+				new ParameterDescriptor[] { OFFSET });
 
-        /**
-         * Constructs a provider with default parameters.
-         */
-        public ProviderLongitudeRotation() {
-            super(2, 2, PARAMETERS);
-        }
+		/**
+		 * Constructs a provider with default parameters.
+		 */
+		public ProviderLongitudeRotation() {
+			super(2, 2, PARAMETERS);
+		}
 
-        /**
-         * Returns the operation type.
-         */
-        @Override
-        public Class<Conversion> getOperationType() {
-            return Conversion.class;
-        }
+		/**
+		 * Returns the operation type.
+		 */
+		@Override
+		public Class<Conversion> getOperationType() {
+			return Conversion.class;
+		}
 
-        /**
-         * Creates a transform from the specified group of parameter values.
-         *
-         * @param  values The group of parameter values.
-         * @return The created math transform.
-         * @throws ParameterNotFoundException if a required parameter was not found.
-         */
-        protected MathTransform createMathTransform(final ParameterValueGroup values)
-                throws ParameterNotFoundException
-        {
-            final double offset = doubleValue(OFFSET, values);
-            return create(AffineTransform.getTranslateInstance(offset, 0));
-        }
-    }
+		/**
+		 * Creates a transform from the specified group of parameter values.
+		 *
+		 * @param values
+		 *            The group of parameter values.
+		 * @return The created math transform.
+		 * @throws ParameterNotFoundException
+		 *             if a required parameter was not found.
+		 */
+		protected MathTransform createMathTransform(
+				final ParameterValueGroup values)
+				throws ParameterNotFoundException {
+			final double offset = doubleValue(OFFSET, values);
+			return create(AffineTransform.getTranslateInstance(offset, 0));
+		}
+	}
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform2D.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform2D.java
@@ -16,10 +16,9 @@
  */
 package org.geotools.referencing.operation.transform;
 
-import org.opengis.referencing.operation.Matrix;
 import org.opengis.referencing.operation.MathTransform2D;
+import org.opengis.referencing.operation.Matrix;
 import org.opengis.referencing.operation.NoninvertibleTransformException;
-
 
 /**
  * Projective transform in 2D case.
@@ -28,32 +27,33 @@ import org.opengis.referencing.operation.NoninvertibleTransformException;
  * @version $Id$
  * @author Jan Jezek
  */
-final class ProjectiveTransform2D extends ProjectiveTransform implements MathTransform2D {
-    /**
-     * For cross-version compatibility.
-     */
-    private static final long serialVersionUID = -3101392684596817045L;
+final class ProjectiveTransform2D extends ProjectiveTransform implements
+		MathTransform2D {
+	/**
+	 * For cross-version compatibility.
+	 */
+	private static final long serialVersionUID = -3101392684596817045L;
 
-    /**
-     * Creates projective transform from a matrix.
-     */
-    public ProjectiveTransform2D(final Matrix matrix) {
-        super(matrix);
-    }
+	/**
+	 * Creates projective transform from a matrix.
+	 */
+	public ProjectiveTransform2D(final Matrix matrix) {
+		super(matrix);
+	}
 
-    /**
-     * Creates the inverse transform of this object.
-     */
-    @Override
-    public MathTransform2D inverse() throws NoninvertibleTransformException {
-        return (MathTransform2D) super.inverse();
-    }
+	/**
+	 * Creates the inverse transform of this object.
+	 */
+	@Override
+	public MathTransform2D inverse() throws NoninvertibleTransformException {
+		return (MathTransform2D) super.inverse();
+	}
 
-    /**
-     * Creates an inverse transform using the specified matrix.
-     */
-    @Override
-    MathTransform2D createInverse(final Matrix matrix) {
-        return new ProjectiveTransform2D(matrix);
-    }
+	/**
+	 * Creates an inverse transform using the specified matrix.
+	 */
+	@Override
+	ProjectiveTransform2D createInverse(final Matrix matrix) {
+		return new ProjectiveTransform2D(matrix);
+	}
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform2D.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform2D.java
@@ -16,9 +16,10 @@
  */
 package org.geotools.referencing.operation.transform;
 
-import org.opengis.referencing.operation.MathTransform2D;
 import org.opengis.referencing.operation.Matrix;
+import org.opengis.referencing.operation.MathTransform2D;
 import org.opengis.referencing.operation.NoninvertibleTransformException;
+
 
 /**
  * Projective transform in 2D case.
@@ -27,33 +28,32 @@ import org.opengis.referencing.operation.NoninvertibleTransformException;
  * @version $Id$
  * @author Jan Jezek
  */
-final class ProjectiveTransform2D extends ProjectiveTransform implements
-		MathTransform2D {
-	/**
-	 * For cross-version compatibility.
-	 */
-	private static final long serialVersionUID = -3101392684596817045L;
+final class ProjectiveTransform2D extends ProjectiveTransform implements MathTransform2D {
+    /**
+     * For cross-version compatibility.
+     */
+    private static final long serialVersionUID = -3101392684596817045L;
 
-	/**
-	 * Creates projective transform from a matrix.
-	 */
-	public ProjectiveTransform2D(final Matrix matrix) {
-		super(matrix);
-	}
+    /**
+     * Creates projective transform from a matrix.
+     */
+    public ProjectiveTransform2D(final Matrix matrix) {
+        super(matrix);
+    }
 
-	/**
-	 * Creates the inverse transform of this object.
-	 */
-	@Override
-	public MathTransform2D inverse() throws NoninvertibleTransformException {
-		return (MathTransform2D) super.inverse();
-	}
+    /**
+     * Creates the inverse transform of this object.
+     */
+    @Override
+    public MathTransform2D inverse() throws NoninvertibleTransformException {
+        return (MathTransform2D) super.inverse();
+    }
 
-	/**
-	 * Creates an inverse transform using the specified matrix.
-	 */
-	@Override
-	ProjectiveTransform2D createInverse(final Matrix matrix) {
-		return new ProjectiveTransform2D(matrix);
-	}
+    /**
+     * Creates an inverse transform using the specified matrix.
+     */
+    @Override
+    ProjectiveTransform2D createInverse(final Matrix matrix) {
+        return new ProjectiveTransform2D(matrix);
+    }
 }

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/ProjectiveTransform2DTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/ProjectiveTransform2DTest.java
@@ -1,0 +1,42 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.referencing.operation.transform;
+
+import org.geotools.referencing.operation.matrix.GeneralMatrix;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.NoninvertibleTransformException;
+
+/**
+ * Tests the {@link ProjectiveTransform2D} classes.
+ *
+ * @source $URL$
+ * @version $Id$
+ * @author Alexey Valikov
+ */
+public final class ProjectiveTransform2DTest {
+	// Tests that ProjectiveTransform2D is invertible
+	@Test
+	public void testInvertible() throws NoninvertibleTransformException {
+		final GeneralMatrix matrix = new GeneralMatrix(3);
+		matrix.setElement(0, 1, -1);
+		matrix.setElement(1, 0, 1);
+		final MathTransform transform = new ProjectiveTransform2D(matrix);
+		Assert.assertNotNull(transform.inverse());
+	}
+}

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/ProjectiveTransform2DTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/operation/transform/ProjectiveTransform2DTest.java
@@ -1,8 +1,8 @@
 /*
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
- * 
- *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    (C) 2001-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -13,6 +13,9 @@
  *    but WITHOUT ANY WARRANTY; without even the implied warranty of
  *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *    Lesser General Public License for more details.
+ *
+ *    This package contains documentation from OpenGIS specifications.
+ *    OpenGIS consortium's work is fully acknowledged here.
  */
 package org.geotools.referencing.operation.transform;
 
@@ -30,13 +33,13 @@ import org.opengis.referencing.operation.NoninvertibleTransformException;
  * @author Alexey Valikov
  */
 public final class ProjectiveTransform2DTest {
-	// Tests that ProjectiveTransform2D is invertible
-	@Test
-	public void testInvertible() throws NoninvertibleTransformException {
-		final GeneralMatrix matrix = new GeneralMatrix(3);
-		matrix.setElement(0, 1, -1);
-		matrix.setElement(1, 0, 1);
-		final MathTransform transform = new ProjectiveTransform2D(matrix);
-		Assert.assertNotNull(transform.inverse());
-	}
+    // Tests that ProjectiveTransform2D is invertible
+    @Test
+    public void testInvertible() throws NoninvertibleTransformException {
+        final GeneralMatrix matrix = new GeneralMatrix(3);
+        matrix.setElement(0, 1, -1);
+        matrix.setElement(1, 0, 1);
+        final MathTransform transform = new ProjectiveTransform2D(matrix);
+        Assert.assertNotNull(transform.inverse());
+    }
 }


### PR DESCRIPTION
This is a fix for https://osgeo-org.atlassian.net/browse/GEOT-5198.

As the test case demonstrates, inversing `ProjectiveTransform2D` throws a class cast exception. Subclasses should use the provided `createInverse(...)` method when creating the inverse transformation.

(I've signed and submitted the contributor agreement/license today.)