### PR TITLE
squid:S1905 - Redundant casts should not be used

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/CRS2GeoTiffMetadataAdapter.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/CRS2GeoTiffMetadataAdapter.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -795,7 +795,7 @@ public final class CRS2GeoTiffMetadataAdapter {
 		parseDatum(datum, metadata);
 
 		// angular unit
-		final Unit<?> angularUnit = ((EllipsoidalCS) geographicCRS.getCoordinateSystem()).getAxis(0).getUnit();
+		final Unit<?> angularUnit = (geographicCRS.getCoordinateSystem()).getAxis(0).getUnit();
 		parseUnit(angularUnit, 0, metadata);
 
 		// prime meridian

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffMetadata2CRSAdapter.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffMetadata2CRSAdapter.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -801,7 +801,7 @@ public final class GeoTiffMetadata2CRSAdapter {
     private void refineParameters(final GeographicCRS baseCRS, final ParameterValueGroup parameters)
             throws InvalidParameterValueException, ParameterNotFoundException {
             // set the remaining parameters.
-            final GeodeticDatum tempDatum = ((GeodeticDatum) baseCRS.getDatum());
+            final GeodeticDatum tempDatum = baseCRS.getDatum();
             final DefaultEllipsoid tempEll = (DefaultEllipsoid) tempDatum.getEllipsoid();
             double inverseFlattening = tempEll.getInverseFlattening();
             double semiMajorAxis = tempEll.getSemiMajorAxis();

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Crop.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Crop.java
@@ -445,7 +445,7 @@ public class Crop extends Operation2D {
 					cropRoi, 
 					roiTolerance,
 					forceMosaic,
-                    (hints instanceof Hints) ? (Hints) hints: new Hints(hints),
+                    (hints instanceof Hints) ? hints: new Hints(hints),
                     source,
                     sourceCornerGridToWorld);
 		} else {

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Resampler2D.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Resampler2D.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -800,9 +800,9 @@ final class Resampler2D extends GridCoverage2D {
                 /*  {7} */ targetImage.getOperationName(),
                 /*  {8} */ Integer.valueOf(1),
                 /*  {9} */ ImageUtilities.getInterpolationName(interpolation),
-                /* {10} */ (background != null) ? background.length == 1 ? (Double.isNaN(background[0]) ? (Object) "NaN"
-                                 : (Object) Double.valueOf(background[0]))
-                                 : (Object) XArray.toString(background, locale)
+                /* {10} */ (background != null) ? background.length == 1 ? (Double.isNaN(background[0]) ? "NaN"
+                                 : Double.valueOf(background[0]))
+                                 : XArray.toString(background, locale)
                                  : "No background used" }));
         }
         

--- a/modules/library/coverage/src/main/java/org/geotools/image/GTWarpPropertyGenerator.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/GTWarpPropertyGenerator.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -82,7 +82,7 @@ public class GTWarpPropertyGenerator extends PropertyGeneratorImpl {
             ParameterBlock pb = op.getParameterBlock();
 
             // Retrieve the rendered source image and its ROI.
-            RenderedImage src = (RenderedImage) pb.getRenderedSource(0);
+            RenderedImage src = pb.getRenderedSource(0);
             Object property = src.getProperty("ROI");
             if (property == null || property.equals(java.awt.Image.UndefinedProperty)
                     || !(property instanceof ROI)) {

--- a/modules/library/coverage/src/main/java/org/geotools/image/io/ImageIOExt.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/io/ImageIOExt.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2001-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2001-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -228,7 +228,7 @@ public class ImageIOExt {
     
         ImageInputStreamSpi spi = null;
         while (iter.hasNext()) {
-            spi = (ImageInputStreamSpi) iter.next();
+            spi = iter.next();
             if (spi.getInputClass().isInstance(input)) {
                 
                 // Stream creation check

--- a/modules/library/coverage/src/main/java/org/geotools/resources/coverage/IntersectUtils.java
+++ b/modules/library/coverage/src/main/java/org/geotools/resources/coverage/IntersectUtils.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2006-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -75,7 +75,7 @@ public class IntersectUtils {
     private static boolean intersects(GeometryCollection gc, Geometry g) {
     	final int size=gc.getNumGeometries();
         for (int i = 0; i < size; i++) {
-            Geometry g1 = (Geometry)gc.getGeometryN(i);
+            Geometry g1 = gc.getGeometryN(i);
             if( g1.intersects(g) )
                 return true;
         }
@@ -88,7 +88,7 @@ public class IntersectUtils {
     private static boolean intersects(GeometryCollection gc1, GeometryCollection gc2) {
     	final int size=gc1.getNumGeometries();
         for (int i = 0; i < size; i++) {
-            Geometry g1 = (Geometry)gc1.getGeometryN(i);
+            Geometry g1 = gc1.getGeometryN(i);
             if( intersects(gc2, g1) )
                 return true;
         }
@@ -130,7 +130,7 @@ public class IntersectUtils {
         List<Geometry> ret = new ArrayList<Geometry>();
         final int size=gc.getNumGeometries();
         for (int i = 0; i < size; i++) {
-            Geometry g1 = (Geometry)gc.getGeometryN(i);
+            Geometry g1 = gc.getGeometryN(i);
             collect(g1.intersection(g), ret);
         }
         return ret;
@@ -143,7 +143,7 @@ public class IntersectUtils {
         List<Geometry> ret = new ArrayList<Geometry>();
         final int size=gc1.getNumGeometries();
         for (int i = 0; i < size; i++) {
-            Geometry g1 = (Geometry)gc1.getGeometryN(i);
+            Geometry g1 = gc1.getGeometryN(i);
             List<Geometry> partial = intersection(gc2, g1);
             ret.addAll(partial);
         }

--- a/modules/library/coverage/src/main/java/org/geotools/resources/image/ImageUtilities.java
+++ b/modules/library/coverage/src/main/java/org/geotools/resources/image/ImageUtilities.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2001-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2001-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -525,13 +525,13 @@ public final class ImageUtilities {
         if (n != 0) {
             // If layout is not set, OpImage uses the layout of the *first*
             // source image according OpImage constructor javadoc.
-            RenderedImage source = (RenderedImage) sources.get(0);
+            RenderedImage source = sources.get(0);
             int minXL = result.getMinX  (source);
             int minYL = result.getMinY  (source);
             int maxXL = result.getWidth (source) + minXL;
             int maxYL = result.getHeight(source) + minYL;
             for (int i=0; i<n; i++) {
-                source = (RenderedImage) sources.get(i);
+                source = sources.get(i);
                 final int minX = source.getMinX  ();
                 final int minY = source.getMinY  ();
                 final int maxX = source.getWidth () + minX;
@@ -553,7 +553,7 @@ public final class ImageUtilities {
             }
             // If the bounds changed, adjust the tile size.
             if (result != layout) {
-                source = (RenderedImage) sources.get(0);
+                source = sources.get(0);
                 if (result.isValid(ImageLayout.TILE_WIDTH_MASK)) {
                     final int oldSize = result.getTileWidth(source);
                     final int newSize = toTileSize(result.getWidth(source), oldSize);
@@ -917,18 +917,18 @@ public final class ImageUtilities {
             Rational scaleXRational = Rational.approximate(scaleX,RATIONAL_TOLERANCE);
             Rational scaleYRational = Rational.approximate(scaleY,RATIONAL_TOLERANCE);
     
-            long scaleXRationalNum = (long) scaleXRational.num;
-            long scaleXRationalDenom = (long) scaleXRational.denom;
-            long scaleYRationalNum = (long) scaleYRational.num;
-            long scaleYRationalDenom = (long) scaleYRational.denom;
+            long scaleXRationalNum = scaleXRational.num;
+            long scaleXRationalDenom = scaleXRational.denom;
+            long scaleYRationalNum = scaleYRational.num;
+            long scaleYRationalDenom = scaleYRational.denom;
     
             Rational transXRational = Rational.approximate(transX,RATIONAL_TOLERANCE);
             Rational transYRational = Rational.approximate(transY,RATIONAL_TOLERANCE);
     
-            long transXRationalNum = (long) transXRational.num;
-            long transXRationalDenom = (long) transXRational.denom;
-            long transYRationalNum = (long) transYRational.num;
-            long transYRationalDenom = (long) transYRational.denom;
+            long transXRationalNum = transXRational.num;
+            long transXRationalDenom = transXRational.denom;
+            long transYRationalNum = transYRational.num;
+            long transYRationalDenom = transYRational.denom;
     
             int x0 = source.getMinX();
             int y0 = source.getMinY();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1905 - Redundant casts should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1905
Please let me know if you have any questions.
George Kankava