### PR TITLE
Include YSLD in the default build

### DIFF
--- a/modules/unsupported/pom.xml
+++ b/modules/unsupported/pom.xml
@@ -176,9 +176,12 @@
        </modules>
      </profile>
      <profile>
-       <id>yld</id>
+       <id>ysld</id>
+       <activation>
+          <property><name>all</name></property>
+        </activation>
        <modules>
-         <module>yld</module>
+         <module>ysld</module>
        </modules>
      </profile>
      <profile>
@@ -222,6 +225,7 @@
     <module>geopkg</module>
     <module>mbtiles</module>
     <module>wfs-ng</module>
+    <module>ysld</module>
   </modules>
 
 </project>


### PR DESCRIPTION
I would like to include YSLD in the default build so it gets published to the Maven repository so projects using GeoTools (like GeoScript) can use YSLD.

https://osgeo-org.atlassian.net/browse/GEOT-5402

Thanks!
Jared