### PR TITLE
[GEOT-5251] App-schema can't set string value to complex type extending anyType

### DIFF
--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/filter/XPathTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/filter/XPathTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2005-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -17,13 +17,25 @@
 
 package org.geotools.data.complex.filter;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xsd.XSDElementDeclaration;
+import org.eclipse.xsd.util.XSDResourceFactoryImpl;
+import org.geotools.data.complex.config.AppSchemaFeatureTypeRegistry;
+import org.geotools.data.complex.config.EmfComplexFeatureReader;
 import org.geotools.data.complex.config.Types;
 import org.geotools.gml3.GMLSchema;
 import org.geotools.test.AppSchemaTestSupport;
+import org.geotools.xml.SchemaIndex;
+import org.junit.BeforeClass;
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.opengis.feature.type.ComplexType;
+import org.opengis.feature.type.Name;
 
 /**
  * 
@@ -36,6 +48,20 @@ import static org.junit.Assert.assertTrue;
  * @since 2.4
  */
 public class XPathTest extends AppSchemaTestSupport {
+
+    private static final String UNRESTRICTED_CONTENT_SCHEMA_LOCATION = "/test-data/unrestrictedContent.xsd";
+    private static final String URI = "http://www.geotools.org/appschema/test";
+
+    private static EmfComplexFeatureReader reader;
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        reader = EmfComplexFeatureReader.newInstance();
+
+        //need to register custom factory to load schema resources
+        Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap()
+                                          .put("xsd", new XSDResourceFactoryImpl());
+    }
 
     /**
      * Test that some simple-content and non-simple-content types are correctly detected.
@@ -50,4 +76,35 @@ public class XPathTest extends AppSchemaTestSupport {
         assertFalse(Types.isSimpleContentType(GMLSchema.ABSTRACTFEATURECOLLECTIONTYPE_TYPE));
     }
 
+    /**
+     * Test that elements with arbitrary mixed content are correctly detected.
+     * @throws Exception
+     */
+    @Test
+    public void testHasUnrestrictedContent() throws Exception {
+        SchemaIndex schemaIndex = reader.parse(getClass().getResource(
+                UNRESTRICTED_CONTENT_SCHEMA_LOCATION));
+
+        XSDElementDeclaration unrestrictedElDecl = schemaIndex.getElementDeclaration(new QName(URI,
+                "unrestrictedEl"));
+        assertNotNull(unrestrictedElDecl);
+        XSDElementDeclaration restrictedElDecl = schemaIndex.getElementDeclaration(new QName(URI,
+                "restrictedEl"));
+        assertNotNull(restrictedElDecl);
+
+        AppSchemaFeatureTypeRegistry typeRegistry = new AppSchemaFeatureTypeRegistry();
+        typeRegistry.addSchemas(schemaIndex);
+
+        Name unrestrictedTypeName = Types.typeName(URI, "UnrestrictedType");
+        ComplexType unrestrictedType = (ComplexType) typeRegistry
+                .getAttributeType(unrestrictedTypeName);
+        assertNotNull(unrestrictedType);
+        assertTrue(Types.hasUnrestrictedContent(unrestrictedType));
+
+        Name restrictedTypeName = Types.typeName(URI, "RestrictedType");
+        ComplexType restrictedType = (ComplexType) typeRegistry
+                .getAttributeType(restrictedTypeName);
+        assertNotNull(restrictedType);
+        assertFalse(Types.hasUnrestrictedContent(restrictedType));
+    }
 }

--- a/modules/extension/app-schema/app-schema/src/test/resources/test-data/unrestrictedContent.xsd
+++ b/modules/extension/app-schema/app-schema/src/test/resources/test-data/unrestrictedContent.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.geotools.org/appschema/test"
+    xmlns:ast="http://www.geotools.org/appschema/test"
+    elementFormDefault="qualified">
+
+    <complexType name="UnrestrictedType">
+        <complexContent>
+            <extension base="anyType">
+                <attribute name="attr1" type="string" />
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="unrestrictedEl" type="ast:UnrestrictedType" />
+
+    <complexType name="RestrictedType">
+        <complexContent>
+            <restriction base="anyType">
+                <sequence>
+                    <element name="counter" type="int" />
+                </sequence>
+                <attribute name="attr1" type="string" />
+            </restriction>
+        </complexContent>
+    </complexType>
+    <element name="restrictedEl" type="ast:RestrictedType" />
+
+</schema>

--- a/modules/extension/complex/src/main/java/org/geotools/data/complex/ComplexFeatureConstants.java
+++ b/modules/extension/complex/src/main/java/org/geotools/data/complex/ComplexFeatureConstants.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2010-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2010-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -75,6 +75,11 @@ public class ComplexFeatureConstants {
      */
     public static final Name SIMPLE_CONTENT = new NameImpl(null, "simpleContent");
     
+    /**
+     * Fake attribute name for arbitrary mixed contents of a complex type, eg. swe:DataArray/swe:values of swe:EncodedValuesPropertyType type
+     */
+    public static final Name UNRESTRICTED_CONTENT = new NameImpl(null, "unrestrictedContent");
+
     /**
      * Constant to indicate the last row from denormalised rows.
      */

--- a/modules/extension/complex/src/main/java/org/geotools/data/complex/config/Types.java
+++ b/modules/extension/complex/src/main/java/org/geotools/data/complex/config/Types.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2005-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -18,8 +18,15 @@
 package org.geotools.data.complex.config;
 
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import org.eclipse.xsd.XSDComplexTypeDefinition;
+import org.eclipse.xsd.XSDContentTypeCategory;
+import org.eclipse.xsd.XSDDerivationMethod;
 import org.eclipse.xsd.XSDElementDeclaration;
+import org.eclipse.xsd.XSDTypeDefinition;
+import org.geotools.util.logging.Logging;
 import org.geotools.xs.XSSchema;
 import org.opengis.feature.type.AttributeType;
 import org.opengis.feature.type.ComplexType;
@@ -46,7 +53,9 @@ import org.opengis.feature.type.PropertyType;
  *         /java/org/geotools/feature/Types.java $
  */
 public class Types extends org.geotools.feature.type.Types {
-    
+
+    private static final Logger LOGGER = Logging.getLogger(Types.class);
+
     /**
      * Return true if an attribute from a type is an element.
      * 
@@ -87,7 +96,7 @@ public class Types extends org.geotools.feature.type.Types {
             return isSimpleContentType(superType);
         }
     }
-    
+
     public static boolean isGeometryType(AttributeType type) {
         if (type instanceof GeometryType) {
             return true;
@@ -99,4 +108,54 @@ public class Types extends org.geotools.feature.type.Types {
         }
         return false;
     }
+
+    /**
+     * Returns true if the type is either <code>xs:anyType</code> or is derived from <code>xs:anyType</code> by extension and has mixed content.
+     * 
+     * <p>
+     * Example:
+     * 
+     * <pre>
+     *  &lt;complexType name="TestType"&gt;
+     *    &lt;complexContent&gt;
+     *      &lt;extension base="anyType"&gt;
+     *        &lt;attribute name="attr1" type="string" /&gt;
+     *      &lt;/extension&gt;
+     *    &lt;/complexContent&gt;
+     *  &lt;/complexType&gt;
+     * </pre>
+     * 
+     * </p>
+     * 
+     * @param type
+     * @return
+     */
+    public static boolean hasUnrestrictedContent(PropertyType type) {
+        if (type == XSSchema.ANYTYPE_TYPE) {
+            return true;
+        }
+        PropertyType superType = type.getSuper();
+        if (superType == XSSchema.ANYTYPE_TYPE) {
+            // type was derived from xs:anyType: check derivation mode and content type category
+            Map<Object, Object> userData = type.getUserData();
+            if (userData != null && userData.get(XSDTypeDefinition.class) != null) {
+                XSDTypeDefinition typeDef = (XSDTypeDefinition) userData.get(XSDTypeDefinition.class);
+                if (typeDef instanceof XSDComplexTypeDefinition) {
+                    XSDComplexTypeDefinition complexTypeDef = (XSDComplexTypeDefinition) typeDef;
+                    XSDContentTypeCategory category = complexTypeDef.getContentTypeCategory();
+                    XSDDerivationMethod derivMethod = complexTypeDef.getDerivationMethod();
+
+                    boolean hasMixedContent = XSDContentTypeCategory.MIXED_LITERAL.equals(category);
+                    boolean isExtension = XSDDerivationMethod.EXTENSION_LITERAL.equals(derivMethod);
+                    return isExtension && hasMixedContent;
+                }
+            } else {
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.finer("No XSDTypeDefinition found for type " + type.getName());
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/ComplexSupportXSAnyTypeBinding.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/ComplexSupportXSAnyTypeBinding.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2009, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -48,7 +48,6 @@ import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.filter.identity.Identifier;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Text;
 import org.xml.sax.Attributes;
 
 /**
@@ -406,6 +405,7 @@ public class ComplexSupportXSAnyTypeBinding extends XSAnyTypeBinding {
             }
             GML3EncodingUtils.encodeClientProperties(complex, value);
             GML3EncodingUtils.encodeSimpleContent(complex, document, value);
+            GML3EncodingUtils.encodeUnrestrictedContent(complex, document, value);
         } else if(!isPlaceholderObject(object)) {
             GML3EncodingUtils.encodeAsText(document, value, object);
         }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/FeaturePropertyTypeBinding.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/FeaturePropertyTypeBinding.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -147,6 +147,7 @@ public class FeaturePropertyTypeBinding extends AbstractComplexBinding {
             checkXlinkHref(complex);
             GML3EncodingUtils.encodeClientProperties(complex, value);
             GML3EncodingUtils.encodeSimpleContent(complex, document, value);
+            GML3EncodingUtils.encodeUnrestrictedContent(complex, document, value);
         }
         return value;
     }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/GML3EncodingUtils.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/GML3EncodingUtils.java
@@ -372,6 +372,22 @@ public class GML3EncodingUtils {
         encodeAsText(document, element, value);
     }
 
+    /**
+     * Encode the unrestrictedContent property of a ComplexAttribute (if any) as an XML text node.
+     * 
+     * <p>A property named unrestrictedContent is a convention for representing XSD complexType with
+     * arbitrary mixed content.</p>
+     * 
+     * @param complex
+     * @param document
+     * @param element
+     */
+    public static void encodeUnrestrictedContent(ComplexAttribute complex, Document document,
+            Element element) {
+        Object value = getUnrestrictedContent(complex);
+        encodeAsText(document, element, value);
+    }
+
     public static void encodeAsText(Document document, Element element, Object value) {
         if (value != null) {
             Text text = document.createTextNode(Converters.convert(value, String.class));
@@ -395,4 +411,19 @@ public class GML3EncodingUtils {
         }
     }
 
+    /**
+     * Return the content of a {@link ComplexAttribute} if it represents a complexType with
+     * arbitrary mixed content, otherwise null.
+     * 
+     * @param complex
+     * @return
+     */
+    public static Object getUnrestrictedContent(ComplexAttribute complex) {
+        Property unrestrictedContent = complex.getProperty(new NameImpl("unrestrictedContent"));
+        if (unrestrictedContent == null) {
+            return null;
+        } else {
+            return unrestrictedContent.getValue();
+        }
+    }
 }

--- a/modules/extension/xsd/xsd-gml3/src/test/resources/org/geotools/gml3/bindings/AnyTypeTest.xsd
+++ b/modules/extension/xsd/xsd-gml3/src/test/resources/org/geotools/gml3/bindings/AnyTypeTest.xsd
@@ -17,4 +17,13 @@
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:complexType>
+
+    <xsd:complexType name="UnrestrictedType">
+        <xsd:complexContent>
+            <xsd:extension base="xsd:anyType">
+                <xsd:attribute name="attr1" type="xsd:string" />
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="unrestrictedEl" type="test:UnrestrictedType" substitutionGroup="gml:AbstractObject" />
 </xsd:schema>


### PR DESCRIPTION
Adds support for complex types with arbitrary contents (i.e. derived from `xs:anyType` by extension). Simple content is added to a special property called `unrestrictedContent` and encoded as text.

See [related discussion](http://osgeo-org.1560.x6.nabble.com/App-schema-cannot-set-string-value-to-swe-DataArray-swe-values-element-td5228781.html) on the mailing list.