### PR TITLE
Ensuring that gml 3.2 namespace used when encoding gml 3.2.

### DIFF
--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GMLWriter.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GMLWriter.java
@@ -118,8 +118,14 @@ public class GMLWriter {
             boolean forceDecimal, String gmlPrefix) {
         this.handler = delegate;
         this.namespaces = namespaces;
-        this.coordinates = COORDINATES.derive(gmlPrefix);
-        this.posList = POS_LIST.derive(gmlPrefix);
+
+        String gmlUri = namespaces.getURI(gmlPrefix);
+        if (gmlUri == null) {
+            gmlUri = GML.NAMESPACE;
+        }
+
+        this.coordinates = COORDINATES.derive(gmlPrefix, gmlUri);
+        this.posList = POS_LIST.derive(gmlPrefix, gmlUri);
 
         this.coordFormatter.setMaximumFractionDigits(numDecimals);
         this.coordFormatter.setGroupingUsed(false);

--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/QualifiedName.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/QualifiedName.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -54,13 +54,15 @@ public class QualifiedName extends QName {
      * @return
      */
     public QualifiedName derive(String prefix) {
-        if (prefix.equals(this.prefix)) {
+        return derive(prefix, getNamespaceURI());
+    }
+
+    public QualifiedName derive(String prefix, String uri) {
+        if (prefix.equals(this.prefix) && uri.equals(getNamespaceURI())) {
             return this;
         } else {
-            return new QualifiedName(getNamespaceURI(), getLocalPart(), prefix);
-            
+            return new QualifiedName(uri, getLocalPart(), prefix);
         }
-        
     }
 
     /**

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/CurveEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/CurveEncoder.java
@@ -52,12 +52,12 @@ class CurveEncoder extends GeometryEncoder<LineString> {
 
     QualifiedName arcString;
 
-    protected CurveEncoder(Encoder e, String gmlPrefix) {
+    protected CurveEncoder(Encoder e, String gmlPrefix, String gmlUri) {
         super(e);
-        this.curve = CURVE.derive(gmlPrefix);
-        this.segments = SEGMENTS.derive(gmlPrefix);
-        this.lineStringSegment = LINE_STRING_SEGMENT.derive(gmlPrefix);
-        this.arcString = ARC_STRING.derive(gmlPrefix);
+        this.curve = CURVE.derive(gmlPrefix, gmlUri);
+        this.segments = SEGMENTS.derive(gmlPrefix, gmlUri);
+        this.lineStringSegment = LINE_STRING_SEGMENT.derive(gmlPrefix, gmlUri);
+        this.arcString = ARC_STRING.derive(gmlPrefix, gmlUri);
     }
 
     public void encode(LineString geometry, AttributesImpl atts, GMLWriter handler)

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/EnvelopeEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/EnvelopeEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -47,11 +47,11 @@ class EnvelopeEncoder extends ObjectEncoder<Envelope> {
 
     QualifiedName upperCorner;
 
-    protected EnvelopeEncoder(Encoder e, String gmlPrefix) {
+    protected EnvelopeEncoder(Encoder e, String gmlPrefix, String gmlNamespace) {
         super(e);
-        this.envelope = ENVELOPE.derive(gmlPrefix);
-        this.lowerCorner = LOWER_CORNER.derive(gmlPrefix);
-        this.upperCorner = UPPER_CORNER.derive(gmlPrefix);
+        this.envelope = ENVELOPE.derive(gmlPrefix, gmlNamespace);
+        this.lowerCorner = LOWER_CORNER.derive(gmlPrefix, gmlNamespace);
+        this.upperCorner = UPPER_CORNER.derive(gmlPrefix, gmlNamespace);
     }
 
     @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML32FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML32FeatureCollectionEncoderDelegate.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015-2016, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -72,15 +72,16 @@ public class GML32FeatureCollectionEncoderDelegate extends
         protected QualifiedName member;
 
         String gmlPrefix;
-
+        String gmlUri;
         GML32EncodingUtils encodingUtils;
 
         int numDecimals;
 
         public GML32Delegate(Encoder encoder) {
-            this.gmlPrefix = encoder.getNamespaces()
-                    .getPrefix(org.geotools.gml3.v3_2.GML.NAMESPACE);
-            this.member = MEMBER.derive(gmlPrefix);
+            this.gmlUri =org.geotools.gml3.v3_2.GML.NAMESPACE;
+            this.gmlPrefix = encoder.getNamespaces().getPrefix(gmlUri);
+            
+            this.member = MEMBER.derive(gmlPrefix, gmlUri);
             this.srsSyntax = (SrsSyntax) encoder.getContext().getComponentInstanceOfType(
                     SrsSyntax.class);
             this.encodingUtils = new GML32EncodingUtils();
@@ -108,7 +109,7 @@ public class GML32FeatureCollectionEncoderDelegate extends
         }
 
         public EnvelopeEncoder createEnvelopeEncoder(Encoder e) {
-            return new EnvelopeEncoder(e, gmlPrefix);
+            return new EnvelopeEncoder(e, gmlPrefix, gmlUri);
         }
 
         public void setSrsNameAttribute(AttributesImpl atts, CoordinateReferenceSystem crs) {
@@ -145,18 +146,18 @@ public class GML32FeatureCollectionEncoderDelegate extends
 
         @Override
         public void registerGeometryEncoders(Map<Class, GeometryEncoder> encoders, Encoder encoder) {
-            encoders.put(Point.class, new PointEncoder(encoder, gmlPrefix));
-            encoders.put(MultiPoint.class, new MultiPointEncoder(encoder, gmlPrefix));
-            encoders.put(LineString.class, new LineStringEncoder(encoder, gmlPrefix));
-            encoders.put(LinearRing.class, new LinearRingEncoder(encoder, gmlPrefix));
-            encoders.put(MultiLineString.class, new MultiLineStringEncoder(encoder, gmlPrefix, true));
-            encoders.put(Polygon.class, new PolygonEncoder(encoder, gmlPrefix));
-            encoders.put(MultiPolygon.class, new MultiPolygonEncoder(encoder, gmlPrefix));
-            encoders.put(CircularString.class, new CurveEncoder(encoder, gmlPrefix));
-            encoders.put(CompoundCurve.class, new CurveEncoder(encoder, gmlPrefix));
-            encoders.put(CircularRing.class, new CurveEncoder(encoder, gmlPrefix));
-            encoders.put(CompoundRing.class, new CurveEncoder(encoder, gmlPrefix));
-            encoders.put(GeometryCollection.class, new GeometryCollectionEncoder(encoder, gmlPrefix));
+            encoders.put(Point.class, new PointEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(MultiPoint.class, new MultiPointEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(LineString.class, new LineStringEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(LinearRing.class, new LinearRingEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(MultiLineString.class, new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, true));
+            encoders.put(Polygon.class, new PolygonEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(MultiPolygon.class, new MultiPolygonEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(CircularString.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(CompoundCurve.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(CircularRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(CompoundRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(GeometryCollection.class, new GeometryCollectionEncoder(encoder, gmlPrefix, gmlUri));
         }
 
         @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML3FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML3FeatureCollectionEncoderDelegate.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -16,6 +16,7 @@
  */
 package org.geotools.gml3.simple;
 
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 
@@ -47,6 +48,7 @@ import com.vividsolutions.jts.geom.MultiPoint;
 import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
+import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * {@link SimpleFeatureCollection} encoder delegate for fast GML3 encoding
@@ -77,19 +79,40 @@ public class GML3FeatureCollectionEncoderDelegate extends
 
         private String gmlPrefix;
 
+        private String gmlUri;
+
         private int numDecimals;
 
         private boolean encodeSeparateMember;
 
         public GML3Delegate(Encoder encoder) {
-            this.gmlPrefix = encoder.getNamespaces().getPrefix(GML.NAMESPACE);
-            this.featureMembers = FEATURE_MEMBERS.derive(gmlPrefix);
-            this.featureMember = FEATURE_MEMBER.derive(gmlPrefix);
+            this.gmlPrefix = findGMLPrefix(encoder);
+            
+            String gmlURI = encoder.getNamespaces().getURI(gmlPrefix);
+            this.gmlUri = gmlURI != null ? gmlURI : GML.NAMESPACE;
+
+            this.featureMembers = FEATURE_MEMBERS.derive(gmlPrefix, gmlURI);
+            this.featureMember = FEATURE_MEMBER.derive(gmlPrefix, gmlURI);
             this.srsSyntax = (SrsSyntax) encoder.getContext().getComponentInstanceOfType(
                     SrsSyntax.class);
             this.numDecimals = getNumDecimals(encoder.getConfiguration());
             this.encodeSeparateMember = encoder.getConfiguration().hasProperty(
                     GMLConfiguration.ENCODE_FEATURE_MEMBER);
+        }
+
+        String findGMLPrefix(Encoder encoder) {
+            NamespaceSupport ns = encoder.getNamespaces();
+            Enumeration<String> p = ns.getPrefixes();
+            while (p.hasMoreElements()) {
+                String prefix = p.nextElement();
+                String uri = ns.getURI(prefix);
+
+                if (uri.startsWith(GML.NAMESPACE)) {
+                    return prefix;
+                }
+            }
+
+            return "gml";
         }
 
         private int getNumDecimals(Configuration configuration) {
@@ -113,7 +136,7 @@ public class GML3FeatureCollectionEncoderDelegate extends
         }
 
         public EnvelopeEncoder createEnvelopeEncoder(Encoder e) {
-            return new EnvelopeEncoder(e, gmlPrefix);
+            return new EnvelopeEncoder(e, gmlPrefix, gmlUri);
         }
 
         public void setSrsNameAttribute(AttributesImpl atts, CoordinateReferenceSystem crs) {
@@ -158,18 +181,18 @@ public class GML3FeatureCollectionEncoderDelegate extends
 
         @Override
         public void registerGeometryEncoders(Map<Class, GeometryEncoder> encoders, Encoder encoder) {
-            encoders.put(Point.class, new PointEncoder(encoder, gmlPrefix));
-            encoders.put(MultiPoint.class, new MultiPointEncoder(encoder, gmlPrefix));
-            encoders.put(LineString.class, new LineStringEncoder(encoder, gmlPrefix));
-            encoders.put(LinearRing.class, new LinearRingEncoder(encoder, gmlPrefix));
-            encoders.put(MultiLineString.class, new MultiLineStringEncoder(encoder, gmlPrefix, false));
-            encoders.put(MultiCurve.class, new MultiLineStringEncoder(encoder, gmlPrefix, true));
-            encoders.put(Polygon.class, new PolygonEncoder(encoder, gmlPrefix));
-            encoders.put(MultiPolygon.class, new MultiPolygonEncoder(encoder, gmlPrefix));
-            encoders.put(CircularString.class, new CurveEncoder(encoder, gmlPrefix));
-            encoders.put(CompoundCurve.class, new CurveEncoder(encoder, gmlPrefix));
-            encoders.put(CircularRing.class, new CurveEncoder(encoder, gmlPrefix));
-            encoders.put(CompoundRing.class, new CurveEncoder(encoder, gmlPrefix));
+            encoders.put(Point.class, new PointEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(MultiPoint.class, new MultiPointEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(LineString.class, new LineStringEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(LinearRing.class, new LinearRingEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(MultiLineString.class, new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(MultiCurve.class, new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, true));
+            encoders.put(Polygon.class, new PolygonEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(MultiPolygon.class, new MultiPolygonEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(CircularString.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(CompoundCurve.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(CircularRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(CompoundRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
         }
 
         @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
@@ -31,6 +31,7 @@ import org.geotools.geometry.jts.CompoundCurve;
 import org.geotools.geometry.jts.CompoundRing;
 import org.geotools.gml2.simple.GMLWriter;
 import org.geotools.gml2.simple.GeometryEncoder;
+import org.geotools.gml3.GML;
 import org.geotools.xml.Encoder;
 import org.xml.sax.helpers.AttributesImpl;
 
@@ -43,10 +44,10 @@ public class GenericGeometryEncoder extends GeometryEncoder<Geometry> {
 
     Encoder encoder;
     String gmlPrefix;
+    String gmlUri;
 
     public GenericGeometryEncoder(Encoder encoder) {
-        super(encoder);
-        this.encoder = encoder;
+        this(encoder, "gml", GML.NAMESPACE);
     }
 
     /**
@@ -54,10 +55,11 @@ public class GenericGeometryEncoder extends GeometryEncoder<Geometry> {
      * @param encoder
      * @param gmlPrefix
      */
-    public GenericGeometryEncoder(Encoder encoder, String gmlPrefix) {
+    public GenericGeometryEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
         this.encoder = encoder;
         this.gmlPrefix = gmlPrefix;
+        this.gmlUri = gmlUri;
     }
 
     @Override
@@ -68,30 +70,26 @@ public class GenericGeometryEncoder extends GeometryEncoder<Geometry> {
                 LineStringEncoder.LINE_STRING);
             lineString.encode((LineString) geometry, atts, handler);
         } else if (geometry instanceof Point) {
-            PointEncoder pt = new PointEncoder(encoder, gmlPrefix == null ? "gml" : gmlPrefix);
+            PointEncoder pt = new PointEncoder(encoder, gmlPrefix, gmlUri);
             pt.encode((Point) geometry, atts, handler);
         } else if (geometry instanceof Polygon) {
-            PolygonEncoder polygon = new PolygonEncoder(encoder, gmlPrefix == null ? "gml" : gmlPrefix);
+            PolygonEncoder polygon = new PolygonEncoder(encoder, gmlPrefix, gmlUri);
             polygon.encode((Polygon) geometry, atts, handler);
         } else if (geometry instanceof MultiLineString) {
-            MultiLineStringEncoder multiLineString = new MultiLineStringEncoder(
-                                                        encoder, gmlPrefix, true);
+            MultiLineStringEncoder multiLineString = new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, true);
             multiLineString.encode((MultiLineString) geometry, atts, handler);
         } else if (geometry instanceof MultiPoint) {
-            MultiPointEncoder multiPoint = new MultiPointEncoder(encoder,
-                                            gmlPrefix);
+            MultiPointEncoder multiPoint = new MultiPointEncoder(encoder, gmlPrefix, gmlUri);
             multiPoint.encode((MultiPoint) geometry, atts, handler);
         } else if (geometry instanceof MultiPolygon) {
-            MultiPolygonEncoder multiPolygon = new MultiPolygonEncoder(encoder,
-                                                gmlPrefix);
+            MultiPolygonEncoder multiPolygon = new MultiPolygonEncoder(encoder, gmlPrefix, gmlUri);
             multiPolygon.encode((MultiPolygon) geometry, atts, handler);
         } else if (geometry instanceof LinearRing) {
-            LinearRingEncoder linearRing = new LinearRingEncoder(encoder,
-                                                gmlPrefix);
+            LinearRingEncoder linearRing = new LinearRingEncoder(encoder, gmlPrefix, gmlUri);
             linearRing.encode((LinearRing) geometry, atts, handler);
         } else if (geometry instanceof CircularString || geometry instanceof CompoundCurve
                         || geometry instanceof CircularRing || geometry instanceof CompoundRing) {
-            CurveEncoder curve = new CurveEncoder(encoder, gmlPrefix);
+            CurveEncoder curve = new CurveEncoder(encoder, gmlPrefix, gmlUri);
             curve.encode((LineString) geometry, atts, handler);
         } else {
             throw new Exception("Unsupported geometry " + geometry.toString());

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
@@ -38,8 +38,8 @@ public class GeometryCollectionEncoder extends GeometryEncoder<GeometryCollectio
     QualifiedName element;
     static Encoder encoder;
 
-    public GeometryCollectionEncoder(Encoder encoder, String gmlPrefix) {
-        this(encoder, GEOMETRY_COLLECTION.derive(gmlPrefix));
+    public GeometryCollectionEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
+        this(encoder, GEOMETRY_COLLECTION.derive(gmlPrefix, gmlUri));
     }
 
     public GeometryCollectionEncoder(Encoder encoder, QualifiedName name) {

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LineStringEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LineStringEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -37,8 +37,8 @@ class LineStringEncoder extends GeometryEncoder<LineString> {
 
     QualifiedName element;
 
-    protected LineStringEncoder(Encoder encoder, String gmlPrefix) {
-        this(encoder, LINE_STRING.derive(gmlPrefix));
+    protected LineStringEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
+        this(encoder, LINE_STRING.derive(gmlPrefix, gmlUri));
     }
 
     protected LineStringEncoder(Encoder encoder, QualifiedName element) {

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LinearRingEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LinearRingEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -30,7 +30,7 @@ class LinearRingEncoder extends LineStringEncoder {
 
     static final QualifiedName LINEAR_RING = new QualifiedName(GML.NAMESPACE, "LinearRing", "gml");
 
-    protected LinearRingEncoder(Encoder encoder, String gmlPrefix) {
-        super(encoder, LINEAR_RING.derive(gmlPrefix));
+    protected LinearRingEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
+        super(encoder, LINEAR_RING.derive(gmlPrefix, gmlUri));
     }
 }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiLineStringEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiLineStringEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -57,18 +57,18 @@ class MultiLineStringEncoder extends GeometryEncoder<Geometry> {
 
     boolean curveEncoding;
 
-    protected MultiLineStringEncoder(Encoder encoder, String gmlPrefix, boolean curveEncoding) {
+    protected MultiLineStringEncoder(Encoder encoder, String gmlPrefix, String gmlUri, boolean curveEncoding) {
         super(encoder);
-        lse = new LineStringEncoder(encoder, gmlPrefix);
-        lre = new LinearRingEncoder(encoder, gmlPrefix);
-        ce = new CurveEncoder(encoder, gmlPrefix);
+        lse = new LineStringEncoder(encoder, gmlPrefix, gmlUri);
+        lre = new LinearRingEncoder(encoder, gmlPrefix, gmlUri);
+        ce = new CurveEncoder(encoder, gmlPrefix, gmlUri);
         this.curveEncoding = curveEncoding;
         if(curveEncoding) {
-            multiContainer = MULTI_CURVE.derive(gmlPrefix);
-            member = CURVE_MEMBER.derive(gmlPrefix);
+            multiContainer = MULTI_CURVE.derive(gmlPrefix, gmlUri);
+            member = CURVE_MEMBER.derive(gmlPrefix, gmlUri);
         } else {
-            multiContainer = MULTI_LINE_STRING.derive(gmlPrefix);
-            member = LINE_STRING_MEMBER.derive(gmlPrefix);
+            multiContainer = MULTI_LINE_STRING.derive(gmlPrefix, gmlUri);
+            member = LINE_STRING_MEMBER.derive(gmlPrefix, gmlUri);
         }
     }
 

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPointEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPointEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -43,11 +43,11 @@ class MultiPointEncoder extends GeometryEncoder<MultiPoint> {
 
     QualifiedName pointMember;
 
-    protected MultiPointEncoder(Encoder encoder, String gmlPrefix) {
+    protected MultiPointEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
-        pe = new PointEncoder(encoder, gmlPrefix);
-        multiPoint = MULTI_POINT.derive(gmlPrefix);
-        pointMember = POINT_MEMBER.derive(gmlPrefix);
+        pe = new PointEncoder(encoder, gmlPrefix, gmlUri);
+        multiPoint = MULTI_POINT.derive(gmlPrefix, gmlUri);
+        pointMember = POINT_MEMBER.derive(gmlPrefix, gmlUri);
     }
 
     @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPolygonEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPolygonEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -46,11 +46,11 @@ class MultiPolygonEncoder extends GeometryEncoder<MultiPolygon> {
 
     PolygonEncoder pe;
 
-    protected MultiPolygonEncoder(Encoder encoder, String gmlPrefix) {
+    protected MultiPolygonEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
-        pe = new PolygonEncoder(encoder, gmlPrefix);
-        multiSurface = MULTI_SURFACE.derive(gmlPrefix);
-        surfaceMember = SURFACE_MEMBER.derive(gmlPrefix);
+        pe = new PolygonEncoder(encoder, gmlPrefix, gmlUri);
+        multiSurface = MULTI_SURFACE.derive(gmlPrefix, gmlUri);
+        surfaceMember = SURFACE_MEMBER.derive(gmlPrefix, gmlUri);
     }
 
     @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PointEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PointEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -40,10 +40,10 @@ class PointEncoder extends GeometryEncoder<Point> {
 
     QualifiedName pos;
 
-    protected PointEncoder(Encoder encoder, String gmlPrefix) {
+    protected PointEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
-        point = POINT.derive(gmlPrefix);
-        pos = POS.derive(gmlPrefix);
+        point = POINT.derive(gmlPrefix, gmlUri);
+        pos = POS.derive(gmlPrefix, gmlUri);
     }
 
     @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PolygonEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PolygonEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -50,13 +50,13 @@ class PolygonEncoder extends GeometryEncoder<Polygon> {
 
     RingEncoder re;
 
-    protected PolygonEncoder(Encoder encoder, String gmlPrefix) {
+    protected PolygonEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
-        polygon = POLYGON.derive(gmlPrefix);
-        exterior = EXTERIOR.derive(gmlPrefix);
-        interior = INTERIOR.derive(gmlPrefix);
-        lre = new LinearRingEncoder(encoder, gmlPrefix);
-        re = new RingEncoder(encoder, gmlPrefix);
+        polygon = POLYGON.derive(gmlPrefix, gmlUri);
+        exterior = EXTERIOR.derive(gmlPrefix, gmlUri);
+        interior = INTERIOR.derive(gmlPrefix, gmlUri);
+        lre = new LinearRingEncoder(encoder, gmlPrefix, gmlUri);
+        re = new RingEncoder(encoder, gmlPrefix, gmlUri);
     }
     
     @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/RingEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/RingEncoder.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -35,9 +35,9 @@ public class RingEncoder extends MultiLineStringEncoder {
 
     private QualifiedName ring;
 
-    protected RingEncoder(Encoder e, String gmlPrefix) {
-        super(e, gmlPrefix, true);
-        this.ring = RING.derive(gmlPrefix);
+    protected RingEncoder(Encoder e, String gmlPrefix, String gmlUri) {
+        super(e, gmlPrefix, gmlUri, true);
+        this.ring = RING.derive(gmlPrefix, gmlUri);
     }
 
     @Override

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/CurveEncoderTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/CurveEncoderTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -18,6 +18,7 @@
 package org.geotools.gml3.simple;
 
 import org.geotools.geometry.jts.WKTReader2;
+import org.geotools.gml3.GML;
 import org.w3c.dom.Document;
 
 import com.vividsolutions.jts.geom.Geometry;
@@ -25,7 +26,7 @@ import com.vividsolutions.jts.geom.Geometry;
 public class CurveEncoderTest extends GeometryEncoderTestSupport {
 
     public void testEncodeCircle() throws Exception {
-        CurveEncoder encoder = new CurveEncoder(gtEncoder, "gml");
+        CurveEncoder encoder = new CurveEncoder(gtEncoder, "gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2()
                 .read("CIRCULARSTRING(-10 0, -8 2, -6 0, -8 -2, -10 0)");
         Document doc = encode(encoder, geometry);
@@ -40,7 +41,7 @@ public class CurveEncoderTest extends GeometryEncoderTestSupport {
     }
 
     public void testEncodeCompound() throws Exception {
-        CurveEncoder encoder = new CurveEncoder(gtEncoder, "gml");
+        CurveEncoder encoder = new CurveEncoder(gtEncoder, "gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2()
                 .read("COMPOUNDCURVE(CIRCULARSTRING(0 0, 2 0, 2 1, 2 3, 4 3),(4 3, 4 5, 1 4, 0 0))");
         Document doc = encode(encoder, geometry);

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/CurvePolygonEncoderTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/CurvePolygonEncoderTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -18,6 +18,7 @@
 package org.geotools.gml3.simple;
 
 import org.geotools.geometry.jts.WKTReader2;
+import org.geotools.gml3.GML;
 import org.w3c.dom.Document;
 
 import com.vividsolutions.jts.geom.Geometry;
@@ -25,7 +26,7 @@ import com.vividsolutions.jts.geom.Geometry;
 public class CurvePolygonEncoderTest extends GeometryEncoderTestSupport {
 
     public void testCircle() throws Exception {
-        PolygonEncoder encoder = new PolygonEncoder(gtEncoder, "gml");
+        PolygonEncoder encoder = new PolygonEncoder(gtEncoder, "gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2()
                 .read("CURVEPOLYGON(CIRCULARSTRING(-10 0, -8 2, -6 0, -8 -2, -10 0))");
         Document doc = encode(encoder, geometry);
@@ -42,7 +43,7 @@ public class CurvePolygonEncoderTest extends GeometryEncoderTestSupport {
     }
 
     public void testDonut() throws Exception {
-        PolygonEncoder encoder = new PolygonEncoder(gtEncoder, "gml");
+        PolygonEncoder encoder = new PolygonEncoder(gtEncoder, "gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2()
                 .read("CURVEPOLYGON(CIRCULARSTRING(-7 -8, -5 -6, -3 -8, -5 -10, -7 -8),CIRCULARSTRING(-6 -8, -5 -7, -4 -8, -5 -9, -6 -8))");
         Document doc = encode(encoder, geometry);
@@ -65,7 +66,7 @@ public class CurvePolygonEncoderTest extends GeometryEncoderTestSupport {
     }
 
     public void testComplex() throws Exception {
-        PolygonEncoder encoder = new PolygonEncoder(gtEncoder, "gml");
+        PolygonEncoder encoder = new PolygonEncoder(gtEncoder, "gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2()
                 .read("CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 0, 2 0, 2 1, 2 3, 4 3),(4 3, 4 5, 1 4, 0 0)), "
                         + "CIRCULARSTRING(1.7 1, 1.4 0.4, 1.6 0.4, 1.6 0.5, 1.7 1) )");

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryCollectionEncoderTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryCollectionEncoderTest.java
@@ -20,6 +20,7 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.ParseException;
 
 import org.geotools.geometry.jts.WKTReader2;
+import org.geotools.gml3.GML;
 import org.w3c.dom.Document;
 /**
  * Unit test for GeometryCollectionEncoder
@@ -29,8 +30,7 @@ import org.w3c.dom.Document;
 public class GeometryCollectionEncoderTest extends GeometryEncoderTestSupport {
 
     public void testGeometryCollectionEncoder() throws ParseException, Exception {
-        GeometryCollectionEncoder gce = new GeometryCollectionEncoder(gtEncoder,
-            "gml");
+        GeometryCollectionEncoder gce = new GeometryCollectionEncoder(gtEncoder,"gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2().read(
             "GEOMETRYCOLLECTION (LINESTRING"
             + " (180 200, 160 180), POINT (19 19), POINT (20 10))");

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiCurveEncoderTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiCurveEncoderTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -18,6 +18,7 @@
 package org.geotools.gml3.simple;
 
 import org.geotools.geometry.jts.WKTReader2;
+import org.geotools.gml3.GML;
 import org.w3c.dom.Document;
 
 import com.vividsolutions.jts.geom.Geometry;
@@ -25,7 +26,7 @@ import com.vividsolutions.jts.geom.Geometry;
 public class MultiCurveEncoderTest extends GeometryEncoderTestSupport {
 
     public void testEncodeMultiCompound() throws Exception {
-        MultiLineStringEncoder encoder = new MultiLineStringEncoder(gtEncoder, "gml", true);
+        MultiLineStringEncoder encoder = new MultiLineStringEncoder(gtEncoder, "gml", GML.NAMESPACE, true);
         Geometry geometry = new WKTReader2()
                 .read("MULTICURVE((100 100, 120 120), COMPOUNDCURVE(CIRCULARSTRING(0 0, 2 0, 2 1, 2 3, 4 3),(4 3, 4 5, 1 4, 0 0)))");
         Document doc = encode(encoder, geometry);
@@ -64,7 +65,7 @@ public class MultiCurveEncoderTest extends GeometryEncoderTestSupport {
     }
 
     public void testEncodeMultiCurve() throws Exception {
-        MultiLineStringEncoder encoder = new MultiLineStringEncoder(gtEncoder, "gml", true);
+        MultiLineStringEncoder encoder = new MultiLineStringEncoder(gtEncoder, "gml", GML.NAMESPACE, true);
         Geometry geometry = new WKTReader2()
                 .read("MULTICURVE((105 105, 125 125), CIRCULARSTRING(-10 0, -8 2, -6 0, -8 -2, -10 0))");
         Document doc = encode(encoder, geometry);
@@ -92,7 +93,7 @@ public class MultiCurveEncoderTest extends GeometryEncoderTestSupport {
     }
     
     public void testEncodeMultiLineString() throws Exception {
-        MultiLineStringEncoder encoder = new MultiLineStringEncoder(gtEncoder, "gml", false);
+        MultiLineStringEncoder encoder = new MultiLineStringEncoder(gtEncoder, "gml", GML.NAMESPACE, false);
         Geometry geometry = new WKTReader2()
                 .read("MULTILINESTRING((105 105, 125 125))");
         Document doc = encode(encoder, geometry);


### PR DESCRIPTION
- Updated QualifiedName to accept a namespace uri
- Grabbing the namespace uri from the namespace context