### PR TITLE
[GEOT-5327] Support for 'matchCase' in WFS GetFeature request (v1.0.0)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/FilterSAXParser.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/FilterSAXParser.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
  *        
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -283,9 +283,9 @@ public class FilterSAXParser {
                 ((LikeFilterImpl) curFilter).setExpression(expression);
                 curState = "pattern";
             } else if (curState.equals("pattern")) {
-                if (attributes.size() != NUM_LIKE_ATTS) {
+                if (attributes.size() < NUM_LIKE_ATTS) {
                     throw new IllegalFilterException(
-                        "Got wrong number of attributes (expecting 3): "
+                        "Got wrong number of attributes (expecting minimum 3): "
                         + attributes.size() + "\n" + attributes);
                 }
 
@@ -312,8 +312,12 @@ public class FilterSAXParser {
                 }
                 
                 LOGGER.fine("escape char is " + escapeChar);
-
-              
+                
+                String matchCase = (String) attributes.get("matchCase");
+                if (matchCase != null) {
+                    ((LikeFilterImpl) curFilter).setMatchingCase( Boolean.parseBoolean(matchCase) );
+                }
+                
                 ((LikeFilterImpl) curFilter).setPattern(expression, wildcard,
                     singleChar, escapeChar);
                 curState = "complete";


### PR DESCRIPTION
WFS GetFeature request (version 1.0.0) does not support "matchCase" option. It throws an exception. And geoserver therefore throws it.

It fixes the issue:
https://osgeo-org.atlassian.net/browse/GEOT-5327

This feature was funded by: Tracasa (http://www.tracasa.es/en)