### PR TITLE
Fix OracleDialect.unwrap() to work when wrapped by LifeCycleConnection.

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCConnectionLifecycleOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCConnectionLifecycleOnlineTest.java
@@ -19,11 +19,7 @@ package org.geotools.jdbc;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Properties;
 
-import org.geotools.data.DataStore;
-import org.geotools.data.DataStoreFinder;
 import org.geotools.data.DefaultTransaction;
 import org.geotools.data.Query;
 import org.geotools.data.Transaction;
@@ -105,23 +101,6 @@ public abstract class JDBCConnectionLifecycleOnlineTest extends JDBCTestSupport 
             // we don't actually expect an exception to percolate up since it's happening
             // on the closeSafe method, that swallows exceptions
             featureStore.getCount(Query.ALL);
-        }
-    }
-    
-    public void testLifeCycleDoubleUnwrap() {
-        try {
-            // Use startup SQL when connecting so the connection is
-            // doubly wrapped (adding LifeCycleConnection).
-            // That tests ability of OracleDialect to unwrap properly.
-            Properties addStartupSql = (Properties) fixture.clone();
-            addStartupSql.setProperty(JDBCDataStoreFactory.SQL_ON_BORROW.key,
-                    "select sysdate from dual");
-            HashMap params = createDataStoreFactoryParams();
-            params.putAll(addStartupSql);
-            DataStore withWrap = (JDBCDataStore) DataStoreFinder.getDataStore(params);
-            withWrap.dispose();
-        } catch (Exception e) {
-            throw new RuntimeException("Connection unwrap test failed!", e);
         }
     }
     

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCConnectionLifecycleOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCConnectionLifecycleOnlineTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCConnectionLifecycleOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCConnectionLifecycleOnlineTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCConnectionLifecycleOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCConnectionLifecycleOnlineTest.java
@@ -19,7 +19,11 @@ package org.geotools.jdbc;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Properties;
 
+import org.geotools.data.DataStore;
+import org.geotools.data.DataStoreFinder;
 import org.geotools.data.DefaultTransaction;
 import org.geotools.data.Query;
 import org.geotools.data.Transaction;
@@ -101,6 +105,23 @@ public abstract class JDBCConnectionLifecycleOnlineTest extends JDBCTestSupport 
             // we don't actually expect an exception to percolate up since it's happening
             // on the closeSafe method, that swallows exceptions
             featureStore.getCount(Query.ALL);
+        }
+    }
+    
+    public void testLifeCycleDoubleUnwrap() {
+        try {
+            // Use startup SQL when connecting so the connection is
+            // doubly wrapped (adding LifeCycleConnection).
+            // That tests ability of OracleDialect to unwrap properly.
+            Properties addStartupSql = (Properties) fixture.clone();
+            addStartupSql.setProperty(JDBCDataStoreFactory.SQL_ON_BORROW.key,
+                    "select sysdate from dual");
+            HashMap params = createDataStoreFactoryParams();
+            params.putAll(addStartupSql);
+            DataStore withWrap = (JDBCDataStore) DataStoreFinder.getDataStore(params);
+            withWrap.dispose();
+        } catch (Exception e) {
+            throw new RuntimeException("Connection unwrap test failed!", e);
         }
     }
     

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -34,11 +34,6 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 
-import oracle.jdbc.OracleConnection;
-import oracle.sql.ARRAY;
-import oracle.sql.Datum;
-import oracle.sql.STRUCT;
-
 import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.data.jdbc.datasource.DataSourceFinder;
 import org.geotools.data.jdbc.datasource.UnWrapper;
@@ -73,6 +68,11 @@ import com.vividsolutions.jts.geom.MultiPoint;
 import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
+
+import oracle.jdbc.OracleConnection;
+import oracle.sql.ARRAY;
+import oracle.sql.Datum;
+import oracle.sql.STRUCT;
 
 /**
  * 
@@ -127,7 +127,12 @@ public class OracleDialect extends PreparedStatementSQLDialect {
      */
     public static final String GEODETIC = "geodetic";
     
-    UnWrapper uw;
+    /**
+     * Map of <code>UnWrapper</code> objects keyed by the class of <code>Connection</code>
+     * it is an unwrapper for. This avoids the overhead of at each unwrap.
+     */
+    Map<Class<? extends Connection>, UnWrapper> uwMap = 
+            new HashMap<Class<? extends Connection>, UnWrapper>();
 
     /**
      * A map from JTS Geometry type to Oracle geometry type. See Oracle Spatial documentation,
@@ -617,23 +622,30 @@ public class OracleDialect extends PreparedStatementSQLDialect {
         }
         
         try {
-            // first lookup ever? (we have UNWRAPPER_NOT_FOUND as a sentinel for a lookup that
-            // will not work (we assume the datasource will always return connections we can
-            // unwrap, or never).
-            if (uw == null) {
-                UnWrapper unwrapper = DataSourceFinder.getUnWrapper(cx);
+            // Unwrap the connection multiple levels as necessary to get at the underlying
+            // OracleConnection. Maintain a map of UnWrappers to avoid searching
+            // the registry every time we need to unwrap.
+            Connection testCon = cx;
+            do {
+                UnWrapper unwrapper = uwMap.get(testCon.getClass());
                 if (unwrapper == null) {
-                    uw = UNWRAPPER_NOT_FOUND;
-                } else {
-                    uw = unwrapper;
+                    unwrapper = DataSourceFinder.getUnWrapper(testCon);
+                    if (unwrapper == null) {
+                        unwrapper = UNWRAPPER_NOT_FOUND;
+                    }
+                    uwMap.put(testCon.getClass(), unwrapper);
                 }
-            }
-            if (uw != null && uw != UNWRAPPER_NOT_FOUND) {
-                Connection uwcx = uw.unwrap( cx );
-                if ( uwcx != null && uwcx instanceof OracleConnection ) {
-                    return (OracleConnection) uwcx;
+                if (unwrapper == UNWRAPPER_NOT_FOUND) {
+                    // give up and try legacy approaches below
+                    break;
                 }
-            } else if (cx instanceof Wrapper) {
+                testCon = unwrapper.unwrap(testCon);
+                if (testCon instanceof OracleConnection) {
+                    return (OracleConnection) testCon;
+                }
+            } while (testCon != null);
+
+            if (cx instanceof Wrapper) {
                 // try to use java 6 unwrapping
                 try {
                     Wrapper w = cx;

--- a/modules/unsupported/csv/src/test/java/org/geotools/data/csv/CSVWriteTest.java
+++ b/modules/unsupported/csv/src/test/java/org/geotools/data/csv/CSVWriteTest.java
@@ -1,7 +1,7 @@
 /* GeoTools - The Open Source Java GIS Toolkit
  * http://geotools.org
  *
- * (C) 2010-2014, Open Source Geospatial Foundation (OSGeo)
+ * (C) 2010-2015, Open Source Geospatial Foundation (OSGeo)
  *
  * This file is hereby placed into the Public Domain. This means anyone is
  * free to do whatever they wish with this file. Use it well and enjoy!
@@ -36,7 +36,6 @@ import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.factory.Hints;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.JTSFactoryFinder;
@@ -307,8 +306,11 @@ public class CSVWriteTest {
         String contents2 = new String(baos2.toByteArray(), StandardCharsets.UTF_8);
 
         // Making sure whitespace doesn't cause problems
+        // and adjust for potential windows line endings.
         contents1 = contents1.replace(" ", "").trim();
         contents2 = contents2.replace(" ", "").trim();
+        contents1 = contents1.replace("\r", "");
+        contents2 = contents2.replace("\r", "");
 
         assertEquals("Contents of both files should be the same", contents1, contents2);
     }


### PR DESCRIPTION
See JIRA GEOT-5239. The unwrap code would succeed only for a single
level of wrapping.  If the DataStore is configured with startup-sql
the connection will be additionally wrapped by LifeCycleConnection
which makes the unwrap throw an exception as it fails to obtain
OracleConnection.

Modified OracleDialect to loop thru multiple levels of unwrapping when
necessary instead of assuming one level. Given potential multiple
levels of wrap, the code now maintains a Map of UnWrappers to preserve
optimized (minimal) access to DataSourceFinder.getUnWrapper().

Also updated the JDBCConnectionLifecycleOnlineTest to include a new
testLifeCycleDoubleUnwrap() member.  The test simply created a DataStore
with startup SQL. This alone makes the (unfixed) code fail (without
actually reading any SDO geometry) since the OracleNGDataStore
explcitly invokes OracleDialect during construction of the DataStore.