### PR TITLE
13.x backport of doc pages caused by codehaus shutdown

### DIFF
--- a/docs/common.py
+++ b/docs/common.py
@@ -26,14 +26,13 @@ import re
 extensions = ['sphinx.ext.todo','sphinx.ext.extlinks']
 
 extlinks = { 
-    'wiki': ('http://docs.codehaus.org/display/GEOTOOLS/%s',''),
+    'wiki': ('https://github.com/geotools/geotools/wiki/%s',''),
     'website': ('http://geotools.org/%s',''),
     'geoserver': ('http://docs.geoserver.org/latest/en/user/%s',''),
     'developer': ('http://docs.geotools.org/latest/developer/%s',''),
     'user': ('http://docs.geotools.org/latest/userguide/%s',''),
-    'geot': ('https://jira.codehaus.org/browse/GEOT-%s','GEOT-')
+    'geot': ('https://osgeo-org.atlassian.net/browse/GEOT-%s','GEOT-')
 }
-
 
 # Add any paths that contain templates here, relative to this directory.
 #templates_path = ['_templates']

--- a/docs/developer/communication.rst
+++ b/docs/developer/communication.rst
@@ -52,11 +52,11 @@ current activity of the project.
 Issue Tracker
 ---------------
 
-GeoTools tracks tasks, issues and bugs with its JIRA tracker, generously provided by Atlassian and hosted by CodeHaus.
+GeoTools tracks tasks, issues and bugs with its JIRA tracker, generously provided by OSGeo and hosted by Atlassian.
 
 This is where all bugs should be reported, in addition to requested features and improvements.
 
-* http://jira.codehaus.org/secure/BrowseProject.jspa?id=10270
+* https://osgeo-org.atlassian.net/projects/GEOT
 
 Filling out all fields is specially important for bug reports:
 
@@ -96,33 +96,16 @@ IRC Breakout Meetings
   email list allowing interested parties to attend.
 
 
-Confluence
-----------
+Wiki
+----
 
-Confluence has been used since March 2004 to allow anyone (developers and users) to
-work on design ideas and change proposals.
+The development team has migrated to the use of GitHub wiki (in April of 2015) to work on design ideas and change proposals. Prior to this time Confluence was used.
 
-Because of spammers our procedure to get read/write access to the wiki has gotten a tad annoying.
+* https://github.com/geotools/geotools/wiki
 
-It is documented at the bottom of our home wiki page:
+Developers can edit the wiki directly using the Edit button provided. 
 
-1. Create an account for confluence: http://docs.codehaus.org/signup.action
-2. Create an account for codehaus: http://xircles.codehaus.org/signup
-3. Go to your personal details page: http://xircles.codehaus.org/my/details
-4. Use the form to fill in your Confluence Username from step one.
-
-   http://xircles.codehaus.org/projects/geotools
-
-5. Go to the GeoTools project page: http://xircles.codehaus.org/projects/geotools
-6. And click on Apply to join as a developer
-7. Wait for a GeoTools Project Management Committee Member to grant you permission
-8. Once you have an account, you just need to login and click on the edit button to modify a page.
-
-Tips:
-
-* One way to start contributing to the wiki documentation is to fix mistakes, clarify confusing
-  content or by contributing an article on an area of the GeoTools code base you are
-  familiar with.
+If you do not have commit access and would like to submit a change proposal please email geotools-devel and a commmitter can post on your behalf.
 
 Websites
 --------
@@ -134,9 +117,8 @@ http://geotools.org/                          GeoTools website                  
 http://geotoolsnews.blogspot.com/             GeoTools Blog                               Blogger
 http://sourceforge.net/projects/geotools/     Used for project downloads.                 SourceForge
 https://github.com/geotools                   Source code                                 GitHub
-http://jira.codehaus.org/browse/GEOT          JIRA Issue Tracker                          CodeHaus
-http://docs.codehaus.org/display/GEOTOOLS     Confluence wiki for developer collaboration CodeHaus
-http://xircles.codehaus.org/projects/geotools CodeHaus project page for single sign on    CodeHaus
+https://osgeo-org.atlassian.net/projects/GEOT JIRA Issue Tracker                          Atlassian
+https://github.com/geotools/geotools/wiki     Wiki for developer collaboration            GitHub
 ============================================= =========================================== ============
 
 GeoTools has entries on a number of other public websites:
@@ -148,8 +130,9 @@ GeoTools has entries on a number of other public websites:
 * http://gis.stackexchange.com/questions/tagged/geotools
 * http://www.slashgeo.org/category/Tags/GeoTools
 
-We have a number of facilities we no longer use:
+We have a archived a number of facilities we no longer use:
 
+* http://old.geotools.org/
 * http://docs.codehaus.org/display/GEOTDOC/Home
 * http://docs.codehaus.org/display/GEOT/Home
 * http://svn.osgeo.org/geotools/trunk

--- a/docs/developer/procedures/add.rst
+++ b/docs/developer/procedures/add.rst
@@ -158,7 +158,7 @@ Uploading to Ibiblio
    are one of the lucky few you will have to ask someone else to do that part for you.
 3. To do this create a JIRA task requesting that your jar be uploaded/
    
-   * http://jira.codehaus.org/secure/CreateIssue!default.jspa
+   * https://osgeo-org.atlassian.net/secure/CreateIssue!default.jspa
 
 4. In this task request include the following information:
    

--- a/docs/developer/procedures/check.rst
+++ b/docs/developer/procedures/check.rst
@@ -1,9 +1,9 @@
 Gold Star Quality Assurance Check
 ==================================
 
-The GeoTools Module Matrix makes use of a gold star system, 3 stars or more is great, an X is used to indicate non working modules.
+GeoTools Modules makes use of a gold star system, 3 stars or more is great, an X is used to indicate non working modules.
 
-* http://docs.codehaus.org/display/GEOTOOLS/Module+Matrix
+Check each module for a README.md for developer notes.
 
 This test is something quick, accessible and visible to end users.
 

--- a/docs/developer/procedures/create.rst
+++ b/docs/developer/procedures/create.rst
@@ -47,10 +47,10 @@ Lets follow a couple of steps - just to start out with. The goal here is to let 
       CC: geotools-devel@lists.sourceforge.net
       Subject: Commit Access request for Fish module
 
-      Well as requested I have read the developers guide (some of it looks out of date?),
-      and created a wiki page for my proposed module:
+      As requested I have read the developers guide (some of it looks out of date?),
+      and submitted a documentation page for my proposed module:
 
-         http://docs.codehaus.org/display/GEOTOOLS/Fish
+         http://docs.geotools.org/latest/userguide/unsupported/fish.html
 
       I think all I need is commit access and I can get going.
 

--- a/docs/developer/procedures/proposal.rst
+++ b/docs/developer/procedures/proposal.rst
@@ -127,8 +127,9 @@ Once you have the proposal page in place, and the Jira issue ready to capture di
   the GeoTools change proposal process and emailing the list.
   
   Here are the links:
-  - http://jira.codehaus.org/browse/GEOT-1083
-  - http://docs.codehaus.org/display/GEOTOOLS/FunctionImpl Library separation
+  
+  - https://osgeo-org.atlassian.net/projects/GEOT-1083
+  - https://github.com/geotools/geotools/wiki/Describe-Function-with-FunctionName
   
   This change requires the introduction of *new* API (namely Library), and
   will require the deprecation of our existing FunctionFactory extension

--- a/docs/developer/procedures/release.rst
+++ b/docs/developer/procedures/release.rst
@@ -21,7 +21,7 @@ The following are necessary to perform a GeoTools release:
 #. Commit access to the GeoTools `Git repository <https://Github.com/geotools/geotools>`_
 #. Build access to `Jenkins <http://ares.boundlessgeo.com/jenkins/>`_
 #. Edit access to the GeoTools `Blog <http://www.blogger.com/blogger.g?blogID=5176900881057973693#overview>`_
-#. Administration rights to `GeoTools JIRA <https://jira.codehaus.org/browse/GEOT>`__
+#. Administration rights to `GeoTools JIRA <https://osgeo-org.atlassian.net/projects/GEOT/>`__
 #. Release/file management privileges in `SourceForge <https://sourceforge.net/projects/geotools/>`_
 
 Versions and revisions
@@ -65,7 +65,7 @@ Run the `geotools-release-jira <http://ares.boundlessgeo.com/jenkins/job/geotool
 
   The password for the ``JIRA_USER``.
      
-This job will perform the tasks in JIRA to release ``VERSION``. Navigate to `JIRA <http://jira.codehaus.org/browse/GEOT>`_ and verify that the version has actually been released.
+This job will perform the tasks in JIRA to release ``VERSION``. Navigate to `JIRA <https://osgeo-org.atlassian.net/projects/GEOT>`_ and verify that the version has actually been released.
 
 If you are cutting the first RC of a series, create the stable branch
 ---------------------------------------------------------------------
@@ -86,6 +86,7 @@ When creating the first release candidate of a series some extra steps need to b
       git commit . -m "Updating version numbers to 11-SNAPSHOT"
       git push geotools master
 
+* Create the new beta version in `JIRA <https://osgeo-org.atlassian.net/projects/GEOT>`_ for issues on master; for example, if master is now ``14-SNAPSHOT``, create a Jira version ``14-beta`` for the first release of the ``14.x`` series
 
 * Announce on the mailing list that the new stable branch has been created and that the feature freeze on master is over
 
@@ -179,7 +180,7 @@ Announce on GeoTools Blog
 #. You will need to correct the following information: 
 
    * Update the Sourceforge links above to reflect the release
-   * Update the Release Notes by choosing the the correct version from `JIRA changelogs <https://jira.codehaus.org/browse/GEOT#selectedTab=com.atlassian.jira.plugin.system.project:changelog-panel&allVersions=false>`_
+:   * Update the Release Notes by choosing the the correct version from `JIRA changelogs <https://osgeo-org.atlassian.net/projects/GEOT?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page>`_
    * For a new stable series, be sure to thank those involved with the release (testing, completed proposals, docs, and so on)
 
 #. The public entry point will be here: http://geotoolsnews.blogspot.com/

--- a/docs/developer/roles/committee.rst
+++ b/docs/developer/roles/committee.rst
@@ -25,7 +25,7 @@ The GeoTools PMC is the formal "Project Steering Committee" for GeoTools:
 * The PMC is responsible for providing a "GeoTools Officer" to the OSGeo Foundation to act as a
   point of contact.
   
-  * Jody Garnett ( `jgarnett <https://jira.codehaus.org/secure/ViewProfile.jspa?name=jgarnett>`_ )
+  * Jody Garnett ( `jgarnett <https://github.com/jodygarnett>`_ )
 
 * Other Foundation committees may make request of the project in order to facilitate different
   initiatives such as promotion, fundraising, education and so forth. The only reliable request
@@ -73,9 +73,7 @@ PMC members:
 
 * Keep abreast of project administration communication
   
-  * `Issue Tracker "admin" <https://jira.codehaus.org/browse/GEOT/component/10520>`_
-    
-    watchers list: `aaime <https://jira.codehaus.org/secure/ViewProfile.jspa?name=aaime>`_ , `bencaradocdavies <https://jira.codehaus.org/secure/ViewProfile.jspa?name=bencaradocdavies>`_ , `christian.mueller@nvoe.at <https://jira.codehaus.org/secure/ViewProfile.jspa?name=christian.mueller%40nvoe.at>`_ , `ianturton <https://jira.codehaus.org/secure/ViewProfile.jspa?name=ianturton>`_ , `jgarnett <https://jira.codehaus.org/secure/ViewProfile.jspa?name=jgarnett>`_ , `jdeolive <https://jira.codehaus.org/secure/ViewProfile.jspa?name=jdeolive>`_ , `simboss <https://jira.codehaus.org/secure/ViewProfile.jspa?name=simboss>`_
+  * `Issue Tracker "admin" <https://osgeo-org.atlassian.net/projects/GEOT>`_
 
   * `Administration List <https://lists.sourceforge.net/lists/listinfo/geotools-administration>`_
 

--- a/docs/developer/roles/maintainer.rst
+++ b/docs/developer/roles/maintainer.rst
@@ -60,7 +60,7 @@ We have a "relaxed" set of requirements for "unsupported" modules - providing a 
    Recommended:
    
    * User documentation will help reduce the amount of email you recieve
-   * Set up a module wiki page (see `Module Matrix <http://docs.codehaus.org/display/GEOTOOLS/Module+Matrix>`_ for the complete list)
+   * Set up a module README.md page
     
 3. We have no process for "volunteering" to work on an unsupported module at this time; email the
    developer list and we will figure it out.

--- a/docs/themes/geotools-web/page.html
+++ b/docs/themes/geotools-web/page.html
@@ -34,8 +34,6 @@
             </script>
         </div>
         <div class="sphinxsidebarwrapper">
-
-          <a href="http://codehaus.org/"><img src="_static/img/codehaus-logo-only.png" width=82 height=74 style="padding: 2; border: 0;"></a><br/>
           
           <a href="http://sourceforge.net/projects/geotools/"><img src="_static/img/sflogo.gif" width=88 heigh=33 style="padding: 2; border: 0;"></a><br/>
           

--- a/docs/themes/geotools/page.html
+++ b/docs/themes/geotools/page.html
@@ -31,7 +31,7 @@
             <ul id="top-nav">
                 <li class="first"><a href="http://docs.geotools.org">Documentation</a></li>
                 <li><a href="http://sourceforge.net/projects/geotools/files">Downloads</a></li>
-                <li><a href="http://docs.codehaus.org/display/GEOTOOLS/Home">Wiki</a></li>
+                <li><a href="https://github.com/geotools/geotools/wiki">Wiki</a></li>
                 <li><a href="http://geotools.org/about.html">About</a></li>
                 <li><a href="http://geotoolsnews.blogspot.com">Blog</a></li>
             </ul>

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -19,7 +19,7 @@ and :doc:`extension </extension/index>`.
    using the project issue tracker.
    
    * :doc:`Create an Issue </welcome/support>` .
-   * `Known Documentation Issues <https://jira.codehaus.org/browse/GEOT/component/10521>`_ (Issue Tracker)
+   * `Known Documentation Issues <https://osgeo-org.atlassian.net/issues/?jql=project%20%3D%20GEOT%20AND%20component%20%3D%20docs>`_ (Issue Tracker)
    * `Jody Garnett <mailto: jody.garnett@gmail.com>`_ (Module Maintainer)
    
    For small typos and source code corrections email the module maintainer above.

--- a/docs/user/library/cql/ecql.rst
+++ b/docs/user/library/cql/ecql.rst
@@ -5,7 +5,7 @@ The ECQL language is intended as an extension of CQL, thus you can write all pre
 
 References
 
-* `ECQL Parser Design <http://docs.codehaus.org/display/GEOTOOLS/ECQL+Parser+Design>`_ (wiki with BNF)
+* `ECQL Parser Design <http://old.geotools.org/ECQL-Parser-Design_110493908.html`_ (design doc with BNF)
 * `GeoServer CQL Examples <http://docs.geoserver.org/latest/en/user/tutorials/cql/cql_tutorial.html>`_ (geoserver)
 
 ECQL Utility Class

--- a/docs/user/library/referencing/faq.rst
+++ b/docs/user/library/referencing/faq.rst
@@ -21,7 +21,7 @@ If this doesn't work you can try this more brutal, System wide approach...
 See also:
 
 * :doc:`/library/referencing/order`
-* A `Jira issue <http://jira.codehaus.org/browse/GEOT-2995>`_ discussing this problem
+* A `Jira issue <https://osgeo-org.atlassian.net/projects/GEOT-2995>`_ discussing this problem
 
 Q: How to choose an EPSG Authority?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user/welcome/support.rst
+++ b/docs/user/welcome/support.rst
@@ -65,18 +65,19 @@ or people like you hiring an organisation to for specific work.
 Issue Tracker
 -------------
 
-GeoTools tracks tasks, issues and bugs with its JIRA tracker, generously provided by OSGeo and hosted by Atlassian. This is where all bugs should be reported, in addition to requested features
+GeoTools tracks tasks, issues and bugs with its JIRA tracker, generously provided by OSGeo and hosted by. This is where all bugs should be reported, in addition to requested features
 and improvements.
 
 To create an issue:
 
-1. Sign up with CodeHaus: `Signup <http://xircles.codehaus.org/signup>`_ .
-   This CodeHaus username is used for both the issue tracker and the wiki.
-2. `Login <http://jira.codehaus.org/>`
-3. Once you are logged in you can create a new issue
+1. [Log In](https://osgeo-org.atlassian.net/login) to <osgeo-org.atlassian.net>.
    
-   * Navigate to the `GeoTools JIRA page <http://jira.codehaus.org/browse/GEOT>`_
-   * Press the **Create New Issue** at the top of the page
+   * If this is your first time you can [create an account](https://osgeo-org.atlassian.net/admin/users/sign-up) using the link at the bottom of the Sign In screen.
+
+3. Once logged in you can [Create](https://osgeo-org.atlassian.net/secure/CreateIssue!default.jspa) an issue from the button at the top of the page
+   
+   * Navigate to the `GeoTools JIRA page <https://osgeo-org.atlassian.net/projects/GEOT>`_
+   * Press the **Create** at the top of the page
    
    .. image:: /images/CreateIssue.png
    
@@ -109,8 +110,7 @@ To create an issue:
    Note: This is why you must sign up for an account, so that JIRA can email you
    when updates are done. Your email will not be used for anything else. One nice
    little feature of JIRA is that if you reply to the email sent for notification,
-   including jira@codehaus.org as a recipient, then the reply will show up as a
-   comment on the issue.
+   then the reply will show up as a comment on the issue.
 
 7. When will your bug be fixed?
    

--- a/docs/user/welcome/upgrade.rst
+++ b/docs/user/welcome/upgrade.rst
@@ -45,7 +45,7 @@ GeoTools 10.0
 
 .. sidebar:: Wiki
 
-   * `GeoTools 10.0 <http://docs.codehaus.org/display/GEOTOOLS/10.x>`_
+   * `GeoTools 10.0 <https://github.com/geotools/geotools/wiki/10.x>`_
 
    For background details on any API changes review the change proposals above.
 
@@ -65,7 +65,7 @@ GeoTools 9.0
 
 .. sidebar:: Wiki
 
-   * `GeoTools 9.0 <http://docs.codehaus.org/display/GEOTOOLS/9.x>`_
+   * `GeoTools 9.0 <https://github.com/geotools/geotools/wiki/9.x>`_
 
    For background details on any API changes review the change proposals above.
 
@@ -240,7 +240,7 @@ GeoTools 8.0
 
 .. sidebar:: Wiki
 
-   * `GeoTools 8.0 <http://docs.codehaus.org/display/GEOTOOLS/8.x>`_
+   * `GeoTools 8.0 <https://github.com/geotools/geotools/wiki/8.x>`_
 
    You are encouraged to review the change proposals for GeoTools 8.0 for background information
    on the following changes.
@@ -380,7 +380,7 @@ GeoTools 2.7
 
 .. sidebar:: Wiki
 
-   * `GeoTools 2.7.0 <http://docs.codehaus.org/display/GEOTOOLS/2.7.x>`_
+   * `GeoTools 2.7.0 <https://github.com/geotools/geotools/wiki/2.7.x>`_
 
    You are encouraged to review the change proposals for GeoTools 2.7.0 for background information
    on the following changes.
@@ -578,7 +578,7 @@ GeoTools 2.6
 
 .. sidebar:: Wiki
 
-   * `GeoTools 2.6.0 <http://docs.codehaus.org/display/GEOTOOLS/2.6.x>`_
+   * `GeoTools 2.6.0 <https://github.com/geotools/geotools/wiki/2.6.x>`_
 
    You are encouraged to review the change proposals for GeoTools 2.6.0 for background information
    on the following changes.
@@ -794,7 +794,7 @@ GeoTools 2.5
 
 .. sidebar:: Wiki
 
-   * `GeoTools 2.5.0 <http://docs.codehaus.org/display/GEOTOOLS/2.5.x>`_
+   * `GeoTools 2.5.0 <https://github.com/geotools/geotools/wiki/2.5.x>`_
 
    You are encouraged to review the change proposals for GeoTools 2.5.0 for background information
    on the following changes.
@@ -1117,7 +1117,7 @@ GeoTools 2.4
 
 .. sidebar:: Wiki
 
-   * `GeoTools 2.4.0 <http://docs.codehaus.org/display/GEOTOOLS/2.4.x>`_
+   * `GeoTools 2.4.0 <https://github.com/geotools/geotools/wiki/2.4.x>`_
 
    You are encouraged to review the change proposals for GeoTools 2.4.0 for background information
    on the following changes.

--- a/docs/web/about.rst
+++ b/docs/web/about.rst
@@ -13,10 +13,11 @@ For an overview of the capabilities of GeoTools please check the User Guide
 
 Current `version <http://docs.geotools.org/latest/developer/conventions/version.html>`_ information:
 
-* `12.x <http://sourceforge.net/projects/geotools/files/GeoTools%2012%20Releases/>`_: Development
-* `11.x <http://sourceforge.net/projects/geotools/files/GeoTools%2011%20Releases/>`_: Stable
+* `13.x <http://sourceforge.net/projects/geotools/files/GeoTools%2013%20Releases/>`_: Development
+* `12.x <http://sourceforge.net/projects/geotools/files/GeoTools%2012%20Releases/>`_: Stable
+* `11.x <http://sourceforge.net/projects/geotools/files/GeoTools%2011%20Releases/>`_: Maintenance
 
-GeoTools is used by a `number of projects <http://docs.codehaus.org/display/GEOTOOLS/Screenshots>`_
+GeoTools is used by a `number of projects <https://github.com/geotools/geotools/wiki/screenshots>`_
 including Web Feature Servers, Web Map Servers, and desktop applications.
 
 Open Source
@@ -39,4 +40,4 @@ release schedule. Please contact us on the
 
 GeoTools follows an open development process. Our policies and procedures are
 documented in the Developers Guide. Both our change proposals and 
-`issue tracker <http://jira.codehaus.org/browse/GEOT>`_ are open.
+`issue tracker <https://osgeo-org.atlassian.net/projects/GEOT>`_ are open.

--- a/docs/web/getinvolved.rst
+++ b/docs/web/getinvolved.rst
@@ -27,7 +27,7 @@ Participation
 
 * Bug Tracker
   
-  GeoTools uses an issue tracker known as `JIRA <http://jira.codehaus.org/browse/GEOT>`_ to manage
+  GeoTools uses an issue tracker known as `JIRA <https://osgeo-org.atlassian.net/projects/GEOT>`_ to manage
   bugs, issues, and new features. If you have found a bug, or if there is a feature that you would
   like to see implemented in GeoTools, please report it in JIRA.
 


### PR DESCRIPTION
Since 13.x is a maintenance release the references to issue tracker should be up-to-date.

This is a backport of @jodygarnett's commit d43b1cd3ca8ec7ded994ded7238d0cd1e78964fb cherry-picked and merged.

