### PR TITLE
GEOT-5296: Apply WFS timeout to read timeout

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSDataStoreFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSDataStoreFactory.java
@@ -107,6 +107,7 @@ public class WFSDataStoreFactory extends WFSDataAccessFactory implements DataSto
         http.setPassword(config.getPassword());
         int timeoutMillis = config.getTimeoutMillis();
         http.setConnectTimeout(timeoutMillis / 1000);
+        http.setReadTimeout(timeoutMillis / 1000);
 
         final URL capabilitiesURL = (URL) URL.lookUp(params);
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
@@ -531,6 +531,7 @@ public class WFSDataAccessFactory implements DataAccessFactory {
         http.setPassword(config.getPassword());
         int timeoutMillis = config.getTimeoutMillis();
         http.setConnectTimeout(timeoutMillis / 1000);
+        http.setReadTimeout(timeoutMillis / 1000);
 
         final URL capabilitiesURL = (URL)URL.lookUp(params);
 


### PR DESCRIPTION
WFSConfig.timeoutMillis is applied to read timeout of HTTPClient, too.
See [GEOT-5296](https://osgeo-org.atlassian.net/browse/GEOT-5296)