### PR TITLE
[GEOT-5394] XPath fails to retrieve gml:id if mapped as ClientProperty

### DIFF
--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/ClientPropertyIdentifierTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/ClientPropertyIdentifierTest.java
@@ -1,0 +1,107 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.data.complex;
+
+import static org.geotools.data.complex.SweValuesTest.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.geotools.data.DataAccess;
+import org.geotools.data.DataAccessFinder;
+import org.geotools.data.FeatureSource;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.filter.FilterFactoryImplNamespaceAware;
+import org.junit.Before;
+import org.junit.Test;
+import org.opengis.feature.Feature;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.PropertyName;
+import org.xml.sax.helpers.NamespaceSupport;
+
+/**
+ * Checks that gml:id attribute can be retrieved also when it is mapped as a regular <code>&lt;ClientProperty&gt;</code> rather than an identifier
+ * (using <code>&lt;idExpression&gt;</code>).
+ * 
+ * @author Stefano Costa, GeoSolutions
+ *
+ */
+public class ClientPropertyIdentifierTest {
+
+    private FilterFactory2 ff;
+
+    private NamespaceSupport namespaces = new NamespaceSupport();
+
+    private FeatureSource obsSource;
+
+    public ClientPropertyIdentifierTest() {
+        namespaces.declarePrefix("om", OM_NS);
+        namespaces.declarePrefix("swe", SWE_NS);
+        namespaces.declarePrefix("gml", GML_NS);
+        namespaces.declarePrefix("xlink", XLINK_NS);
+        ff = new FilterFactoryImplNamespaceAware(namespaces);
+    }
+
+    /**
+     * Load all the data accesses.
+     *
+     * @return
+     * @throws Exception
+     */
+    @Before
+    public void loadDataAccess() throws Exception {
+        /**
+         * Load observation data access
+         */
+        Map dsParams = new HashMap();
+        URL url = SweValuesTest.class.getResource(SWE_VALUES_MAPPING);
+        assertNotNull(url);
+
+        dsParams.put("dbtype", "app-schema");
+        dsParams.put("url", url.toExternalForm());
+        DataAccess<FeatureType, Feature> omsoDataAccess = DataAccessFinder.getDataStore(dsParams);
+        assertNotNull(omsoDataAccess);
+
+        FeatureType observationFeatureType = omsoDataAccess.getSchema(OBSERVATION_FEATURE);
+        assertNotNull(observationFeatureType);
+
+        obsSource = (FeatureSource) omsoDataAccess.getFeatureSource(OBSERVATION_FEATURE);
+        assertNotNull(obsSource);
+        FeatureCollection obsFeatures = (FeatureCollection) obsSource.getFeatures();
+        assertEquals(2, size(obsFeatures));
+    }
+
+    @Test
+    public void testRetrieveTimeInstantGmlId() throws IOException {
+        FilterFactory2 ff = new FilterFactoryImplNamespaceAware(namespaces);
+        PropertyName gmlIdProperty = ff.property("om:resultTime/gml:TimeInstant/@gml:id");
+        try (FeatureIterator featureIt = obsSource.getFeatures().features()) {
+            Feature f = featureIt.next();
+            String gmlId = (String) gmlIdProperty.evaluate(f);
+            assertTrue(gmlId != null && !gmlId.trim().isEmpty());
+        }
+    }
+
+}

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/SweValuesTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/SweValuesTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2015 - 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -59,13 +59,13 @@ public class SweValuesTest {
 
     public static final String XLINK_NS = "http://www.w3.org/1999/xlink";
 
-    static final Name OBSERVATION_TYPE = Types.typeName(OM_NS, "OM_ObservationType");
+    public static final Name OBSERVATION_TYPE = Types.typeName(OM_NS, "OM_ObservationType");
 
-    static final Name OBSERVATION_FEATURE = Types.typeName(OM_NS, "OM_Observation");
+    public static final Name OBSERVATION_FEATURE = Types.typeName(OM_NS, "OM_Observation");
 
-    static FilterFactory2 ff;
+    public static final String SWE_VALUES_MAPPING = "/test-data/sweValuesAsList.xml";
 
-    private static final String schemaBase = "/test-data/";
+    private static FilterFactory2 ff;
 
     private static FeatureSource<FeatureType, Feature> obsSource;
 
@@ -100,8 +100,7 @@ public class SweValuesTest {
          * Load observation data access
          */
         Map dsParams = new HashMap();
-        URL url = SweValuesTest.class.getResource(schemaBase
-                + "sweValuesAsList.xml");
+        URL url = SweValuesTest.class.getResource(SWE_VALUES_MAPPING);
         assertNotNull(url);
 
         dsParams.put("dbtype", "app-schema");
@@ -117,7 +116,7 @@ public class SweValuesTest {
         assertEquals(2, size(obsFeatures));
     }
 
-    private static int size(FeatureCollection<FeatureType, Feature> features) {
+    static int size(FeatureCollection<FeatureType, Feature> features) {
         int size = 0;
         FeatureIterator<Feature> iterator = features.features();
         while (iterator.hasNext()) {

--- a/modules/extension/complex/src/main/java/org/geotools/feature/xpath/XmlAttributeNodePointer.java
+++ b/modules/extension/complex/src/main/java/org/geotools/feature/xpath/XmlAttributeNodePointer.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2011, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2011 - 2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -18,12 +18,14 @@
 package org.geotools.feature.xpath;
 
 import java.util.Map;
+
 import org.apache.commons.jxpath.ri.QName;
 import org.apache.commons.jxpath.ri.model.NodePointer;
 import org.opengis.feature.Attribute;
 import org.opengis.feature.ComplexAttribute;
 import org.opengis.feature.Property;
 import org.opengis.feature.type.Name;
+import org.opengis.filter.identity.Identifier;
 import org.xml.sax.Attributes;
 
 /**
@@ -94,15 +96,16 @@ public class XmlAttributeNodePointer extends NodePointer {
         
         //FIXME - better id checking
         if (name.getLocalPart().equals("id")) {
-            return feature.getIdentifier().getID();
-        }
-        else {
-            Map<Name, Object> map = (Map<Name, Object>) feature.getUserData().get(Attributes.class);
-            if (map != null) {
-                return map.get(name);
-            } else {
-                return null;
+            Identifier id = feature.getIdentifier();
+            if (id != null) {
+                return id.getID();
             }
+        }
+        Map<Name, Object> map = (Map<Name, Object>) feature.getUserData().get(Attributes.class);
+        if (map != null) {
+            return map.get(name);
+        } else {
+            return null;
         }
     }
 


### PR DESCRIPTION
Current code in `XmlAttributeNodePointer` assumes an XML attribute called `id` must be the feature identifier and tries to retrieve it calling `feature.getIdentifier()`; however, if the attribute is not mapped using `<idExpression>` but as a regular `<ClientProperty>`, it will not be used as the feature identifier, in which case `feature.getIdentifier()` will return null (the original code throws a NPE).

This PR solves the issue in the simplest way, falling back to normal attribute extraction when `feature.getIdentifier()` returns nothing.

See: https://osgeo-org.atlassian.net/browse/GEOT-5394
