### PR TITLE
Revert "[GEOT-5224] ArcGrid extension only supports ASCII GRID"

### DIFF
--- a/docs/user/library/coverage/arcgrid.rst
+++ b/docs/user/library/coverage/arcgrid.rst
@@ -1,7 +1,7 @@
 ArcGrid Plugin
 --------------
 
-The arcgrid module in the plugin group provides access to the ARC/INFO ASCII GRID raster format defined by ESRI and used in that company's software suites.
+The arcgrid module in the plugin group provides access to the ARCGRID raster format defined by ESRI and used in that company's software suites.
 
 This is a straightforward plugin with no additional information needed beyond that advertised by the GridCoverageExchange API.
 

--- a/modules/plugin/arcgrid/src/main/java/org/geotools/gce/arcgrid/ArcGridFormat.java
+++ b/modules/plugin/arcgrid/src/main/java/org/geotools/gce/arcgrid/ArcGridFormat.java
@@ -86,8 +86,8 @@ public final class ArcGridFormat extends AbstractGridFormat implements Format {
 	private void setInfo() {
 		HashMap<String, String> info = new HashMap<String, String>();
 
-		info.put("name", "ArcGrid (ASCII)");
-		info.put("description", "ARC/INFO ASCII GRID Coverage Format");
+		info.put("name", "ArcGrid");
+		info.put("description", "Arc Grid Coverage Format");
 		info.put("vendor", "Geotools");
 		info.put("docURL", "http://gdal.velocet.ca/projects/aigrid/index.html");
 		info.put("version", "1.0");


### PR DESCRIPTION
It's breaking the build at the GeoServer level, making WCS capabliities document invalid. 