### PR TITLE
GEOT-5355 Correcting SimpleDateFormat String

### DIFF
--- a/modules/unsupported/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
+++ b/modules/unsupported/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -144,6 +144,7 @@ public class GeoPackage {
         }
     }
 
+    static final String DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     /**
      * database file
      */
@@ -825,7 +826,7 @@ public class GeoPackage {
     }
 
     void addGeoPackageContentsEntry(Entry e) throws IOException {
-        final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-mm-dd'T'HH:MM:ss.SSS'Z'");
+        final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(DATE_FORMAT_STRING);
         DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
         addCRS(e.getSrid());
 
@@ -1833,7 +1834,7 @@ public class GeoPackage {
         e.setDescription(rs.getString("description"));
         e.setTableName(rs.getString("table_name"));
         try {
-            final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-mm-dd'T'HH:MM:ss.SSS'Z'");
+            final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(DATE_FORMAT_STRING);
             
             DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
             


### PR DESCRIPTION
The Format string has the MONTH (MM) and MINUTES (mm) keys swapped.
Correcting the format string and adding assertions to tests.