### PR TITLE
[14.x] XML serialialization bug for GeometryCollection (Generic)

### DIFF
--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML32FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML32FeatureCollectionEncoderDelegate.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.gml3.simple;
 
+import com.vividsolutions.jts.geom.GeometryCollection;
 import java.util.List;
 import java.util.Map;
 
@@ -148,13 +149,14 @@ public class GML32FeatureCollectionEncoderDelegate extends
             encoders.put(MultiPoint.class, new MultiPointEncoder(encoder, gmlPrefix));
             encoders.put(LineString.class, new LineStringEncoder(encoder, gmlPrefix));
             encoders.put(LinearRing.class, new LinearRingEncoder(encoder, gmlPrefix));
-            encoders.put(MultiLineString.class, new MultiLineStringEncoder(encoder, gmlPrefix, true));
+//            encoders.put(MultiLineString.class, new MultiLineStringEncoder(encoder, gmlPrefix));
             encoders.put(Polygon.class, new PolygonEncoder(encoder, gmlPrefix));
             encoders.put(MultiPolygon.class, new MultiPolygonEncoder(encoder, gmlPrefix));
             encoders.put(CircularString.class, new CurveEncoder(encoder, gmlPrefix));
             encoders.put(CompoundCurve.class, new CurveEncoder(encoder, gmlPrefix));
             encoders.put(CircularRing.class, new CurveEncoder(encoder, gmlPrefix));
             encoders.put(CompoundRing.class, new CurveEncoder(encoder, gmlPrefix));
+            encoders.put(GeometryCollection.class, new GeometryCollectionEncoder(encoder, gmlPrefix) );
         }
 
         @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML32FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML32FeatureCollectionEncoderDelegate.java
@@ -149,7 +149,7 @@ public class GML32FeatureCollectionEncoderDelegate extends
             encoders.put(MultiPoint.class, new MultiPointEncoder(encoder, gmlPrefix));
             encoders.put(LineString.class, new LineStringEncoder(encoder, gmlPrefix));
             encoders.put(LinearRing.class, new LinearRingEncoder(encoder, gmlPrefix));
-//            encoders.put(MultiLineString.class, new MultiLineStringEncoder(encoder, gmlPrefix));
+            encoders.put(MultiLineString.class, new MultiLineStringEncoder(encoder, gmlPrefix, true));
             encoders.put(Polygon.class, new PolygonEncoder(encoder, gmlPrefix));
             encoders.put(MultiPolygon.class, new MultiPolygonEncoder(encoder, gmlPrefix));
             encoders.put(CircularString.class, new CurveEncoder(encoder, gmlPrefix));

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
@@ -1,0 +1,98 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gml3.simple;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.LinearRing;
+import com.vividsolutions.jts.geom.MultiLineString;
+import com.vividsolutions.jts.geom.MultiPoint;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
+import org.geotools.geometry.jts.CircularRing;
+import org.geotools.geometry.jts.CircularString;
+import org.geotools.geometry.jts.CompoundCurve;
+import org.geotools.geometry.jts.CompoundRing;
+import org.geotools.gml2.simple.GMLWriter;
+import org.geotools.gml2.simple.GeometryEncoder;
+import org.geotools.xml.Encoder;
+import org.xml.sax.helpers.AttributesImpl;
+
+/**
+ *
+ * @author odie
+ */
+public class GenericGeometryEncoder extends GeometryEncoder<Geometry> {
+
+    Encoder encoder;
+    String gmlPrefix;
+
+    public GenericGeometryEncoder(Encoder encoder) {
+        super(encoder);
+        this.encoder = encoder;
+    }
+
+    /**
+     *
+     * @param encoder
+     * @param gmlPrefix
+     */
+    public GenericGeometryEncoder(Encoder encoder, String gmlPrefix) {
+        super(encoder);
+        this.encoder = encoder;
+        this.gmlPrefix = gmlPrefix;
+    }
+
+    @Override
+    public void encode(Geometry geometry, AttributesImpl atts, GMLWriter handler) throws Exception {
+        if (geometry instanceof LineString) {
+            LineStringEncoder lineString = new LineStringEncoder(encoder,
+                LineStringEncoder.LINE_STRING);
+            lineString.encode((LineString) geometry, atts, handler);
+        } else if (geometry instanceof Point) {
+            PointEncoder pt = new PointEncoder(encoder, gmlPrefix);
+            pt.encode((Point) geometry, atts, handler);
+        } else if (geometry instanceof Polygon) {
+            PolygonEncoder polygon = new PolygonEncoder(encoder, gmlPrefix);
+            polygon.encode((Polygon) geometry, atts, handler);
+//        } else if (geometry instanceof MultiLineString) {
+//            MultiLineStringEncoder multiLineString = new MultiLineStringEncoder(
+//                encoder,
+//                gmlPrefix);
+//            multiLineString.encode((MultiLineString) geometry, atts, handler);
+        } else if (geometry instanceof MultiPoint) {
+            MultiPointEncoder multiPoint = new MultiPointEncoder(encoder,
+                gmlPrefix);
+            multiPoint.encode((MultiPoint) geometry, atts, handler);
+        } else if (geometry instanceof MultiPolygon) {
+            MultiPolygonEncoder multiPolygon = new MultiPolygonEncoder(encoder,
+                gmlPrefix);
+            multiPolygon.encode((MultiPolygon) geometry, atts, handler);
+        } else if (geometry instanceof LinearRing) {
+            LinearRingEncoder linearRing = new LinearRingEncoder(encoder,
+                gmlPrefix);
+            linearRing.encode((LinearRing) geometry, atts, handler);
+        } else if (geometry instanceof CircularString || geometry instanceof CompoundCurve
+                        || geometry instanceof CircularRing || geometry instanceof CompoundRing) {
+            CurveEncoder curve = new CurveEncoder(encoder, gmlPrefix);
+            curve.encode((LineString) geometry, atts, handler);
+        } else {
+            throw new Exception("Unsupported geometry " + geometry.toString());
+        }
+    }
+}

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
@@ -35,7 +35,7 @@ import org.xml.sax.helpers.AttributesImpl;
 
 /**
  *
- * @author odie
+ * @author 
  */
 public class GenericGeometryEncoder extends GeometryEncoder<Geometry> {
 
@@ -70,22 +70,21 @@ public class GenericGeometryEncoder extends GeometryEncoder<Geometry> {
         } else if (geometry instanceof Polygon) {
             PolygonEncoder polygon = new PolygonEncoder(encoder, gmlPrefix);
             polygon.encode((Polygon) geometry, atts, handler);
-//        } else if (geometry instanceof MultiLineString) {
-//            MultiLineStringEncoder multiLineString = new MultiLineStringEncoder(
-//                encoder,
-//                gmlPrefix);
-//            multiLineString.encode((MultiLineString) geometry, atts, handler);
+        } else if (geometry instanceof MultiLineString) {
+            MultiLineStringEncoder multiLineString = new MultiLineStringEncoder(
+                                                        encoder, gmlPrefix, true);
+            multiLineString.encode((MultiLineString) geometry, atts, handler);
         } else if (geometry instanceof MultiPoint) {
             MultiPointEncoder multiPoint = new MultiPointEncoder(encoder,
-                gmlPrefix);
+                                            gmlPrefix);
             multiPoint.encode((MultiPoint) geometry, atts, handler);
         } else if (geometry instanceof MultiPolygon) {
             MultiPolygonEncoder multiPolygon = new MultiPolygonEncoder(encoder,
-                gmlPrefix);
+                                                gmlPrefix);
             multiPolygon.encode((MultiPolygon) geometry, atts, handler);
         } else if (geometry instanceof LinearRing) {
             LinearRingEncoder linearRing = new LinearRingEncoder(encoder,
-                gmlPrefix);
+                                                gmlPrefix);
             linearRing.encode((LinearRing) geometry, atts, handler);
         } else if (geometry instanceof CircularString || geometry instanceof CompoundCurve
                         || geometry instanceof CircularRing || geometry instanceof CompoundRing) {

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
@@ -1,0 +1,47 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.geotools.gml3.simple;
+
+import com.vividsolutions.jts.geom.GeometryCollection;
+import org.geotools.gml2.simple.GMLWriter;
+import org.geotools.gml2.simple.GeometryEncoder;
+import org.geotools.gml2.simple.QualifiedName;
+import org.geotools.gml3.GML;
+import org.geotools.xml.Encoder;
+import org.xml.sax.helpers.AttributesImpl;
+
+/**
+ *
+ * @author odie
+ */
+class GeometryCollectionEncoder extends GeometryEncoder<GeometryCollection> {
+
+    static final QualifiedName GEOMETRY_COLLECTION = new QualifiedName(
+        GML.NAMESPACE, "GeometryCollection", "gml");
+
+    QualifiedName element;
+    static Encoder encoder;
+
+    public GeometryCollectionEncoder(Encoder encoder, String gmlPrefix) {
+        super(encoder);
+        GeometryCollectionEncoder.encoder = encoder;
+    }
+
+    @Override
+    public void encode(GeometryCollection geometry, AttributesImpl atts,
+        GMLWriter handler) throws Exception {
+        if (geometry.getNumGeometries() < 1) {
+            throw new Exception("More than 1 geometry required!");
+        } else {
+            GenericGeometryEncoder gec = new GenericGeometryEncoder(
+                GeometryCollectionEncoder.encoder);
+            for (int i = 0; i < geometry.getNumGeometries(); i++) {
+                gec.encode(geometry, atts, handler);
+            }
+        }
+    }
+
+}

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
@@ -1,7 +1,18 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
  */
 package org.geotools.gml3.simple;
 
@@ -15,7 +26,7 @@ import org.xml.sax.helpers.AttributesImpl;
 
 /**
  *
- * @author odie
+ * @author 
  */
 class GeometryCollectionEncoder extends GeometryEncoder<GeometryCollection> {
 


### PR DESCRIPTION
There is a bug in xml serialization module when using generic geometrycollection, that is, a WKT : GEOMETRYCOLLECTION ( LINESTRING (...), POLYGON (...), POINT (...) ). However, this is something that is supported in WMS. 