### PR TITLE
Allow customization to the CREATE TABLE statement

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -3025,7 +3025,7 @@ public final class JDBCDataStore extends ContentDataStore
         boolean[] nillable, String pkeyColumn, SimpleFeatureType featureType ) throws SQLException {
         //build the create table sql
         StringBuffer sql = new StringBuffer();
-        encodeCreateTable(sql);
+        dialect.encodeCreateTable(sql);
 
         encodeTableName(tableName, sql, null);
         sql.append(" ( ");

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -3025,7 +3025,7 @@ public final class JDBCDataStore extends ContentDataStore
         boolean[] nillable, String pkeyColumn, SimpleFeatureType featureType ) throws SQLException {
         //build the create table sql
         StringBuffer sql = new StringBuffer();
-        sql.append("CREATE TABLE ");
+        encodeCreateTable(sql);
 
         encodeTableName(tableName, sql, null);
         sql.append(" ( ");

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
@@ -903,6 +903,17 @@ public abstract class SQLDialect {
     }
 
     /**
+     * Encodes the CREATE TABLE statement.
+     * <p>
+     * Default implementation adds “CREATE TABLE” to the sql buffer.
+     * Subclasses may choose to override to handle db specific syntax.
+     * </p>
+     */
+    public void encodeCreateTable(StringBuffer sql) {
+        sql.append("CREATE TABLE ");
+    }
+
+    /**
      * Encodes anything post a column in a CREATE TABLE statement.
      * <p>
      * This is appended after the column name and type. Subclasses may choose to override


### PR DESCRIPTION
For developing a datastore for SAP HANA, the `CREATE TABLE` statement needs to be changed to `CREATE COLUMN TABLE`.