### PR TITLE
[GEOT-5390] Backport ColorModelFactory fix to 14.x.

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/ColorModelFactory.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/ColorModelFactory.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2001-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2001-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -223,7 +223,7 @@ final class ColorModelFactory {
     @Override
     public int hashCode() {
         final int categoryCount = categories.length;
-        int code = 962745549 + (numBands*37 + visibleBand)*37 + categoryCount;
+        int code = 962745549 + ((numBands*37 + visibleBand)*37 + type)*37 + categoryCount;
         for (int i=0; i<categoryCount; i++) {
             code += categories[i].hashCode();
             // Better be independant of categories order.
@@ -243,6 +243,7 @@ final class ColorModelFactory {
             final ColorModelFactory that = (ColorModelFactory) other;
             return this.numBands    == that.numBands    &&
                    this.visibleBand == that.visibleBand &&
+                   this.type        == that.type        &&
                    Arrays.equals(this.categories, that.categories);
         }
         return false;

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/ColorModelFactoryTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/ColorModelFactoryTest.java
@@ -1,0 +1,43 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.coverage;
+
+import java.awt.image.ColorModel;
+import java.awt.image.DataBuffer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link ColorModelFactory} implementation.
+ */
+public class ColorModelFactoryTest {
+
+    @Test
+    public void testGetColorModelType() {
+        Category[] categories = new Category[0];
+        ColorModel cm1 = ColorModelFactory.getColorModel(categories, DataBuffer.TYPE_BYTE, 0, 1);
+        assertEquals(DataBuffer.TYPE_BYTE, cm1.getTransferType());
+        ColorModel cm2 = ColorModelFactory.getColorModel(categories, DataBuffer.TYPE_USHORT, 0, 1);
+        assertEquals(DataBuffer.TYPE_USHORT, cm2.getTransferType());
+        ColorModel cm3 = ColorModelFactory.getColorModel(categories, DataBuffer.TYPE_FLOAT, 0, 1);
+        assertEquals(DataBuffer.TYPE_FLOAT, cm3.getTransferType());
+        ColorModel cm4 = ColorModelFactory.getColorModel(categories, DataBuffer.TYPE_DOUBLE, 0, 1);
+        assertEquals(DataBuffer.TYPE_DOUBLE, cm4.getTransferType());
+    }
+}


### PR DESCRIPTION
Fixed ColorModelFactory returning cached ColorModel objects with the wrong data type.