### PR TITLE
Fix compilation failure of "Cartographic CSS parser module" with java 8

### DIFF
--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/DomainCoverage.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/DomainCoverage.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2014, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2014-2015, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -377,7 +377,7 @@ class DomainCoverage {
             }
         }
         if (!merged) {
-            scaleDependentFilters.add(new SLDSelector(new NumberRange<>(range), filter));
+            scaleDependentFilters.add(new SLDSelector(new NumberRange<Double>(range), filter));
         }
     }
 


### PR DESCRIPTION
This pull fixes a travis error of the "Cartographic CSS parser module".

https://s3.amazonaws.com/archive.travis-ci.org/jobs/99390746/log.txt
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project gt-css: Compilation failure
[ERROR] /home/travis/build/geotools/geotools/modules/unsupported/css/src/main/java/org/geotools/styling/css/DomainCoverage.java:[380,69] error: incompatible types: cannot infer type arguments for NumberRange<>
