### PR TITLE
ignore transitive dependency from picocontainer to xml-apis

### DIFF
--- a/modules/extension/xsd/xsd-core/pom.xml
+++ b/modules/extension/xsd/xsd-core/pom.xml
@@ -94,6 +94,12 @@
       <groupId>picocontainer</groupId>
       <artifactId>picocontainer</artifactId>
       <version>1.2</version>
+      <exclusions>
+        <exclusion>
+         <groupId>xml-apis</groupId>
+         <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-jxpath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
   <artifactId>geotools</artifactId>
   <packaging>pom</packaging>
   <version>15-SNAPSHOT</version>
-  <name>Geotools</name>
+  <name>GeoTools</name>
 
   <scm>
     <connection>scm:git:git://github.com/geotools/geotools.git</connection>


### PR DESCRIPTION
We do not use any XML configuration with piccontainer (the XSD module configures dependency injection by hand).