### PR TITLE
removed outdated svn scm sections

### DIFF
--- a/modules/extension/app-schema/app-schema-example/pom.xml
+++ b/modules/extension/app-schema/app-schema-example/pom.xml
@@ -15,10 +15,6 @@
     <artifactId>gt-app-schema-example</artifactId>
     <name>Application Schema Support Example</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema-example</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema-example</url>
-    </scm>
 
     <description>Example for Application Schema Support</description>
 

--- a/modules/extension/app-schema/app-schema-packages/cgiutilities-1.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/cgiutilities-1.0/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.0-4</version>
     <name>CGI Utilities 1.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/cgiutilities-1.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/cgiutilities-1.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/earthresourceml-1.1/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/earthresourceml-1.1/pom.xml
@@ -9,10 +9,6 @@
     <version>1.1.0-3</version>
     <name>Earth Resource 1.1 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/earthresourceml-1.1/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/earthresourceml-1.1/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/filter-1.1/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/filter-1.1/pom.xml
@@ -9,10 +9,6 @@
     <version>1.1.1-2</version>
     <name>OGC Filter 1.1 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/filter-1.1/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/filter-1.1/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/filter-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/filter-2.0/pom.xml
@@ -9,10 +9,6 @@
     <version>2.0.0-2</version>
     <name>OGC Filter 2.0 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/filter-2.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/filter-2.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/geosciml-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/geosciml-2.0/pom.xml
@@ -9,10 +9,6 @@
     <version>2.0.2-4</version>
     <name>Geoscience Markup Language (GeoSciML) 2.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/geosciml-2.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/geosciml-2.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/geosciml-3.0-seegrid/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/geosciml-3.0-seegrid/pom.xml
@@ -9,10 +9,6 @@
     <version>3.0.0-1</version>
     <name>Geoscience Markup Language (GeoSciML) 3.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/geosciml-3.0-seegrid/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/geosciml-3.0-seegrid/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/geosciml-3.2-seegrid/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/geosciml-3.2-seegrid/pom.xml
@@ -5,10 +5,6 @@
 	<artifactId>geosciml-3.2-seegrid</artifactId>
 	<version>3.2.0-1</version>
 	<name>Geoscience Markup Language (GeoSciML) 3.0 application schema</name>
-	<scm>
-		<connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/geosciml-3.2-seegrid/</connection>
-		<url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/geosciml-3.2-seegrid/</url>
-	</scm>
 	<developers>
 		<developer>
 			<name>Rini Angreani</name>

--- a/modules/extension/app-schema/app-schema-packages/geosciml-3.2/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/geosciml-3.2/pom.xml
@@ -6,10 +6,6 @@
 	<artifactId>geosciml-3.2</artifactId>
 	<version>3.2.0-1</version>
 	<name>Geoscience Markup Language (GeoSciML) 3.0 application schema</name>
-	<scm>
-		<connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/geosciml-3.2/</connection>
-		<url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/geosciml-3.2/</url>
-	</scm>
 	<developers>
 		<developer>
 			<name>Rini Angreani</name>

--- a/modules/extension/app-schema/app-schema-packages/gml-3.1/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/gml-3.1/pom.xml
@@ -9,10 +9,6 @@
     <version>3.1.1-4</version>
     <name>Geography Markup Language (GML) 3.1 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/gml-3.1/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/gml-3.1/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/gml-3.2/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/gml-3.2/pom.xml
@@ -9,10 +9,6 @@
     <version>3.2.1-1</version>
     <name>Geography Markup Language (GML) 3.2 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/gml-3.2/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/gml-3.2/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/ic-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/ic-2.0/pom.xml
@@ -9,10 +9,6 @@
     <version>2.0.0-3</version>
     <name>Intelligence Community Information Security Marking (IC ISM) 2.0 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/ic-2.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/ic-2.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/iso-19139-2007/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/iso-19139-2007/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.0-1</version>
     <name>ISO/TS 19139:2007 Geographic MetaData (gmd) schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/iso-19139-2007/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/iso-19139-2007/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/iso-19156-seegrid/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/iso-19156-seegrid/pom.xml
@@ -9,10 +9,6 @@
     <version>2.0.0-1</version>
     <name>ISO 19156 Observations and Measurements 2.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/iso-19156-seegrid/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/iso-19156-seegrid/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/om-1.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/om-1.0/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.0-4</version>
     <name>Observations and Measurements 1.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/om-1.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/om-1.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/om-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/om-2.0/pom.xml
@@ -9,10 +9,6 @@
     <version>2.0.0-1</version>
     <name>Observations and Measurements 2.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/om-2.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/om-2.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/ows-1.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/ows-1.0/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.0-2</version>
     <name>OGC Web Service (OWS) 1.0 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/ows-1.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/ows-1.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/ows-1.1/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/ows-1.1/pom.xml
@@ -9,10 +9,6 @@
     <version>1.1.0-1</version>
     <name>OGC Web Service (OWS) 1.1 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/ows-1.1/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/ows-1.1/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/pom.xml
@@ -15,10 +15,6 @@
     <packaging>pom</packaging>
     <name>Application Schema Packages</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/</url>
-    </scm>
 
     <description>
         This is an aggregating pom used to build remote schema resources into

--- a/modules/extension/app-schema/app-schema-packages/sampling-1.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/sampling-1.0/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.0-4</version>
     <name>Sampling 1.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sampling-1.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sampling-1.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/sampling-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/sampling-2.0/pom.xml
@@ -9,10 +9,6 @@
     <version>2.0.0-1</version>
     <name>Sampling 2.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sampling-2.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sampling-2.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/samplingSpatial-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/samplingSpatial-2.0/pom.xml
@@ -5,10 +5,6 @@
 	<artifactId>samplingSpatial-2.0</artifactId>
 	<version>2.0-1</version>
 	<name>SpatialSamplingFeature.xsd Observations and Measurements - schema</name>
-	<scm>
-		<connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/samplingSpatial-2.0/</connection>
-		<url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/samplingSpatial-2.0/</url>
-	</scm>
 	<developers>
 		<developer>
 			<name>Rini Angreani</name>

--- a/modules/extension/app-schema/app-schema-packages/samplingSpecimen-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/samplingSpecimen-2.0/pom.xml
@@ -9,10 +9,6 @@
     <version>2.0.0-1</version>
     <name>Sampling Specimen 2.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/samplingSpecimen-2.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/samplingSpecimen-2.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/sensorML-1.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/sensorML-1.0/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.1-4</version>
     <name>Sensor Model Language (SensorML) 1.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sensorML-1.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sensorML-1.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/sweCommon-1.0-gml32/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/sweCommon-1.0-gml32/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.1-1</version>
     <name>Sensor Web Enablement (SWE) Common 1.0 (GML 3.2) application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sweCommon-1.0-gml32/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sweCommon-1.0-gml-32/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/sweCommon-1.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/sweCommon-1.0/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.1-4</version>
     <name>Sensor Web Enablement (SWE) Common 1.0 application schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sweCommon-1.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sweCommon-1.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/sweCommon-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/sweCommon-2.0/pom.xml
@@ -5,10 +5,6 @@
 	<artifactId>sweCommon-2.0</artifactId>
 	<version>2.0-1</version>
 	<name>Sensor Web Enablement (SWE) Common 2.0 application schema</name>
-	<scm>
-		<connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sweCommon-2.0/</connection>
-		<url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/sweCommon-2.0/</url>
-	</scm>
 	<developers>
 		<developer>
 			<name>Rini Angreani</name>

--- a/modules/extension/app-schema/app-schema-packages/wfs-1.1/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/wfs-1.1/pom.xml
@@ -9,10 +9,6 @@
     <version>1.1.2-2</version>
     <name>Web Feature Service (WFS) 1.1 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/wfs-1.1/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/wfs-1.1/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/wfs-2.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/wfs-2.0/pom.xml
@@ -9,10 +9,6 @@
     <version>2.0.0-2</version>
     <name>Web Feature Service (WFS) 2.0 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/wfs-2.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/wfs-2.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/xlink-1.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/xlink-1.0/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.0-3</version>
     <name>XLink 1.0 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/xlink-1.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/xlink-1.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/xlink-1999/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/xlink-1999/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.0-1</version>
     <name>XLink 1999 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/xlink-1999/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/xlink-1999/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-packages/xml-1.0/pom.xml
+++ b/modules/extension/app-schema/app-schema-packages/xml-1.0/pom.xml
@@ -9,10 +9,6 @@
     <version>1.0.0-3</version>
     <name>XML 1.0 schema</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/xml-1.0/</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-packages/xml-1.0/</url>
-    </scm>
 
     <developers>
         <developer>

--- a/modules/extension/app-schema/app-schema-resolver/pom.xml
+++ b/modules/extension/app-schema/app-schema-resolver/pom.xml
@@ -14,10 +14,6 @@
     <artifactId>gt-app-schema-resolver</artifactId>
     <name>Application Schema Resolver</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-resolver</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema-resolver</url>
-    </scm>
 
     <description>
         Support for resolution of GML application schemas obtained from an OASIS Catalog,

--- a/modules/extension/app-schema/app-schema/pom.xml
+++ b/modules/extension/app-schema/app-schema/pom.xml
@@ -14,10 +14,6 @@
     <artifactId>gt-app-schema</artifactId>
     <name>Application Schema DataAccess</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/app-schema</url>
-    </scm>
 
     <description>DataAccess to create complex feature types defined in a GML application schema.</description>
 

--- a/modules/extension/app-schema/pom.xml
+++ b/modules/extension/app-schema/pom.xml
@@ -15,10 +15,6 @@
     <packaging>pom</packaging>
     <name>Application Schema Support</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema</url>
-    </scm>
 
     <description>Modules to support creation of complex feature types defined in a GML application schema</description>
 

--- a/modules/extension/app-schema/sample-data-access/pom.xml
+++ b/modules/extension/app-schema/sample-data-access/pom.xml
@@ -14,10 +14,6 @@
     <artifactId>gt-sample-data-access</artifactId>
     <name>Sample DataAccess</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/sample-data-access</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/app-schema/sample-data-access</url>
-    </scm>
 
     <description>DataAccess for testing complex feature integration without introducing app-schema dependency.</description>
 

--- a/modules/extension/brewer/pom.xml
+++ b/modules/extension/brewer/pom.xml
@@ -29,12 +29,6 @@
   <name>Brewer module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/brewer/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/brewer/</url>
-  </scm>
 
   <description>
     Brewer module, which contains ColorBrewer, etc.

--- a/modules/extension/graph/pom.xml
+++ b/modules/extension/graph/pom.xml
@@ -29,12 +29,6 @@
   <name>Feature Based Graphs and Networks</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/graph/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/graph/</url>
-  </scm>
 
   <description>
     Graph classes that builds and walk networks based on Feature relationships.

--- a/modules/extension/grid/pom.xml
+++ b/modules/extension/grid/pom.xml
@@ -15,12 +15,6 @@
     <packaging>jar</packaging>
     <name>Vector grids</name>
 
-    <scm>
-        <connection>
-            scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/grid/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/grid/</url>
-    </scm>
 
     <description>
         The grid module allows users to create vector grids (also known as

--- a/modules/extension/transform/pom.xml
+++ b/modules/extension/transform/pom.xml
@@ -23,12 +23,6 @@
   <name>Feature transforming feature source wrapper</name>
 
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/transform/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/transform/</url>
-  </scm>
 
   <description>
     A FeatureSource/FeatureStore wrapper that can rename attributes, hide others, and create new ones by applying expressions on the wrapped ones

--- a/modules/extension/validation/pom.xml
+++ b/modules/extension/validation/pom.xml
@@ -29,12 +29,6 @@
   <name>Validation Processor and Framework</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/validation/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/validation/</url>
-  </scm>
 
   <description>
     Validation module (and validator batch tool) for use with geotools2.

--- a/modules/extension/wms/pom.xml
+++ b/modules/extension/wms/pom.xml
@@ -29,12 +29,6 @@
   <name>Web Map Server client</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/wms/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/wms/</url>
-  </scm>
 
   <description>
     An OGC Web Map Server client implementation that can be used directly or as 

--- a/modules/extension/xsd/xsd-core/pom.xml
+++ b/modules/extension/xsd/xsd-core/pom.xml
@@ -29,12 +29,6 @@
   <name>XML Parsing</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-core/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-core/</url>
-  </scm>
 
   <description>
     Schema based xml parsing. This module contains tools for creating 

--- a/modules/extension/xsd/xsd-csw/pom.xml
+++ b/modules/extension/xsd/xsd-csw/pom.xml
@@ -28,12 +28,6 @@
   <name>CSW XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/csw/xsd-csw/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/csw/xsd-csw/</url>
-  </scm>
 
   <description>
     Coverage Services for the Web XML support for Geotools.

--- a/modules/extension/xsd/xsd-fes/pom.xml
+++ b/modules/extension/xsd/xsd-fes/pom.xml
@@ -29,12 +29,6 @@
   <name>Filter Encoding Specification XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-fes/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-fes/</url>
-  </scm>
 
   <description>
     Filter XML support for Geotools.

--- a/modules/extension/xsd/xsd-filter/pom.xml
+++ b/modules/extension/xsd/xsd-filter/pom.xml
@@ -29,12 +29,6 @@
   <name>Filter XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-filter/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-filter/</url>
-  </scm>
 
   <description>
     Filter XML support for Geotools.

--- a/modules/extension/xsd/xsd-gml2/pom.xml
+++ b/modules/extension/xsd/xsd-gml2/pom.xml
@@ -28,12 +28,6 @@
   <name>GML2 XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-gml2/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-gml2/</url>
-  </scm>
 
   <description>
     GML2 XML support for Geotools.

--- a/modules/extension/xsd/xsd-gml3/pom.xml
+++ b/modules/extension/xsd/xsd-gml3/pom.xml
@@ -29,12 +29,6 @@
   <name>GML3 XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-gml3/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-gml3/</url>
-  </scm>
 
   <description>
     GML3 XML support for Geotools.

--- a/modules/extension/xsd/xsd-kml/pom.xml
+++ b/modules/extension/xsd/xsd-kml/pom.xml
@@ -28,12 +28,6 @@
   <name>KML XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-kml/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-kml/</url>
-  </scm>
 
   <description>
     Filter XML support for Geotools.

--- a/modules/extension/xsd/xsd-ows/pom.xml
+++ b/modules/extension/xsd/xsd-ows/pom.xml
@@ -28,12 +28,6 @@
   <name>OWS XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-ows/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-ows/</url>
-  </scm>
 
   <description>
     Filter XML support for Geotools.

--- a/modules/extension/xsd/xsd-sld/pom.xml
+++ b/modules/extension/xsd/xsd-sld/pom.xml
@@ -29,12 +29,6 @@
   <name>SLD XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-sld/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-sld/</url>
-  </scm>
 
   <description>
     SLD XML support for Geotools.

--- a/modules/extension/xsd/xsd-wcs/pom.xml
+++ b/modules/extension/xsd/xsd-wcs/pom.xml
@@ -28,12 +28,6 @@
   <name>WCS XML Support</name>
   <url>http://maven.geotools.fr/reports/modules/extension/xsd/xsd-wcs/</url>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/extension/xsd/xsd-wcs/
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/extension/xsd/xsd-wcs/</url>
-  </scm>
 
   <description>
     WCS 1.0.0 Bindings.

--- a/modules/extension/xsd/xsd-wfs/pom.xml
+++ b/modules/extension/xsd/xsd-wfs/pom.xml
@@ -28,12 +28,6 @@
   <name>WFS XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-wfs/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-wfs/</url>
-  </scm>
 
   <description>
     Filter XML support for Geotools.

--- a/modules/extension/xsd/xsd-wms/pom.xml
+++ b/modules/extension/xsd/xsd-wms/pom.xml
@@ -28,12 +28,6 @@
   <name>WMS XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-wms/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-wms/</url>
-  </scm>
 
   <description>
     WMS XML support for Geotools.

--- a/modules/extension/xsd/xsd-wps/pom.xml
+++ b/modules/extension/xsd/xsd-wps/pom.xml
@@ -28,12 +28,6 @@
   <name>WPS XML Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-wps/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/extension/xsd/xsd-wps/</url>
-  </scm>
 
   <description>
     Web Processing Service XML support for Geotools.

--- a/modules/library/api/pom.xml
+++ b/modules/library/api/pom.xml
@@ -29,12 +29,6 @@
   <name>API interfaces</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/api/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/api/</url>
-  </scm>
 
   <description>
     The api module contains the GeoTools public interfaces that are used by

--- a/modules/library/coverage/pom.xml
+++ b/modules/library/coverage/pom.xml
@@ -29,12 +29,6 @@
   <name>Grid Coverage module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/coverage/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/coverage/</url>
-  </scm>
 
   <description>
     Implementation of GridCoverage. Provides support

--- a/modules/library/cql/pom.xml
+++ b/modules/library/cql/pom.xml
@@ -29,12 +29,6 @@
   <name>OGC CQL to Filter parser</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/cql/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/cql/</url>
-  </scm>
 
   <description>
     A parser that takes a Constraint Query Language input string and produces

--- a/modules/library/data/pom.xml
+++ b/modules/library/data/pom.xml
@@ -29,12 +29,6 @@
   <name>DataStore Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/data/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/data/</url>
-  </scm>
 
   <description>
     ContentDataStore implementation and support classes for those implementing

--- a/modules/library/jdbc/pom.xml
+++ b/modules/library/jdbc/pom.xml
@@ -29,12 +29,6 @@
   <name>JDBC DataStore Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/jdbc/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/jdbc/</url>
-  </scm>
 
   <description>
     Abstract datastore implementation and helper classes / apis to be extended

--- a/modules/library/main/pom.xml
+++ b/modules/library/main/pom.xml
@@ -29,12 +29,6 @@
   <name>Main module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/main/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/main/</url>
-  </scm>
 
   <description>
     The main module contains the default implementations of the data model

--- a/modules/library/metadata/pom.xml
+++ b/modules/library/metadata/pom.xml
@@ -29,10 +29,6 @@
   <name>Metadata</name>
   
 
-  <scm>
-    <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/metadata/</connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/metadata/</url>
-  </scm>
 
   <description>
     Contains implementations of metadata and some core utilities classes.

--- a/modules/library/opengis/pom.xml
+++ b/modules/library/opengis/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>Open GIS Interfaces</name>
   
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/opengis/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/opengis/</url>
-  </scm>
 
   <description>
     Standard interfaces implemented throughout the library.

--- a/modules/library/referencing/pom.xml
+++ b/modules/library/referencing/pom.xml
@@ -29,12 +29,6 @@
   <name>Referencing services</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/referencing/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/referencing/</url>
-  </scm>
 
   <description>
     Contains implementations of Coordinate Reference Systems (CRS),

--- a/modules/library/render/pom.xml
+++ b/modules/library/render/pom.xml
@@ -29,12 +29,6 @@
   <name>Render</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/render/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/render/</url>
-  </scm>
 
   <description>
     The render module contains a renderer built around the interface in

--- a/modules/library/sample-data/pom.xml
+++ b/modules/library/sample-data/pom.xml
@@ -29,12 +29,6 @@
   <name>Sample data module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/sample-data/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/sample-data/</url>
-  </scm>
 
   <description>
     Contains sample data for testing purpose.

--- a/modules/library/xml/pom.xml
+++ b/modules/library/xml/pom.xml
@@ -29,12 +29,6 @@
   <name>XML Parsing Support</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/library/xml/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/library/xml/</url>
-  </scm>
 
   <description>
     XML Parser based on the XDO design.

--- a/modules/ogc/net.opengis.csw/pom.xml
+++ b/modules/ogc/net.opengis.csw/pom.xml
@@ -14,12 +14,6 @@
 
   <name>Catalog Services for the Web Model</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/csw/net.opengis.csw
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/csw/net.opengis.csw</url>
-  </scm>
 
   <description>Catalog Services for the Web Schema EMF Model</description>
 

--- a/modules/ogc/net.opengis.fes/pom.xml
+++ b/modules/ogc/net.opengis.fes/pom.xml
@@ -15,12 +15,6 @@
   <name>Filter Encoding Specification Model</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.fes
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.fes</url>
-  </scm>
 
   <description>Filter Encoding Specification Schema EMF Model</description>
 

--- a/modules/ogc/net.opengis.ows/pom.xml
+++ b/modules/ogc/net.opengis.ows/pom.xml
@@ -15,12 +15,6 @@
   <name>Open Web Services Model</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.ows
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.ows</url>
-  </scm>
 
   <description>Open Web Services Schema EMF Model</description>
 

--- a/modules/ogc/net.opengis.wcs/pom.xml
+++ b/modules/ogc/net.opengis.wcs/pom.xml
@@ -15,12 +15,6 @@
   <name>Web Coverage Service Model</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.wcs
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.wcs</url>
-  </scm>
 
   <description>Web Coverage Service Schema EMF Model</description>
 

--- a/modules/ogc/net.opengis.wfs/pom.xml
+++ b/modules/ogc/net.opengis.wfs/pom.xml
@@ -15,12 +15,6 @@
   <name>Web Feature Service Model</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.wfs
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.wfs</url>
-  </scm>
 
   <description>Web Feature Service Schema EMF Model</description>
 

--- a/modules/ogc/net.opengis.wps/pom.xml
+++ b/modules/ogc/net.opengis.wps/pom.xml
@@ -15,12 +15,6 @@
   <name>Web Processing Service Model</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.wps
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/net.opengis.wps</url>
-  </scm>
 
   <description>Web Processing Service Schema EMF Model</description>
 

--- a/modules/ogc/org.w3.xlink/pom.xml
+++ b/modules/ogc/org.w3.xlink/pom.xml
@@ -15,12 +15,6 @@
   <name>Xlink Model</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/org.w3.xlink
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/ogc/org.w3.xlink</url>
-  </scm>
 
   <description>Xlink Schema EMF Model</description>
 

--- a/modules/plugin/arcgrid/pom.xml
+++ b/modules/plugin/arcgrid/pom.xml
@@ -29,12 +29,6 @@
   <name>ArcGrid datasource module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/arcgrid/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/arcgrid/</url>
-  </scm>
 
   <description>
     Datasource created to read ArcGrid raster format. Currently Serving

--- a/modules/plugin/arcsde/common/pom.xml
+++ b/modules/plugin/arcsde/common/pom.xml
@@ -26,12 +26,6 @@
   <name>ArcSDE support classes</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/arcsde/common/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/arcsde/common/</url>
-  </scm>
 
   <description> ArcSDE support classes, including session pooling and JNDI support. </description>
   <licenses>

--- a/modules/plugin/arcsde/datastore/pom.xml
+++ b/modules/plugin/arcsde/datastore/pom.xml
@@ -26,12 +26,6 @@
 	<name>ArcSDE DataStore plugin</name>
 
 
-	<scm>
-		<connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/arcsde/datastore/
-    </connection>
-		<url>http://svn.osgeo.org/geotools/trunk/modules/plugin/arcsde/datastore/</url>
-	</scm>
 
 	<description> ArcSDE DataStore plugin. </description>
 	<licenses>

--- a/modules/plugin/arcsde/sde-dummy/pom.xml
+++ b/modules/plugin/arcsde/sde-dummy/pom.xml
@@ -29,12 +29,6 @@
   <name>ArcSDE dummy api</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/arcsde/sde-dummy/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/arcsde/sde-dummy/</url>
-  </scm>
 
   <description>
     ArcSDE dummy api.

--- a/modules/plugin/charts/pom.xml
+++ b/modules/plugin/charts/pom.xml
@@ -29,12 +29,6 @@
   <name>Dynamic symbolizer module based on JFreeChart and Eastwood</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/unsupported/charts/
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/unsupported/charts/</url>
-  </scm>
 
   <description>
     TODO

--- a/modules/plugin/coverage-multidim/coverage-api/pom.xml
+++ b/modules/plugin/coverage-multidim/coverage-api/pom.xml
@@ -27,12 +27,6 @@
   <artifactId>gt-coverage-api</artifactId>
   <packaging>jar</packaging>
   <name>API interfaces</name>
-  <scm>
-    <connection>
-      scm:svn:https://svn.osgeo.org/geotools/trunk/modules/plugin/coverage-multidim/coverage-api/
-    </connection>
-  <url>https://svn.osgeo.org/geotools/trunk/modules/plugin/coverage-multidim/coverage-api/</url>
- </scm>
 
   <description>
   </description>

--- a/modules/plugin/coverage-multidim/netcdf/pom.xml
+++ b/modules/plugin/coverage-multidim/netcdf/pom.xml
@@ -22,12 +22,6 @@
   <artifactId>gt-netcdf</artifactId>
   <packaging>jar</packaging>
   <name>NetCDF gridcoverage module</name>
-  <scm>
-    <connection>
-      scm:svn:https://svn.osgeo.org/geotools/trunk/modules/plugin/coverage-multidim/netcdf/
-    </connection>
-  <url>https://svn.osgeo.org/geotools/trunk/modules/plugin/coverage-multidim/netcdf/</url>
- </scm>
 
   <description>
     Datasource created to read NetCDF format. 

--- a/modules/plugin/coverage-multidim/pom.xml
+++ b/modules/plugin/coverage-multidim/pom.xml
@@ -23,12 +23,6 @@
   <packaging>pom</packaging>
   <name>Coverage Multidimensional Module</name>
 
-  <scm>
-    <connection>
-      scm:svn:https://svn.osgeo.org/geotools/trunk/modules/plugin/coverage-multidim/
-    </connection>
-  <url>https://svn.osgeo.org/geotools/trunk/modules/plugin/coverage-multidim/</url>
- </scm>
 
   <description>
     Module for Coverage experiment and ND GeoTools plugins.

--- a/modules/plugin/epsg-extension/pom.xml
+++ b/modules/plugin/epsg-extension/pom.xml
@@ -29,12 +29,6 @@
   <name>Extensions to EPSG authority factory</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/epsg-extension/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/epsg-extension/</url>
-  </scm>
 
   <description>
     Contains extra CRS defined by ESRI (and other parties) in the EPSG namespace.

--- a/modules/plugin/epsg-hsql/pom.xml
+++ b/modules/plugin/epsg-hsql/pom.xml
@@ -29,12 +29,6 @@
   <name>EPSG Authority Service using HSQL database</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/epsg-hsql/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/epsg-hsql/</url>
-  </scm>
 
   <description>
     Connection to an embedded EPSG database in HSQL format.

--- a/modules/plugin/epsg-postgresql/pom.xml
+++ b/modules/plugin/epsg-postgresql/pom.xml
@@ -29,12 +29,6 @@
   <name>EPSG Authority Service using PostgreSQL database</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/epsg-postgresql/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/epsg-postgresql/</url>
-  </scm>
 
   <description>
     Connection to an EPSG postgreSQL database.

--- a/modules/plugin/epsg-wkt/pom.xml
+++ b/modules/plugin/epsg-wkt/pom.xml
@@ -29,12 +29,6 @@
   <name>EPSG Authority Service using WKT file</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/epsg-wkt/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/epsg-wkt/</url>
-  </scm>
 
   <description>
     EPSG and AUTO authority factories are defined for data.crs.CRSService.

--- a/modules/plugin/feature-pregeneralized/pom.xml
+++ b/modules/plugin/feature-pregeneralized/pom.xml
@@ -29,12 +29,6 @@
   <name>Feature-Pregeneralized</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/plugin/feature-pregeneralized/
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/plugin/feature-pregeneralized/</url>
-  </scm>
 
   <description>
 	Feature Source with prebuild generalizations

--- a/modules/plugin/geotiff/pom.xml
+++ b/modules/plugin/geotiff/pom.xml
@@ -29,12 +29,6 @@
   <name>GeoTIFF grid coverage exchange module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/geotiff/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/geotiff/</url>
-  </scm>
 
   <description>
     Datasource created to read GeoTIFF raster format.

--- a/modules/plugin/grassraster/pom.xml
+++ b/modules/plugin/grassraster/pom.xml
@@ -29,12 +29,6 @@
   <name>grass raster datasource module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/grassraster/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/grassraster/</url>
-  </scm>
 
   <description>
     This datasource reads the GRASS DEM format.

--- a/modules/plugin/gtopo30/pom.xml
+++ b/modules/plugin/gtopo30/pom.xml
@@ -29,12 +29,6 @@
   <name>GTopo30 datasource module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/gtopo30/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/gtopo30/</url>
-  </scm>
 
   <description>
     This datasource reads the GTOPO30 DEM format.

--- a/modules/plugin/image/pom.xml
+++ b/modules/plugin/image/pom.xml
@@ -29,12 +29,6 @@
   <name>WorldImage datasource module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/image/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/image/</url>
-  </scm>
 
   <description>
     Grid coverage reader for image georeferenced by a world file.

--- a/modules/plugin/imageio-ext-gdal/pom.xml
+++ b/modules/plugin/imageio-ext-gdal/pom.xml
@@ -28,12 +28,6 @@
   <name>ImageI/O-Ext based grid coverage readers</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/imageio-ext-gdal/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/imageio-ext-gdal/</url>
-  </scm>
 
   <description>
     Extension of the of Grid Coverage plugins, leveraging on the GDAL raster data access

--- a/modules/plugin/imagemosaic-jdbc/pom.xml
+++ b/modules/plugin/imagemosaic-jdbc/pom.xml
@@ -29,12 +29,6 @@
   <name>imagemosaic-jdbc module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/geotools/trunk/modules/plugin/imagemosaic-jdbc/
-    </connection>
-    <url>http://svn.geotools.org/geotools/trunk/modules/plugin/imagemosaic-jdbc/</url>
-  </scm>
 
   <description>
 	Plugin for reading tiled images from a JDBC Data Source

--- a/modules/plugin/imagemosaic/pom.xml
+++ b/modules/plugin/imagemosaic/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>imagemosaic datasource module</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/imagemosaic/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/imagemosaic/</url>
-  </scm>
 
   <description>
     Datasource created to read a mosaic of georeferenced images or geotiff, jp2k, ...

--- a/modules/plugin/imagepyramid/pom.xml
+++ b/modules/plugin/imagepyramid/pom.xml
@@ -32,12 +32,6 @@
   <name>imagepyramid datasource module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/imagepyramid/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/imagepyramid/</url>
-  </scm>
 
   <description>
     Datasource created to read a pyramid of georeferenced images or geotiff 

--- a/modules/plugin/jdbc/jdbc-db2/pom.xml
+++ b/modules/plugin/jdbc/jdbc-db2/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>DB2 DataStore</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-db2/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-db2/</url>
-  </scm>
 
   <description>
 	DataStore for DB2 Database.

--- a/modules/plugin/jdbc/jdbc-h2/pom.xml
+++ b/modules/plugin/jdbc/jdbc-h2/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>H2 DataStore</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-h2/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-h2/</url>
-  </scm>
 
   <description>
 	DataStore for H2 Database.

--- a/modules/plugin/jdbc/jdbc-mysql/pom.xml
+++ b/modules/plugin/jdbc/jdbc-mysql/pom.xml
@@ -29,12 +29,6 @@
   <name>MySQL DataStore</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-mysql
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-mysql</url>
-  </scm>
 
   <description>
 	DataStore for MySQL Database.

--- a/modules/plugin/jdbc/jdbc-oracle/pom.xml
+++ b/modules/plugin/jdbc/jdbc-oracle/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>Oracle DataStore</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-oracle/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-oracle/</url>
-  </scm>
 
   <description>
 	DataStore for Oracle Database.

--- a/modules/plugin/jdbc/jdbc-postgis/pom.xml
+++ b/modules/plugin/jdbc/jdbc-postgis/pom.xml
@@ -29,12 +29,6 @@
   <name>PostGIS DataStore</name>
   
 
-  <scm>
-    <connection> q
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-postgis
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-postgis</url>
-  </scm>
 
   <description>
 	DataStore for PostGIS Database.

--- a/modules/plugin/jdbc/jdbc-spatialite/pom.xml
+++ b/modules/plugin/jdbc/jdbc-spatialite/pom.xml
@@ -29,12 +29,6 @@
   <name>SpatiaLite DataStore</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-spatialite/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/jdbc/jdbc-spatialite/</url>
-  </scm>
 
   <description>DataStore for SpatiaLite Database</description>
 

--- a/modules/plugin/jdbc/jdbc-sqlserver/pom.xml
+++ b/modules/plugin/jdbc/jdbc-sqlserver/pom.xml
@@ -23,12 +23,6 @@
 	<name>SQL Server DataStore</name>
 	<url>http://maven.geotools.fr/reports/modules/plugin/jdbc/jdbc-sqlserver/</url>
 
-	<scm>
-		<connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/plugin/jdbc/jdbc-sqlserver
-    </connection>
-		<url>http://svn.geotools.org/trunk/modules/plugin/jdbc/jdbc-sqlserver</url>
-	</scm>
 
 	<description>
 	DataStore for SQL Server Database.

--- a/modules/plugin/jdbc/jdbc-teradata/pom.xml
+++ b/modules/plugin/jdbc/jdbc-teradata/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>Teradata DataStore</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/jdbc-teradata
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/jdbc-teradata</url>
-  </scm>
 
   <description>
     DataStore for Teradata Database.

--- a/modules/plugin/jdbc/pom.xml
+++ b/modules/plugin/jdbc/pom.xml
@@ -28,12 +28,6 @@
   <packaging>pom</packaging>
   <name>JDBC DataStore Plugins</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/plugin/jdbc/
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/plugin/jdbc/</url>
-  </scm>
 
   <licenses>
     <license>

--- a/modules/plugin/jp2k/pom.xml
+++ b/modules/plugin/jp2k/pom.xml
@@ -26,12 +26,6 @@
   <artifactId>gt-jp2k</artifactId>
   <packaging>jar</packaging>
   <name>JP2K based grid coverage readers</name>
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/jp2k/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/jp2k/</url>
-  </scm>
 
   <description>
     Extension of the of Grid Coverage plugins, leveraging on the JP2K raster data access

--- a/modules/plugin/ogr/ogr-bridj/pom.xml
+++ b/modules/plugin/ogr/ogr-bridj/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>Bridj OGR DataStore Module</name>
   
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/plugin/ogr/ogr-bridj
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/plugin/ogr/ogr-bridj</url>
-  </scm>
 
   <description>
     A datastore levearing OGR BRIDJ bindings for reading/writing a slew of data formats

--- a/modules/plugin/ogr/ogr-core/pom.xml
+++ b/modules/plugin/ogr/ogr-core/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>Core OGR DataStore Module</name>
   
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/plugin/ogr/ogr-core
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/plugin/ogr/ogr-core</url>
-  </scm>
 
   <licenses>
     <license>

--- a/modules/plugin/ogr/ogr-jni/pom.xml
+++ b/modules/plugin/ogr/ogr-jni/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>JNI OGR DataStore Module</name>
   
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/plugin/ogr/ogr-jni
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/plugin/ogr/ogr-jni</url>
-  </scm>
 
   <description>
     A datastore levearing OGR JNI bindings for reading/writing a slew of data formats

--- a/modules/plugin/ogr/pom.xml
+++ b/modules/plugin/ogr/pom.xml
@@ -28,12 +28,6 @@
   <packaging>pom</packaging>
   <name>OGR DataStore Module</name>
   
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/plugin/ogr/
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/plugin/ogr/</url>
-  </scm>
 
   <description>
     A datastore leveraging OGR for reading/writing a slew of data formats

--- a/modules/plugin/property/pom.xml
+++ b/modules/plugin/property/pom.xml
@@ -29,12 +29,6 @@
   <name>Property File DataStore</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/property/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/property/</url>
-  </scm>
 
   <description>
     DataStore using Java properties files, a useful reference implementation

--- a/modules/plugin/referencing3D/pom.xml
+++ b/modules/plugin/referencing3D/pom.xml
@@ -29,12 +29,6 @@
   <name>Vertical coordinate transformations</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/referencing3D/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/referencing3D/</url>
-  </scm>
 
   <description>
     Transforms coordinates from "heights above the ellipsoid" to "heights above

--- a/modules/plugin/shapefile/pom.xml
+++ b/modules/plugin/shapefile/pom.xml
@@ -29,12 +29,6 @@
   <name>Shapefile module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/shapefile/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/shapefile/</url>
-  </scm>
 
   <description>
     DataStore supporting the ESRI shapefile format. NG version

--- a/modules/plugin/svg/pom.xml
+++ b/modules/plugin/svg/pom.xml
@@ -29,12 +29,6 @@
   <name>Dynamic symbolizers for SVG symbols</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/plugin/svg
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/plugin/svg</url>
-  </scm>
 
   <description>
     Plugin allowing gt-render to draw scalar vector graphic symbols.

--- a/modules/unsupported/app-schema/pom.xml
+++ b/modules/unsupported/app-schema/pom.xml
@@ -15,10 +15,6 @@
     <packaging>pom</packaging>
     <name>Application Schema Support (Unsupported Modules)</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/app-schema</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/app-schema</url>
-    </scm>
 
     <description>Modules to support creation of complex feature types defined in a GML application schema (unsupported modules)</description>
 

--- a/modules/unsupported/app-schema/webservice/pom.xml
+++ b/modules/unsupported/app-schema/webservice/pom.xml
@@ -14,10 +14,6 @@
     <artifactId>gt-webservice</artifactId>
     <name>Web Service DataAccess</name>
 
-    <scm>
-        <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/app-schema/webservice</connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/app-schema/webservice</url>
-    </scm>
 
     <description>
         DataAccess to create complex feature types defined in a GML application schema,

--- a/modules/unsupported/caching/pom.xml
+++ b/modules/unsupported/caching/pom.xml
@@ -29,12 +29,6 @@
   <name>Caching</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/unsupported/caching/
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/unsupported/caching/</url>
-  </scm>
 
   <description>
     Originally a Google Summer of Code 2007 project (Caching data in uDig), 

--- a/modules/unsupported/coverage-multidim/geotiff/pom.xml
+++ b/modules/unsupported/coverage-multidim/geotiff/pom.xml
@@ -29,12 +29,6 @@
   <name>GeoTIFF grid coverage exchange module</name>
   <url>http://maven.geotools.fr/reports/modules/plugin/geotiff/</url>
 
-  <scm>
-    <connection>
-      scm:svn:https://www.geo-solutions.it/svn/repo/geotoolsPlugins/gt-2.6.x/modules/unsupported/ndplugins/geotiff/
-    </connection>
-    <url>https://www.geo-solutions.it/svn/repo/geotoolsPlugins/gt-2.6.x/modules/unsupported/ndplugins/geotiff/</url>
-  </scm>
 
   <description>
     Datasource created to read GeoTIFF raster format.

--- a/modules/unsupported/coverage-multidim/hdf4/pom.xml
+++ b/modules/unsupported/coverage-multidim/hdf4/pom.xml
@@ -22,12 +22,6 @@
   <artifactId>gt-hdf4</artifactId>
   <packaging>jar</packaging>
   <name>HDF4 gridcoverage module</name>
-  <scm>
-    <connection>
-      scm:svn:https://svn.osgeo.org/geotools/trunk/modules/unsupported/coverage-experiment/hdf4/
-    </connection>
-  <url>https://svn.osgeo.org/geotools/trunk/modules/unsupported/coverage-experiment/hdf4/</url>
- </scm>
 
   <description>
     Core of the ND GeoTools plugin.

--- a/modules/unsupported/coverage-multidim/pom.xml
+++ b/modules/unsupported/coverage-multidim/pom.xml
@@ -27,12 +27,6 @@
   <packaging>pom</packaging>
   <name>Coverage Multidimensional Module</name>
 
-  <scm>
-    <connection>
-      scm:svn:https://svn.osgeo.org/geotools/trunk/modules/unsupported/coverage-multidim/
-    </connection>
-  <url>https://svn.osgeo.org/geotools/trunk/modules/unsupported/coverage-multidim/</url>
- </scm>
 
   <description>
     Module for Coverage experiment and ND GeoTools plugins.

--- a/modules/unsupported/coveragetools/pom.xml
+++ b/modules/unsupported/coveragetools/pom.xml
@@ -73,12 +73,6 @@
   <name>Coverage tools</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/unsupported/coveragetools/
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/unsupported/coveragetools/</url>
-  </scm>
 
   <description>
     Coverage tools (tools for building overviews, pyramids and the like)

--- a/modules/unsupported/edigeo/pom.xml
+++ b/modules/unsupported/edigeo/pom.xml
@@ -16,12 +16,6 @@
   <name>EDIGEO format module</name>
   
   
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/geotools/branches/2.5.x/modules/unsupported/edigeo/
-    </connection>
-    <url>http://svn.geotools.org/geotools/branches/2.5.x/modules/unsupported/edigeo/</url>
-  </scm>
  
   <description>
     Support for the EDIGEO format.

--- a/modules/unsupported/efeature/pom.xml
+++ b/modules/unsupported/efeature/pom.xml
@@ -38,12 +38,6 @@
     <url>www.osgeo.org</url>
   </organization>
   
-<!--  <scm>-->
-<!--     <connection>-->
-<!--        scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/efeature/-->
-<!--     </connection>-->
-<!--     <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/efeature/</url>-->
-<!--  </scm> -->
   
   <!-- for your project. -->
   <inceptionYear>2011</inceptionYear>

--- a/modules/unsupported/epsg-oracle/pom.xml
+++ b/modules/unsupported/epsg-oracle/pom.xml
@@ -29,12 +29,6 @@
   <name>EPSG Authority Factory for Oracle</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/epsg-oracle/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/epsg-oracle/</url>
-  </scm>
 
   <description>
     This plugin allows you to make use of an oracle database as the host of your

--- a/modules/unsupported/excel/pom.xml
+++ b/modules/unsupported/excel/pom.xml
@@ -23,12 +23,6 @@
   <packaging>jar</packaging>
 
   <name>Excel</name>
-<scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/excel
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/excel</url>
-  </scm>
 
   <description>
     Implementation of DataStore allowing geotools code to work with an

--- a/modules/unsupported/feature-aggregate/pom.xml
+++ b/modules/unsupported/feature-aggregate/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>Aggregating DataStore</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/jdbc-ng/jdbc-ingres
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/jdbc-ng/jdbc-ingres</url>
-  </scm>
 
   <description>Aggreates N data stores exposing the same feature types into one</description>
 

--- a/modules/unsupported/geojson/pom.xml
+++ b/modules/unsupported/geojson/pom.xml
@@ -27,12 +27,6 @@
     <packaging>jar</packaging>
     <name>GeoJSON Support</name>
 
-    <scm>
-        <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/geojson/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/geojson/</url>
-    </scm>
 
     <description>
     Provides GeoJSON Encoding and Parsing support.

--- a/modules/unsupported/geometry/pom.xml
+++ b/modules/unsupported/geometry/pom.xml
@@ -28,12 +28,6 @@
   <packaging>jar</packaging>
   <name>Geometries</name>
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/geometry/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/geometry/</url>
-  </scm>
 
   <description>
     Implementations of ISO 19107 (Spatial Schema).

--- a/modules/unsupported/geopkg/pom.xml
+++ b/modules/unsupported/geopkg/pom.xml
@@ -27,12 +27,6 @@
     <packaging>jar</packaging>
     <name>GeoPackage Module</name>
 
-    <scm>
-        <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/geopkg/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/geopkg/</url>
-    </scm>
 
     <description>
     Provides read and write support for GeoPackage SQLite format.

--- a/modules/unsupported/georest/pom.xml
+++ b/modules/unsupported/georest/pom.xml
@@ -28,12 +28,6 @@
     <packaging>jar</packaging>
     <name>Rest based GeoJson DataStore</name>
 
-    <scm>
-        <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/georest/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/georest/</url>
-    </scm>
 
     <description>
     Provides a DataStore based on a GeoJson rest service.

--- a/modules/unsupported/geotiff_new/pom.xml
+++ b/modules/unsupported/geotiff_new/pom.xml
@@ -23,12 +23,6 @@
 	<name>GeoTIFF grid coverage exchange module</name>
 
 
-	<scm>
-		<connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/geotiff/
-    </connection>
-		<url>http://svn.osgeo.org/geotools/trunk/modules/plugin/geotiff/</url>
-	</scm>
 
 	<description>
     Datasource created to read GeoTIFF raster format.

--- a/modules/unsupported/imagecollection/pom.xml
+++ b/modules/unsupported/imagecollection/pom.xml
@@ -29,12 +29,6 @@
   <name>ImageCollection module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/imagecollection/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/imagecollection/</url>
-  </scm>
 
   <description>
     Datasource created to read images from an ImageCollection available on a folder.

--- a/modules/unsupported/jdbc-ng/jdbc-ingres/pom.xml
+++ b/modules/unsupported/jdbc-ng/jdbc-ingres/pom.xml
@@ -30,12 +30,6 @@
   <name>Ingres DataStore</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/jdbc-ng/jdbc-ingres
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/jdbc-ng/jdbc-ingres</url>
-  </scm>
 
   <description>
 	DataStore for Ingres Database.

--- a/modules/unsupported/jdbc-ng/pom.xml
+++ b/modules/unsupported/jdbc-ng/pom.xml
@@ -30,12 +30,6 @@
   <name>Next Generation JDBC DataStores</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.geotools.org/trunk/modules/unsupported/jdbc-ng/
-    </connection>
-    <url>http://svn.geotools.org/trunk/modules/unsupported/jdbc-ng/</url>
-  </scm>
 
   <licenses>
     <license>

--- a/modules/unsupported/jts-wrapper/pom.xml
+++ b/modules/unsupported/jts-wrapper/pom.xml
@@ -31,12 +31,6 @@
   <name>ISO 19107 implementation using JTS</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/jts-wrapper/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/jts-wrapper/</url>
-  </scm>
 
   <description>
      This is a basic 2D ISO 19107 implementation which uses 

--- a/modules/unsupported/matfile5/pom.xml
+++ b/modules/unsupported/matfile5/pom.xml
@@ -33,12 +33,6 @@
       <imageio.mat.version>1.1M012010</imageio.mat.version>
   </properties>
       
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/matfile5
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/matfile5/</url>
-  </scm>
 
   <description>
     Extension of the of Grid Coverage plugins, to read matlab files with georefencing information.

--- a/modules/unsupported/process-feature/pom.xml
+++ b/modules/unsupported/process-feature/pom.xml
@@ -28,12 +28,6 @@
     <packaging>jar</packaging>
     <name>Process Feature</name>
 
-    <scm>
-        <connection>
-            scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/process-feature/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/process-feature/</url>
-    </scm>
 
     <description>
       Processes for handling of features and feature collections.

--- a/modules/unsupported/process-geometry/pom.xml
+++ b/modules/unsupported/process-geometry/pom.xml
@@ -28,12 +28,6 @@
     <packaging>jar</packaging>
     <name>Process Geometry</name>
 
-    <scm>
-        <connection>
-            scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/process-geometry/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/process-geometry/</url>
-    </scm>
 
     <description>
       Processes for handling of geometry.

--- a/modules/unsupported/process-raster/pom.xml
+++ b/modules/unsupported/process-raster/pom.xml
@@ -28,12 +28,6 @@
     <packaging>jar</packaging>
     <name>Process Raster</name>
 
-    <scm>
-        <connection>
-            scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/process-raster/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/process-raster/</url>
-    </scm>
 
     <description>
       Processes for handling of raster information; often wrapping up jai-tools

--- a/modules/unsupported/process/pom.xml
+++ b/modules/unsupported/process/pom.xml
@@ -28,12 +28,6 @@
     <packaging>jar</packaging>
     <name>Process</name>
 
-    <scm>
-        <connection>
-            scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/process/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/process/</url>
-    </scm>
 
     <description>
       An API for creating custom processes/operations plus a

--- a/modules/unsupported/swing/pom.xml
+++ b/modules/unsupported/swing/pom.xml
@@ -27,12 +27,6 @@
     <packaging>jar</packaging>
     <name>Swing widgets</name>
 
-    <scm>
-        <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/extension/widgets-swing/
-        </connection>
-        <url>http://svn.osgeo.org/geotools/trunk/modules/extension/widgets-swing/</url>
-    </scm>
 
     <description>
     Provides widgets for map display and other GUI elements

--- a/modules/unsupported/vpf/pom.xml
+++ b/modules/unsupported/vpf/pom.xml
@@ -29,12 +29,6 @@
   <name>VPF Plugin</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/vpf/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/vpf/</url>
-  </scm>
 
   <description>
     DataStore plugin for VPF format.

--- a/modules/unsupported/wfs-ng/pom.xml
+++ b/modules/unsupported/wfs-ng/pom.xml
@@ -29,12 +29,6 @@
   <name>WFS client module (NG)</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/wfs/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/wfs/</url>
-  </scm>
 
   <description>
     Implementation of DataStore allowing geotools code to work with an

--- a/modules/unsupported/wfs/pom.xml
+++ b/modules/unsupported/wfs/pom.xml
@@ -29,12 +29,6 @@
   <name>WFS client module</name>
   
 
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/plugin/wfs/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/plugin/wfs/</url>
-  </scm>
 
   <description>
     Implementation of DataStore allowing geotools code to work with an

--- a/modules/unsupported/wps/pom.xml
+++ b/modules/unsupported/wps/pom.xml
@@ -27,12 +27,6 @@
   <packaging>jar</packaging>
   <name>Web Processing Service</name>
   
-  <scm>
-    <connection>
-      scm:svn:http://svn.osgeo.org/geotools/trunk/modules/unsupported/wps/
-    </connection>
-    <url>http://svn.osgeo.org/geotools/trunk/modules/unsupported/wps/</url>
-  </scm>
   
   <description>
     Web Processing Service implementation.


### PR DESCRIPTION
this pull removes all scm sections in pom.xml files consequently since these are outdated

```
<scm>
    <connection>scm:svn:http://svn.osgeo.org/geotools/trunk/....</connection>
    <url>http://svn.osgeo.org/geotools/trunk/...</url>
</scm>
``` 
