### PR TITLE
GEOS-7152: wfs-ng geoscript compatibility

### DIFF
--- a/modules/unsupported/wfs-ng/pom.xml
+++ b/modules/unsupported/wfs-ng/pom.xml
@@ -156,7 +156,7 @@
     </dependency>
     <dependency>
       <groupId>xpp3</groupId>
-      <artifactId>xpp3</artifactId>
+      <artifactId>xpp3_min</artifactId>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSDataStore.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSDataStore.java
@@ -19,6 +19,7 @@ package org.geotools.data.wfs;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -316,6 +317,10 @@ public class WFSDataStore extends ContentDataStore {
         Name name = new NameImpl(namespaceURI, localName);
         this.names.remove(name);
         configuredStoredQueries.remove(localName);
+    }
+    
+    public URL getCapabilitiesURL() {
+       return client.getCapabilitiesURL();
     }
 
 }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
@@ -372,4 +372,8 @@ public class WFSClient extends AbstractOpenWebService<WFSGetCapabilities, QName>
     public String getAxisOrderFilter(){
         return config.getAxisOrderFilter();
     }
+    
+    public URL getCapabilitiesURL() {
+        return serverURL;
+    }
 }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlFeatureParser.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlFeatureParser.java
@@ -43,9 +43,9 @@ import org.opengis.feature.type.GeometryType;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.xmlpull.mxp1.MXParser;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
-import org.xmlpull.v1.XmlPullParserFactory;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
@@ -86,14 +86,11 @@ public abstract class XmlFeatureParser<FT extends FeatureType, F extends Feature
 		this.featureName = featureDescriptorName.getLocalPart();
 		this.targetType = targetType;
 
-		XmlPullParserFactory factory;
 		try {
-			factory = XmlPullParserFactory.newInstance();
-			factory.setNamespaceAware(true);
-			factory.setValidating(false);
+                        parser = new MXParser();
+                        parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
 
 			// parse root element
-			parser = factory.newPullParser();
 			parser.setInput(inputStream, "UTF-8");
 			parser.nextTag();
 			parser.require(START_TAG, WFS.NAMESPACE,

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlSimpleFeatureParser.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlSimpleFeatureParser.java
@@ -48,9 +48,9 @@ import org.opengis.feature.type.GeometryType;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.xmlpull.mxp1.MXParser;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
-import org.xmlpull.v1.XmlPullParserFactory;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
@@ -111,14 +111,11 @@ public class XmlSimpleFeatureParser implements GetFeatureParser {
         this.builder = new SimpleFeatureBuilder(targetType);
         this.axisOrder = axisOrder;
 
-        XmlPullParserFactory factory;
         try {
-            factory = XmlPullParserFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setValidating(false);
+            parser = new MXParser();
+            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
 
             // parse root element
-            parser = factory.newPullParser();
             parser.setInput(inputStream, "UTF-8");
             parser.nextTag();
             parser.require(START_TAG, null, WFS.FeatureCollection.getLocalPart());


### PR DESCRIPTION
* Replace xpp3 dependency and replace by xpp3_min (and stop using XmlPullParserFactory).
xpp3 is unfortunately not compatibility with groovy! (LinkageError)

* implement getCapabilitiesURL so that geoscript-groovy can be ported without code changes