### PR TITLE
squid:S3008 - Static non-final field names should comply with a naming convention

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/GridGeometry2D.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/GridGeometry2D.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2001-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2001-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -83,7 +83,7 @@ public class GridGeometry2D extends GeneralGridGeometry {
     /**
      * Helpers methods for 2D CRS creation. Will be constructed only when first needed.
      */
-    private static ReferencingFactoryContainer FACTORIES;
+    private static ReferencingFactoryContainer factories;
 
     /**
      * The two-dimensional part of the coordinate reference system.
@@ -716,13 +716,13 @@ public class GridGeometry2D extends GeneralGridGeometry {
         if (crs == null || crs.getCoordinateSystem().getDimension() <= 2) {
             return crs;
         }
-        if (FACTORIES == null) {
-            FACTORIES = ReferencingFactoryContainer.instance(null);
+        if (factories == null) {
+            factories = ReferencingFactoryContainer.instance(null);
             // No need to synchronize: this is not a big deal if
             // two ReferencingFactoryContainer instances are created.
         }
         final CoordinateReferenceSystem reducedCRS;
-        reducedCRS = FACTORIES.separate(crs, new int[] {axisDimensionX, axisDimensionY});
+        reducedCRS = factories.separate(crs, new int[] {axisDimensionX, axisDimensionY});
         assert reducedCRS.getCoordinateSystem().getDimension() == 2 : reducedCRS;
         return reducedCRS;
     }

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/Interpolator2D.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/Interpolator2D.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2001-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2001-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -81,7 +81,7 @@ public final class Interpolator2D extends GridCoverage2D {
     /**
      * Default interpolations, in preference order. Will be constructed only when first needed.
      */
-    private static Interpolation[] DEFAULTS;
+    private static Interpolation[] defaults;
 
     /**
      * Transform from "real world" coordinates to grid coordinates.
@@ -159,7 +159,7 @@ public final class Interpolator2D extends GridCoverage2D {
 	/**
 	 * Default {@link BorderExtender} is {@link BorderExtenderCopy}.
 	 */
-	public static int DEFAULT_BORDER_EXTENDER_TYPE=BorderExtender.BORDER_COPY;
+	public static int defaultBorderExtenderType=BorderExtender.BORDER_COPY;
 
     /**
      * Constructs a new interpolator using default interpolations.
@@ -168,14 +168,14 @@ public final class Interpolator2D extends GridCoverage2D {
      */
     public static GridCoverage2D create(final GridCoverage2D coverage) {
         // No need to synchronize: not a big deal if two arrays are created.
-        if (DEFAULTS == null) {
-            DEFAULTS = new Interpolation[] {
+        if (defaults == null) {
+            defaults = new Interpolation[] {
                 Interpolation.getInstance(Interpolation.INTERP_BICUBIC),
                 Interpolation.getInstance(Interpolation.INTERP_BILINEAR),
                 Interpolation.getInstance(Interpolation.INTERP_NEAREST)
             };
         }
-        return create(coverage, DEFAULTS);
+        return create(coverage, defaults);
     }
 
     /**
@@ -244,7 +244,7 @@ public final class Interpolator2D extends GridCoverage2D {
 	    this.interpolation = interpolations[index];
 	    //border extender
 	    if(be== null){
-	    	this.borderExtender= BorderExtender.createInstance(DEFAULT_BORDER_EXTENDER_TYPE);
+	    	this.borderExtender= BorderExtender.createInstance(defaultBorderExtenderType);
 	    }
 	    else
 	    	this.borderExtender=be;

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverage2DReader.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverage2DReader.java
@@ -118,7 +118,7 @@ public abstract class AbstractGridCoverage2DReader implements GridCoverage2DRead
     /**
      * Small number used for double comparisons
      */
-    protected static double EPS = 1e-6;
+    protected static double eps = 1e-6;
 
     /**
      * This contains the number of overviews.aaa
@@ -1333,7 +1333,7 @@ public abstract class AbstractGridCoverage2DReader implements GridCoverage2DRead
         final double scaleY = originalGridRange.getSpan(1) / (1.0 * ssHeight);
         final AffineTransform tempRaster2Model = new AffineTransform((AffineTransform) raster2Model);
         AffineTransform scale = new AffineTransform(scaleX, 0, 0, scaleY, 0, 0);
-        if (!XAffineTransform.isIdentity(scale, EPS)) {
+        if (!XAffineTransform.isIdentity(scale, eps)) {
             // the transformation includes the pixel is center shift, we need to
             // remove it before rescaling, and then apply it back later
             tempRaster2Model.concatenate(CoverageUtilities.CENTER_TO_CORNER);

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/FileSystemFileSetManager.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/FileSystemFileSetManager.java
@@ -25,15 +25,15 @@ import java.util.logging.Logger;
 
 public class FileSystemFileSetManager implements FileSetManager{
 
-    private static Logger LOGGER = Logger.getLogger(FileSystemFileSetManager.class.toString()); 
+    private static Logger logger = Logger.getLogger(FileSystemFileSetManager.class.toString()); 
 
     private List<String> fileSet = Collections.synchronizedList(new ArrayList<String>());
 
     @Override
     public void addFile(String filePath) {
         fileSet.add(filePath);
-        if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.fine("Adding file " + filePath + " to the fileSet");
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine("Adding file " + filePath + " to the fileSet");
         }
     }
 
@@ -46,8 +46,8 @@ public class FileSystemFileSetManager implements FileSetManager{
     public void removeFile(String filePath) {
         final boolean contains = fileSet.contains(filePath);
         if (contains) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine("Removing file " + filePath + " to the fileSet and deleting it");
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine("Removing file " + filePath + " to the fileSet and deleting it");
             }
             try {
                 final File file = new File(filePath);
@@ -59,8 +59,8 @@ public class FileSystemFileSetManager implements FileSetManager{
                 }
                 deleteFile(file);
             } catch (Throwable t){
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.fine("Exception occurred while deleting file: " + filePath + 
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.fine("Exception occurred while deleting file: " + filePath + 
                             "\n" + t.getLocalizedMessage());
                 }
             }
@@ -72,8 +72,8 @@ public class FileSystemFileSetManager implements FileSetManager{
 
     private void deleteFile(File file) {
         boolean deleted = file.delete();
-        if (!deleted && LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.fine("Unable to delete file " + file.getAbsolutePath());
+        if (!deleted && logger.isLoggable(Level.FINE)) {
+            logger.fine("Unable to delete file " + file.getAbsolutePath());
         }
     }
 

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffConstants.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffConstants.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -147,7 +147,7 @@ public final class GeoTiffConstants {
 
 	public static final int UNDEFINED = 0;
 	
-	public static TIFFTag NODATA_TAG = new TIFFTag("GDAL_NODATA", GeoTiffConstants.TIFFTAG_NODATA, 
+	public static TIFFTag nodataTag = new TIFFTag("GDAL_NODATA", GeoTiffConstants.TIFFTAG_NODATA, 
                 TIFFTag.TIFF_ASCII);
 
 	

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffIIOMetadataEncoder.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffIIOMetadataEncoder.java
@@ -501,7 +501,7 @@ public class GeoTiffIIOMetadataEncoder {
 	}
 	
 	protected static TIFFTag getNoDataTag() {
-	        return GeoTiffConstants.NODATA_TAG;
+	        return GeoTiffConstants.nodataTag;
         }
 
 	private GeoKeyEntry getNonNullGeoKeyEntry(int keyID) {

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/BaseMathOperationJAI.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/BaseMathOperationJAI.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -72,7 +72,7 @@ public abstract class BaseMathOperationJAI extends OperationJAI {
             null, // Unit of measure
             true);
 
-    private static Set<ParameterDescriptor> REPLACED_DESCRIPTORS;
+    private static final Set<ParameterDescriptor> REPLACED_DESCRIPTORS;
 
     static {
         final Set<ParameterDescriptor> replacedDescriptors = new HashSet<ParameterDescriptor>();

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/BaseStatisticsOperationJAI.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/BaseStatisticsOperationJAI.java
@@ -118,7 +118,7 @@ public abstract class BaseStatisticsOperationJAI extends
 			null, // Unit of measure
 			true);
 
-	private static Set<ParameterDescriptor> REPLACED_DESCRIPTORS;
+	private static final Set<ParameterDescriptor> REPLACED_DESCRIPTORS;
 
 	static {
 		final Set<ParameterDescriptor> replacedDescriptors = new HashSet<ParameterDescriptor>();

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/BandMerge.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/BandMerge.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *    (C) 2014 TOPP - www.openplans.org.
  *
  *    This library is free software; you can redistribute it and/or
@@ -155,7 +155,7 @@ public class BandMerge extends OperationJAI {
 
     private static final Logger LOGGER = Logging.getLogger(BandMerge.class);
 
-    private static Set<ParameterDescriptor> REPLACED_DESCRIPTORS;
+    private static final Set<ParameterDescriptor> REPLACED_DESCRIPTORS;
 
     // Replace the old parameter descriptor group with a new one with the old parameters and the new
     // ones defined above.

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Mosaic.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Mosaic.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2014-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2014-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -20,7 +20,6 @@ import it.geosolutions.jaiext.JAIExt;
 import it.geosolutions.jaiext.range.NoDataContainer;
 import it.geosolutions.jaiext.range.Range;
 import it.geosolutions.jaiext.range.RangeFactory;
-import sun.font.CreatedFontTracker;
 
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
@@ -36,8 +35,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.media.jai.ImageLayout;
-import javax.media.jai.Interpolation;
-import javax.media.jai.InterpolationNearest;
 import javax.media.jai.JAI;
 import javax.media.jai.ParameterBlockJAI;
 import javax.media.jai.PlanarImage;
@@ -70,7 +67,6 @@ import org.geotools.resources.i18n.Errors;
 import org.geotools.resources.image.ImageUtilities;
 import org.geotools.util.Utilities;
 import org.jaitools.imageutils.ImageLayout2;
-import org.opengis.coverage.ColorInterpretation;
 import org.opengis.coverage.Coverage;
 import org.opengis.coverage.grid.GridGeometry;
 import org.opengis.metadata.spatial.PixelOrientation;
@@ -197,7 +193,7 @@ public class Mosaic extends OperationJAI {
             null, // Unit of measure
             false);
 
-    private static Set<ParameterDescriptor> REPLACED_DESCRIPTORS;
+    private static final Set<ParameterDescriptor> REPLACED_DESCRIPTORS;
 
     // Replace the old parameter descriptor group with a new one with the old parameters and the new
     // ones defined above.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3008 - Static non-final field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS3008
Please let me know if you have any questions.
George Kankava