### PR TITLE
GEOT-5334, fixing overflow in ClassificationFunction.round.

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/ClassificationFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/ClassificationFunction.java
@@ -204,7 +204,7 @@ public abstract class ClassificationFunction extends DefaultExpression implement
     protected double round(double value, int decimalPlaces) {
     	double divisor = Math.pow(10, decimalPlaces);
     	double newVal = value * divisor;
-    	newVal =  (new Long(Math.round(newVal)).intValue())/divisor; 
+        newVal = Math.round(newVal) / divisor;
     	return newVal;
     }
     

--- a/modules/library/main/src/test/java/org/geotools/filter/function/ClassificationFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/ClassificationFunctionTest.java
@@ -50,4 +50,9 @@ public class ClassificationFunctionTest extends FunctionTestSupport {
         assertEquals(1.1, classifier.round(1.12, 1), 0);
         assertEquals(0.35, classifier.round(0.34523, 2), 0);
     }
+
+    public void testRoundOverflow() throws Exception {
+        EqualIntervalFunction eif = (EqualIntervalFunction) ff.function("EqualInterval", Expression.NIL);
+        assertEquals(1477946338495.3d, eif.round(1477946338495.25d, 1));
+    }
 }


### PR DESCRIPTION
Fixed by removing intermediate conversion to int. Removed uneccessary use of
Long wrapper class as well.