### PR TITLE
[GEOT-5298] fixed read access while content changed

### DIFF
--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureReader.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureReader.java
@@ -17,7 +17,11 @@
 package org.geotools.data.memory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.geotools.data.DataSourceException;
@@ -30,20 +34,27 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 public class MemoryFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeature>{
-    ContentState state;
+
     SimpleFeatureType featureType;
     Iterator<SimpleFeature> iterator;
 
     public MemoryFeatureReader(ContentState state, Query query) throws IOException {
-        this.state = state;
         featureType = state.getFeatureType();
-        String typeName = getFeatureType().getTypeName();
-        MemoryDataStore store = (MemoryDataStore) state.getEntry().getDataStore();
-        iterator = store.features(typeName).values().iterator();
+
+        final MemoryDataStore store = (MemoryDataStore) state.getEntry().getDataStore();
+        final Map<String, SimpleFeature> features = store.features(featureType.getTypeName());
+        synchronized (features) {
+            final Collection<SimpleFeature> featureCollection = features.values();
+            final List<SimpleFeature> internalCollection = new ArrayList<SimpleFeature>();
+            if (features != null) {
+                internalCollection.addAll(featureCollection);
+            }
+            iterator = internalCollection.iterator();
+        }
     }
 
     public SimpleFeatureType getFeatureType() {
-        return state.getFeatureType();
+        return featureType;
     }
 
     public SimpleFeature next()

--- a/modules/library/data/src/test/java/org/geotools/data/memory/MemoryFeatureReaderTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/memory/MemoryFeatureReaderTest.java
@@ -1,0 +1,118 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.memory;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+import org.geotools.data.DataTestCase;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.FeatureReader;
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Query;
+import org.geotools.data.Transaction;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+
+public class MemoryFeatureReaderTest extends DataTestCase {
+
+    private MemoryDataStore memoryDataStore;
+
+    private final Transaction transaction = new DefaultTransaction();
+
+    public MemoryFeatureReaderTest(String name) {
+        super(name);
+    }
+
+    public void setUp() throws Exception {
+        super.setUp();
+        memoryDataStore = new MemoryDataStore(roadFeatures);
+    }
+
+    public void testReaderIsNotBrokenWhileWritingFeatureDirectly()
+            throws IOException {
+        // a write should not "destroy" readers
+        int expectedFeatureCount = roadFeatures.length;
+        int currentFeatureCount = 0;
+
+        FeatureReader<SimpleFeatureType, SimpleFeature> featureReader = memoryDataStore
+                .getFeatureReader(
+                        new Query(roadType.getTypeName(), Filter.INCLUDE),
+                        transaction);
+
+        // start iterating through content
+        if (featureReader.hasNext()) {
+            featureReader.next();
+            currentFeatureCount++;
+        }
+        SimpleFeature newFeature = SimpleFeatureBuilder.template(roadType, null);
+
+        memoryDataStore.addFeature(newFeature);
+
+        assertReaderHasFeatureCount(expectedFeatureCount, currentFeatureCount, featureReader);
+    }
+
+    public void testReaderIsNotBrokenWhileWritingWithWriterAndTransaction()
+            throws IOException {
+        // a write should not "destroy" readers
+        int expectedFeatureCount = roadFeatures.length;
+        int currentFeatureCount = 0;
+
+        FeatureReader<SimpleFeatureType, SimpleFeature> featureReader = memoryDataStore
+                .getFeatureReader(
+                        new Query(roadType.getTypeName(), Filter.INCLUDE),
+                        transaction);
+
+        // start iterating through content
+        if (featureReader.hasNext()) {
+            featureReader.next();
+            currentFeatureCount++;
+        }
+
+        FeatureWriter<SimpleFeatureType, SimpleFeature> featureWriter = memoryDataStore
+                .getFeatureWriter(roadType.getTypeName(), transaction);
+
+        while (featureWriter.hasNext()) {
+            featureWriter.next();
+        }
+
+        SimpleFeature newFeature = featureWriter.next();
+        assertNotNull(newFeature);
+
+        transaction.commit();
+
+        assertReaderHasFeatureCount(expectedFeatureCount, currentFeatureCount, featureReader);
+    }
+
+    public void shutDown() throws IOException {
+        transaction.close();
+    }
+
+    private void assertReaderHasFeatureCount(int expectedFeatureCount,
+            int currentFeatureCount,
+            FeatureReader<SimpleFeatureType, SimpleFeature> featureReader) throws IOException {
+        while (featureReader.hasNext()) {
+            featureReader.next();
+            currentFeatureCount++;
+        }
+
+        assertEquals("a write in MemoryDataStore should not 'destroy' readers",
+                expectedFeatureCount, currentFeatureCount);
+    }
+}


### PR DESCRIPTION
It fixes broken Readers while internal storage has changed. Having this in mind the reader is temporary inconsintent until another Reader is created but only if quantity of features for this specific FeatureType in DataStore changed in between