### PR TITLE
MemoryDataStore thread safety for internal collections

### DIFF
--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryDataStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryDataStore.java
@@ -24,16 +24,12 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.logging.Level;
 
-import org.geotools.data.AbstractDataStore;
 import org.geotools.data.DataSourceException;
 import org.geotools.data.FeatureReader;
-import org.geotools.data.FeatureWriter;
 import org.geotools.data.Query;
-import org.geotools.data.SchemaNotFoundException;
-import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.store.ContentDataStore;
@@ -41,19 +37,12 @@ import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.NameImpl;
-import org.geotools.feature.simple.SimpleFeatureBuilder;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.Feature;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.IllegalAttributeException;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.Name;
-import org.opengis.filter.Filter;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * This is an example implementation of a DataStore used for testing.
@@ -70,16 +59,25 @@ import com.vividsolutions.jts.geom.Geometry;
  * 
  * <p>
  * This class will also illustrate the use of In-Process locking when the time comes.
+ * 
+ * Note: While iteration through the Map using {@link #features(String)} its possible 
+ * other threads writing features at the same time. If so the iterator represents a slightly 
+ * out-of-date DataSet, depending on the amount of data has been written in between.
+ * 
+ * Adding and removing features is thread-safe.
+ * 
+ * Its possible to remove schemas to free memory, if required.
  * </p>
  *
  * @author jgarnett
+ * @author Frank Gasdorf
  *
  *
  * @source $URL$
  */
 public class MemoryDataStore extends ContentDataStore {
     /** Memory holds Map of Feature by fid by typeName. */
-    protected Map<String,Map<String,SimpleFeature>> memory = new LinkedHashMap<String,Map<String,SimpleFeature>>();
+    protected Map<String,ConcurrentSkipListMap<String,SimpleFeature>> memory = new LinkedHashMap<String,ConcurrentSkipListMap<String,SimpleFeature>>();
 
     /** Schema holds FeatureType by typeName */
     protected Map<String,SimpleFeatureType> schema = new HashMap<String,SimpleFeatureType>();
@@ -93,10 +91,9 @@ public class MemoryDataStore extends ContentDataStore {
      * @param schema An empty feature collection of this type will be made available
      */
     public MemoryDataStore(SimpleFeatureType featureType) {
-        Map<String,SimpleFeature> featureMap = new LinkedHashMap<String,SimpleFeature>();
+    	ConcurrentSkipListMap<String,SimpleFeature> featureMap = new ConcurrentSkipListMap<String,SimpleFeature>();
         String typeName = featureType.getTypeName();
-        schema.put(typeName, featureType);
-        memory.put(typeName, featureMap);
+        putSchemaAndFeaturesSync(typeName, featureType, featureMap);
     }
     public MemoryDataStore(FeatureCollection<SimpleFeatureType,SimpleFeature> collection) {
         addFeatures(collection);
@@ -130,7 +127,7 @@ public class MemoryDataStore extends ContentDataStore {
             // use an order preserving map, so that features are returned in the same
             // order as they were inserted. This is important for repeatable rendering
             // of overlapping features.
-            Map<String,SimpleFeature> featureMap = new LinkedHashMap<String,SimpleFeature>();
+            ConcurrentSkipListMap<String,SimpleFeature> featureMap = new ConcurrentSkipListMap<String,SimpleFeature>();
             String typeName;
             SimpleFeature feature;
 
@@ -150,8 +147,7 @@ public class MemoryDataStore extends ContentDataStore {
                 featureMap.put(feature.getID(), feature);
             }
 
-            schema.put(typeName, featureType);
-            memory.put(typeName, featureMap);
+            putSchemaAndFeaturesSync(typeName, featureType, featureMap);
         } catch (IllegalAttributeException e) {
             throw new DataSourceException("Problem using reader", e);
         }
@@ -160,7 +156,7 @@ public class MemoryDataStore extends ContentDataStore {
         }
     }
 
-    /**
+	/**
      * Configures MemoryDataStore with FeatureReader.
      *
      * @param reader New contents to add
@@ -171,7 +167,7 @@ public class MemoryDataStore extends ContentDataStore {
     public void addFeatures(SimpleFeatureIterator reader) throws IOException {
         try {
             SimpleFeatureType featureType;
-            Map<String,SimpleFeature> featureMap = new LinkedHashMap<String,SimpleFeature>();
+            ConcurrentSkipListMap<String,SimpleFeature> featureMap = new ConcurrentSkipListMap<String,SimpleFeature>();
             String typeName;
             SimpleFeature feature;
 
@@ -191,8 +187,7 @@ public class MemoryDataStore extends ContentDataStore {
                 featureMap.put(feature.getID(), feature);
             }
 
-            schema.put(typeName, featureType);
-            memory.put(typeName, featureMap);
+            putSchemaAndFeaturesSync(typeName, featureType, featureMap);
         }
         finally {
             reader.close();
@@ -214,27 +209,25 @@ public class MemoryDataStore extends ContentDataStore {
             throw new IllegalArgumentException("Provided SimpleFeatureCollection is empty");
         }
 
-        synchronized (memory) {
-            for (Iterator<?> i = collection.iterator(); i.hasNext();) {
-                addFeatureInternal((SimpleFeature) i.next());
-            }
+    
+        for (Iterator<?> i = collection.iterator(); i.hasNext();) {
+            addFeatureInternal((SimpleFeature) i.next());
         }
     }
+    
     public void addFeatures(FeatureCollection<SimpleFeatureType,SimpleFeature> collection) {
         if ((collection == null) ) {
             throw new IllegalArgumentException("Provided SimpleFeatureCollection is empty");
         }
-        synchronized (memory) {
-            try {
-                collection.accepts( new FeatureVisitor(){
-                    public void visit(Feature feature) {
-                        addFeatureInternal( (SimpleFeature) feature );
-                    }                
-                }, null );
-            }
-            catch( IOException ignore){
-                LOGGER.log( Level.FINE, "Unable to add all features", ignore );
-            }
+        try {
+            collection.accepts( new FeatureVisitor(){
+                public void visit(Feature feature) {
+                    addFeatureInternal( (SimpleFeature) feature );
+                }                
+            }, null );
+        }
+        catch( IOException ignore){
+            LOGGER.log( Level.FINE, "Unable to add all features", ignore );
         }
     }
     /**
@@ -248,11 +241,9 @@ public class MemoryDataStore extends ContentDataStore {
         if ((features == null) || (features.length == 0)) {
             throw new IllegalArgumentException("Provided features are empty");
         }
-
-        synchronized (memory) {
-            for (int i = 0; i < features.length; i++) {
-                addFeatureInternal(features[i]);
-            }
+    
+        for (int i = 0; i < features.length; i++) {
+            addFeatureInternal(features[i]);
         }
     }
 
@@ -260,8 +251,8 @@ public class MemoryDataStore extends ContentDataStore {
      * Adds a single Feature to the correct typeName entry.
      * 
      * <p>
-     * This is an internal opperation used for setting up MemoryDataStore - please use
-     * FeatureWriter for generatl use.
+     * This is an internal operation used for setting up MemoryDataStore - please use
+     * FeatureWriter for general use.
      * </p>
      * 
      * <p>
@@ -271,9 +262,7 @@ public class MemoryDataStore extends ContentDataStore {
      * @param feature Individual feature to add
      */
     public void addFeature(SimpleFeature feature) {
-        synchronized (memory) {
-            addFeatureInternal(feature);
-        }
+        addFeatureInternal(feature);
     }
 
     private void addFeatureInternal(SimpleFeature feature) {
@@ -286,9 +275,9 @@ public class MemoryDataStore extends ContentDataStore {
 
         String typeName = featureType.getTypeName();
 
-        Map<String,SimpleFeature> featuresMap;
-
-        if (!memory.containsKey(typeName)) {
+        Map<String,SimpleFeature> featuresMap = getFeatureMapSync(typeName);
+        
+        if (featuresMap == null) {
             try {
                 createSchema(featureType);
             } catch (IOException e) {
@@ -298,11 +287,12 @@ public class MemoryDataStore extends ContentDataStore {
             }
         }
 
-        featuresMap = memory.get(typeName);
+        featuresMap = getFeatureMapSync(typeName);
         featuresMap.put(feature.getID(), feature);
     }
 
-    /**
+
+	/**
      * Access featureMap for typeName.
      *
      * @param typeName
@@ -312,11 +302,11 @@ public class MemoryDataStore extends ContentDataStore {
      * @throws IOException If typeName cannot be found
      */
     protected Map<String,SimpleFeature> features(String typeName) throws IOException {
-        synchronized (memory) {
-            if (memory.containsKey(typeName)) {
-                return memory.get(typeName);
-            }
-        }
+    	Map<String, SimpleFeature> synchedFeatureMap = getFeatureMapSync(typeName);
+    	
+    	if (synchedFeatureMap != null) {
+    		return synchedFeatureMap;
+    	}
 
         throw new IOException("Type name " + typeName + " not found");
     }
@@ -366,17 +356,42 @@ public class MemoryDataStore extends ContentDataStore {
     public void createSchema(SimpleFeatureType featureType) throws IOException {
         String typeName = featureType.getTypeName();
 
-        if (memory.containsKey(typeName)) {
+        Map<String, SimpleFeature> synchedFeatureMap = getFeatureMapSync(typeName);
+        
+        if (synchedFeatureMap != null) {
             // we have a conflict
             throw new IOException(typeName + " already exists");
         }
             // insertion order preserving map
-            Map<String,SimpleFeature> featuresMap = new LinkedHashMap<String,SimpleFeature>();
-            schema.put(typeName, featureType);
-            memory.put(typeName, featuresMap);
+        ConcurrentSkipListMap<String,SimpleFeature> featureMap = new ConcurrentSkipListMap<String,SimpleFeature>();
+        putSchemaAndFeaturesSync(typeName, featureType, featureMap);
     }
 
-    /* (non-Javadoc)
+    private Map<String, SimpleFeature> getFeatureMapSync(String typeName) {
+        if (typeName == null) {
+            return null;
+        }
+    
+        synchronized (memory) {
+            return memory.get(typeName);
+        }
+    
+    }
+
+    private void putSchemaAndFeaturesSync(String typeName,
+            SimpleFeatureType featureType,
+            ConcurrentSkipListMap<String, SimpleFeature> featureMap) {
+        synchronized (schema) {
+            schema.put(typeName, featureType);
+        }
+    
+        synchronized (memory) {
+            memory.put(typeName, featureMap);
+        }
+    }
+    
+    /*
+     * (non-Javadoc)
      * @see org.geotools.data.store.ContentDataStore#removeSchema(java.lang.String)
      */
     @Override
@@ -386,7 +401,7 @@ public class MemoryDataStore extends ContentDataStore {
             synchronized (schema) {
                 schema.remove(typeName);
             }
-
+    
             synchronized (memory) {
                 memory.remove(typeName);
             }

--- a/modules/library/data/src/test/java/org/geotools/data/memory/MemoryDataStoreTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/memory/MemoryDataStoreTest.java
@@ -19,7 +19,9 @@ package org.geotools.data.memory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.geotools.data.DataStore;
@@ -72,7 +74,7 @@ import com.vividsolutions.jts.geom.MultiLineString;
  * DOCUMENT ME!
  * 
  * @author Jody Garnett, Refractions Research
- *
+ * @author Frank Gasdorf
  *
  * @source $URL$
  */
@@ -443,17 +445,17 @@ public class MemoryDataStoreTest extends DataTestCase {
                 new Integer(1),
                 line(new int[] { 1, 1, 2, 2, 4, 2, 5, 1 }),
                 "r1"
-            }, null
+            }, "r1"
         );
         dynFeatures[1] = SimpleFeatureBuilder.build(roadType, new Object[] {
                 new Integer(2), line(new int[] { 3, 0, 3, 2, 3, 3, 3, 4 }),
                 "r2"
-            }, null
+            }, "r2"
         );
         dynFeatures[2] = SimpleFeatureBuilder.build(roadType, new Object[] {
                 new Integer(3),
                 line(new int[] { 3, 2, 4, 2, 5, 3 }), "r3"
-            }, null
+            }, "r3"
         );
         assertOrderSame(dynFeatures);
     }
@@ -507,7 +509,6 @@ public class MemoryDataStoreTest extends DataTestCase {
      * @return DOCUMENT ME!
      * @throws NoSuchElementException DOCUMENT ME!
      * @throws IOException DOCUMENT ME!
-     * @throws IllegalAttributeException DOCUMENT ME!
      */
     boolean covers(  FeatureReader<SimpleFeatureType, SimpleFeature> reader, SimpleFeature[] array ) throws NoSuchElementException,
             IOException {
@@ -871,7 +872,7 @@ public class MemoryDataStoreTest extends DataTestCase {
 
          FeatureReader<SimpleFeatureType, SimpleFeature> reader = data.getFeatureReader(new Query("road", rd1Filter), defaultTransaction);
 
-         Geometry geom1 = (Geometry) reader.next().getDefaultGeometry();
+        Geometry geom1 = (Geometry) reader.next().getDefaultGeometry();
         reader.close();
         assertEquals(new Coordinate(0, 0), geom1.getCoordinates()[0]);
         assertEquals(new Coordinate(0, 1), geom1.getCoordinates()[1]);
@@ -1233,10 +1234,8 @@ public class MemoryDataStoreTest extends DataTestCase {
         store1.setTransaction(defaultTransaction);
         class Listener implements FeatureListener {
 
-            String name;
-            List events = new ArrayList();
+            List<FeatureEvent> events = new ArrayList<FeatureEvent>();
             public Listener( String name ) {
-                this.name = name;
             }
 
             public void changed( FeatureEvent featureEvent ) {
@@ -1417,6 +1416,7 @@ public class MemoryDataStoreTest extends DataTestCase {
         } while ( then > System.currentTimeMillis() - 515 );     
         assertFalse(isLocked("road", "road.rd1"));
     }
+
     public void testRemoveSchema() throws IOException {
         // two featureTypes should be in
         List<Name> names = data.getNames();
@@ -1442,7 +1442,33 @@ public class MemoryDataStoreTest extends DataTestCase {
         } catch (IOException e) {
             fail("remove Schema should act gracfully if it has never been created for that type");
         }
+    }
 
+    public void testConcurrentModificationExcpetionWritingWhileReading() throws IOException {
+    	Map<String, SimpleFeature> features = data.features("road");
+    	assertTrue(features.size() >= 2);
+    	Iterator<SimpleFeature> iterator = features.values().iterator();
+    	if (iterator.hasNext()) {
+    		iterator.next();
+    	}
+    	FeatureWriter<SimpleFeatureType, SimpleFeature> writer = data.getFeatureWriter("road", Transaction.AUTO_COMMIT);
+    	GeometryFactory fac = new GeometryFactory();
+    	
+    	try {
+            while (writer.hasNext()) {
+                writer.next();
+            }
+            // create a new feature
+            SimpleFeature newFeature = writer.next();
+            newFeature.setDefaultGeometry(fac.createLineString(new Coordinate[]{new Coordinate(10, 10), new Coordinate(20, 20)}));
+            writer.write();
+            
+        } finally {
+            writer.close();
+        }
+    	// 2nd iterator.next() causes java.util.ConcurrentModificationException"
+    	iterator.next();
+    	
         // still the same size and no IOException
         List<Name> namesAfterRemove = data.getNames();
         assertNotNull(namesAfterRemove);


### PR DESCRIPTION
If a Reader is iterating through the collection and a Writer (e.g. from Datastream) uses a Transaction to write SimpleFeatures the reader can get ConcurrentModificationException if not finished meanwhile. That can break rendering (BasicFeatureRenderer in uDig).

Implications : The reader might work on a slightly out-of-date DataSet, depending on the amount of data has been written in between.
