### PR TITLE
[GEOT-5079] PostGISDialect Error with PostGIS 2.0

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGeographyOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGeographyOnlineTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2006-2010, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -17,6 +17,7 @@
 package org.geotools.data.postgis;
 
 import java.awt.RenderingHints;
+import java.sql.Connection;
 
 import org.geotools.data.DataUtilities;
 import org.geotools.data.Query;
@@ -132,5 +133,15 @@ public class PostgisGeographyOnlineTest extends JDBCGeographyOnlineTest {
         assertEquals(0d, ls.getStartPoint().getY());
         assertEquals(4d, ls.getEndPoint().getX());
         assertEquals(4d, ls.getEndPoint().getY());
+    }
+
+    public void testDimensionFromFirstGeography() throws Exception {
+        Connection cx = dataStore.getDataSource().getConnection();
+        PostGISDialect dialect = ((PostGISDialect) dataStore.getSQLDialect());
+        assertEquals((Integer) 0, dialect.getDimensionFromFirstGeo("public",
+                "geopoint", "geo", cx));
+        assertEquals((Integer) 1, dialect.getDimensionFromFirstGeo("public",
+                "geoline", "geo", cx));
+        dataStore.closeSafe(cx);
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGeometryOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGeometryOnlineTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2009, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -15,6 +15,8 @@
  *    Lesser General Public License for more details.
  */
 package org.geotools.data.postgis;
+
+import java.sql.Connection;
 
 import org.geotools.jdbc.JDBCGeometryOnlineTest;
 import org.geotools.jdbc.JDBCGeometryTestSetup;
@@ -36,4 +38,17 @@ public class PostgisGeometryOnlineTest extends JDBCGeometryOnlineTest {
         // linear ring type is not a supported type in postgis
     }
 
+    public void testDimensionFromFirstGeometry() throws Exception {
+        Connection cx = dataStore.getDataSource().getConnection();
+        PostGISDialect dialect = ((PostGISDialect) dataStore.getSQLDialect());
+        assertEquals((Integer) 0, dialect.getDimensionFromFirstGeo("public",
+                "dim_point", "geom", cx));
+        assertEquals((Integer) 1, dialect.getDimensionFromFirstGeo("public",
+                "dim_line", "geom", cx));
+        assertEquals((Integer) 2, dialect.getDimensionFromFirstGeo("public",
+                "dim_polygon", "geom", cx));
+        assertEquals((Integer) 1, dialect.getDimensionFromFirstGeo("public",
+                "dim_collection", "geom", cx));
+        dataStore.closeSafe(cx);
+    }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGeometryTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGeometryTestSetup.java
@@ -31,6 +31,29 @@ public class PostgisGeometryTestSetup extends JDBCGeometryTestSetup {
     }
 
     @Override
+    protected void setUpData() throws Exception {
+        super.setUpData();
+
+        //create tables for dimension test
+        run("CREATE TABLE dim_point AS SELECT ST_GeomFromText('POINT(-120.0 40.0)',"
+                + "4326) as geom;");
+        run("CREATE TABLE dim_line AS SELECT ST_GeomFromText('LINESTRING(-120.0 40.0,"
+                + "-130.0 50.0)', 4326) as geom;");
+        run("CREATE TABLE dim_polygon AS SELECT ST_GeomFromText('POLYGON((-120.0 40.0,"
+                + "-130.0 40.0, -130.0 50.0, -130.0 40.0, -120.0 40.0))', 4326) as geom;");
+        run("CREATE TABLE dim_collection AS SELECT ST_GeomFromText('GEOMETRYCOLLECTION("
+                + "POINT(-120.0 40.0),LINESTRING(-120.0 40.0,-130.0 50.0))',4326) as geom");
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        dropSpatialTable("dim_point");
+        dropSpatialTable("dim_line");
+        dropSpatialTable("dim_polygon");
+        dropSpatialTable("dim_collection");
+    }
+
+    @Override
     protected void dropSpatialTable(String tableName) throws Exception {
         runSafe("DELETE FROM GEOMETRY_COLUMNS WHERE F_TABLE_NAME = '" + tableName + "'");
         runSafe("DROP TABLE \"" + tableName + "\"");


### PR DESCRIPTION
Fixes [GEOT-5079](https://osgeo-org.atlassian.net/browse/GEOT-5079).

When PostGIS geometry/geography dimensionaly can't be determined from the `geometry_columns` or `geography_columns` tables (due to missing records or permissions issue), `PostGISDialect` falls back to sampling the first geometry with a dimension function. The `DIMENSION` function doesn't exist in PostGIS 2.x; [`ST_DIMENSION`](http://postgis.net/docs/ST_Dimension.html) should be used instead.

Commit includes test cases for both geometry and geography types.

I can backport to 14.x and 13.x once this is merged to master.