### PR TITLE
[GEOT-5227]  GeometryBuilder setCoordianteReferenceSystem() should be setCoordinateReferenceSystem()

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/geometry/GeometryBuilder.java
+++ b/modules/library/referencing/src/main/java/org/geotools/geometry/GeometryBuilder.java
@@ -126,7 +126,24 @@ public class GeometryBuilder {
         return crs;
     }
 
+    /**
+         Set the CoordinateReferenceSystem for the geometries that will be produced.
+         
+         @param crs the CoordinateReferenceSystem to set
+         
+         @deprecated Use setCoordinateReferenceSystem() instead.
+     */
+    @Deprecated
     public void setCoordianteReferenceSystem( CoordinateReferenceSystem crs ) {
+            setCoordinateReferenceSystem( crs );
+    }
+    
+    /**
+        Set the CoordinateReferenceSystem for the geometries that will be produced.
+        
+        @param crs the CoordinateReferenceSystem to set
+     */
+    public void setCoordinateReferenceSystem( CoordinateReferenceSystem crs ) {
         if( this.crs != crs ){
             hints.remove(Hints.CRS);
             hints.put( Hints.CRS, crs );
@@ -314,14 +331,14 @@ public class GeometryBuilder {
 		if (position == null) {
 			throw new NullPointerException();
 		}
-		setCoordianteReferenceSystem(position.getDirectPosition().getCoordinateReferenceSystem());
+		setCoordinateReferenceSystem(position.getDirectPosition().getCoordinateReferenceSystem());
 		DirectPosition copy = (DirectPosition) getPositionFactory().createDirectPosition(position.getDirectPosition().getCoordinate());
 		return getPrimitiveFactory().createPoint(copy);
 	}
 
 	public Primitive createPrimitive(Envelope envelope) throws MismatchedReferenceSystemException, MismatchedDimensionException {
 		LineSegment segment = processBoundsToSegment(envelope);		
-		setCoordianteReferenceSystem(envelope.getCoordinateReferenceSystem());
+		setCoordinateReferenceSystem(envelope.getCoordinateReferenceSystem());
 		return processSegmentToPrimitive( envelope, segment, 1 );	
 	}
 	

--- a/modules/unsupported/geometry/src/test/java/org/geotools/geometry/iso/aggregate/AggregateGeometryBuilderTest.java
+++ b/modules/unsupported/geometry/src/test/java/org/geotools/geometry/iso/aggregate/AggregateGeometryBuilderTest.java
@@ -67,7 +67,7 @@ public class AggregateGeometryBuilderTest extends TestCase {
 		assertTrue(position.equals(point.getCentroid()));
 		
 		// change CRS and test
-		builder.setCoordianteReferenceSystem(DefaultGeographicCRS.WGS84_3D);
+		builder.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84_3D);
 		PrimitiveFactory primitiveFactory3D = builder.getPrimitiveFactory();
 		Point point3D = primitiveFactory3D.createPoint(new double[] { 48.44, -123.37, 1.0 });
 		
@@ -75,7 +75,7 @@ public class AggregateGeometryBuilderTest extends TestCase {
 		assertFalse(point.equals(point3D));
 		
 		// back to 2D
-		builder.setCoordianteReferenceSystem(DefaultGeographicCRS.WGS84);
+		builder.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84);
 		PositionFactory pf = builder.getPositionFactory();
 		PrimitiveFactoryImpl primf = (PrimitiveFactoryImpl) builder.getPrimitiveFactory();
 		AggregateFactory agf = builder.getAggregateFactory();

--- a/modules/unsupported/geometry/src/test/java/org/geotools/geometry/iso/coordinate/DirectPositionTest.java
+++ b/modules/unsupported/geometry/src/test/java/org/geotools/geometry/iso/coordinate/DirectPositionTest.java
@@ -42,7 +42,7 @@ public class DirectPositionTest extends TestCase {
         
         GeometryBuilder builder = new GeometryBuilder(DefaultGeographicCRS.WGS84); 
         gf2D = builder.getGeometryFactory();
-        builder.setCoordianteReferenceSystem(DefaultGeographicCRS.WGS84_3D);
+        builder.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84_3D);
         gf3D = builder.getGeometryFactory();
         
     }

--- a/modules/unsupported/geometry/src/test/java/org/geotools/geometry/iso/operations/CentroidTest.java
+++ b/modules/unsupported/geometry/src/test/java/org/geotools/geometry/iso/operations/CentroidTest.java
@@ -63,7 +63,7 @@ public class CentroidTest extends TestCase {
 
 		
 		// === 3D ===
-		this.builder.setCoordianteReferenceSystem(DefaultGeographicCRS.WGS84_3D);
+		this.builder.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84_3D);
 		this.crs = DefaultGeographicCRS.WGS84_3D;
 		
 		// Test Points and MultiPoints

--- a/modules/unsupported/geometry/src/test/java/org/geotools/geometry/iso/primitive/PrimitiveGeometryBuilderTest.java
+++ b/modules/unsupported/geometry/src/test/java/org/geotools/geometry/iso/primitive/PrimitiveGeometryBuilderTest.java
@@ -54,7 +54,7 @@ public class PrimitiveGeometryBuilderTest extends TestCase {
 		assertTrue(position.equals(point.getCentroid()));
 		
 		// change CRS and test
-		builder.setCoordianteReferenceSystem(DefaultGeographicCRS.WGS84_3D);
+		builder.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84_3D);
 		primitiveFactory = builder.getPrimitiveFactory();
 		Point point3D = primitiveFactory.createPoint(new double[] { 48.44, -123.37, 1.0 });
 		


### PR DESCRIPTION
Changes name, adds deprecation annotation and updates tests.

There are some documentation updates, which I'll provide as part of a larger cleanup.