### PR TITLE
[GEOT-4737] Use of PostGIS ST_Simplify causes small polygons to disappear completely

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreAPIOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreAPIOnlineTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2009, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -16,8 +16,18 @@
  */
 package org.geotools.data.postgis;
 
+import java.sql.Connection;
+
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.factory.Hints;
 import org.geotools.jdbc.JDBCDataStoreAPIOnlineTest;
 import org.geotools.jdbc.JDBCDataStoreAPITestSetup;
+import org.geotools.util.Version;
+
+import com.vividsolutions.jts.geom.Geometry;
 
 /**
  * 
@@ -35,4 +45,58 @@ public class PostgisDataStoreAPIOnlineTest extends JDBCDataStoreAPIOnlineTest {
     public void testGetFeatureWriterConcurrency() throws Exception {
         // postgis will lock indefinitely, won't throw an exception
     }
+
+    /**
+     * Test PostGIS specific collapsed simplified geometries (GEOT-4737)
+     * @throws Exception
+     */
+    public void testSimplificationPreserveCollapsed() throws Exception {
+        Connection cx = dataStore.getDataSource().getConnection();
+        PostGISDialect dialect = ((PostGISDialect) dataStore.getSQLDialect());
+        Version version = dialect.getVersion(cx);
+        dataStore.closeSafe(cx);
+
+        // Would use Assume.assumeTrue here, but this class extends TestCase
+        // and thus is run as a JUnit 3 test, which reports false assumptions
+        // as failures
+        if(version.compareTo(PostGISDialect.V_2_2_0) < 0) {
+            return;
+        }
+
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("simplify_polygon"));
+
+        if (fs.getSupportedHints().contains(Hints.GEOMETRY_SIMPLIFICATION)==false)
+            return;
+
+        SimpleFeatureCollection fColl = fs.getFeatures();
+                SimpleFeatureIterator iterator = fColl.features();
+                Geometry original = null;
+                try {
+                    if (iterator.hasNext()) {
+                        original = (Geometry) iterator.next().getDefaultGeometry();
+                    }
+                } finally {
+                    iterator.close();
+                }
+        double width = original.getEnvelope().getEnvelopeInternal().getWidth();
+
+        Query query = new Query();
+        Hints hints = new Hints(Hints.GEOMETRY_SIMPLIFICATION,width*2);
+        query.setHints(hints);
+
+        Geometry simplified = null;
+        fColl = fs.getFeatures(query);
+            iterator = fColl.features();
+            try {
+                if (iterator.hasNext())
+                    simplified = (Geometry) iterator.next().getDefaultGeometry();
+            } finally {
+                iterator.close();
+            }
+
+        // PostGIS 2.2+ should use ST_Simplify's preserveCollapsed flag
+        assertNotNull("Simplified geometry is null", simplified);
+        assertTrue(original.getNumPoints()>=simplified.getNumPoints());
+    }
+
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreAPITestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreAPITestSetup.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2009, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -28,6 +28,19 @@ public class PostgisDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
 
     public PostgisDataStoreAPITestSetup(JDBCTestSetup delegate) {
         super(delegate);
+    }
+
+    @Override
+    protected void setUpData() throws Exception {
+        super.setUpData();
+        dropSimplifyPolygonTable();
+        createSimplifyPolygonTable();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        dropSimplifyPolygonTable();
     }
 
     @Override
@@ -121,4 +134,14 @@ public class PostgisDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
         runSafe("DROP TABLE \"road\"");
     }
 
+    protected void createSimplifyPolygonTable() throws Exception {
+        run("CREATE TABLE \"simplify_polygon\" AS SELECT ST_GeomFromText('POLYGON(("
+                + "-165.96 64.51,-165.96 64.5,-165.97 64.5,-165.97 64.51,-165.96 64.51))'"
+                + ",4326) as \"geom\"");
+    }
+
+    protected void dropSimplifyPolygonTable() {
+        runSafe("DELETE FROM GEOMETRY_COLUMNS WHERE F_TABLE_NAME = 'simplify_polygon'");
+        runSafe("DROP TABLE \"simplify_polygon\"");
+    }
 }


### PR DESCRIPTION
Fixes [GEOT-4737](https://osgeo-org.atlassian.net/browse/GEOT-4737).

Now that PostGIS has implemented a `preserveCollapsed` flag for `ST_Simplify` in PostGIS 2.2, GeoTools can set that flag to true when using PostGIS 2.2+.

Includes test case.

https://trac.osgeo.org/postgis/ticket/2093
http://postgis.net/docs/manual-2.2/ST_Simplify.html

Will backport to 14.x and 13.x when merged to master.