### PR TITLE
[GEOT-5289] Use java.util.ServiceLoader instead of javax.imageio.spi.ServiceRegistry

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/expression/PropertyAccessors.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/PropertyAccessors.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -19,9 +19,8 @@ package org.geotools.filter.expression;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.ServiceLoader;
 
-import org.geotools.factory.FactoryRegistry;
 import org.geotools.factory.Hints;
 
 /**
@@ -45,17 +44,16 @@ public class PropertyAccessors {
         cache.add( new NullPropertyAccessorFactory()); //NC - added       
         cache.add( new SimpleFeaturePropertyAccessorFactory());
         cache.add( new DirectPropertyAccessorFactory());       
-        Iterator factories = FactoryRegistry
-                 .lookupProviders(PropertyAccessorFactory.class);
+        Iterator<PropertyAccessorFactory> factories = ServiceLoader.load(PropertyAccessorFactory.class).iterator();
          while (factories.hasNext()) {
-            Object factory = factories.next();
+            PropertyAccessorFactory factory = factories.next();
             if ( factory instanceof SimpleFeaturePropertyAccessorFactory || factory instanceof DirectPropertyAccessorFactory
                  || factory instanceof NullPropertyAccessorFactory )
                 continue;
             
-            cache.add((PropertyAccessorFactory) factory);
+            cache.add(factory);
          }
-         FACTORY_CACHE = (PropertyAccessorFactory[]) cache.toArray(new PropertyAccessorFactory[cache.size()]);
+         FACTORY_CACHE = cache.toArray(new PropertyAccessorFactory[cache.size()]);
     }
     
     /**

--- a/modules/library/metadata/src/main/java/org/geotools/factory/AbstractFactory.java
+++ b/modules/library/metadata/src/main/java/org/geotools/factory/AbstractFactory.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -26,8 +26,6 @@ import java.util.Iterator;
 import java.io.Writer;
 import java.io.IOException;
 import java.awt.RenderingHints;
-import javax.imageio.spi.ServiceRegistry;
-import javax.imageio.spi.RegisterableService;
 
 import org.opengis.referencing.AuthorityFactory;
 import org.geotools.util.Utilities;
@@ -44,14 +42,14 @@ import org.geotools.resources.i18n.ErrorKeys;
  * <ul>
  *   <li>An initially empty {@linkplain #hints map of hints} to be filled by subclasses
  *       constructors. They are the hints to be returned by {@link #getImplementationHints}.</li>
- *   <li>An automatic {@linkplain ServiceRegistry#setOrdering ordering} applied
+ *   <li>An automatic {@linkplain FactoryRegistry#setOrdering ordering} applied
  *       on the basis of subclasses-provided {@linkplain #priority} rank.</li>
  * </ul>
  * <p>
  * When more than one factory implementation is
- * {@linkplain ServiceRegistry#registerServiceProvider registered} for the same category (i.e. they
+ * {@linkplain FactoryRegistry#registerServiceProvider registered} for the same category (i.e. they
  * implement the same {@link Factory} sub-interface), the actual instance to be used is selected
- * according their {@linkplain ServiceRegistry#setOrdering ordering} and user-supplied
+ * according their {@linkplain FactoryRegistry#setOrdering ordering} and user-supplied
  * {@linkplain Hints hints}. Hints have precedence. If more than one factory matches the hints
  * (including the common case where the user doesn't provide any hint at all), then ordering
  * matter.
@@ -125,7 +123,7 @@ public class AbstractFactory implements Factory, RegisterableService {
     /**
      * The minimum priority for a factory, which is {@value}. Factories with lowest priority
      * will be used only if there is no other factory in the same
-     * {@linkplain ServiceRegistry#getCategories category}.
+     * {@linkplain FactoryRegistry#getCategories category}.
      *
      * @see #priority
      * @see #onRegistration
@@ -143,7 +141,7 @@ public class AbstractFactory implements Factory, RegisterableService {
     /**
      * The maximum priority for a factory, which is {@value}. Factories with highest
      * priority will be preferred to any other factory in the same
-     * {@linkplain ServiceRegistry#getCategories category}.
+     * {@linkplain FactoryRegistry#getCategories category}.
      *
      * @see #priority
      * @see #onRegistration
@@ -288,7 +286,7 @@ public class AbstractFactory implements Factory, RegisterableService {
      * @see #MINIMUM_PRIORITY
      * @see #MAXIMUM_PRIORITY
      */
-    public void onRegistration(final ServiceRegistry registry, final Class category) {
+    public void onRegistration(final FactoryRegistry registry, final Class category) {
         for (final Iterator it=registry.getServiceProviders(category, false); it.hasNext();) {
             final Object provider = it.next();
             if (provider!=this && provider instanceof AbstractFactory) {
@@ -321,7 +319,7 @@ public class AbstractFactory implements Factory, RegisterableService {
      *                 deregistered.
      * @param category The registry category from which this object is being deregistered.
      */
-    public void onDeregistration(final ServiceRegistry registry, final Class category) {
+    public void onDeregistration(final FactoryRegistry registry, final Class category) {
         // No action needed.
     }
 

--- a/modules/library/metadata/src/main/java/org/geotools/factory/PartiallyOrderedSet.java
+++ b/modules/library/metadata/src/main/java/org/geotools/factory/PartiallyOrderedSet.java
@@ -114,17 +114,6 @@ class PartiallyOrderedSet<E> extends AbstractSet<E> {
         }
 
         /**
-         * Returns <code>true</code> if an edge exists between this node and the given node.
-         *
-         * @param node a <code>DigraphNode</code>.
-         *
-         * @return <code>true</code> if the node is the target of an edge.
-         */
-        public boolean hasEdge(DigraphNode node) {
-            return outNodes.contains(node);
-        }
-
-        /**
          * Removes a directed edge from the graph. The outNodes list of this node is updated
          * and the in-degree of the other node is decremented.
          *
@@ -144,6 +133,7 @@ class PartiallyOrderedSet<E> extends AbstractSet<E> {
         /**
          * Removes this node from the graph, updating neighboring nodes appropriately.
          */
+        @SuppressWarnings("unchecked")
         public void dispose() {
             Object[] inNodesArray = inNodes.toArray();
             for(int i=0; i<inNodesArray.length; i++) {
@@ -306,12 +296,5 @@ class PartiallyOrderedSet<E> extends AbstractSet<E> {
         DigraphNode secondPONode = poNodes.get(second);
 
         return firstPONode.removeEdge(secondPONode) || secondPONode.removeEdge(firstPONode);
-    }
-
-    /**
-     * Returns <code>true</code> if an ordering exists between two nodes.
-     */
-    public boolean hasOrdering(Object preferred, Object other) {
-        return poNodes.get(preferred).hasEdge(poNodes.get(other));
     }
 }

--- a/modules/library/metadata/src/main/java/org/geotools/factory/PartiallyOrderedSet.java
+++ b/modules/library/metadata/src/main/java/org/geotools/factory/PartiallyOrderedSet.java
@@ -1,0 +1,317 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.factory;
+
+import java.util.AbstractSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A set of <code>Object</code>s with pairwise orderings between them.
+ * The <code>iterator</code> method provides the elements in topologically sorted order.
+ * Elements participating in a cycle are not returned.
+ *
+ * Unlike the <code>SortedSet</code> and <code>SortedMap</code> interfaces, which require their 
+ * elements to implement the <code>Comparable</code> interface, this class receives ordering
+ * information via its <code>setOrdering</code> and <code>unsetPreference</code> methods.
+ * This difference is due to the fact that the relevant ordering between elements is unlikely to
+ * be inherent in the elements themselves; rather, it is set dynamically according to application
+ * policy. For example, in a service provider registry situation, an application might allow the
+ * user to set a preference order for service provider objects supplied by a trusted vendor over 
+ * those supplied by another.
+ * 
+ * @since 15.0
+ */
+class PartiallyOrderedSet<E> extends AbstractSet<E> {
+
+    // The topological sort (roughly) follows the algorithm described in
+    // Horowitz and Sahni, _Fundamentals of Data Structures_ (1976), p. 315.
+
+    // Maps Objects to DigraphNodes that contain them
+    private final Map<E, DigraphNode> poNodes = new HashMap<>();
+
+    // The set of Objects
+    private final Set<E> nodes = poNodes.keySet();
+
+    /**
+     * A node in a directed graph. In addition to an arbitrary <code>Object</code> containing
+     * user data associated with the node, each node maintains a <code>Set</code>s of nodes
+     * which are pointed to by the current node (available from <code>getOutNodes</code>).
+     * The in-degree of the node (that is, number of nodes that point to the current node)
+     * may be queried.
+     */
+    private class DigraphNode implements Cloneable {
+
+        /** The data associated with this node. */
+        private final E data;
+
+        /** A <code>Set</code> of neighboring nodes pointed to by this node. */
+        private final Set<DigraphNode> outNodes = new HashSet<>();
+
+        /** The in-degree of the node. */
+        private int inDegree = 0;
+
+        /** A <code>Set</code> of neighboring nodes that point to this node. */
+        private final Set<DigraphNode> inNodes = new HashSet<>();
+
+        /**
+         * Constructs a new <code>DigraphNode</code>.
+         * @param data The data associated with this node
+         */
+        public DigraphNode(E data) {
+            this.data = data;
+        }
+
+        /** 
+         * Returns the <code>Object</code> referenced by this node.
+         */
+        public E getData() {
+            return data;
+        }
+
+        /**
+         * Returns an <code>Iterator</code> containing the nodes pointed to by this node.
+         */
+        public Iterator<DigraphNode> getOutNodes() {
+            return outNodes.iterator();
+        }
+
+        /**
+         * Adds a directed edge to the graph. The outNodes list of this node is updated
+         * and the in-degree of the other node is incremented.
+         *
+         * @param node a <code>DigraphNode</code>.
+         *
+         * @return <code>true</code> if the node was not previously the target of an edge.
+         */
+        public boolean addEdge(DigraphNode node) {
+            if (outNodes.contains(node)) {
+                return false;
+            }
+
+            outNodes.add(node);
+            node.inNodes.add(this);
+            node.incrementInDegree();
+            return true;
+        }
+
+        /**
+         * Returns <code>true</code> if an edge exists between this node and the given node.
+         *
+         * @param node a <code>DigraphNode</code>.
+         *
+         * @return <code>true</code> if the node is the target of an edge.
+         */
+        public boolean hasEdge(DigraphNode node) {
+            return outNodes.contains(node);
+        }
+
+        /**
+         * Removes a directed edge from the graph. The outNodes list of this node is updated
+         * and the in-degree of the other node is decremented.
+         *
+         * @return <code>true</code> if the node was previously the target of an edge.
+         */
+        public boolean removeEdge(DigraphNode node) {
+            if (!outNodes.contains(node)) {
+                return false;
+            }
+
+            outNodes.remove(node);
+            node.inNodes.remove(this);
+            node.decrementInDegree();
+            return true;
+        }
+
+        /**
+         * Removes this node from the graph, updating neighboring nodes appropriately.
+         */
+        public void dispose() {
+            Object[] inNodesArray = inNodes.toArray();
+            for(int i=0; i<inNodesArray.length; i++) {
+                ((DigraphNode) inNodesArray[i]).removeEdge(this);
+            }
+
+            Object[] outNodesArray = outNodes.toArray();
+            for(int i=0; i<outNodesArray.length; i++) {
+                removeEdge(((DigraphNode) outNodesArray[i]));
+            }
+        }
+
+        /** Returns the in-degree of this node. */
+        public int getInDegree() {
+            return inDegree;
+        }
+
+        /** Increments the in-degree of this node. */
+        private void incrementInDegree() {
+            ++inDegree;
+        }
+
+        /** Decrements the in-degree of this node. */
+        private void decrementInDegree() {
+            --inDegree;
+        }
+    }
+
+    private class PartialOrderIterator implements Iterator<E> {
+
+        private final LinkedList<DigraphNode> zeroList = new LinkedList<>();
+        private final Map<DigraphNode, Integer> inDegrees = new HashMap<>();
+
+        public PartialOrderIterator(Iterator<DigraphNode> iter) {
+            // Initialize scratch in-degree values, zero list
+            while (iter.hasNext()) {
+                DigraphNode node = iter.next();
+                int inDegree = node.getInDegree();
+                inDegrees.put(node, new Integer(inDegree));
+
+                // Add nodes with zero in-degree to the zero list
+                if (inDegree == 0) {
+                    zeroList.add(node);
+                }
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return !zeroList.isEmpty();
+        }
+
+        @Override
+        public E next() {
+            DigraphNode first = zeroList.removeFirst();
+
+            // For each out node of the output node, decrement its in-degree
+            Iterator<DigraphNode> outNodes = first.getOutNodes();
+            while (outNodes.hasNext()) {
+                DigraphNode node = outNodes.next();
+                int inDegree = inDegrees.get(node).intValue() - 1;
+                inDegrees.put(node, new Integer(inDegree));
+
+                // If the in-degree has fallen to 0, place the node on the list
+                if (inDegree == 0) {
+                    zeroList.add(node);
+                }
+            }
+
+            return first.getData();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+    
+    /**
+     * Constructs a <code>PartiallyOrderedSet</code>.
+     */
+    public PartiallyOrderedSet() {}
+
+    @Override
+    public int size() {
+        return nodes.size();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return nodes.contains(o);
+    }
+
+    /**
+     * Returns an iterator over the elements contained in this collection, with an ordering 
+     * that respects the orderings set by the <code>setOrdering</code> method.
+     */
+    @Override
+    public Iterator<E> iterator() {
+        return new PartialOrderIterator(poNodes.values().iterator());
+    }
+
+    /**
+     * Adds an <code>Object</code> to this <code>PartiallyOrderedSet</code>.
+     */
+    @Override
+    public boolean add(E o) {
+        if (nodes.contains(o)) {
+            return false;
+        }
+
+        poNodes.put(o, new DigraphNode(o));
+        return true;
+    }
+
+    /**
+     * Removes an <code>Object</code> from this
+     * <code>PartiallyOrderedSet</code>.
+     */
+    @Override
+    public boolean remove(Object o) {
+        DigraphNode node = poNodes.get(o);
+        if (node == null) {
+            return false;
+        }
+
+        poNodes.remove(o);
+        node.dispose();
+        return true;
+    }
+
+    @Override
+    public void clear() {
+        poNodes.clear();
+    }
+
+    /**
+     * Sets an ordering between two nodes. When an iterator is requested, the first node will
+     * appear earlier in the sequence than the second node.  If a prior ordering existed between
+     * the nodes in the opposite order, it is removed.
+     *
+     * @return <code>true</code> if no prior ordering existed between the nodes,
+     * <code>false</code>otherwise.
+     */
+    public boolean setOrdering(Object first, Object second) {
+        DigraphNode firstPONode = poNodes.get(first);
+        DigraphNode secondPONode = poNodes.get(second);
+
+        secondPONode.removeEdge(firstPONode);
+        return firstPONode.addEdge(secondPONode);
+    }
+
+    /**
+     * Removes any ordering between two nodes.
+     *
+     * @return true if a prior prefence existed between the nodes.
+     */
+    public boolean unsetOrdering(Object first, Object second) {
+        DigraphNode firstPONode = poNodes.get(first);
+        DigraphNode secondPONode = poNodes.get(second);
+
+        return firstPONode.removeEdge(secondPONode) || secondPONode.removeEdge(firstPONode);
+    }
+
+    /**
+     * Returns <code>true</code> if an ordering exists between two nodes.
+     */
+    public boolean hasOrdering(Object preferred, Object other) {
+        return poNodes.get(preferred).hasEdge(poNodes.get(other));
+    }
+}

--- a/modules/library/metadata/src/main/java/org/geotools/factory/RegisterableService.java
+++ b/modules/library/metadata/src/main/java/org/geotools/factory/RegisterableService.java
@@ -1,0 +1,51 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.factory;
+
+/**
+ * An optional interface that may be provided by service provider objects that will be registered
+ * with a <code>FactoryRegistry</code>. If this interface is present, notification of registration
+ * and deregistration will be performed.
+ *
+ * @since 15.0
+ * @see FactoryRegistry
+ */
+public interface RegisterableService {
+
+    /**
+     * Called when an object implementing this interface is added to the given
+     * <code>category</code> of the given <code>registry</code>. The object may already be 
+     * registered under another category or categories.
+     *
+     * @param registry a <code>FactoryRegistry</code> where this object has been registered.
+     * @param category a <code>Class</code> object indicating the registry category under which 
+     * this object has been registered.
+     */
+    void onRegistration(FactoryRegistry registry, Class<?> category);
+
+    /**
+     * Called when an object implementing this interface is removed from the given
+     * <code>category</code> of the given <code>registry</code>. The object may still be
+     * registered under another category or categories.
+     *
+     * @param registry a <code>FactoryRegistry</code> from which this object is being
+     * (wholly or partially) deregistered.
+     * @param category a <code>Class</code> object indicating the registry category from which
+     * this object is being deregistered.
+     */
+    void onDeregistration(FactoryRegistry registry, Class<?> category);
+}

--- a/modules/library/opengis/src/main/java/org/opengis/referencing/Factory.java
+++ b/modules/library/opengis/src/main/java/org/opengis/referencing/Factory.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2011-2015, Open Source Geospatial Foundation (OSGeo)
  *    (C) 2003-2005, Open Geospatial Consortium Inc.
  *    
  *    All Rights Reserved. http://www.opengis.org/legal/
@@ -36,7 +36,7 @@ public interface Factory {
     /**
      * Returns the vendor responsible for creating this factory implementation. Many implementations
      * may be available for the same factory interface. Implementations are usually managed by a
-     * {@linkplain javax.imageio.spi.ServiceRegistry service registry}.
+     * {@linkplain java.util.ServiceLoader service loader}.
      *
      * @return The vendor for this factory implementation.
      */

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/ReferencingFactoryFinder.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/ReferencingFactoryFinder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Set;
-
-import javax.imageio.spi.ServiceRegistry;
 
 import org.geotools.factory.FactoryCreator;
 import org.geotools.factory.FactoryFinder;
@@ -573,7 +571,7 @@ loop:       for (int i=0; ; i++) {
     /**
      * A filter for factories provided by a given vendor.
      */
-    private static final class VendorFilter implements ServiceRegistry.Filter {
+    private static final class VendorFilter implements FactoryRegistry.Filter {
         /** The vendor to filter. */
         private final String vendor;
 
@@ -630,7 +628,7 @@ loop:       for (int i=0; ; i++) {
     /**
      * A filter for factories provided for a given authority.
      */
-    private static final class AuthorityFilter implements ServiceRegistry.Filter {
+    private static final class AuthorityFilter implements FactoryRegistry.Filter {
         /** The authority to filter. */
         private final String authority;
 

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/ReferencingObjectFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/ReferencingObjectFactory.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -84,7 +84,7 @@ public class ReferencingObjectFactory extends ReferencingFactory
 
     /**
      * Constructs a default factory. This method is public in order to allows instantiations
-     * from a {@linkplain javax.imageio.spi.ServiceRegistry service registry}. Users should
+     * from a {@linkplain java.util.ServiceLoader service loader}. Users should
      * not instantiate this factory directly, but use one of the following lines instead:
      *
      * <blockquote><pre>

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/ThreadedEpsgFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/ThreadedEpsgFactory.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2001-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2001-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -20,15 +20,10 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import javax.sql.DataSource;
-import java.util.Iterator;
-import java.util.Comparator;
-import java.util.Collections;
 import java.util.jar.Attributes.Name;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import javax.imageio.spi.ServiceRegistry;
 import javax.naming.InitialContext;
-import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 import javax.naming.NoInitialContextException;
 
@@ -41,7 +36,6 @@ import org.opengis.referencing.operation.CoordinateOperationAuthorityFactory;
 
 import org.geotools.factory.GeoTools;
 import org.geotools.factory.Hints;
-import org.geotools.factory.FactoryRegistry;
 import org.geotools.metadata.iso.citation.Citations;
 import org.geotools.referencing.ReferencingFactoryFinder;
 import org.geotools.referencing.factory.AbstractAuthorityFactory;

--- a/modules/unsupported/efeature/src/main/java/org/geotools/data/efeature/EFeatureContextFactory.java
+++ b/modules/unsupported/efeature/src/main/java/org/geotools/data/efeature/EFeatureContextFactory.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
-
-import javax.imageio.spi.ServiceRegistry;
 
 import org.geotools.data.efeature.impl.EFeatureContextImpl;
 import org.geotools.data.efeature.impl.EFeatureIDFactoryImpl;
@@ -53,7 +51,7 @@ public class EFeatureContextFactory implements BufferedFactory {
     
     /**
      * Weak reference to instance cached by the 
-     * {@link ServiceRegistry service registry}.
+     * {@link java.util.ServiceLoader service loader}.
      */
     private static WeakReference<EFeatureContextFactory> eInstance;
     

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSExtensions.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSExtensions.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2014, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -20,9 +20,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.Set;
-
-import javax.imageio.spi.ServiceRegistry;
 
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.factory.FactoryNotFoundException;
@@ -143,7 +142,7 @@ public class WFSExtensions {
                          * Now that we're on the correct classloader lets perform the lookup
                          */
                         Iterator<WFSResponseFactory> providers;
-                        providers = ServiceRegistry.lookupProviders(WFSResponseFactory.class);
+                        providers = ServiceLoader.load(WFSResponseFactory.class).iterator();
                         registry = new HashSet<WFSResponseFactory>();
                         while (providers.hasNext()) {
                             WFSResponseFactory provider = providers.next();

--- a/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/protocol/wfs/WFSExtensions.java
+++ b/modules/unsupported/wfs/src/main/java/org/geotools/data/wfs/protocol/wfs/WFSExtensions.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -20,9 +20,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.Set;
-
-import javax.imageio.spi.ServiceRegistry;
 
 import org.eclipse.emf.ecore.EObject;
 import org.geotools.data.wfs.WFSDataStore;
@@ -127,7 +126,7 @@ public class WFSExtensions {
                          * Now that we're on the correct classloader lets perform the lookup
                          */
                         Iterator<WFSResponseParserFactory> providers;
-                        providers = ServiceRegistry.lookupProviders(WFSResponseParserFactory.class);
+                        providers = ServiceLoader.load(WFSResponseParserFactory.class).iterator();
                         registry = new HashSet<WFSResponseParserFactory>();
                         while (providers.hasNext()) {
                             WFSResponseParserFactory provider = providers.next();


### PR DESCRIPTION
PR for https://osgeo-org.atlassian.net/browse/GEOT-5289

The goal is to make GeoTools run with Java 9, now that [JDK-8068749](https://bugs.openjdk.java.net/browse/JDK-8068749) has been delivered.
As a consequence FactoryRegistry do not extends javax.imageio.spi.ServiceRegistry anymore but provides almost the same public API as before to minimize the impact as much as possible.