### PR TITLE
squid:S1197 - Array designators "[]" should be on the type, not the variable

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverage2DReader.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverage2DReader.java
@@ -619,7 +619,7 @@ public abstract class AbstractGridCoverage2DReader implements GridCoverage2DRead
     protected final void decimationOnReadingControl(String coverageName, Integer imageChoice, ImageReadParam readP, double[] requestedRes) {
         {
             int w, h;
-            double selectedRes[] = new double[2];
+            double[] selectedRes = new double[2];
             final int choice = imageChoice.intValue();
             if (choice == 0) {
                 // highest resolution

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/FileSystemFileSetManager.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/FileSystemFileSetManager.java
@@ -80,7 +80,7 @@ public class FileSystemFileSetManager implements FileSetManager{
     @Override
     public void purge() {
         if (!fileSet.isEmpty()) {
-            String files[] = (String[])fileSet.toArray(new String[fileSet.size()]);
+            String[] files = (String[])fileSet.toArray(new String[fileSet.size()]);
             for (String filePath: files) {
                 removeFile(filePath);
             }

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffIIOMetadataDecoder.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffIIOMetadataDecoder.java
@@ -39,7 +39,7 @@ THE SOFTWARE.
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -330,12 +330,12 @@ public final class GeoTiffIIOMetadataDecoder {
         if (node == null) {
             return null;
         }
-        final double tiePoints[] = getTiffDoubles(node);
+        final double[] tiePoints = getTiffDoubles(node);
         if (tiePoints == null || tiePoints.length <= 0) {
             return null;
         }
         final int numTiePoints = tiePoints.length / 6;
-        final TiePoint retVal[] = new TiePoint[numTiePoints];
+        final TiePoint[] retVal = new TiePoint[numTiePoints];
         int initialIndex = 0;
         for (int i = 0; i < numTiePoints; i++) {
             initialIndex = i * 6;

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffIIOMetadataEncoder.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffIIOMetadataEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -769,7 +769,7 @@ public class GeoTiffIIOMetadataEncoder {
 			Iterator<String> keys = tiffTagsMetadata.keySet().iterator();
 			while (keys.hasNext()){
 				String key = keys.next();
-				String setIdPair[] = key.split(":");
+				String[] setIdPair = key.split(":");
 				String set = TagSet.BASELINE.toString();
 				if (setIdPair.length > 1){
 					set = setIdPair[0].toUpperCase();

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/BaseStatisticsOperationJAI.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/BaseStatisticsOperationJAI.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2005-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -329,7 +329,7 @@ public abstract class BaseStatisticsOperationJAI extends
 			MathTransform worldToGridTransform) throws TransformException {
 		final boolean isIdentity = worldToGridTransform.isIdentity();
 		final java.awt.Polygon retValue = new java.awt.Polygon();
-		final double coords[] = new double[2];
+		final double[] coords = new double[2];
 		final LineString exteriorRing = roiInput.getExteriorRing();
 		final CoordinateSequence exteriorRingCS = exteriorRing
 				.getCoordinateSequence();

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/GridCoverage2DRIA.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/GridCoverage2DRIA.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2011-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2011-2016, Open Source Geospatial Foundation (OSGeo)
  *    (C) 2014 TOPP - www.openplans.org.
  *
  *    This library is free software; you can redistribute it and/or
@@ -323,7 +323,7 @@ public class GridCoverage2DRIA extends GeometricOpImage {
             throw new IndexOutOfBoundsException("Bad src");// JaiI18N.getString("Generic1"));
         }
 
-        double coords[] = new double[] { srcPt.getX(), srcPt.getY() };
+        double[] coords = new double[] { srcPt.getX(), srcPt.getY() };
 
         try {
             mapSrcPoint(coords);
@@ -416,7 +416,7 @@ public class GridCoverage2DRIA extends GeometricOpImage {
             throw new IndexOutOfBoundsException("Bad src");// JaiI18N.getString("Generic1"));
         }
 
-        double coords[] = new double[] { destPt.getX(), destPt.getY() };
+        double[] coords = new double[] { destPt.getX(), destPt.getY() };
 
         try {
             mapDestPoint(coords);
@@ -1355,7 +1355,7 @@ public class GridCoverage2DRIA extends GeometricOpImage {
         height += y0;
         int index = 0; // destRect index
 
-        double xy[] = new double[2];
+        double[] xy = new double[2];
 
         for (int y = y0; y < height; y += periodY) {
             for (int x = x0; x < width; x += periodX) {

--- a/modules/library/coverage/src/main/java/org/geotools/image/ImageWorker.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/ImageWorker.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2006-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -1708,7 +1708,7 @@ public class ImageWorker {
 
             switch (datatype) {
             case DataBuffer.TYPE_BYTE: {
-                final byte data[][] = new byte[numDestinationBands][256];
+                final byte[][] data = new byte[numDestinationBands][256];
                 icm.getReds(data[0]);
                 if (numDestinationBands >= 2)
                     // remember to optimize for grayscale images
@@ -1755,7 +1755,7 @@ public class ImageWorker {
 
             case DataBuffer.TYPE_USHORT: {
                 final int mapSize = icm.getMapSize();
-                final short data[][] = new short[numDestinationBands][mapSize];
+                final short[][] data = new short[numDestinationBands][mapSize];
                 for (int i = 0; i < mapSize; i++) {
                     data[0][i] = (short) icm.getRed(i);
                     if (numDestinationBands >= 2)
@@ -2515,7 +2515,7 @@ public class ImageWorker {
 
         // Prepare the new ColorModel.
         // Get the old map and update it as needed.
-        final byte rgb[][] = new byte[4][mapSize];
+        final byte[][] rgb = new byte[4][mapSize];
         cm.getReds(rgb[0]);
         cm.getGreens(rgb[1]);
         cm.getBlues(rgb[2]);

--- a/modules/library/coverage/src/main/java/org/geotools/image/palette/ColorReduction.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/palette/ColorReduction.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2008-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2008-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -114,7 +114,7 @@ public class ColorReduction extends PointOpImage {
 		final int w = sourceRaster.getWidth();
 		final int h = sourceRaster.getHeight();
 		final int numBands = sourceRaster.getSampleModel().getNumBands();
-		final int rgba[] = new int[numBands];
+		final int[] rgba = new int[numBands];
 		final boolean sourceHasAlpha = sourceColorModel.hasAlpha();
 		final int alphaBand = sourceHasAlpha ? numBands - 1 : -1;
 		final int minx = sourceRaster.getMinX();

--- a/modules/library/coverage/src/main/java/org/geotools/image/palette/CustomPaletteBuilder.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/palette/CustomPaletteBuilder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -155,7 +155,7 @@ public final class CustomPaletteBuilder {
 		//
 		// //
 		final int numBands = src.getSampleModel().getNumBands();
-		final int rgba[] = new int[numBands];
+		final int[] rgba = new int[numBands];
 		final boolean sourceHasAlpha = (numBands % 2 == 0);
 		final int alphaBand = sourceHasAlpha ? numBands - 1 : -1;
 		final int minx_ = src.getMinX();
@@ -411,7 +411,7 @@ public final class CustomPaletteBuilder {
 		//
 		// //
 		final int numBands = src.getSampleModel().getNumBands();
-		final int rgba[] = new int[numBands];
+		final int[] rgba = new int[numBands];
 		final boolean discriminantTransparency = transparency != Transparency.OPAQUE;
 		final int transpBand = numBands - 1;
 		final int minx_ = src.getMinX();

--- a/modules/library/coverage/src/main/java/org/geotools/image/palette/InverseColorMapOp.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/palette/InverseColorMapOp.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -145,7 +145,7 @@ public final class InverseColorMapOp implements BufferedImageOp {
 		//
 		// //
 		final int numBands = src.getSampleModel().getNumBands();
-		final int rgba[] = new int[numBands];
+		final int[] rgba = new int[numBands];
 		final boolean sourceHasAlpha = (numBands % 2 == 0);
 		final int alphaBand = sourceHasAlpha ? numBands - 1 : -1;
 		final EfficientInverseColorMapComputation invCM = rasterOp.getInvCM();

--- a/modules/library/coverage/src/main/java/org/geotools/image/palette/InverseColorMapRasterOp.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/palette/InverseColorMapRasterOp.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -131,7 +131,7 @@ public final class InverseColorMapRasterOp implements RasterOp {
 		final int numBands = src.getSampleModel().getNumBands();
 		final boolean sourceHasAlpha = (numBands % 2 == 0);
 		final int alphaBand = sourceHasAlpha ? numBands - 1 : -1;
-		final int rgba[] = new int[numBands];
+		final int[] rgba = new int[numBands];
 		for (int y = srcMinY, y_ = dstMinY; y < srcMaxY; y++, y_++) {
 			for (int x = srcMinX, x_ = dstMinX; x < srcMaxX; x++, x_++) {
 				src.getPixel(x, y, rgba);

--- a/modules/library/coverage/src/main/java/org/geotools/resources/coverage/FeatureUtilities.java
+++ b/modules/library/coverage/src/main/java/org/geotools/resources/coverage/FeatureUtilities.java
@@ -312,7 +312,7 @@ public final class FeatureUtilities {
 			MathTransform worldToGridTransform, List<Point2D> points)
 			throws TransformException {
 		final boolean isIdentity = worldToGridTransform.isIdentity();
-		final double coords[] = new double[2];
+		final double[] coords = new double[2];
 		final LineString exteriorRing = roiInput.getExteriorRing();
 		final CoordinateSequence exteriorRingCS = exteriorRing
 				.getCoordinateSequence();

--- a/modules/library/coverage/src/main/java/org/geotools/resources/image/ImageUtilities.java
+++ b/modules/library/coverage/src/main/java/org/geotools/resources/image/ImageUtilities.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2001-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2001-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -135,12 +135,12 @@ public final class ImageUtilities {
 	                mediaLib=AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
 	                     public Boolean run() {
 	                    	 try {
-	                    		//get the method
-	                    		final Class<?> params[] = {};
-								Method method= mImage.getDeclaredMethod("isAvailable", params);
+	                                //get the method
+	                                final Class<?>[] params = {};
+	                                Method method= mImage.getDeclaredMethod("isAvailable", params);
 
 								//invoke
-	                    		final Object paramsObj[] = {};
+	                                final Object[] paramsObj = {};
 
 	        		        	final Object o=mImage.newInstance();
 		                        return (Boolean) method.invoke(o, paramsObj);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1197
Please let me know if you have any questions.
George Kankava