### PR TITLE
GEOT-5354: fix ReferencedEnvelope3D.distance bug

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope3D.java
+++ b/modules/library/api/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope3D.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2005-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2005-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -576,7 +576,7 @@ public class ReferencedEnvelope3D extends ReferencedEnvelope implements Bounding
 		if (maxz < env.minz)
 			dz = env.minz - maxz;
 		else if (minz > env.maxz)
-			dy = minz - env.maxz;
+			dz = minz - env.maxz;
 
 		// if either is zero, the envelopes overlap either vertically or
 		// horizontally

--- a/modules/library/api/src/test/java/org/geotools/geometry/jts/ReferencedEnvelope3DTest.java
+++ b/modules/library/api/src/test/java/org/geotools/geometry/jts/ReferencedEnvelope3DTest.java
@@ -155,4 +155,12 @@ public class ReferencedEnvelope3DTest {
         ReferencedEnvelope worldBounds2D = bounds.transform( DefaultGeographicCRS.WGS84, true );
         assertEquals( DefaultGeographicCRS.WGS84, worldBounds2D.getCoordinateReferenceSystem() );
     }
+    
+    @Test
+    public void testDistanceWhenMinZOfThisIsGreaterThanMaxZOfOther() {
+        CoordinateReferenceSystem crs = DefaultEngineeringCRS.CARTESIAN_3D;
+        ReferencedEnvelope3D a = new ReferencedEnvelope3D( 2.0, 3.0, 2.0, 3.0, 2.0, 3.0, crs );
+        ReferencedEnvelope3D b = new ReferencedEnvelope3D( 0.0, 1.0, 0.0, 1.0, 0.0, 0.5, crs );
+        assertEquals(Math.sqrt(1*1+1*1+1.5*1.5), a.distance(b), 0.00001);
+    }
 }


### PR DESCRIPTION
This PR fixes a bug with `ReferencedEnvelope3D.distance` which under certain circumstances will incorrectly calculate distance.

I've included a unit test that failed with the original code (but now passes). There was no existing test coverage for  `ReferencedEnvelope3D.distance` in this module and not great coverage of other methods  in `ReferencedEnvelope3D` and other classes in say the `org.geotools.geometry.jts` package. Once this PR is accepted I can have a look at some improvements in this area.