### PR TITLE
[GEOT-4317] url encoding of WMS layer name

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetFeatureInfoRequest.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetFeatureInfoRequest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2016, Open Source Geospatial Foundation (OSGeo)
  *    
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -74,7 +74,7 @@ public abstract class AbstractGetFeatureInfoRequest extends AbstractWMSRequest i
             try {
                 // spaces are converted to plus signs, but must be %20 for url calls [GEOT-4317]
                 queryLayerString = queryLayerString + URLEncoder.encode(layer.getName(), "UTF-8").replaceAll("\\+", "%20");; //$NON-NLS-1$
-            } catch (UnsupportedEncodingException e) {
+            } catch (UnsupportedEncodingException | NullPointerException e) {
                 queryLayerString = queryLayerString + layer.getName();
             }
 

--- a/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetFeatureInfoRequest.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetFeatureInfoRequest.java
@@ -72,7 +72,8 @@ public abstract class AbstractGetFeatureInfoRequest extends AbstractWMSRequest i
         while( iter.hasNext() ) {
             Layer layer = (Layer) iter.next();
             try {
-                queryLayerString = queryLayerString + URLEncoder.encode(layer.getName(), "UTF-8"); //$NON-NLS-1$
+                // spaces are converted to plus signs, but must be %20 for url calls [GEOT-4317]
+                queryLayerString = queryLayerString + URLEncoder.encode(layer.getName(), "UTF-8").replaceAll("\\+", "%20");; //$NON-NLS-1$
             } catch (UnsupportedEncodingException e) {
                 queryLayerString = queryLayerString + layer.getName();
             }

--- a/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetMapRequest.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetMapRequest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2016, Open Source Geospatial Foundation (OSGeo)
  *    
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -79,14 +79,14 @@ public abstract class AbstractGetMapRequest extends AbstractWMSRequest implement
                 try {
                     // spaces are converted to plus signs, but must be %20 for url calls [GEOT-4317]
                     layerString = layerString + URLEncoder.encode(layerName, "UTF-8").replaceAll("\\+", "%20");
-                } catch (UnsupportedEncodingException e) {
+                } catch (UnsupportedEncodingException | NullPointerException e) {
                     layerString = layerString + layerName;
                 }
                 styleName = styleName == null ? "" : styleName;
                 try {
 
-                    styleString = styleString + URLEncoder.encode(styleName, "UTF-8");
-                } catch (UnsupportedEncodingException e1) {
+                    styleString = styleString + URLEncoder.encode(styleName, "UTF-8").replaceAll("\\+", "%20");
+                } catch (UnsupportedEncodingException | NullPointerException e1) {
                     styleString = styleString + styleName;
                 }
                 

--- a/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetMapRequest.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/wms/request/AbstractGetMapRequest.java
@@ -77,7 +77,8 @@ public abstract class AbstractGetMapRequest extends AbstractWMSRequest implement
                 String styleName = (String) styleIter.previous();
                 
                 try {
-                    layerString = layerString + URLEncoder.encode(layerName, "UTF-8");
+                    // spaces are converted to plus signs, but must be %20 for url calls [GEOT-4317]
+                    layerString = layerString + URLEncoder.encode(layerName, "UTF-8").replaceAll("\\+", "%20");
                 } catch (UnsupportedEncodingException e) {
                     layerString = layerString + layerName;
                 }

--- a/modules/extension/wms/src/test/java/org/geotools/data/wms/test/AbstractGetMapRequestTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/data/wms/test/AbstractGetMapRequestTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -46,8 +46,8 @@ public class AbstractGetMapRequestTest extends TestCase {
 		URL finalURL = request.getFinalURL();
         //System.out.println(finalURL);
 		String processedURL = finalURL.toExternalForm();
-		assertTrue(processedURL.indexOf("LAYERS=Layer2,Provincial+Boundary") != -1);
-		assertTrue(processedURL.indexOf("STYLES=,Two+words") != -1);
+		assertTrue(processedURL.indexOf("LAYERS=Layer2,Provincial%20Boundary") != -1);
+		assertTrue(processedURL.indexOf("STYLES=,Two%20words") != -1);
         assertTrue(processedURL.indexOf("SERVICE=WMS") != -1);
 	}
 	


### PR DESCRIPTION
Since wms layer names with spaces are possible with ArcGIS Server, here is an update on how urls on the wms requests are built (see https://osgeo-org.atlassian.net/browse/GEOT-4317)

Signed-off-by: HendrikPeilke <Hendrik.Peilke@ibykus.de>