### PR TITLE
[GEOT-5367] Add a group by visitor

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -1183,6 +1183,13 @@ public abstract class SQLDialect {
      */
     public boolean isAggregatedSortSupported(String function) {
         return false;
+    }
+
+    /**
+     * Returns true if this dialect supports group by clause.
+     */
+    public boolean isGroupBySupported() {
+        return true;
     }
     
     /**

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGroupByVisitorOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGroupByVisitorOnlineTest.java
@@ -1,0 +1,250 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.jdbc;
+
+import org.geotools.data.DefaultQuery;
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.feature.visitor.Aggregate;
+import org.geotools.feature.visitor.GroupByVisitor;
+import org.geotools.feature.visitor.GroupByVisitorBuilder;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+public abstract class JDBCGroupByVisitorOnlineTest extends JDBCTestSupport {
+
+    public void testSimpleGroupByWithMax() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(Aggregate.MAX, "building_type");
+        assertTrue(value.size() == 3);
+        checkValueContains(value, "HOUSE", "6.0");
+        checkValueContains(value, "FABRIC", "500.0");
+        checkValueContains(value, "SCHOOL", "60.0");
+    }
+
+    public void testMultipleGroupByWithMax() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(Aggregate.MAX, "building_type", "energy_type");
+        assertTrue(value.size() == 11);
+        checkValueContains(value, "SCHOOL", "WIND", "20.0");
+        checkValueContains(value, "SCHOOL", "FUEL", "60.0");
+        checkValueContains(value, "HOUSE", "NUCLEAR", "4.0");
+        checkValueContains(value, "SCHOOL", "SOLAR", "30.0");
+        checkValueContains(value, "SCHOOL", "FLOWING_WATER", "50.0");
+        checkValueContains(value, "SCHOOL", "NUCLEAR", "10.0");
+        checkValueContains(value, "HOUSE", "FUEL", "6.0");
+        checkValueContains(value, "FABRIC", "NUCLEAR", "150.0");
+        checkValueContains(value, "FABRIC", "SOLAR", "30.0");
+        checkValueContains(value, "FABRIC", "FLOWING_WATER", "500.0");
+        checkValueContains(value, "FABRIC", "WIND", "20.0");
+    }
+
+    public void testMultipleGroupByWithMaxWithFilter() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(energyConsumptionGreaterThan(50.0),
+                Aggregate.MAX, "building_type", "energy_type");
+        assertTrue(value.size() == 3);
+        checkValueContains(value, "SCHOOL", "FUEL", "60.0");
+        checkValueContains(value, "FABRIC", "NUCLEAR", "150.0");
+        checkValueContains(value, "FABRIC", "FLOWING_WATER", "500.0");
+    }
+
+    public void testMultipleGroupByWithMaxWithLimitOffset() throws Exception {
+        if (!dataStore.getSQLDialect().isLimitOffsetSupported()) {
+            return;
+        }
+        List<Object[]> value = genericGroupByTestTest(queryWithLimits(0, 3),
+                Aggregate.MAX, "building_type", "energy_type");
+        assertFalse(value.isEmpty());
+        assertTrue(value.size() <= 3);
+    }
+
+    public void testSimpleGroupByWithMin() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(Aggregate.MIN, "building_type");
+        checkValueContains(value, "HOUSE", "4.0");
+        checkValueContains(value, "FABRIC", "20.0");
+        checkValueContains(value, "SCHOOL", "10.0");
+    }
+
+    public void testMultipleGroupByWithMin() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(Aggregate.MIN, "building_type", "energy_type");
+        checkValueContains(value, "SCHOOL", "WIND", "20.0");
+        checkValueContains(value, "SCHOOL", "FUEL", "60.0");
+        checkValueContains(value, "HOUSE", "NUCLEAR", "4.0");
+        checkValueContains(value, "SCHOOL", "SOLAR", "30.0");
+        checkValueContains(value, "SCHOOL", "FLOWING_WATER", "50.0");
+        checkValueContains(value, "SCHOOL", "NUCLEAR", "10.0");
+        checkValueContains(value, "HOUSE", "FUEL", "6.0");
+        checkValueContains(value, "FABRIC", "NUCLEAR", "150.0");
+        checkValueContains(value, "FABRIC", "SOLAR", "30.0");
+        checkValueContains(value, "FABRIC", "FLOWING_WATER", "500.0");
+        checkValueContains(value, "FABRIC", "WIND", "20.0");
+    }
+
+    public void testMultipleGroupByWithMinWithFilter() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(energyConsumptionGreaterThan(50.0),
+                Aggregate.MIN, "building_type", "energy_type");
+        assertTrue(value.size() == 3);
+        checkValueContains(value, "SCHOOL", "FUEL", "60.0");
+        checkValueContains(value, "FABRIC", "NUCLEAR", "150.0");
+        checkValueContains(value, "FABRIC", "FLOWING_WATER", "500.0");
+    }
+
+    public void testMultipleGroupByWithMinWithLimitOffset() throws Exception {
+        if (!dataStore.getSQLDialect().isLimitOffsetSupported()) {
+            return;
+        }
+        List<Object[]> value = genericGroupByTestTest(queryWithLimits(0, 3),
+                Aggregate.MIN, "building_type", "energy_type");
+        assertFalse(value.isEmpty());
+        assertTrue(value.size() <= 3);
+    }
+
+    public void testSimpleGroupByWithCount() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(Aggregate.COUNT, "building_type");
+        checkValueContains(value, "HOUSE", "2");
+        checkValueContains(value, "FABRIC", "4");
+        checkValueContains(value, "SCHOOL", "6");
+    }
+
+    public void testMultipleGroupByWithCount() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(Aggregate.COUNT, "building_type", "energy_type");
+        checkValueContains(value, "SCHOOL", "WIND", "1");
+        checkValueContains(value, "SCHOOL", "FUEL", "1");
+        checkValueContains(value, "HOUSE", "NUCLEAR", "1");
+        checkValueContains(value, "SCHOOL", "SOLAR", "1");
+        checkValueContains(value, "SCHOOL", "FLOWING_WATER", "1");
+        checkValueContains(value, "SCHOOL", "NUCLEAR", "2");
+        checkValueContains(value, "HOUSE", "FUEL", "1");
+        checkValueContains(value, "FABRIC", "NUCLEAR", "1");
+        checkValueContains(value, "FABRIC", "SOLAR", "1");
+        checkValueContains(value, "FABRIC", "FLOWING_WATER", "1");
+        checkValueContains(value, "FABRIC", "WIND", "1");
+    }
+
+    public void testMultipleGroupByWithCountWithFilter() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(energyConsumptionGreaterThan(50.0),
+                Aggregate.COUNT, "building_type", "energy_type");
+        assertTrue(value.size() == 3);
+        checkValueContains(value, "SCHOOL", "FUEL", "1");
+        checkValueContains(value, "FABRIC", "NUCLEAR", "1");
+        checkValueContains(value, "FABRIC", "FLOWING_WATER", "1");
+    }
+
+    public void testMultipleGroupByWithCountWithLimitOffset() throws Exception {
+        if (!dataStore.getSQLDialect().isLimitOffsetSupported()) {
+            return;
+        }
+        List<Object[]> value = genericGroupByTestTest(queryWithLimits(0, 3),
+                Aggregate.COUNT, "building_type", "energy_type");
+        assertFalse(value.isEmpty());
+        assertTrue(value.size() <= 3);
+    }
+
+    public void testSimpleGroupByWithSum() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(Aggregate.SUM, "building_type");
+        checkValueContains(value, "HOUSE", "10.0");
+        checkValueContains(value, "FABRIC", "700.0");
+        checkValueContains(value, "SCHOOL", "180.0");
+    }
+
+    public void testMultipleGroupByWithSum() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(Aggregate.SUM, "building_type", "energy_type");
+        checkValueContains(value, "FABRIC", "FLOWING_WATER", "500.0");
+        checkValueContains(value, "FABRIC", "NUCLEAR", "150.0");
+        checkValueContains(value, "FABRIC", "SOLAR", "30.0");
+        checkValueContains(value, "FABRIC", "WIND", "20.0");
+        checkValueContains(value, "HOUSE", "FUEL", "6.0");
+        checkValueContains(value, "HOUSE", "NUCLEAR", "4.0");
+        checkValueContains(value, "SCHOOL", "FLOWING_WATER", "50.0");
+        checkValueContains(value, "SCHOOL", "FUEL", "60.0");
+        checkValueContains(value, "SCHOOL", "NUCLEAR", "20.0");
+        checkValueContains(value, "SCHOOL", "SOLAR", "30.0");
+        checkValueContains(value, "SCHOOL", "WIND", "20.0");
+    }
+
+    public void testMultipleGroupByWithSumWithFilter() throws Exception {
+        List<Object[]> value = genericGroupByTestTest(energyConsumptionGreaterThan(50.0),
+                Aggregate.SUM, "building_type", "energy_type");
+        assertTrue(value.size() == 3);
+        checkValueContains(value, "SCHOOL", "FUEL", "60.0");
+        checkValueContains(value, "FABRIC", "NUCLEAR", "150.0");
+        checkValueContains(value, "FABRIC", "FLOWING_WATER", "500.0");
+    }
+
+    public void testWithMinWithLimitOffset() throws Exception {
+        if (!dataStore.getSQLDialect().isLimitOffsetSupported()) {
+            return;
+        }
+        List<Object[]> value = genericGroupByTestTest(queryWithLimits(0, 3),
+                Aggregate.SUM, "building_type", "energy_type");
+        assertFalse(value.isEmpty());
+        assertTrue(value.size() <= 3);
+    }
+
+    private Query queryWithLimits(int lower, int upper) {
+        DefaultQuery query = new DefaultQuery(tname("buildings"));
+        query.setStartIndex(lower);
+        query.setMaxFeatures(upper);
+        return query;
+    }
+
+    private Query energyConsumptionGreaterThan(double value) {
+        FilterFactory filterFactory = dataStore.getFilterFactory();
+        Filter filter = filterFactory.greater(filterFactory.property(aname("energy_consumption")), filterFactory.literal(value));
+        return new DefaultQuery(tname("buildings"), filter);
+    }
+
+    private List<Object[]> genericGroupByTestTest(Aggregate aggregateVisitor,
+                                                  String... groupByAttributes) throws IOException {
+        return genericGroupByTestTest(Query.ALL, aggregateVisitor, groupByAttributes);
+    }
+
+    private List<Object[]> genericGroupByTestTest(Query query, Aggregate aggregateVisitor,
+                                                  String... groupByAttributes) throws IOException {
+        ContentFeatureSource featureSource = dataStore.getFeatureSource(tname("buildings_group_by_tests"));
+        SimpleFeatureType featureType = featureSource.getSchema();
+        GroupByVisitorBuilder visitorBuilder = new GroupByVisitorBuilder()
+                .withAggregateAttribute("energy_consumption", featureType)
+                .withAggregateVisitor(aggregateVisitor);
+        for (String groupByAttribute : groupByAttributes) {
+            visitorBuilder.withGroupByAttribute(groupByAttribute, featureType);
+        }
+        GroupByVisitor visitor = visitorBuilder.build();
+        featureSource.accepts(query, visitor, null);
+        assertTrue(visitor.wasOptimized());
+        assertFalse(visitor.wasVisited());
+        List<Object[]> value = visitor.getResult().toList();
+        assertNotNull(value);
+        return value;
+    }
+
+    private void checkValueContains(List<Object[]> value, String... expectedResult) {
+        assertTrue(value.stream().anyMatch(result -> {
+            if (result.length != expectedResult.length) {
+                return false;
+            }
+            for (int i = 0; i < result.length; i++) {
+                if (!result[i].toString().equals(expectedResult[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }));
+    }
+}

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGroupByVisitorTestSetup.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGroupByVisitorTestSetup.java
@@ -1,0 +1,37 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.jdbc;
+
+public abstract class JDBCGroupByVisitorTestSetup extends JDBCDelegatingTestSetup {
+
+    protected JDBCGroupByVisitorTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected final void setUpData() throws Exception {
+        try {
+            dropBuildingsTable();
+        } finally {
+            createBuildingsTable();
+        }
+    }
+
+    protected abstract void createBuildingsTable() throws Exception;
+
+    protected abstract void dropBuildingsTable() throws Exception;
+}

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/Aggregate.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/Aggregate.java
@@ -1,0 +1,166 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.feature.visitor;
+
+import org.geotools.util.Converters;
+import org.geotools.util.UnsupportedImplementationException;
+import org.opengis.filter.expression.Expression;
+
+/**
+ * This Enum contains all the visitors that can be used with the group by visitor.
+ * Each visitor supported by the group by visitor has to provide a consistent way to
+ * create a new instance and if the visitor result can be optimized a way to wrap
+ * the raw result.
+ */
+public enum Aggregate {
+
+    AVERAGE {
+        @Override
+        public FeatureCalc create(Expression aggregateAttribute) {
+            return new AverageVisitor(aggregateAttribute);
+        }
+
+        @Override
+        public CalcResult wrap(Expression aggregateAttribute, Object value) {
+            throw new UnsupportedImplementationException("Wrapping raw result of average visitor not supported.");
+        }
+    },
+    COUNT {
+        @Override
+        public FeatureCalc create(Expression aggregateAttribute) {
+            return new CountVisitor();
+        }
+
+        @Override
+        public CalcResult wrap(Expression aggregateAttribute, Object value) {
+            CountVisitor visitor = new CountVisitor();
+            visitor.setValue(Converters.convert(value, Integer.class));
+            return visitor.getResult();
+        }
+    },
+    MAX {
+        @Override
+        public FeatureCalc create(Expression aggregateAttribute) {
+            return new MaxVisitor(aggregateAttribute);
+        }
+
+        @Override
+        public CalcResult wrap(Expression aggregateAttribute, Object value) {
+            MaxVisitor visitor = new MaxVisitor(aggregateAttribute);
+            visitor.setValue(value);
+            return visitor.getResult();
+        }
+    },
+    MEDIAN {
+        @Override
+        public FeatureCalc create(Expression aggregateAttribute) {
+            return new MedianVisitor(aggregateAttribute);
+        }
+
+        @Override
+        public CalcResult wrap(Expression aggregateAttribute, Object value) {
+            throw new UnsupportedImplementationException("Wrapping raw result of mean visitor not supported.");
+        }
+    },
+    MIN {
+        @Override
+        public FeatureCalc create(Expression aggregateAttribute) {
+            return new MinVisitor(aggregateAttribute);
+        }
+
+        @Override
+        public CalcResult wrap(Expression aggregateAttribute, Object value) {
+            MinVisitor visitor = new MinVisitor(aggregateAttribute);
+            visitor.setValue(value);
+            return visitor.getResult();
+        }
+    },
+    STD_DEV {
+        @Override
+        public FeatureCalc create(Expression aggregateAttribute) {
+            return new StandardDeviationVisitor(aggregateAttribute);
+        }
+
+        @Override
+        public CalcResult wrap(Expression aggregateAttribute, Object value) {
+            throw new UnsupportedImplementationException("Wrapping raw result of standard deviation visitor not supported.");
+        }
+    },
+    SUM {
+        @Override
+        public FeatureCalc create(Expression aggregateAttribute) {
+            return new SumVisitor(aggregateAttribute);
+        }
+
+        @Override
+        public CalcResult wrap(Expression aggregateAttribute, Object value) {
+            SumVisitor visitor = new SumVisitor(aggregateAttribute);
+            visitor.setValue(value);
+            return visitor.getResult();
+        }
+    };
+
+    /**
+     * Creates a new visitor using an aggregate attribute.
+     *
+     * @param aggregateAttribute the aggregate attribute to be used by the visitor
+     * @return a new instance of the visitor
+     */
+    public abstract FeatureCalc create(Expression aggregateAttribute);
+
+    /**
+     * Wraps a raw value in the appropriate visitor calculation result. The typical usage of this is to wrap values
+     * returned by stores able to handle the visitor (for example the JDBCDataStore).
+     *
+     * @param aggregateAttribute the aggregate attribute to be used by the visitor
+     * @param value              the raw value to be wrapped
+     * @return value wrapped in the appropriate visitor calculation result
+     */
+    public abstract CalcResult wrap(Expression aggregateAttribute, Object value);
+
+    /**
+     * Helper method that given a visitor name returns the appropriate enum constant.
+     * The performed match by name is more permissive that the default one. The match will
+     * not be case sensitive and slightly different names can be used (camel case versus snake case).
+     *
+     * @param visitorName the visitor name
+     * @return this enum constant that machs the visitor name
+     */
+    public static Aggregate permissiveValueOf(String visitorName) {
+        switch (visitorName.toLowerCase()) {
+            case "average":
+                return AVERAGE;
+            case "count":
+                return COUNT;
+            case "max":
+                return MAX;
+            case "median":
+                return MEDIAN;
+            case "min":
+                return MIN;
+            case "std_dev":
+                return STD_DEV;
+            case "stddev":
+                return STD_DEV;
+            case "sum":
+                return SUM;
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Visitor with name '%s' is not a valid group by visitor.", visitorName));
+        }
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/GroupByVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/GroupByVisitor.java
@@ -1,0 +1,340 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.feature.visitor;
+
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
+import org.geotools.feature.DefaultFeatureCollection;
+import org.opengis.feature.Feature;
+import org.opengis.feature.FeatureVisitor;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.expression.Expression;
+import org.opengis.util.ProgressListener;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Group features by one or several attributes and applies an aggregator visitor to each group.
+ */
+public class GroupByVisitor implements FeatureCalc {
+
+    private final Aggregate aggregateVisitor;
+    private final Expression aggregateAttribute;
+    private final FeatureCalc aggregateVisitorProtoType;
+    private final List<Expression> groupByAttributes;
+    private final ProgressListener progressListener;
+
+    private final InMemoryGroupBy inMemoryGroupBy = new InMemoryGroupBy();
+
+    private CalcResult optimizationResult = CalcResult.NULL_RESULT;
+
+    public GroupByVisitor(Aggregate aggregateVisitor, Expression aggregateAttribute,
+                          List<Expression> groupByAttributes, ProgressListener progressListener) {
+        this.aggregateVisitor = aggregateVisitor;
+        this.aggregateAttribute = aggregateAttribute;
+        this.groupByAttributes = groupByAttributes;
+        this.progressListener = progressListener;
+        aggregateVisitorProtoType = aggregateVisitor.create(aggregateAttribute);
+    }
+
+    public boolean wasOptimized() {
+        return optimizationResult != null;
+    }
+
+    public boolean wasVisited() {
+        return !inMemoryGroupBy.groupByIndexes.isEmpty();
+    }
+
+    /**
+     * This method computes and returns the group by visitor result. If the computation was optimized
+     * the optimization result is returned otherwise the result is computed in memory. If for some
+     * reason an optimization result exists and there are visited features, an in memory computation
+     * is performed and is merged with the existing optimization results.
+     *
+     * @return group by visitor result
+     */
+    @Override
+    public CalcResult getResult() {
+        // do a in memory computation for any visited feature
+        Map<List<Object>, CalcResult> results = inMemoryGroupBy.visit();
+        // create the result, if no feature was visited this will be an empty result that can be safely merged
+        GroupByResult result = new GroupByResult(results, aggregateVisitor, groupByAttributes);
+        if (optimizationResult == CalcResult.NULL_RESULT) {
+            // there is no optimization result so we just return the created one
+            return result;
+        }
+        // an optimization result exists, we merge both
+        return optimizationResult.merge(result);
+    }
+
+    @Override
+    public void visit(Feature feature) {
+        inMemoryGroupBy.index((SimpleFeature) feature);
+    }
+
+    public Expression getExpression() {
+        return aggregateAttribute;
+    }
+
+    public FeatureVisitor getAggregateVisitor() {
+        return aggregateVisitorProtoType;
+    }
+
+    public List<Expression> getGroupByAttributes() {
+        return groupByAttributes;
+    }
+
+    /**
+     * Methods that allow optimizations to directly set the group by visitor result instead
+     * of computing it visiting all the features. Aggregate visitor results are wrapped with
+     * the appropriate feature calculation type.
+     *
+     * @param value the group by visitor result
+     */
+    public void setValue(List<GroupByRawResult> value) {
+        Map<List<Object>, CalcResult> results = new HashMap<>();
+        for (GroupByRawResult groupByRawResult : value) {
+            // wrap the aggregate visitor result with the appropriate feature calculation type
+            results.put(groupByRawResult.groupByValues, aggregateVisitor.wrap(aggregateAttribute, groupByRawResult.visitorValue));
+        }
+        // create a new group by result using the raw values returned by the optimization
+        GroupByResult newResult = new GroupByResult(results, aggregateVisitor, groupByAttributes);
+        if (optimizationResult == CalcResult.NULL_RESULT) {
+            // if no current result we simply return the new one
+            optimizationResult = newResult;
+        } else {
+            // if a result already exists we merge it with the new one
+            optimizationResult = optimizationResult.merge(newResult);
+        }
+    }
+
+    /**
+     * Helper class that should be used by optimizations to set the results.
+     */
+    public static class GroupByRawResult {
+
+        final List<Object> groupByValues;
+        final Object visitorValue;
+
+        public GroupByRawResult(List<Object> groupByValues, Object visitorsValue) {
+            this.groupByValues = groupByValues;
+            this.visitorValue = visitorsValue;
+        }
+    }
+
+    /**
+     * Helper class that do the computations for the group by visitor in memory.
+     */
+    private class InMemoryGroupBy {
+
+        // feature collections grouped by the group by attributes
+        private final Map<List<Object>, DefaultFeatureCollection> groupByIndexes = new HashMap<>();
+
+        /**
+         * Add a feature to the appropriate group by feature collection.
+         *
+         * @param feature the feature to be indexed
+         */
+        void index(SimpleFeature feature) {
+            // list of group by attributes values
+            List<Object> groupByValues = groupByAttributes.stream()
+                    .map(expression -> expression.evaluate(feature)).collect(Collectors.toList());
+            // check if a feature collection already for the group by values
+            DefaultFeatureCollection featureCollection = groupByIndexes.get(groupByValues);
+            if (featureCollection == null) {
+                // we create a feature collection for the group by values
+                featureCollection = new DefaultFeatureCollection();
+                groupByIndexes.put(groupByValues, featureCollection);
+            }
+            featureCollection.add(feature);
+        }
+
+        /**
+         * We apply a copy of the aggregation visitor to each feature collection.
+         *
+         * @return the result of applying the aggregation visitor to eac feature collection
+         */
+        Map<List<Object>, CalcResult> visit() {
+            Map<List<Object>, CalcResult> results = new HashMap<>();
+            for (Map.Entry<List<Object>, DefaultFeatureCollection> entry : groupByIndexes.entrySet()) {
+                // creating a new aggregation visitor for the current feature collection
+                FeatureCalc visitor = aggregateVisitor.create(aggregateAttribute);
+                try {
+                    // visiting the feature collection with the aggregation visitor
+                    entry.getValue().accepts(visitor, progressListener);
+                } catch (Exception exception) {
+                    throw new RuntimeException("Error visiting features collections.", exception);
+                }
+                // we add the aggregation visitor to the results
+                results.put(entry.getKey(), visitor.getResult());
+            }
+            return results;
+        }
+    }
+
+    /**
+     * This class implements the feature calculation result of the group by visitor.
+     */
+    public static class GroupByResult implements CalcResult {
+
+        private final Map<List<Object>, CalcResult> results;
+        private final Aggregate aggregateVisitor;
+        private final List<Expression> groupByAttributes;
+
+        public GroupByResult(Map<List<Object>, CalcResult> results, Aggregate aggregateVisitor, List<Expression> groupByAttributes) {
+            this.results = results;
+            this.aggregateVisitor = aggregateVisitor;
+            this.groupByAttributes = groupByAttributes;
+        }
+
+        public Map<List<Object>, CalcResult> getResults() {
+            return results;
+        }
+
+        public Aggregate getAggregateVisitor() {
+            return aggregateVisitor;
+        }
+
+        public List<Expression> getGroupByAttributes() {
+            return groupByAttributes;
+        }
+
+        @Override
+        public boolean isCompatible(CalcResult newResult) {
+            if (newResult == CalcResult.NULL_RESULT) {
+                // compatible with NULL result
+                return true;
+            }
+            if (!(newResult instanceof GroupByResult)) {
+                // not compatible with results that are not group by results
+                return false;
+            }
+            GroupByResult groupByResult = (GroupByResult) newResult;
+            // compatible only if the aggregation visitor is the same and the group by attributes are the same
+            return aggregateVisitor == groupByResult.getAggregateVisitor()
+                    && groupByAttributes.equals(groupByResult.getGroupByAttributes());
+        }
+
+        @Override
+        public CalcResult merge(CalcResult newResult) {
+            if (!isCompatible(newResult)) {
+                // not compatible results
+                throw new IllegalArgumentException(String.format(
+                        "Feature calculation result '%s' is not compatible it this result '%s'.",
+                        newResult.getClass().getSimpleName(), GroupByResult.class.getSimpleName()));
+            }
+            if (newResult == CalcResult.NULL_RESULT) {
+                // if the new result is a NULL result we simply return a copy of this result
+                return new GroupByResult(results, aggregateVisitor, groupByAttributes);
+            }
+            // the merged results are initialized with the content of this result
+            Map<List<Object>, CalcResult> mergedResults = new HashMap<>(results);
+            for (Map.Entry<List<Object>, CalcResult> entry : ((GroupByResult) newResult).getResults().entrySet()) {
+                // check if this result contains the same aggregation result
+                CalcResult existingResult = mergedResults.get(entry.getKey());
+                if (existingResult != null) {
+                    // the aggregation result exist in both results so we merge them
+                    mergedResults.put(entry.getKey(), existingResult.merge(entry.getValue()));
+                } else {
+                    // the aggregation result only exists in the new result
+                    mergedResults.put(entry.getKey(), entry.getValue());
+                }
+            }
+            // we return a new group by result with the merged values
+            return new GroupByResult(mergedResults, aggregateVisitor, groupByAttributes);
+        }
+
+        @Override
+        public Object getValue() {
+            return toArray();
+        }
+
+        @Override
+        public int toInt() {
+            return 0;
+        }
+
+        @Override
+        public double toDouble() {
+            return 0;
+        }
+
+        @Override
+        public String toString() {
+            return null;
+        }
+
+        @Override
+        public long toLong() {
+            return 0;
+        }
+
+        @Override
+        public float toFloat() {
+            return 0;
+        }
+
+        @Override
+        public Geometry toGeometry() {
+            return null;
+        }
+
+        @Override
+        public Envelope toEnvelope() {
+            return null;
+        }
+
+        @Override
+        public Point toPoint() {
+            return null;
+        }
+
+        @Override
+        public Set toSet() {
+            return results.entrySet().stream().map(this::entryToArray).collect(Collectors.toSet());
+        }
+
+        @Override
+        public List toList() {
+            return results.entrySet().stream().map(this::entryToArray).collect(Collectors.toList());
+        }
+
+        @Override
+        public Object[] toArray() {
+            return results.entrySet().stream().map(this::entryToArray).toArray();
+        }
+
+        /**
+         * The keys of the map will be List instead of arrays, since arrays don't give a decent hash code.
+         */
+        @Override
+        public Map toMap() {
+            return results.entrySet().stream().collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> entry.getValue().getValue())
+            );
+        }
+
+        private Object[] entryToArray(Map.Entry<List<Object>, CalcResult> entry) {
+            Object[] result = Arrays.copyOf(entry.getKey().toArray(), entry.getKey().size() + 1);
+            result[entry.getKey().size()] = entry.getValue().getValue();
+            return result;
+        }
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/GroupByVisitorBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/GroupByVisitorBuilder.java
@@ -1,0 +1,132 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.feature.visitor;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.util.NullProgressListener;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.expression.Expression;
+import org.opengis.util.ProgressListener;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * <p>Helper class to help building a valid group by visitor.</p>
+ * <p>A valid group by visitor requires an aggregate attribute, an aggregate visitor and at least one group by attribute. </p>
+ */
+public final class GroupByVisitorBuilder {
+
+    private Expression aggregateAttribute;
+    private Aggregate aggregateVisitor;
+    private List<Expression> groupByAttributes = new ArrayList<>();
+    private ProgressListener progressListener;
+
+    public GroupByVisitorBuilder withAggregateAttribute(int attributeTypeIndex, SimpleFeatureType type) {
+        aggregateAttribute = toExpression(attributeTypeIndex, type);
+        return this;
+    }
+
+    public GroupByVisitorBuilder withAggregateAttribute(String attributeName, SimpleFeatureType type) {
+        aggregateAttribute = toExpression(attributeName, type);
+        return this;
+    }
+
+    public GroupByVisitorBuilder withAggregateAttribute(Expression aggregateAttribute) {
+        this.aggregateAttribute = aggregateAttribute;
+        return this;
+    }
+
+    public GroupByVisitorBuilder withAggregateVisitor(Aggregate aggregateVisitor) {
+        this.aggregateVisitor = aggregateVisitor;
+        return this;
+    }
+
+    public GroupByVisitorBuilder withAggregateVisitor(String aggregateVisitorName) {
+        this.aggregateVisitor = Aggregate.permissiveValueOf(aggregateVisitorName);
+        return this;
+    }
+
+    public GroupByVisitorBuilder withGroupByAttribute(int attributeTypeIndex, SimpleFeatureType type) {
+        groupByAttributes.add(toExpression(attributeTypeIndex, type));
+        return this;
+    }
+
+    public GroupByVisitorBuilder withGroupByAttribute(String attributeName, SimpleFeatureType type) {
+        groupByAttributes.add(toExpression(attributeName, type));
+        return this;
+    }
+
+    public GroupByVisitorBuilder withGroupByAttributes(Collection<String> attributesNames, SimpleFeatureType type) {
+        for (String attributeName : attributesNames) {
+            withGroupByAttribute(attributeName, type);
+        }
+        return this;
+    }
+
+    public GroupByVisitorBuilder withGroupByAttribute(Expression groupByAttribute) {
+        groupByAttributes.add(groupByAttribute);
+        return this;
+    }
+
+    public GroupByVisitorBuilder withProgressListener(ProgressListener progressListener) {
+        this.progressListener = progressListener;
+        return this;
+    }
+
+    private Expression toExpression(int attributeTypeIndex, SimpleFeatureType type) {
+        FilterFactory filterFactory = CommonFactoryFinder.getFilterFactory(null);
+        AttributeDescriptor attribute = type.getDescriptor(attributeTypeIndex);
+        if (attribute == null) {
+            throw new IllegalArgumentException("Attribute index '" + attributeTypeIndex + "' is not valid.");
+        }
+        return filterFactory.property(attribute.getLocalName());
+    }
+
+    private Expression toExpression(String attributeName, SimpleFeatureType type) {
+        FilterFactory filterFactory = CommonFactoryFinder.getFilterFactory(null);
+        AttributeDescriptor attribute = type.getDescriptor(attributeName);
+        if (attribute == null) {
+            throw new IllegalArgumentException("Attribute '" + attributeName + "' is not valid.");
+        }
+        return filterFactory.property(attribute.getLocalName());
+    }
+
+    /**
+     * Create a group by visitor checking that all mandatory values are present.
+     *
+     * @return a new group by visitor
+     */
+    public GroupByVisitor build() {
+        if (aggregateAttribute == null) {
+            throw new IllegalArgumentException("An aggregate attribute is required.");
+        }
+        if (aggregateVisitor == null) {
+            throw new IllegalArgumentException("An aggregate visitor is required.");
+        }
+        if (groupByAttributes == null || groupByAttributes.isEmpty()) {
+            throw new IllegalArgumentException("At least one group by attribute is required.");
+        }
+        if (progressListener == null) {
+            progressListener = new NullProgressListener();
+        }
+        return new GroupByVisitor(aggregateVisitor, aggregateAttribute, groupByAttributes, progressListener);
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/feature/visitor/GroupByVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/visitor/GroupByVisitorTest.java
@@ -1,0 +1,371 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.feature.visitor;
+
+import com.vividsolutions.jts.io.WKTReader;
+import org.geotools.data.DataUtilities;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.util.NullProgressListener;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This class implement the test that checks the group by visitor behavior with different aggregate visitors.
+ * All the computations will be performed in memory. Optimization tests are implemented in the specific stores.
+ */
+public class GroupByVisitorTest {
+
+    private static WKTReader wktParser = new WKTReader();
+
+    private static SimpleFeatureType buildingType;
+    private static FeatureCollection featureCollection;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // the building feature type that will be used during the tests
+        buildingType = DataUtilities.createType("buildings", "id:Integer,building_id:String," +
+                "building_type:String,energy_type:String,energy_consumption:Double,geo:Geometry");
+        // the building features that will be used during the tests
+        SimpleFeature[] buildingFeatures = new SimpleFeature[]{
+                SimpleFeatureBuilder.build(buildingType, new Object[]{1, "SCHOOL_A", "SCHOOL", "FLOWING_WATER", 50.0, wktParser.read("POINT(-5 -5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{2, "SCHOOL_A", "SCHOOL", "NUCLEAR", 10.0, wktParser.read("POINT(-5 -5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{3, "SCHOOL_A", "SCHOOL", "WIND", 20.0, wktParser.read("POINT(-5 -5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{4, "SCHOOL_B", "SCHOOL", "SOLAR", 30.0, wktParser.read("POINT(5 5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{5, "SCHOOL_B", "SCHOOL", "FUEL", 60.0, wktParser.read("POINT(5 5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{6, "SCHOOL_B", "SCHOOL", "NUCLEAR", 10.0, wktParser.read("POINT(5 5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{7, "FABRIC_A", "FABRIC", "FLOWING_WATER", 500.0, wktParser.read("POINT(-5 5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{8, "FABRIC_A", "FABRIC", "NUCLEAR", 150.0, wktParser.read("POINT(-5 5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{9, "FABRIC_B", "FABRIC", "WIND", 20.0, wktParser.read("POINT(5 -5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{10, "FABRIC_B", "FABRIC", "SOLAR", 30.0, wktParser.read("POINT(5 -5)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{11, "HOUSE_A", "HOUSE", "FUEL", 6.0, wktParser.read("POINT(0 0)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{12, "HOUSE_B", "HOUSE", "NUCLEAR", 4.0, wktParser.read("POINT(0 0)")}, null),
+        };
+        // creating the bulding featrue collection
+        featureCollection = DataUtilities.collection(buildingFeatures);
+    }
+
+    @Test
+    public void testGroupByWithAverageAndSingleAttribute() throws Exception {
+        testVisitor("energy_consumption", "Average", "building_type", new Object[][]{
+                new Object[]{"SCHOOL", 30.0},
+                new Object[]{"FABRIC", 175.0},
+                new Object[]{"HOUSE", 5.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithAverageAndTwoAttributes() throws Exception {
+        testVisitor("energy_consumption", "Average", "building_type", "energy_type", new Object[][]{
+                new Object[]{"FABRIC", "FLOWING_WATER", 500.0},
+                new Object[]{"FABRIC", "NUCLEAR", 150.0},
+                new Object[]{"FABRIC", "SOLAR", 30.0},
+                new Object[]{"FABRIC", "WIND", 20.0},
+                new Object[]{"HOUSE", "FUEL", 6.0},
+                new Object[]{"HOUSE", "NUCLEAR", 4.0},
+                new Object[]{"SCHOOL", "FLOWING_WATER", 50.0},
+                new Object[]{"SCHOOL", "FUEL", 60.0},
+                new Object[]{"SCHOOL", "NUCLEAR", 10.0},
+                new Object[]{"SCHOOL", "SOLAR", 30.0},
+                new Object[]{"SCHOOL", "WIND", 20.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithCountAndSingleAttribute() throws Exception {
+        testVisitor("energy_consumption", "Count", "building_type", new Object[][]{
+                new Object[]{"SCHOOL", 6},
+                new Object[]{"FABRIC", 4},
+                new Object[]{"HOUSE", 2}
+        });
+    }
+
+    @Test
+    public void testGroupByWithCountAndTwoAttributes() throws Exception {
+        testVisitor("energy_consumption", "Count", "building_type", "energy_type", new Object[][]{
+                new Object[]{"FABRIC", "FLOWING_WATER", 1},
+                new Object[]{"FABRIC", "NUCLEAR", 1},
+                new Object[]{"FABRIC", "SOLAR", 1},
+                new Object[]{"FABRIC", "WIND", 1},
+                new Object[]{"HOUSE", "FUEL", 1},
+                new Object[]{"HOUSE", "NUCLEAR", 1},
+                new Object[]{"SCHOOL", "FLOWING_WATER", 1},
+                new Object[]{"SCHOOL", "FUEL", 1},
+                new Object[]{"SCHOOL", "NUCLEAR", 2},
+                new Object[]{"SCHOOL", "SOLAR", 1},
+                new Object[]{"SCHOOL", "WIND", 1}
+        });
+    }
+
+    @Test
+    public void testGroupByWithMaxAndSingleAttribute() throws Exception {
+        testVisitor("energy_consumption", "Max", "building_type", new Object[][]{
+                new Object[]{"SCHOOL", 60.0},
+                new Object[]{"FABRIC", 500.0},
+                new Object[]{"HOUSE", 6.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithMaxAndTwoAttributes() throws Exception {
+        testVisitor("energy_consumption", "Max", "building_type", "energy_type", new Object[][]{
+                new Object[]{"FABRIC", "FLOWING_WATER", 500.0},
+                new Object[]{"FABRIC", "NUCLEAR", 150.0},
+                new Object[]{"FABRIC", "SOLAR", 30.0},
+                new Object[]{"FABRIC", "WIND", 20.0},
+                new Object[]{"HOUSE", "FUEL", 6.0},
+                new Object[]{"HOUSE", "NUCLEAR", 4.0},
+                new Object[]{"SCHOOL", "FLOWING_WATER", 50.0},
+                new Object[]{"SCHOOL", "FUEL", 60.0},
+                new Object[]{"SCHOOL", "NUCLEAR", 10.0},
+                new Object[]{"SCHOOL", "SOLAR", 30.0},
+                new Object[]{"SCHOOL", "WIND", 20.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithMedianAndSingleAttribute() throws Exception {
+        testVisitor("energy_consumption", "Median", "building_type", new Object[][]{
+                new Object[]{"SCHOOL", 25.0},
+                new Object[]{"FABRIC", 90.0},
+                new Object[]{"HOUSE", 5.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithMedianAndTwoAttributes() throws Exception {
+        testVisitor("energy_consumption", "Median", "building_type", "energy_type", new Object[][]{
+                new Object[]{"FABRIC", "FLOWING_WATER", 500.0},
+                new Object[]{"FABRIC", "NUCLEAR", 150.0},
+                new Object[]{"FABRIC", "SOLAR", 30.0},
+                new Object[]{"FABRIC", "WIND", 20.0},
+                new Object[]{"HOUSE", "FUEL", 6.0},
+                new Object[]{"HOUSE", "NUCLEAR", 4.0},
+                new Object[]{"SCHOOL", "FLOWING_WATER", 50.0},
+                new Object[]{"SCHOOL", "FUEL", 60.0},
+                new Object[]{"SCHOOL", "NUCLEAR", 10.0},
+                new Object[]{"SCHOOL", "SOLAR", 30.0},
+                new Object[]{"SCHOOL", "WIND", 20.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithMinAndSingleAttribute() throws Exception {
+        testVisitor("energy_consumption", "Min", "building_type", new Object[][]{
+                new Object[]{"SCHOOL", 10.0},
+                new Object[]{"FABRIC", 20.0},
+                new Object[]{"HOUSE", 4.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithMinAndTwoAttributes() throws Exception {
+        testVisitor("energy_consumption", "Min", "building_type", "energy_type", new Object[][]{
+                new Object[]{"FABRIC", "FLOWING_WATER", 500.0},
+                new Object[]{"FABRIC", "NUCLEAR", 150.0},
+                new Object[]{"FABRIC", "SOLAR", 30.0},
+                new Object[]{"FABRIC", "WIND", 20.0},
+                new Object[]{"HOUSE", "FUEL", 6.0},
+                new Object[]{"HOUSE", "NUCLEAR", 4.0},
+                new Object[]{"SCHOOL", "FLOWING_WATER", 50.0},
+                new Object[]{"SCHOOL", "FUEL", 60.0},
+                new Object[]{"SCHOOL", "NUCLEAR", 10.0},
+                new Object[]{"SCHOOL", "SOLAR", 30.0},
+                new Object[]{"SCHOOL", "WIND", 20.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithStdDevAndSingleAttribute() throws Exception {
+        testVisitor("energy_consumption", "StdDev", "building_type", new Object[][]{
+                new Object[]{"SCHOOL", 19.149},
+                new Object[]{"FABRIC", 194.487},
+                new Object[]{"HOUSE", 1.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithStdDevAndTwoAttributes() throws Exception {
+        testVisitor("energy_consumption", "StdDev", "building_type", "energy_type", new Object[][]{
+                new Object[]{"FABRIC", "FLOWING_WATER", 0.0},
+                new Object[]{"FABRIC", "NUCLEAR", 0.0},
+                new Object[]{"FABRIC", "SOLAR", 0.0},
+                new Object[]{"FABRIC", "WIND", 0.0},
+                new Object[]{"HOUSE", "FUEL", 0.0},
+                new Object[]{"HOUSE", "NUCLEAR", 0.0},
+                new Object[]{"SCHOOL", "FLOWING_WATER", 0.0},
+                new Object[]{"SCHOOL", "FUEL", 0.0},
+                new Object[]{"SCHOOL", "NUCLEAR", 0.0},
+                new Object[]{"SCHOOL", "SOLAR", 0.0},
+                new Object[]{"SCHOOL", "WIND", 0.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithSumDevAndSingleAttribute() throws Exception {
+        testVisitor("energy_consumption", "Sum", "building_type", new Object[][]{
+                new Object[]{"SCHOOL", 180.0},
+                new Object[]{"FABRIC", 700.0},
+                new Object[]{"HOUSE", 10.0}
+        });
+    }
+
+    @Test
+    public void testGroupByWithSumDevAndTwoAttributes() throws Exception {
+        testVisitor("energy_consumption", "Sum", "building_type", "energy_type", new Object[][]{
+                new Object[]{"FABRIC", "FLOWING_WATER", 500.0},
+                new Object[]{"FABRIC", "NUCLEAR", 150.0},
+                new Object[]{"FABRIC", "SOLAR", 30.0},
+                new Object[]{"FABRIC", "WIND", 20.0},
+                new Object[]{"HOUSE", "FUEL", 6.0},
+                new Object[]{"HOUSE", "NUCLEAR", 4.0},
+                new Object[]{"SCHOOL", "FLOWING_WATER", 50.0},
+                new Object[]{"SCHOOL", "FUEL", 60.0},
+                new Object[]{"SCHOOL", "NUCLEAR", 20.0},
+                new Object[]{"SCHOOL", "SOLAR", 30.0},
+                new Object[]{"SCHOOL", "WIND", 20.0}
+        });
+    }
+
+    @Test
+    public void testMergingGroupByResults() throws Exception {
+        // creating the features collections that will be used to test the merge behavior
+        FeatureCollection featureCollectionA = featureCollection;
+        FeatureCollection featureCollectionB = DataUtilities.collection(new SimpleFeature[]{
+                SimpleFeatureBuilder.build(buildingType, new Object[]{1, "SCHOOL_C", "SCHOOL", "NUCLEAR", 100.0, wktParser.read("POINT(-15 -15)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{1, "SCHOOL_C", "SCHOOL", "FUEL", 15.0, wktParser.read("POINT(-15 -15)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{2, "FABRIC_C", "FABRIC", "NUCLEAR", 250.0, wktParser.read("POINT(-25 -25)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{2, "FABRIC_C", "FABRIC", "WIND", 75.0, wktParser.read("POINT(-25 -25)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{2, "HOUSE_C", "HOUSE", "WIND", 10.0, wktParser.read("POINT(-35 -35)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{2, "HOUSE_C", "HOUSE", "DARK_MATTER", 850.0, wktParser.read("POINT(-35 -35)")}, null),
+                SimpleFeatureBuilder.build(buildingType, new Object[]{2, "THEATER_A", "THEATER", "WIND", 200.0, wktParser.read("POINT(-45 -45)")}, null)
+        });
+        // we visit the first feature collection calculating the energy consumption average by building type
+        GroupByVisitor visitorA = executeVisitor(featureCollectionA, "energy_consumption", "Average", new String[]{"building_type"});
+        checkResults(visitorA.getResult(), new Object[][]{
+                new Object[]{"SCHOOL", 30.0},
+                new Object[]{"FABRIC", 175.0},
+                new Object[]{"HOUSE", 5.0}
+        });
+        // we visit the second feature collection calculating the energy consumption average by building type
+        GroupByVisitor visitorB = executeVisitor(featureCollectionB, "energy_consumption", "Average", new String[]{"building_type"});
+        checkResults(visitorB.getResult(), new Object[][]{
+                new Object[]{"SCHOOL", 57.5},
+                new Object[]{"FABRIC", 162.5},
+                new Object[]{"HOUSE", 430.0},
+                new Object[]{"THEATER", 200.0}
+        });
+        // we merge the result of the two previous visitors
+        checkResults(visitorA.getResult().merge(visitorB.getResult()), new Object[][]{
+                new Object[]{"SCHOOL", 36.875},
+                new Object[]{"FABRIC", 170.833},
+                new Object[]{"HOUSE", 217.5},
+                new Object[]{"THEATER", 200.0}
+        });
+    }
+
+    private void testVisitor(String aggregateAttribute, String aggregateVisitor,
+                             String groupByAttribute, Object[][] expectedResults) throws Exception {
+        testVisitor(aggregateAttribute, aggregateVisitor, new String[]{groupByAttribute}, expectedResults);
+    }
+
+    private void testVisitor(String aggregateAttribute, String aggregateVisitor, String firstGroupByAttribute,
+                             String secondGroupByAttribute, Object[][] expectedResults) throws Exception {
+        testVisitor(aggregateAttribute, aggregateVisitor, new String[]{firstGroupByAttribute, secondGroupByAttribute}, expectedResults);
+    }
+
+    private void testVisitor(String aggregateAttribute, String aggregateVisitor,
+                             String[] groupByAttributes, Object[][] expectedResults) throws Exception {
+        GroupByVisitor visitor = executeVisitor(featureCollection, aggregateAttribute, aggregateVisitor, groupByAttributes);
+        checkResults(visitor.getResult(), expectedResults);
+    }
+
+    /**
+     * Helper method that construct the group by visitor and visit the given feature collection. The visitor result
+     * is also checked against the expected result.
+     */
+    private GroupByVisitor executeVisitor(FeatureCollection featureCollection, String aggregateAttribute,
+                                          String aggregateVisitor, String[] groupByAttributes) throws Exception {
+        GroupByVisitorBuilder visitorBuilder = new GroupByVisitorBuilder()
+                .withAggregateAttribute(aggregateAttribute, buildingType)
+                .withAggregateVisitor(aggregateVisitor);
+        for (String groupByAttribute : groupByAttributes) {
+            visitorBuilder.withGroupByAttribute(groupByAttribute, buildingType);
+        }
+        GroupByVisitor visitor = visitorBuilder.build();
+        featureCollection.accepts(visitor, new NullProgressListener());
+        return visitor;
+    }
+
+    /**
+     * Helper method the checks if the calculation result contains the expected result.
+     */
+    private void checkResults(CalcResult calcResult, Object[][] expectedResults) {
+        assertThat(calcResult, notNullValue());
+        Object[] results = calcResult.toArray();
+        assertThat(results.length, is(expectedResults.length));
+        for (Object[] expectedResult : expectedResults) {
+            assertThat(contains(results, expectedResult), is(true));
+        }
+    }
+
+    /**
+     * Helper method that checks if the number of results and the number of expected results
+     * are the same and if the expected results are contained in the results.
+     */
+    private boolean contains(Object[] results, Object[] expectedResult) {
+        for (Object result : results) {
+            assertThat(result, instanceOf(Object[].class));
+            if (checkArraysAreEqual((Object[]) result, expectedResult)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Helper method that compare two arrays. This method will compare double values by difference (0.001).
+     */
+    private boolean checkArraysAreEqual(Object[] arrayA, Object[] arrayB) {
+        assertThat(arrayA, notNullValue());
+        assertThat(arrayB, notNullValue());
+        if (arrayA.length != arrayB.length) {
+            return false;
+        }
+        for (int i = 0; i < arrayA.length; i++) {
+            assertThat(arrayA[i], notNullValue());
+            assertThat(arrayB[i], notNullValue());
+            if (!arrayA[i].getClass().equals(arrayB[i].getClass())) {
+                return false;
+            }
+            if (arrayA[i] instanceof Double) {
+                double difference = Math.abs((double) arrayA[i] - (double) arrayB[i]);
+                if (difference > 0.001) {
+                    return false;
+                }
+            } else if (!arrayA[i].equals(arrayB[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGroupByVisitorOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGroupByVisitorOnlineTest.java
@@ -1,0 +1,27 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCGroupByVisitorOnlineTest;
+
+public class PostgisGroupByVisitorOnlineTest extends JDBCGroupByVisitorOnlineTest {
+
+    @Override
+    protected PostgisGroupByVisitorTestSetup createTestSetup() {
+        return new PostgisGroupByVisitorTestSetup(new PostGISTestSetup());
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGroupByVisitorTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGroupByVisitorTestSetup.java
@@ -1,0 +1,51 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCGroupByVisitorTestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class PostgisGroupByVisitorTestSetup extends JDBCGroupByVisitorTestSetup {
+
+    public PostgisGroupByVisitorTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void createBuildingsTable() throws Exception {
+        run("CREATE TABLE BUILDINGS_GROUP_BY_TESTS (id int4 PRIMARY KEY, building_id text, " +
+                "building_type text, energy_type text, energy_consumption numeric);");
+        run("INSERT INTO BUILDINGS_GROUP_BY_TESTS VALUES " +
+                "(1, 'SCHOOL_A', 'SCHOOL', 'FLOWING_WATER', 50.0)," +
+                "(2, 'SCHOOL_A', 'SCHOOL', 'NUCLEAR', 10.0)," +
+                "(3, 'SCHOOL_A', 'SCHOOL', 'WIND', 20.0)," +
+                "(4, 'SCHOOL_B', 'SCHOOL', 'SOLAR', 30.0)," +
+                "(5, 'SCHOOL_B', 'SCHOOL', 'FUEL', 60.0)," +
+                "(6, 'SCHOOL_B', 'SCHOOL', 'NUCLEAR', 10.0)," +
+                "(7, 'FABRIC_A', 'FABRIC', 'FLOWING_WATER', 500.0)," +
+                "(8, 'FABRIC_A', 'FABRIC', 'NUCLEAR', 150.0)," +
+                "(9, 'FABRIC_B', 'FABRIC', 'WIND', 20.0)," +
+                "(10, 'FABRIC_B', 'FABRIC', 'SOLAR', 30.0)," +
+                "(11, 'HOUSE_A', 'HOUSE', 'FUEL', 6.0)," +
+                "(12, 'HOUSE_B', 'HOUSE', 'NUCLEAR', 4.0);");
+    }
+
+    @Override
+    protected void dropBuildingsTable() throws Exception {
+        runSafe("DROP TABLE BUILDINGS_GROUP_BY_TESTS");
+    }
+}

--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/AggregateProcess.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/AggregateProcess.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2011-2016, Open Source Geospatial Foundation (OSGeo)
  *    (C) 2008-2011 TOPP - www.openplans.org.
  *
  *    This library is free software; you can redistribute it and/or
@@ -18,23 +18,12 @@
 package org.geotools.process.vector;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.feature.visitor.AbstractCalcResult;
-import org.geotools.feature.visitor.AverageVisitor;
-import org.geotools.feature.visitor.CalcResult;
-import org.geotools.feature.visitor.CountVisitor;
-import org.geotools.feature.visitor.FeatureCalc;
-import org.geotools.feature.visitor.MaxVisitor;
-import org.geotools.feature.visitor.MedianVisitor;
-import org.geotools.feature.visitor.MinVisitor;
-import org.geotools.feature.visitor.StandardDeviationVisitor;
-import org.geotools.feature.visitor.SumVisitor;
+import org.geotools.feature.visitor.*;
 import org.geotools.process.ProcessException;
 import org.geotools.process.factory.DescribeParameter;
 import org.geotools.process.factory.DescribeProcess;
@@ -67,17 +56,33 @@ public class AggregateProcess implements VectorProcess {
      * @return aggregate Results
      */
     public static Results process(SimpleFeatureCollection features, String aggAttribute, Set<AggregationFunction> functions, Boolean singlePass, ProgressListener progressListener) throws ProcessException, IOException {
-        AggregateProcess process = new AggregateProcess();
-        return process.execute(features, aggAttribute, functions, singlePass, progressListener);
+        return process(features, aggAttribute, functions, null, singlePass, progressListener);
     }
+
+    public static Results process(SimpleFeatureCollection features, String aggAttribute, Set<AggregationFunction> functions,
+                                  List<String> groupByAttributes, Boolean singlePass, ProgressListener progressListener) throws ProcessException, IOException {
+        AggregateProcess process = new AggregateProcess();
+        return process.execute(features, aggAttribute, functions, singlePass, groupByAttributes, progressListener);
+     }
     
+    public Results execute(SimpleFeatureCollection features,String aggAttribute,Set<AggregationFunction> functions,
+                           boolean singlePass, ProgressListener progressListener) throws ProcessException, IOException {
+        return execute(features, aggAttribute, functions, singlePass, null, progressListener);
+    }
+
     @DescribeResult(name = "result", description = "Aggregation results (one value for each function computed)")
     public Results execute(
             @DescribeParameter(name = "features", description = "Input feature collection") SimpleFeatureCollection features,
             @DescribeParameter(name = "aggregationAttribute", min = 0, description = "Attribute on which to perform aggregation") String aggAttribute,
             @DescribeParameter(name = "function", description = "An aggregate function to compute. Functions include Count, Average, Max, Median, Min, StdDev, and Sum.", collectionType = AggregationFunction.class) Set<AggregationFunction> functions,
             @DescribeParameter(name = "singlePass", description = "If True computes all aggregation values in a single pass (this will defeat DBMS-specific optimizations)", defaultValue = "false") boolean singlePass,
+            @DescribeParameter(name = "groupByAttributes", min = 0, description = "List of group by attributes", collectionType = String.class) List<String> groupByAttributes,
             ProgressListener progressListener) throws ProcessException, IOException {
+
+        if (groupByAttributes != null && !groupByAttributes.isEmpty()) {
+            // this request as group by attributes which need special care
+            return handleGroupByVisitor(features, aggAttribute, functions, groupByAttributes, progressListener);
+        }
 
         int attIndex = -1;
         List<AttributeDescriptor> atts = features.getSchema().getAttributeDescriptors();
@@ -140,7 +145,56 @@ public class AggregateProcess implements VectorProcess {
             }
         }
 
-        return new Results(results);
+        return new Results(aggAttribute, functions, results);
+    }
+
+    /**
+     * Helper method that handle requests that have group by attributes by wrapping the functions in group by visitors.
+     */
+    private Results handleGroupByVisitor(SimpleFeatureCollection features, String aggAttribute, Set<AggregationFunction> functions,
+                                         List<String> rawGroupByAttributes, ProgressListener progressListener) throws IOException {
+        // building a group by visitor for every aggregate function
+        List<GroupByVisitor> groupByVisitors = functions.stream().map(function -> new GroupByVisitorBuilder()
+                .withAggregateAttribute(aggAttribute, features.getSchema())
+                .withAggregateVisitor(function.name())
+                .withGroupByAttributes(rawGroupByAttributes, features.getSchema())
+                .withProgressListener(progressListener)
+                .build()).collect(Collectors.toList());
+        // visiting the features collection with each visitor
+        for (GroupByVisitor visitor : groupByVisitors) {
+            features.accepts(visitor, progressListener);
+        }
+        // extracting the results from each group by visitor
+        List<Map<List<Object>, Object>> results = groupByVisitors.stream()
+                .map(visitor -> (Map<List<Object>, Object>)visitor.getResult().toMap())
+                .collect(Collectors.toList());
+        return new Results(aggAttribute, functions, rawGroupByAttributes, mergeResults(results, rawGroupByAttributes.size()));
+    }
+
+    /**
+     * Helper method that merge all group by visitors results in a tabular format. Each line of the table is composed
+     * of the group by attributes values and the aggregation functions results.
+     */
+    private List<Object[]> mergeResults(List<Map<List<Object>, Object>> results, int groupByAttributesNumber) {
+        List<Object[]> mergedResults = new ArrayList<>();
+        if(results.isEmpty()) {
+            // no results so nothing to do
+            return mergedResults;
+        }
+        // the size of each line is the number of the group by attributes plus the number of aggregation functions
+        int resultSize = groupByAttributesNumber + results.size();
+        // the group by attributes values are equal for all the visitors so we use the first visitor result to grab all the group by values
+        for(List<Object> groupByAttributes : results.get(0).keySet()) {
+            // we create the table line that will contains all the results
+            Object[] mergedResult = Arrays.copyOf(groupByAttributes.toArray(), resultSize);
+            // we extract from each group by visitor result the aggregation function result and add it to out table line
+            for(int i = 0; i < results.size(); i++) {
+                mergedResult[groupByAttributesNumber + i] = results.get(i).get(groupByAttributes);
+            }
+            // we add the current line to the table
+            mergedResults.add(mergedResult);
+        }
+        return mergedResults;
     }
 
     private List<String> attNames(List<AttributeDescriptor> atts) {
@@ -196,8 +250,28 @@ public class AggregateProcess implements VectorProcess {
         Double standardDeviation;
         Double sum;
         Long count;
-        
-        public Results(EnumMap<AggregationFunction, Number> results) {
+
+        // this values are used by output formats that want to add more meta information (the JSON tabular output format for example)
+        String aggregateAttribute;
+        Set<AggregationFunction> functions;
+        List<String> groupByAttributes;
+        List<Object[]> groupByResult;
+        EnumMap<AggregationFunction, Number> results;
+
+
+        // this constructor is used to output group by results
+        public Results(String aggregateAttribute, Set<AggregationFunction> functions, List<String> groupByAttributes, List<Object[]> groupByResult) {
+            this.aggregateAttribute = aggregateAttribute;
+            this.functions = functions;
+            this.groupByAttributes = groupByAttributes;
+            this.groupByResult = groupByResult;
+        }
+
+        // this constructor is used to output normal aggregations results
+        public Results(String aggregateAttribute, Set<AggregationFunction> functions, EnumMap<AggregationFunction, Number> results) {
+            this.aggregateAttribute = aggregateAttribute;
+            this.functions = functions;
+            this.results = results;
             min = toDouble(results.get(AggregationFunction.Min));
             max = toDouble(results.get(AggregationFunction.Max));
             median = toDouble(results.get(AggregationFunction.Median));
@@ -241,6 +315,25 @@ public class AggregateProcess implements VectorProcess {
             return count;
         }
 
+        public String getAggregateAttribute() {
+            return aggregateAttribute;
+        }
+
+        public Set<AggregationFunction> getFunctions() {
+            return functions;
+        }
+
+        public List<String> getGroupByAttributes() {
+            return groupByAttributes;
+        }
+
+        public List<Object[]> getGroupByResult() {
+            return groupByResult;
+        }
+
+        public EnumMap<AggregationFunction, Number> getResults() {
+            return results;
+        }
     }
 
 }

--- a/modules/unsupported/process-feature/src/test/java/org/geotools/process/vector/AggregateProcessTest.java
+++ b/modules/unsupported/process-feature/src/test/java/org/geotools/process/vector/AggregateProcessTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2011-2016, Open Source Geospatial Foundation (OSGeo)
  *    (C) 2001-2007 TOPP - www.openplans.org.
  *
  *    This library is free software; you can redistribute it and/or
@@ -17,10 +17,12 @@
  */
 package org.geotools.process.vector;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -63,4 +65,16 @@ public class AggregateProcessTest {
         assertTrue( result.sum > 0 );
     }
 
+    @Test
+    public void testSumWithGroupBy() throws Exception {
+        SimpleFeatureSource source = bugs.getFeatureSource("bugsites");
+        Set<AggregationFunction> functions = EnumSet.of(AggregationFunction.Sum);
+        Results result = AggregateProcess.process( source.getFeatures(), "cat", functions, Collections.singletonList("str1"), true, null);
+        // we expect a group by result
+        assertNotNull(result.getGroupByResult());
+        // the group by result should not be empty
+        assertTrue(result.getGroupByResult().size() > 0);
+        // the size of each line result should be 2 (one group by attribute and one aggregation function)
+        assertTrue(result.getGroupByResult().get(0).length == 2);
+    }
 }


### PR DESCRIPTION
The current aggregation visitors (AverageVisitor, CountVisitor, MaxVisitor, MedianVisitor, MinVisitor, StandardDeviationVisitor and SumVisitor) don’t support a “group by” behavior. For example, we are able to compute the average electrical consumption per building. But we are not able to ask the average electrical consumption per building type.

The idea is to add new "group by" visitor that will be able to group features by type and apply a visitor on them. The JDBCDataStore will be extend to natively support the "group by" behavior. The existing Aggregator process will also be extended to support the "group by" behavior.

All of this will be done preserving backwards compatibility.

Mailing list discussion about this:
http://osgeo-org.1560.x6.nabble.com/Adding-quot-group-by-quot-support-to-the-current-aggregation-visitors-td5249393.html

Issue: https://osgeo-org.atlassian.net/browse/GEOT-5367