### PR TITLE
Removed accessor method that nobody uses in GeometryAttributeImpl

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/GeometryAttributeImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/GeometryAttributeImpl.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -75,17 +75,13 @@ public class GeometryAttributeImpl extends AttributeImpl implements
 	    return (GeometryDescriptor) super.getDescriptor();
 	}
 	
-	public Geometry getValue() {
-		return (Geometry) super.getValue();
+	public Object getValue() {
+	    return (Geometry) super.getValue();
 	}
 
 	public void setValue(Object newValue) throws IllegalArgumentException,
 	        IllegalStateException {
-	    setValue( (Geometry) newValue );
-	}
-	
-	public void setValue(Geometry geometry) {
-		super.setValue(geometry);
+	    super.setValue( (Geometry) newValue );
 	}
 
 	/**

--- a/modules/library/main/src/main/java/org/geotools/feature/GeometryAttributeImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/GeometryAttributeImpl.java
@@ -75,13 +75,23 @@ public class GeometryAttributeImpl extends AttributeImpl implements
 	    return (GeometryDescriptor) super.getDescriptor();
 	}
 	
-	public Object getValue() {
+	/** 
+	 * @deprecated
+	 */
+	public Geometry getValue() {
 	    return (Geometry) super.getValue();
 	}
 
 	public void setValue(Object newValue) throws IllegalArgumentException,
 	        IllegalStateException {
 	    super.setValue( (Geometry) newValue );
+	}
+	
+	/** 
+         * @deprecated
+         */
+	public void setValue(Geometry geometry) {
+	    super.setValue(geometry);
 	}
 
 	/**


### PR DESCRIPTION
I removed unused, unnecessary getter/setter methods.
the interface returns Object not Geometry and nobody uses this "impl" class directly.