### PR TITLE
[GEOT-5349] Use encodeSchemaName(...) while looking up GT_PK_METADATA

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/MetadataTablePrimaryKeyFinder.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/MetadataTablePrimaryKeyFinder.java
@@ -128,7 +128,7 @@ public class MetadataTablePrimaryKeyFinder extends PrimaryKeyFinder {
                             StringBuffer sb = new StringBuffer();
                             sb.append("SELECT * FROM ");
                             if (metadataSchema != null) {
-                                sb.append(metadataSchema);
+                                store.getSQLDialect().encodeSchemaName(metadataSchema, sb);
                                 sb.append(".");
                             }
                             sb.append(tableName).append(" WHERE 1 = 0");
@@ -157,7 +157,7 @@ public class MetadataTablePrimaryKeyFinder extends PrimaryKeyFinder {
             StringBuffer sb = new StringBuffer();
             sb.append("SELECT * FROM ");
             if (metadataSchema != null) {
-                sb.append(metadataSchema);
+                store.getSQLDialect().encodeSchemaName(metadataSchema, sb);
                 sb.append(".");
             }
             sb.append(tableName);


### PR DESCRIPTION
This provides a fix for [GEOT-5349](https://osgeo-org.atlassian.net/browse/GEOT-5349) by encoding the schema name.