### PR TITLE
[GEOT-5256] added removeSchema Support for MemoryDataStore

### DIFF
--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryDataStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryDataStore.java
@@ -375,4 +375,32 @@ public class MemoryDataStore extends ContentDataStore {
             schema.put(typeName, featureType);
             memory.put(typeName, featuresMap);
     }
+
+    /* (non-Javadoc)
+     * @see org.geotools.data.store.ContentDataStore#removeSchema(java.lang.String)
+     */
+    @Override
+    public void removeSchema(String typeName) throws IOException {
+        if (typeName != null) {
+            // graceful remove, its fine if the type has never been registered
+            synchronized (schema) {
+                schema.remove(typeName);
+            }
+
+            synchronized (memory) {
+                memory.remove(typeName);
+            }
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.geotools.data.store.ContentDataStore#removeSchema(org.opengis.feature.type.Name)
+     */
+    @Override
+    public void removeSchema(Name typeName) throws IOException {
+        if (typeName != null && typeName.getLocalPart() != null) {
+            removeSchema(typeName.getLocalPart());
+        }
+    }
+
 }

--- a/modules/library/data/src/test/java/org/geotools/data/memory/MemoryDataStoreTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/memory/MemoryDataStoreTest.java
@@ -54,6 +54,7 @@ import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.Id;
@@ -1415,5 +1416,36 @@ public class MemoryDataStoreTest extends DataTestCase {
             Thread.sleep( 15 );            
         } while ( then > System.currentTimeMillis() - 515 );     
         assertFalse(isLocked("road", "road.rd1"));
+    }
+    public void testRemoveSchema() throws IOException {
+        // two featureTypes should be in
+        List<Name> names = data.getNames();
+        assertNotNull(names);
+        assertEquals(2, names.size());
+
+        data.removeSchema("road");
+
+        List<Name> namesAfterRemove = data.getNames();
+        assertNotNull(namesAfterRemove);
+        assertEquals(1, namesAfterRemove.size());
+    }
+
+    public void testRemoveTypeThatDoesntExistsGracefulWithoutIOException()
+            throws IOException {
+        // two featureTypes should be in
+        List<Name> names = data.getNames();
+        assertNotNull(names);
+        assertEquals(2, names.size());
+
+        try {
+            data.removeSchema("typeThatDoesntExists");
+        } catch (IOException e) {
+            fail("remove Schema should act gracfully if it has never been created for that type");
+        }
+
+        // still the same size and no IOException
+        List<Name> namesAfterRemove = data.getNames();
+        assertNotNull(namesAfterRemove);
+        assertEquals(2, namesAfterRemove.size());
     }
 }


### PR DESCRIPTION
To remove Schemas from MemoryDataStore removeSchema-methods should be overriden by impelemtations of ContenDataStore otherwise UnsupportedOperationException are thrown.

fixes https://osgeo-org.atlassian.net/browse/GEOT-5256