### PR TITLE
Upgrade to commons-collections 3.2.2 to address CVE-2015-8103

### DIFF
--- a/modules/extension/app-schema/app-schema/pom.xml
+++ b/modules/extension/app-schema/app-schema/pom.xml
@@ -73,7 +73,7 @@
         2.1, since xml (SchemaIndexImpl) depends on commons-collections 3.1 -->
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>3.2.2</version>  <!-- Updated for security (CVE-2015-8103) binary compatible with 3.1 -->
         </dependency>
         <dependency>
             <!-- override transitive dependency from commons-digester 1.7 which depends on commons-collections 

--- a/modules/extension/xsd/xsd-core/pom.xml
+++ b/modules/extension/xsd/xsd-core/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.1</version>
+        <version>3.2.2</version>  <!-- Updated for security (CVE-2015-8103) binary compatible with 3.1 -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -859,7 +859,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.1</version>  <!-- Same as the dependency in commons-pool -->
+        <version>3.2.2</version>  <!-- Updated for security (CVE-2015-8103) binary compatible with 3.1 -->
       </dependency>
       <dependency>
         <groupId>commons-pool</groupId>


### PR DESCRIPTION
* Prevent Java Serialization vulnerability of having cc 3.2.1 and earlier on the classpath
* https://commons.apache.org/proper/commons-collections/security-reports.html

Signed-off-by: Andrew Hulbert <andrew.hulbert@ccri.com>