### PR TITLE
Maven Repository management cleanup

### DIFF
--- a/docs/user/artifacts/xml/pom.xml
+++ b/docs/user/artifacts/xml/pom.xml
@@ -8,32 +8,5 @@
     <version>1.0-SNAPSHOT</version>
     <name>Purchase Order XML Support</name>
 
-    <repositories>
-        <repository>
-            <id>maven2-repository.dev.java.net</id>
-            <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-        <repository>
-            <id>java.net</id>
-            <name>java.net Maven Repository</name>
-            <url>https://maven-repository.dev.java.net/nonav/repository
-            </url>
-            <layout>legacy</layout>
-        </repository>
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-        <repository>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-          <id>boundless</id>
-          <name>Boundless Maven Repository</name>
-          <url>http://repo.boundlessgeo.com/main</url>
-        </repository>
-    </repositories>
 
 </project>

--- a/docs/user/tutorial/datastore/artifacts/pom.xml
+++ b/docs/user/tutorial/datastore/artifacts/pom.xml
@@ -44,26 +44,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>maven2-repository.dev.java.net</id>
-      <name>Java.net repository</name>
-      <url>http://download.java.net/maven/2</url>
-    </repository>
-    <repository>
-      <id>osgeo</id>
-      <name>Open Source Geospatial Foundation Repository</name>
-      <url>http://download.osgeo.org/webdav/geotools/</url>
-    </repository>
-    <repository>
-       <snapshots>
-         <enabled>true</enabled>
-       </snapshots>
-       <id>boundless</id>
-       <name>Boundless Maven Repository</name>
-       <url>http://repo.boundlessgeo.com/main</url>
-    </repository>
-  </repositories>
 
   <build>
     <plugins>

--- a/docs/user/tutorial/feature/artifacts/pom.xml
+++ b/docs/user/tutorial/feature/artifacts/pom.xml
@@ -27,16 +27,4 @@
   </dependency>
  </dependencies>
 
- <repositories>
-  <repository>
-   <id>maven2-repository.dev.java.net</id>
-   <name>Java.net repository</name>
-   <url>http://download.java.net/maven/2</url>
-  </repository>
-  <repository>
-   <id>osgeo</id>
-   <name>Open Source Geospatial Foundation Repository</name>
-   <url>http://download.osgeo.org/webdav/geotools/</url>
-  </repository>
- </repositories>
 </project>

--- a/docs/user/tutorial/filter/artifacts/pom.xml
+++ b/docs/user/tutorial/filter/artifacts/pom.xml
@@ -39,16 +39,4 @@
             <version>${geotools.version}</version>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>maven2-repository.dev.java.net</id>
-            <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-    </repositories>
 </project>

--- a/docs/user/tutorial/geometry/artifacts/pom.xml
+++ b/docs/user/tutorial/geometry/artifacts/pom.xml
@@ -30,16 +30,4 @@
             <version>${geotools.version}</version>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>maven2-repository.dev.java.net</id>
-            <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-    </repositories>
 </project>

--- a/docs/user/tutorial/map/artifacts/pom.xml
+++ b/docs/user/tutorial/map/artifacts/pom.xml
@@ -30,16 +30,4 @@
             <version>${geotools.version}</version>
         </dependency>
       </dependencies>
-    <repositories>
-        <repository>
-            <id>maven2-repository.dev.java.net</id>
-            <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-    </repositories>
 </project>

--- a/docs/user/tutorial/quickstart/artifacts/pom.xml
+++ b/docs/user/tutorial/quickstart/artifacts/pom.xml
@@ -31,16 +31,4 @@
             <version>${geotools.version}</version>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>maven2-repository.dev.java.net</id>
-            <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-    </repositories>
 </project>

--- a/docs/user/tutorial/raster/artifacts/pom.xml
+++ b/docs/user/tutorial/raster/artifacts/pom.xml
@@ -45,16 +45,4 @@
             <version>${geotools.version}</version>
         </dependency>
       </dependencies>
-    <repositories>
-        <repository>
-            <id>maven2-repository.dev.java.net</id>
-            <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-    </repositories>
 </project>

--- a/modules/plugin/coverage-multidim/pom.xml
+++ b/modules/plugin/coverage-multidim/pom.xml
@@ -89,23 +89,18 @@
 
   <repositories>
     <repository>
-      <id>geosolutions</id>
-      <name>GeoSolutions libraries repository</name>
-      <url>http://maven.geo-solutions.it/</url>
-    </repository>
-    <repository>
       <id>unidata</id>
       <name>Unidata UCAR Libraries repository</name>
       <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata/</url>
     </repository> 
-    </repositories>
+  </repositories>
 
   <!-- =========================================================== -->
   <!--     Modules for the build in approximate dependency order   -->
   <!-- =========================================================== -->
-      <modules>
-        <module>coverage-api</module>
-        <module>grib</module>
-        <module>netcdf</module>
+  <modules>
+    <module>coverage-api</module>
+    <module>grib</module>
+    <module>netcdf</module>
   </modules>
- </project>
+</project>

--- a/modules/unsupported/coverage-multidim/geotiff/pom.xml
+++ b/modules/unsupported/coverage-multidim/geotiff/pom.xml
@@ -134,12 +134,5 @@
     </dependency>
   </dependencies>
 
- <repositories>
-    <repository>
-      <id>geosolutions</id>
-      <name>GeoSolutions libraries repository</name>
-      <url>http://www.geo-solutions.it/maven_repo</url>
-    </repository>
- </repositories>
 
 </project>

--- a/modules/unsupported/coverage-multidim/pom.xml
+++ b/modules/unsupported/coverage-multidim/pom.xml
@@ -93,22 +93,17 @@
 
   <repositories>
     <repository>
-      <id>geosolutions</id>
-      <name>GeoSolutions libraries repository</name>
-      <url>http://maven.geo-solutions.it/</url>
-    </repository>
-    <repository>
       <id>unidata</id>
       <name>Unidata UCAR Libraries repository</name>
       <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata/</url>
     </repository> 
-    </repositories>
+  </repositories>
 
   <!-- =========================================================== -->
   <!--     Modules for the build in approximate dependency order   -->
   <!-- =========================================================== -->
-      <modules>
-        <module>geotiff</module>
-        <module>hdf4</module>
+  <modules>
+    <module>geotiff</module>
+    <module>hdf4</module>
   </modules>
- </project>
+</project>

--- a/modules/unsupported/excel/pom.xml
+++ b/modules/unsupported/excel/pom.xml
@@ -119,17 +119,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <id>maven2-repository.dev.java.net</id>
-      <name>Java.net repository</name>
-      <url>http://download.java.net/maven/2</url>
-    </repository>
-    <repository>
-      <id>osgeo</id>
-      <name>Open Source Geospatial Foundation Repository</name>
-      <url>http://download.osgeo.org/webdav/geotools/</url>
-    </repository>
-  </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1889,7 +1889,7 @@
       </snapshots>
       <id>boundless</id>
       <name>Boundless Maven Repository</name>
-      <url>http://repo.boundlessgeo.com/main/</url>
+      <url>https://boundless.artifactoryonline.com/boundless/snapshot/</url>
     </repository>
 
   </repositories>
@@ -1913,7 +1913,7 @@
       </snapshots>
       <id>boundless</id>
       <name>Boundless Maven Repository</name>
-      <url>http://repo.boundlessgeo.com/main/</url>
+      <url>https://boundless.artifactoryonline.com/boundless/snapshot/</url>
     </pluginRepository> 
     <pluginRepository>
      <id>sonatype-snapshots</id>


### PR DESCRIPTION
To avoid duplication of code in sub-modules and miminize the risk to forget something, if configuration changes this pull request adresses the issue. Only unique entries of repositories are still present in sub-modules such as
 * Unidata UCAR Libraries repository (https://artifacts.unidata.ucar.edu/content/repositories/unidata/)
 * Restlet Maven Repository (http://maven.restlet.org)
 * nativelibs4java-repo (http://nativelibs4java.sourceforge.net/maven)

In addition all boundless repository definitions (plugin-repository, repository, and distributionManagement) using the same url. 

A full build with an empty local repository finished successfully.

Maybe its worth to think about moving this to top-level root or remove all repository definitions and following maven guide-lines (e.g. https://maven.apache.org/enforcer/enforcer-rules/bannedRepositories.html). This isn't adressed by this pull request 
