### PR TITLE
MatchCase attribute support in WFS 1.1 filter encoding

### DIFF
--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
@@ -133,6 +133,10 @@ public class OGCPropertyIsLikeTypeBinding extends AbstractComplexBinding {
             return isLike.getEscape();
         }
 
+        if ("matchCase".equals(name.getLocalPart())) {
+            return isLike.isMatchingCase();
+        }
+        
         return null;
     }
 }

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/FilterMockData.java
@@ -35,6 +35,7 @@ import org.opengis.filter.PropertyIsGreaterThan;
 import org.opengis.filter.PropertyIsGreaterThanOrEqualTo;
 import org.opengis.filter.PropertyIsLessThan;
 import org.opengis.filter.PropertyIsLessThanOrEqualTo;
+import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.PropertyIsNotEqualTo;
 import org.opengis.filter.expression.Add;
 import org.opengis.filter.expression.Divide;
@@ -142,6 +143,10 @@ public class FilterMockData {
     
     public static Function function() {
         return f.function("abs", f.property("foo"));
+    }
+    
+    static PropertyIsLike propertyIsLike() {
+        return f.like(propertyName(), "foo", "x", "y", "z", false);
     }
     
     static Element propertyIsLike(Document document, Node parent) {

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/OGCPropertyIsLikeTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/OGCPropertyIsLikeTypeBindingTest.java
@@ -16,7 +16,10 @@
  */
 package org.geotools.filter.v1_1;
 
+import org.geotools.filter.v1_0.OGC;
 import org.opengis.filter.PropertyIsLike;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 
 /**
@@ -38,5 +41,39 @@ public class OGCPropertyIsLikeTypeBindingTest extends FilterTestSupport {
         assertEquals("y", isLike.getSingleChar());
         assertEquals("z", isLike.getEscape());
         assertEquals(false, isLike.isMatchingCase());
+    }
+    
+    public void testEncode() throws Exception {
+        Document doc = encode(FilterMockData.propertyIsLike(), OGC.PropertyIsLike);
+        
+        Element pn = getElementByQName( doc, OGC.PropertyName );
+        assertNotNull(pn);
+        assertEquals( "foo", pn.getFirstChild().getNodeValue() );
+        
+        Element l = getElementByQName( doc, OGC.Literal );
+        assertEquals( "foo", l.getFirstChild().getNodeValue() );
+        
+        assertEquals("x", doc.getDocumentElement().getAttribute("wildCard"));
+        assertEquals("y", doc.getDocumentElement().getAttribute("singleChar"));
+        assertEquals("z", doc.getDocumentElement().getAttribute("escapeChar"));
+        assertEquals("false", doc.getDocumentElement().getAttribute("matchCase"));
+    }
+    
+    public void testEncodeAsFilter() throws Exception {
+        Document doc = encode(FilterMockData.propertyIsLike(), OGC.Filter);
+        print(doc);
+        
+        assertEquals(1,
+            doc.getDocumentElement()
+               .getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart()).getLength());
+        assertEquals(1,
+            doc.getDocumentElement()
+               .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+
+        Element e = getElementByQName( doc, OGC.PropertyIsLike);
+        assertEquals("x", e.getAttribute("wildCard"));
+        assertEquals("y", e.getAttribute("singleChar"));
+        assertEquals("z", e.getAttribute("escapeChar"));
+        assertEquals("false", e.getAttribute("matchCase"));
     }
 }


### PR DESCRIPTION
MatchCase attribute in PropertyIsLike is correctly handled when decoded in gt filter, but ignored when a gt filter is encoded to WFS 1.1 filter.
As far as I understand WFS Filter 2.0 specification doesn't support MatchCase in PropertyIsLike, so I have not modified v2.0 tests.