### PR TITLE
GEOT-4909, fixing issues when saxon used as encoder transformer.

### DIFF
--- a/modules/extension/xsd/pom.xml
+++ b/modules/extension/xsd/pom.xml
@@ -81,6 +81,23 @@
     </plugins>
   </build-->
 
+  <profiles>
+    <profile>
+      <id>saxon</id>
+      <dependencies>
+         <dependency>
+           <groupId>net.sf.saxon</groupId>
+           <artifactId>Saxon-HE</artifactId>
+           <version>9.6.0-6</version>
+           <scope>test</scope>
+         </dependency>
+      </dependencies>
+      <properties>
+        <test.args>-Djavax.xml.transform.TransformerFactory=net.sf.saxon.jaxp.SaxonTransformerFactory</test.args>
+      </properties>
+    </profile>
+  </profiles>
+
   <modules>
     <module>xsd-core</module>
     <module>xsd-gml2</module>

--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GMLWriter.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GMLWriter.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -26,6 +26,7 @@ import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.NamespaceSupport;
 
 import com.vividsolutions.jts.geom.CoordinateSequence;
@@ -184,8 +185,15 @@ public class GMLWriter {
         if (qualifiedName == null) {
             qualifiedName = qualify(qn.getNamespaceURI(), qn.getLocalPart(), null);
         }
+        if (atts == null) {
+            atts =new AttributesImpl();
+        }
         if (qualifiedName != null) {
-            handler.startElement(null, null, qualifiedName, atts);
+            String localName = null;
+            if (qualifiedName.contains(":")) {
+                localName = qualifiedName.split(":")[1];
+            }
+            handler.startElement(qn.getNamespaceURI(), localName, qualifiedName, atts);
         } else {
             handler.startElement(qn.getNamespaceURI(), qn.getLocalPart(), null, atts);
         }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/CurveEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/CurveEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -89,7 +89,7 @@ class CurveEncoder extends GeometryEncoder<LineString> {
     private void encodeLinestring(LineString geometry, GMLWriter handler)
             throws Exception {
         AttributesImpl atts = new AttributesImpl();
-        atts.addAttribute(null, "interpolation", "interpolation", null, "linear");
+        atts.addAttribute(GML.NAMESPACE, "interpolation", "interpolation", "", "linear");
         handler.startElement(lineStringSegment, atts);
 
         handler.posList(geometry.getCoordinateSequence());
@@ -100,7 +100,7 @@ class CurveEncoder extends GeometryEncoder<LineString> {
     private void encodeCurve(SingleCurvedGeometry curve, GMLWriter handler)
             throws Exception {
         AttributesImpl atts = new AttributesImpl();
-        atts.addAttribute(null, "interpolation", "interpolation", null, "circularArc3Points");
+        atts.addAttribute(GML.NAMESPACE, "interpolation", "interpolation", "", "circularArc3Points");
         handler.startElement(arcString, atts);
 
         handler.posList(new LiteCoordinateSequence(curve.getControlPoints()));

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryEncoderTestSupport.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryEncoderTestSupport.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -75,7 +75,7 @@ public abstract class GeometryEncoderTestSupport extends GML3TestSupport {
         Properties outputProps = new Properties();
         outputProps.setProperty(INDENT_AMOUNT_KEY, "2");
         xmls.getTransformer().setOutputProperties(outputProps);
-        xmls.getTransformer().setOutputProperty(OutputKeys.METHOD, "XML");
+        xmls.getTransformer().setOutputProperty(OutputKeys.METHOD, "xml");
         xmls.setResult(new StreamResult(out));
 
         GMLWriter handler = new GMLWriter(xmls, gtEncoder.getNamespaces(), 6, false, "gml");

--- a/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/bindings/PropertyTypeBinding.java
+++ b/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/bindings/PropertyTypeBinding.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -32,6 +32,7 @@ import org.w3c.dom.Element;
 import org.xml.sax.ContentHandler;
 
 import com.vividsolutions.jts.geom.Geometry;
+import org.xml.sax.helpers.AttributesImpl;
 
 
 /**
@@ -113,9 +114,10 @@ public class PropertyTypeBinding extends AbstractComplexEMFBinding {
                     
                     Object value = ((PropertyType) object).getValue();
                     
-                    output.startElement(WFS.NAMESPACE, VALUE, "wfs:" + VALUE, null);
+                    output.startElement(WFS.NAMESPACE, VALUE, "wfs:" + VALUE, new AttributesImpl());
                     if (value instanceof Geometry) {
                         Encoder encoder = new Encoder(new org.geotools.gml2.GMLConfiguration());
+                        encoder.setInline(true);
                         encoder.encode(value, org.geotools.gml2.GML._Geometry, output);
                     }
                     else {

--- a/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/v2_0/bindings/PropertyTypeBinding.java
+++ b/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/v2_0/bindings/PropertyTypeBinding.java
@@ -1,3 +1,19 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
 package org.geotools.wfs.v2_0.bindings;
 
 import javax.xml.namespace.QName;
@@ -16,6 +32,7 @@ import org.w3c.dom.Element;
 import org.xml.sax.ContentHandler;
 
 import com.vividsolutions.jts.geom.Geometry;
+import org.xml.sax.helpers.AttributesImpl;
 
 public class PropertyTypeBinding extends AbstractComplexEMFBinding {
        
@@ -52,9 +69,10 @@ public class PropertyTypeBinding extends AbstractComplexEMFBinding {
                     
                     Object value = ((PropertyType) object).getValue();
                     
-                    output.startElement(WFS.NAMESPACE, WFS.Value.getLocalPart(), "wfs:" + WFS.Value.getLocalPart(), null);
+                    output.startElement(WFS.NAMESPACE, WFS.Value.getLocalPart(), "wfs:" + WFS.Value.getLocalPart(), new AttributesImpl());
                     if (value instanceof Geometry) {
                         Encoder encoder = new Encoder(new org.geotools.gml2.GMLConfiguration());
+                        encoder.setInline(true);
                         encoder.encode(value, org.geotools.gml2.GML._Geometry, output);
                     }
                     else {

--- a/modules/extension/xsd/xsd-wps/src/main/java/org/geotools/wps/bindings/ComplexDataTypeBinding.java
+++ b/modules/extension/xsd/xsd-wps/src/main/java/org/geotools/wps/bindings/ComplexDataTypeBinding.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/bindings/ComplexDataTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/bindings/ComplexDataTypeBindingTest.java
@@ -156,6 +156,7 @@ public class ComplexDataTypeBindingTest extends WPSTestSupport {
                 String ns = "http://www.geotools.org";
                 String local = "myElement";
                 String qualified = "gt:myElement";
+                output.startPrefixMapping("gt", ns);
                 output.startElement(ns, local, qualified, new org.xml.sax.helpers.AttributesImpl());
                 String txt = "hello world";
                 output.characters(txt.toCharArray(), 0, txt.length());

--- a/modules/library/main/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/main/src/main/java/org/geotools/xml/XMLUtils.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *    
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -15,6 +15,10 @@
  *    Lesser General Public License for more details.
  */
 package org.geotools.xml;
+
+import org.xml.sax.helpers.NamespaceSupport;
+
+import javax.xml.namespace.QName;
 
 /**
  * XML related utilities not otherwise found in base libraries
@@ -62,6 +66,26 @@ public class XMLUtils {
     }
 
     /**
+     * Creates a qualified name from a string by parsing out the colon as the 
+     * prefix / local separator. 
+     * 
+     * @param name The possibly qualified name.
+     * @param namespaces The namespace prefix uri mappings.
+     */
+    public static QName qName(String name, NamespaceSupport namespaces) {
+        int dot = name.indexOf(':');
+        if (dot > -1) {
+            String[] split = name.split(":");
+            String prefix = split[0];
+            String local = split[1];
+            
+            return new QName(namespaces.getURI(prefix), local, prefix);
+        }
+
+        return new QName(name);
+    }
+
+    /**
      * Returns true if the character provided is valid according to XML 1.0
      * 
      * @param c
@@ -71,4 +95,5 @@ public class XMLUtils {
         return (c == 0x9) || (c == 0xA) || (c == 0xD) || ((c >= 0x20) && (c <= 0xD7FF))
                 || ((c >= 0xE000) && (c <= 0xFFFD)) || ((c >= 0x10000) && (c <= 0x10FFFF));
     }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <test.maxHeapSize>256M</test.maxHeapSize>
     <javadoc.maxHeapSize>1536M</javadoc.maxHeapSize>
     <test.forkMode>once</test.forkMode>
+    <test.args></test.args>
     <src.output>${basedir}/target</src.output>
     <imageio.ext.version>1.1.13</imageio.ext.version>
     <jaiext.version>1.0.8</jaiext.version>
@@ -1370,7 +1371,7 @@
             <exclude>${stress.skip.pattern}</exclude>
             <exclude>${test.exclude.pattern}</exclude>
           </excludes>
-          <argLine>-Xmx${test.maxHeapSize} ${jvm.opts} -Dorg.geotools.test.extensive=${extensive.tests} -Dorg.geotools.test.interactive=${interactive.tests} -Dorg.geotools.image.test.skip=${skip.image.tests} -Dorg.geotools.image.test.interactive=${interactive.image} -Djava.awt.headless=${java.awt.headless} -Dsun.java2d.d3d=${sun.java2d.d3d} -Djava.io.tmpdir="${java.io.tmpdir}" -Djava.library.path="${java.library.path}"</argLine>
+          <argLine>-Xmx${test.maxHeapSize} ${jvm.opts} -Dorg.geotools.test.extensive=${extensive.tests} -Dorg.geotools.test.interactive=${interactive.tests} -Dorg.geotools.image.test.skip=${skip.image.tests} -Dorg.geotools.image.test.interactive=${interactive.image} -Djava.awt.headless=${java.awt.headless} -Dsun.java2d.d3d=${sun.java2d.d3d} -Djava.io.tmpdir="${java.io.tmpdir}" -Djava.library.path="${java.library.path}" ${test.args}</argLine>
           <!-- Ignores test failure only if we are generating a       -->
           <!-- report for publication on the web site. See the        -->
           <!-- profiles section at the begining of this pom.xml file. -->


### PR DESCRIPTION
- Ensuring attributes returns empty string rather than null for no uri
- Using “xml” rather than “XML” for output method key value (mandated
but the spec)