### PR TITLE
[GEOT-5757] Handle ArcSDE invalid extents for empty feature classes

### DIFF
--- a/modules/plugin/arcsde/datastore/src/main/java/org/geotools/arcsde/filter/GeometryEncoderSDE.java
+++ b/modules/plugin/arcsde/datastore/src/main/java/org/geotools/arcsde/filter/GeometryEncoderSDE.java
@@ -256,11 +256,20 @@ public class GeometryEncoderSDE extends DefaultFilterVisitor implements FilterVi
         }
 
         try {
-            SeShape extent = new SeShape(this.sdeLayer.getCoordRef());
-            extent.generateRectangle(seExtent);
-
             // Now make an SeShape
             SeShape filterShape;
+
+            if(seExtent.isEmpty() == true)
+            {
+                // The extent of the sdeLayer is uninitialised so create an extent.
+                // If seExtent.isEmpty() == true, when passed to SeShape.generateRectangle()
+                // an exception occurs.
+                filterShape = new SeShape(this.sdeLayer.getCoordRef());
+            }
+            else
+            {
+                SeShape extent = new SeShape(this.sdeLayer.getCoordRef());
+                extent.generateRectangle(seExtent);
 
             // this is a bit hacky, but I don't yet know this code well enough
             // to do it right. Basically if the geometry collection is
@@ -277,6 +286,7 @@ public class GeometryEncoderSDE extends DefaultFilterVisitor implements FilterVi
             } else {
                 gb = ArcSDEGeometryBuilder.builderFor(geom.getClass());
                 filterShape = gb.constructShape(geom, this.sdeLayer.getCoordRef());
+            }
             }
             // Add the filter to our list
             SeShapeFilter shapeFilter = new SeShapeFilter(getLayerName(),

--- a/modules/plugin/arcsde/datastore/src/test/java/org/geotools/arcsde/data/ArcSDEQueryEmptyTableTest.java
+++ b/modules/plugin/arcsde/datastore/src/test/java/org/geotools/arcsde/data/ArcSDEQueryEmptyTableTest.java
@@ -1,0 +1,123 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ */
+package org.geotools.arcsde.data;
+
+import static org.geotools.filter.text.ecql.ECQL.toFilter;
+
+import org.geotools.arcsde.session.ISession;
+import org.geotools.arcsde.versioning.AutoCommitVersionHandler;
+import org.geotools.data.Query;
+import org.geotools.data.Transaction;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+
+import com.esri.sde.sdk.client.SeVersion;
+
+/**
+ * Test suite for the {@link ArcSDEQuery} query wrapper
+ * 
+ * @author Gabriel Roldan
+ * 
+ * 
+ * @source $URL$
+ *         http://svn.geotools.org/geotools/trunk/gt/modules/plugin/arcsde/datastore/src/test/java
+ *         /org/geotools/arcsde/data/ArcSDEQueryTest.java $
+ * @version $Revision: 1.9 $
+ */
+public class ArcSDEQueryEmptyTableTest {
+
+    private static TestData testData;
+
+    /**
+     * do not access it directly, use {@link #createFilteringQuery()}
+     */
+    private ArcSDEQuery queryFiltered;
+
+    private ArcSDEDataStore dstore;
+
+    private String typeName;
+
+    private Query filteringQuery;
+
+    private SimpleFeatureType ftype;
+
+    @BeforeClass
+    public static void oneTimeSetUp() throws Exception {
+        testData = new TestData();
+        testData.setUp();
+
+        testData.createTempTableEmptyExtent();
+    }
+
+    @AfterClass
+    public static void oneTimeTearDown() {
+        boolean cleanTestTable = false;
+        boolean cleanPool = true;
+        testData.tearDown(cleanTestTable, cleanPool);
+    }
+
+    /**
+     * loads {@code test-data/testparams.properties} into a Properties object, which is used to
+     * obtain test tables names and is used as parameter to find the DataStore
+     */
+    @Before
+    public void setUp() throws Exception {
+        if (testData == null) {
+            oneTimeSetUp();
+        }
+        dstore = testData.getDataStore();
+        typeName = testData.getTempTableName();
+        this.ftype = dstore.getSchema(typeName);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            this.queryFiltered.close();
+        } catch (Exception e) {
+            // no-op
+        }
+        this.queryFiltered = null;
+    }
+
+    @Test
+    public void testFilterLayerWithEmptyExtent() throws Exception {
+        ISession session = dstore.getSession(Transaction.AUTO_COMMIT);
+        FeatureTypeInfo fti = ArcSDEAdapter.fetchSchema(typeName, null, session);
+
+        Filter filter = toFilter("BBOX(SHAPE, 49, -4, 60, 1)");
+        filteringQuery = new Query(typeName, filter);
+        ArcSDEQuery q = ArcSDEQuery.createQuery(session, ftype, filteringQuery, fti
+                .getFidStrategy(), new AutoCommitVersionHandler(
+                SeVersion.SE_QUALIFIED_DEFAULT_VERSION_NAME));
+        int calculated;
+        try {
+            calculated = q.calculateResultCount();
+        } finally {
+            q.session.dispose();
+            q.close();
+        }
+        Assert.assertEquals(0, calculated);
+    }
+}

--- a/modules/plugin/arcsde/sde-dummy/src/main/java/com/esri/sde/sdk/client/SeExtent.java
+++ b/modules/plugin/arcsde/sde-dummy/src/main/java/com/esri/sde/sdk/client/SeExtent.java
@@ -23,4 +23,5 @@ public class SeExtent extends SeServerObj {
     public void setMaxY(double d){}
     public void setMinZ(double d){}
     public void setMaxZ(double d){}
+    public boolean isEmpty() {return true;}
 }


### PR DESCRIPTION
Updated code to handle the case where a ArcSDE feature class has been created but contain no features and so has an invalid extent