### PR TITLE
added repos to pom.xml

### DIFF
--- a/docs/user/tutorial/quickstart/artifacts/pom.xml
+++ b/docs/user/tutorial/quickstart/artifacts/pom.xml
@@ -31,4 +31,16 @@
             <version>${geotools.version}</version>
         </dependency>
     </dependencies>
+    <repositories>
+      <repository>
+          <id>maven2-repository.dev.java.net</id>
+          <name>Java.net repository</name>
+          <url>http://download.java.net/maven/2</url>
+      </repository>
+      <repository>
+          <id>osgeo</id>
+          <name>Open Source Geospatial Foundation Repository</name>
+          <url>http://download.osgeo.org/webdav/geotools/</url>
+      </repository>
+    </repositories>
 </project>

--- a/docs/user/tutorial/quickstart/artifacts/pom2.xml
+++ b/docs/user/tutorial/quickstart/artifacts/pom2.xml
@@ -53,3 +53,4 @@
         </repository>
     </repositories>
 </project>
+


### PR DESCRIPTION
The repos were missing from the pom.xml in the docs which was [confusing new users](https://stackoverflow.com/questions/35381422/geotools-quickstart-package-org-geotools-does-not-exist).

SInce this is not used for the actual build it was easy to miss this change.