### PR TITLE
remove dead code in PropertyDescriptorImpl

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/type/PropertyDescriptorImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/type/PropertyDescriptorImpl.java
@@ -55,10 +55,6 @@ public class PropertyDescriptorImpl implements PropertyDescriptor {
             throw new NullPointerException("name");
         }
         
-        if (type == null) {
-            throw new NullPointerException();
-        }
-        
         if (max > 0 && (max < min) ) {
             throw new IllegalArgumentException("max must be -1, or >= min");
         }


### PR DESCRIPTION
When type is null, the code that throws NullPointerException is repeated.