### PR TITLE
Remove duplicate bbox filter from GetFeatureInfo query

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -208,7 +208,7 @@ public class StreamingRenderer implements GTRenderer {
     int error = 0;
 
     /** Filter factory for creating bounding box filters */
-    private final static FilterFactory2 filterFactory = CommonFactoryFinder.getFilterFactory2(null);
+    protected final static FilterFactory2 filterFactory = CommonFactoryFinder.getFilterFactory2(null);
 
     private final static PropertyName gridPropertyName = filterFactory.property("grid");
 
@@ -1600,8 +1600,8 @@ public class StreamingRenderer implements GTRenderer {
             // DJB:geos-469 if the default geometry was used in the style, we
             // need to grab it.
             if (sae.getDefaultGeometryUsed()
-                    && (!attributeNames.contains(schema.getGeometryDescriptor().getName().toString()))
-                    ) {
+                    && !attributeNames.contains(schema.getGeometryDescriptor().getName().toString())
+                    && !attributeNames.contains("")) {
                 atts.add(filterFactory.property ( schema.getGeometryDescriptor().getName() ));
             }
         } catch (Exception e) {


### PR DESCRIPTION
This duplicate bbox in the SQL query is harmless in most situations,
but not with Oracle. This DB seems to have a bug and don't use
the spacial index if there is two SDO_FILTERS in the where clause
that are fed using bound variables (reproduced in a small java
program that is uses only ojdbc).

From the Mailing list:
SELECT OSM_ID,NAME,TYPE,GEOM as GEOM FROM
 WWW_DATA.BAHNEN_21781 WHERE  (SDO_FILTER(GEOM, :1 , 'mask=anyinteract querytype=WINDOW') = 'TRUE'  OR
 SDO_FILTER(GEOM, :2 , 'mask=anyinteract querytype=WINDOW') = 'TRUE' )
:1 = MDSYS.SDO_GEOMETRY(2003,21781,NULL,MDSYS.SDO_ELEM_INFO_ARRAY(1,1003,3),MDSYS.SDO_ORDINATE_ARRAY(537749.900708669,151378.70118838394,537761.8306244375,151390.63110415262))
:2 = MDSYS.SDO_GEOMETRY(2003,21781,NULL,MDSYS.SDO_ELEM_INFO_ARRAY(1,1003,3),MDSYS.SDO_ORDINATE_ARRAY(537749.900708669,151378.70118838394,537761.8306244375,151390.63110415262))

Twice the same BBox.

So no, not normal.

When I set a break point in StreamingRenderer#findStyleAttributes, I have one attribute in "attributes" when it's created. It has attrPath="". It has been added by sae.visit(rule), deep inside the visitor magic.

Then, in the "if" I'm patching thinks the default geometry is  used, but not part of the attribute list (that's the part that needs fixing) and therefore adds the default geometry. So I end up with two attributes: ["", "GEOM"]

Further down the execution, when the WHERE part of the query is built, we iterate the attributes returned by StreamingRenderer#findStyleAttributes, and for each ones we add the SDO_FILTER with the search BBox. For the one that has an empty name, I guess there is some logic somewhere to replace it by the default geometry's name. Hence we end up with twice exactly the same SDO_FILTER.

And I can see this behavior regardless of the value I set in "Enable advanced projection handling".