### PR TITLE
[GEOT-5391]: Update GT to JAI-EXT 1.0.9 to avoid OOM with big oversampling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <test.args></test.args>
     <src.output>${basedir}/target</src.output>
     <imageio.ext.version>1.1.13</imageio.ext.version>
-    <jaiext.version>1.0.8</jaiext.version>
+    <jaiext.version>1.0.9</jaiext.version>
     <netcdf.version>4.6.2</netcdf.version>
     <jt.version>1.4.0</jt.version>
     <jvm.opts></jvm.opts>


### PR DESCRIPTION
JAI-EXT's RasterClassifier op (used in ColorMap management) has a bug which may result in OOM when dealing with very big images.
geosolutions-it/jai-ext#125

This pull request updates the GT pom.xml to switch to the fixed version