### PR TITLE
Store MemoryDataStore features in each MemoryEntry

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/data/FeatureSource.java
+++ b/modules/library/api/src/main/java/org/geotools/data/FeatureSource.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2008-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -250,6 +250,5 @@ public interface FeatureSource<T extends FeatureType, F extends Feature>{
      * @return a set of {@code RenderingHints#Key} objects; may be empty but never {@code null}
      */
     public Set<RenderingHints.Key> getSupportedHints();
-    
-    // FeatureReader getFeatureReader( Query query ); // ask justin for proposal
+
 }

--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryEntry.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryEntry.java
@@ -1,0 +1,73 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.memory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.geotools.data.store.ContentEntry;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+/**
+ * Entry used to store features (of a single FeatureType).
+ * <p>
+ * <p>
+ * Please be sure to synchronize on entry before access:
+ * <pre><code> synchronize ( entry ){
+ *     entry.memory.put( feature.getID(), feature );
+ * }</code></pre>
+ * 
+ * @author Jody Garnett (Boundless)
+ */
+public class MemoryEntry extends ContentEntry {
+    
+    /**
+     * Schema of managed content.
+     */
+    final SimpleFeatureType schema;
+
+    /**
+     * Memory storage for features (addressed by fid).
+     * <p>
+     * Please be sure to synchronize on entry before access:
+     * <pre><code> synchronize ( entry ){
+     *     entry.memory.put( feature.getID(), feature );
+     * }</code></pre>
+     */
+    Map<String, SimpleFeature> memory;
+
+    /**
+     * Entry to store content of the provided SimpleFeatureType.
+     * 
+     * @param store
+     * @param schema
+     */
+    MemoryEntry( MemoryDataStore store, SimpleFeatureType schema){
+        super( store, schema.getName() );
+        this.schema = schema;
+        memory = new LinkedHashMap<String, SimpleFeature>();
+    }
+
+    protected MemoryState createContentState(ContentEntry entry) {
+        return new MemoryState( (MemoryEntry) entry );
+    }
+    
+    public String toString() {
+        return "MemoryEntry '" + getTypeName()+"': "+memory.size() + " features";
+    }
+}

--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureReader.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureReader.java
@@ -18,10 +18,8 @@ package org.geotools.data.memory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.geotools.data.DataSourceException;
@@ -43,15 +41,11 @@ public class MemoryFeatureReader implements FeatureReader<SimpleFeatureType, Sim
 
     public MemoryFeatureReader(ContentState state, Query query) throws IOException {
         featureType = state.getFeatureType();
-
-        final MemoryDataStore store = (MemoryDataStore) state.getEntry().getDataStore();
-        final Map<String, SimpleFeature> features = store.features(featureType.getTypeName());
-        synchronized (features) {
-            final Collection<SimpleFeature> featureCollection = features.values();
-            final List<SimpleFeature> internalCollection = new ArrayList<SimpleFeature>();
-            if (features != null) {
-                internalCollection.addAll(featureCollection);
-            }
+        MemoryEntry entry = (MemoryEntry) state.getEntry();
+        
+        synchronized (entry) {
+            final List<SimpleFeature> internalCollection = new ArrayList<SimpleFeature>(
+                    entry.memory.values());
             iterator = internalCollection.iterator();
         }
     }

--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureStore.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2015-2016, Open Source Geospatial Foundation (OSGeo)
  *    
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -33,9 +33,12 @@ public class MemoryFeatureStore extends ContentFeatureStore {
     
     public MemoryFeatureStore(ContentEntry entry, Query query) {
         super(entry, query);
-        // TODO Auto-generated constructor stub
     }
     
+    @Override
+    public MemoryState getState() {
+        return (MemoryState) super.getState();
+    }
     @Override
     protected FeatureWriter<SimpleFeatureType, SimpleFeature> getWriterInternal(
             Query query, int flags) throws IOException {

--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureWriter.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureWriter.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2015-2016, Open Source Geospatial Foundation (OSGeo)
  *    
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -18,45 +18,46 @@ package org.geotools.data.memory;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.geotools.data.DataSourceException;
 import org.geotools.data.FeatureWriter;
 import org.geotools.data.Query;
-import org.geotools.data.store.ContentState;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.IllegalAttributeException;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.Name;
 
 /**
  * Update contents of MemoryDataStore. 
  */
 public class MemoryFeatureWriter implements FeatureWriter<SimpleFeatureType, SimpleFeature>{
-    ContentState state;
+    MemoryState state;
     SimpleFeatureType featureType;
-    Map<String,SimpleFeature> contents;
+    Name typeName;
+
     Iterator<SimpleFeature> iterator;
-    
+
     SimpleFeature live = null;
-    
     SimpleFeature current = null; // current Feature returned to user        
     
-    public MemoryFeatureWriter(ContentState state, Query query) throws IOException {
+    public MemoryFeatureWriter(MemoryState state, Query query) throws IOException {
         this.state = state;
-        featureType = state.getFeatureType();
-        String typeName = featureType.getTypeName();
-        MemoryDataStore store = (MemoryDataStore) state.getEntry().getDataStore();
-        contents = store.features(typeName);
-        iterator = contents.values().iterator();
+        this.typeName = state.getEntry().getName();
+        this.featureType = state.getFeatureType();
+        
+        MemoryEntry entry = state.getEntry();
+        synchronized (entry) {
+            iterator = entry.memory.values().iterator();
+        }
     }
     
     public SimpleFeatureType getFeatureType() {
-        return featureType;
+        return state.getFeatureType();
     }
-    
+
     public SimpleFeature next() throws IOException, NoSuchElementException {
         if (hasNext()) {
             // existing content
@@ -66,7 +67,7 @@ public class MemoryFeatureWriter implements FeatureWriter<SimpleFeatureType, Sim
                 current = SimpleFeatureBuilder.copy(live);
             } catch (IllegalAttributeException e) {
                 throw new DataSourceException("Unable to edit " + live.getID() + " of "
-                    + featureType.getTypeName());
+                    + typeName);
             }
         } else {
             // new content
@@ -76,7 +77,7 @@ public class MemoryFeatureWriter implements FeatureWriter<SimpleFeatureType, Sim
                 current = SimpleFeatureBuilder.template(featureType, null);
             } catch (IllegalAttributeException e) {
                 throw new DataSourceException("Unable to add additional Features of "
-                    + featureType.getTypeName());
+                    + typeName);
             }
         }
         
@@ -85,7 +86,7 @@ public class MemoryFeatureWriter implements FeatureWriter<SimpleFeatureType, Sim
 
     
     public void remove() throws IOException {
-        if (contents == null) {
+        if (iterator == null) {
             throw new IOException("FeatureWriter has been closed");
         }
 
@@ -105,7 +106,7 @@ public class MemoryFeatureWriter implements FeatureWriter<SimpleFeatureType, Sim
     }
     
     public void write() throws IOException {
-        if (contents == null) {
+        if (iterator == null) {
             throw new IOException("FeatureWriter has been closed");
         }
     
@@ -126,7 +127,7 @@ public class MemoryFeatureWriter implements FeatureWriter<SimpleFeatureType, Sim
                     live.setAttributes(current.getAttributes());
                 } catch (Exception e) {
                     throw new DataSourceException("Unable to accept modifications to "
-                        + live.getID() + " on " + featureType.getTypeName());
+                        + live.getID() + " on " + typeName);
                 }
     
                 ReferencedEnvelope bounds = new ReferencedEnvelope();
@@ -137,16 +138,18 @@ public class MemoryFeatureWriter implements FeatureWriter<SimpleFeatureType, Sim
             }
         } else {
             // add new content
-            contents.put(current.getID(), current);
+            MemoryEntry entry = state.getEntry();
+            synchronized (entry) {
+                entry.memory.put(current.getID(), current);    
+            }
             current = null;
         }
     }
     
     public boolean hasNext() throws IOException {
-        if (contents == null) {
+        if (iterator == null) {
             throw new IOException("FeatureWriter has been closed");
         }
-        
         return (iterator != null) && iterator.hasNext();
     }
     
@@ -158,8 +161,6 @@ public class MemoryFeatureWriter implements FeatureWriter<SimpleFeatureType, Sim
         if (featureType != null) {
             featureType = null;
         }
-        
-        contents = null;
         current = null;
         live = null;
     }

--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryState.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryState.java
@@ -1,0 +1,50 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.memory;
+
+import org.geotools.data.store.ContentState;
+
+/**
+ * State for MemoryDataStore providing FeatureType and stored features.
+ * @author Jody Garnett (Boundless)
+ */
+public class MemoryState extends ContentState {
+    /**
+     * State for MemoryDataStore providing FeatureType and stored features.
+     *  
+     * @param entry
+     */
+    public MemoryState(MemoryEntry entry) {
+        super(entry);
+    }
+    
+    /**
+     * Creates the state from an existing one.
+     */
+    public MemoryState(MemoryState state) {
+        this(state.getEntry());
+    }
+    
+    @Override
+    public MemoryEntry getEntry() {
+        return (MemoryEntry) super.getEntry();
+    }
+
+    public MemoryState copy() {
+        return new MemoryState(this);
+    }
+}

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentDataStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentDataStore.java
@@ -533,10 +533,9 @@ public abstract class ContentDataStore implements DataStore {
      * @param entry The entry.
      * 
      * @return A new instance of {@link ContentState} for the entry.	
-     *
      */
     protected ContentState createContentState(ContentEntry entry) {
-    	return new ContentState( entry );
+        return new ContentState( entry );
     }
     
     /**

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentEntry.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentEntry.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2006-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -28,14 +28,14 @@ import org.opengis.feature.type.Name;
 
 
 /**
- * An entry for a type or feature source provided by a datastore.
+ * An entry for a type or feature source provided by a DataStore.
  * <p>
- * This class is only of concern to subclasses, client code should never see
- * this class.
+ * This class is only of concern to subclasses, client code should never see this class.
  * </p>
  * <p>
- * An entry maintains state on a per-transaction basis. The {@link #getState(Transaction)}
- * method is used to get at this state.
+ * Each entry maintains state on a per-transaction basis. The {@link #getState(Transaction)} method is
+ * used to get at this state.
+ * 
  * <pre>
  *   <code>
  *   ContentEntry entry = ...;
@@ -54,11 +54,9 @@ import org.opengis.feature.type.Name;
  * @author Jody Garnett, Refractions Research Inc.
  * @author Justin Deoliveira, The Open Planning Project
  *
- *
- *
  * @source $URL$
  */
-public final class ContentEntry {
+public class ContentEntry {
     /**
      * Qualified name of the entry.
      */
@@ -70,14 +68,14 @@ public final class ContentEntry {
     Map<Transaction,ContentState> state;
 
     /**
-     * backpointer to datastore
+     * Backpointer to DataStore.
      */
     ContentDataStore dataStore;
 
     /**
      * Creates the entry.
      * 
-     * @param dataStore The datastore of the entry.
+     * @param dataStore The DataStore of the entry.
      * @param typeName The name of the entry.
      */
     public ContentEntry(ContentDataStore dataStore, Name typeName) {
@@ -168,7 +166,7 @@ public final class ContentEntry {
      * Disposes the entry by disposing all maintained state.
      */
     public void dispose() {
-        //kill all state
+        // clear all states
         for (ContentState s : state.values() ) {
             s.close();
         }
@@ -185,6 +183,6 @@ public final class ContentEntry {
     }
     
     public String toString() {
-        return getTypeName();
+        return "ContentEntry "+ getTypeName();
     }
 }

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -16,6 +16,7 @@
  */
 package org.geotools.data.store;
 
+import java.awt.RenderingHints;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URI;
@@ -53,6 +54,7 @@ import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.sort.SortedFeatureReader;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.factory.Hints;
+import org.geotools.factory.Hints.Key;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -112,26 +114,37 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 public abstract class ContentFeatureSource implements SimpleFeatureSource {
     /**
      * The entry for the feature source.
+     * <p>
+     * This entry is managed by the DataStore and is shared between all live ContentFeatureSource and
+     * ContentFeatureStore instances.
      */
     protected ContentEntry entry;
+
     /**
-     * The transaction to work from
+     * The transaction to work from, use {link {@link ContentEntry#getState(Transaction)} to access
+     * shared state in common to ContentFeatureSource and ContentFeatureStore working on this
+     * Transaction. The use of {@link Transaction#AUTO_COMMIT} is used access the origional/live
+     * content.
      */
     protected Transaction transaction;
+    
     /**
-     * current feature lock
+     * Current feature lock
      */
-    protected FeatureLock lock = FeatureLock.TRANSACTION;    
+    protected FeatureLock lock = FeatureLock.TRANSACTION;
+
     /**
-     * hints
+     * Hints
      */
-    protected Set<Hints.Key> hints;
+    protected Set<Key> hints;
+
     /**
      * The query defining the feature source
      */
     protected Query query;
+
     /**
-     * cached feature type (only set if this instance is a view)
+     * Cached feature type (only set if this instance is a view)
      */
     protected SimpleFeatureType schema;
     
@@ -170,7 +183,7 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
      * The entry for the feature source.
      */
     public ContentEntry getEntry() {
-    	return entry;
+        return entry;
     }
     
     /**
@@ -1093,8 +1106,9 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
      * 
      * @see FeatureSource#getSupportedHints()
      */
-    public final Set getSupportedHints() {
-        return hints;
+    @SuppressWarnings("unchecked")
+    public final Set<RenderingHints.Key> getSupportedHints() {
+        return (Set<RenderingHints.Key>) (Set<?>) hints;
     }
     //
     // Internal API
@@ -1111,7 +1125,7 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
      * </p>
      * @param hints The set of hints supported by the feature source.
      */
-    protected void addHints( Set<Hints.Key> hints ) {
+    protected void addHints( Set<Key> hints ) {
         
     }
  
@@ -1145,7 +1159,7 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
      * <p>
      * Implementations should use {@link SimpleFeatureTypeBuilder} to build the 
      * feature type. Also, the builder should be injected with the feature factory
-     * which has been set on the datastore (see {@link ContentDataStore#getFeatureFactory()}.
+     * which has been set on the DataStore (see {@link ContentDataStore#getFeatureFactory()}.
      * Example:
      * <pre>
      *   SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentState.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentState.java
@@ -38,7 +38,7 @@ import org.opengis.filter.FilterFactory;
 import org.opengis.filter.identity.FeatureId;
 
 /**
- * The state of an entry in a datastore, maintained on a per-transaction basis. For information
+ * The state of an entry in a DataStore, maintained on a per-transaction basis. For information
  * maintained on a typeName basis see {@link ContentEntry}.
  *
  * <h3>Data Cache Synchronization Required</h2>
@@ -455,7 +455,7 @@ public class ContentState {
     /**
      * Copies the state.
      * <p>
-     * Subclasses shold override this method. Any mutable state objects should be cloned.
+     * Subclasses should override this method. Any mutable state objects should be cloned.
      * </p>
      * 
      * @return A copy of the state.

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureStore.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.geotools.data.DefaultQuery;
 import org.geotools.data.FeatureEvent;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureWriter;
@@ -62,7 +61,7 @@ import com.vividsolutions.jts.geom.Geometry;
  */
 public final class JDBCFeatureStore extends ContentFeatureStore {
     
-    private static final Query QUERY_NONE = new DefaultQuery(null, Filter.EXCLUDE); 
+    private static final Query QUERY_NONE = new Query(null, Filter.EXCLUDE); 
     
     /**
      * jdbc feature source to delegate to, we do this b/c we can't inherit from
@@ -75,6 +74,7 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
      * @param entry The datastore entry.
      * @param query The defining query.
      */
+    @SuppressWarnings("unchecked")
     public JDBCFeatureStore(ContentEntry entry,Query query) throws IOException {
         super(entry,query);
         
@@ -88,10 +88,11 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
             }
         };
         
-    	Set<Hints.Key> jdbcHints = new HashSet<Hints.Key>();      		
-    	jdbcHints.addAll(delegate.getSupportedHints());
-    	getDataStore().getSQLDialect().addSupportedHints(jdbcHints);
-    	hints=Collections.unmodifiableSet(jdbcHints);    	
+        Set<Hints.Key> jdbcHints = new HashSet<Hints.Key>();
+
+        jdbcHints.addAll((Set<Hints.Key>) (Set<?>) delegate.getSupportedHints());
+        getDataStore().getSQLDialect().addSupportedHints(jdbcHints);
+        hints=Collections.unmodifiableSet(jdbcHints);    	
     }
     
     /** We handle events internally */
@@ -265,7 +266,7 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
         try {
             //check for insert only
             if ( (flags | WRITER_ADD) == WRITER_ADD ) {
-                DefaultQuery queryNone = new DefaultQuery(query);
+                Query queryNone = new Query(query);
                 queryNone.setFilter(Filter.EXCLUDE);
                 if ( getDataStore().getSQLDialect() instanceof PreparedStatementSQLDialect ) {
                     PreparedStatement ps = getDataStore().selectSQLPS(getSchema(), queryNone, cx);
@@ -287,7 +288,7 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
             postFilter = split[1];
             
             // build up a statement for the content
-            DefaultQuery preQuery = new DefaultQuery(query);
+            Query preQuery = new Query(query);
             preQuery.setFilter(preFilter);
             if(getDataStore().getSQLDialect() instanceof PreparedStatementSQLDialect) {
                 PreparedStatement ps = getDataStore().selectSQLPS(getSchema(), preQuery, cx);
@@ -367,7 +368,7 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
                 ReferencedEnvelope bounds = new ReferencedEnvelope( getSchema().getCoordinateReferenceSystem() );
                 if( state.hasListener() ){
                     // gather bounds before modification
-                    ReferencedEnvelope before = getBounds( new DefaultQuery( getSchema().getTypeName(), preFilter ) );                
+                    ReferencedEnvelope before = getBounds( new Query( getSchema().getTypeName(), preFilter ) );                
                     if( before != null && !before.isEmpty() ){
                         bounds = before;
                     }
@@ -428,7 +429,7 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
                 ReferencedEnvelope bounds = new ReferencedEnvelope( getSchema().getCoordinateReferenceSystem() );
                 if( state.hasListener() ){
                     // gather bounds before modification
-                    ReferencedEnvelope before = getBounds( new DefaultQuery( getSchema().getTypeName(), preFilter ) );                
+                    ReferencedEnvelope before = getBounds( new Query( getSchema().getTypeName(), preFilter ) );                
                     if( before != null && !before.isEmpty() ){
                         bounds = before;
                     }

--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -1735,15 +1735,11 @@ public class DataUtilities {
     /**
      * Create a derived FeatureType
      * 
-     * <p>
-     * </p>
+     * @param featureType Original feature type to derive from.
+     * @param properties If null, every property of the featureType in input will be used
+     * @param override Intended CoordinateReferenceSystem, if null original will be used
      * 
-     * @param featureType
-     * @param properties
-     *            - if null, every property of the feature type in input will be used
-     * @param override
-     * 
-     * 
+     * @return derived FeatureType
      * @throws SchemaException
      */
     public static SimpleFeatureType createSubType(SimpleFeatureType featureType,
@@ -1761,7 +1757,17 @@ public class DataUtilities {
                 namespaceURI);
 
     }
-
+    /**
+     * Create a derived FeatureType
+     * 
+     * @param featureType Original feature type to derive from.
+     * @param properties If null, every property of the featureType in input will be used
+     * @param override Intended CoordinateReferenceSystem, if null original will be used
+     * @param typeName Type name override
+     * @param namespace Namespace override
+     * @return derived FeatureType
+     * @throws SchemaException
+     */
     public static SimpleFeatureType createSubType(SimpleFeatureType featureType,
             String[] properties, CoordinateReferenceSystem override, String typeName, URI namespace)
             throws SchemaException {

--- a/modules/library/main/src/main/java/org/geotools/data/ReTypeFeatureReader.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ReTypeFeatureReader.java
@@ -78,7 +78,7 @@ public class ReTypeFeatureReader implements DelegatingFeatureReader<SimpleFeatur
     /**
      * Constructs a FetureReader that will ReType streaming content.
      *
-     * @param reader Origional FeatureReader
+     * @param reader Original FeatureReader
      * @param featureType Target FeatureType
      */
     public ReTypeFeatureReader(FeatureReader<SimpleFeatureType, SimpleFeature> reader, SimpleFeatureType featureType) {

--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import org.geotools.data.Query;
 import org.geotools.feature.AttributeBuilder;
 import org.geotools.feature.AttributeTypeBuilder;
 import org.geotools.feature.NameImpl;
@@ -1069,29 +1070,30 @@ public class SimpleFeatureTypeBuilder {
         }
         return bindings;
     }
-	
-	/**
-	 * Decodes a srs, supplying a useful error message if there is a problem.
-	 */
-	protected CoordinateReferenceSystem decode( String srs ) {
-	    try {
+
+    /**
+     * Decodes a srs, supplying a useful error message if there is a problem.
+     */
+    protected CoordinateReferenceSystem decode(String srs) {
+        try {
             return CRS.decode(srs);
-        } catch (Exception  e) {
-            String msg = "SRS '" + srs + "' unknown:" + e.getLocalizedMessage(); 
-            throw (IllegalArgumentException) new IllegalArgumentException( msg ).initCause( e );
+        } catch (Exception e) {
+            String msg = "SRS '" + srs + "' unknown:" + e.getLocalizedMessage();
+            throw (IllegalArgumentException) new IllegalArgumentException(msg).initCause(e);
         }
-	}
-	
-	/**
-	 * Create a SimpleFeatureType containing just the descriptors indicated.
-	 * @param original SimpleFeatureType
-	 * @param types name of types to include in result
-	 * @return SimpleFeatureType containing just the types indicated by name
-	 */
-	public static SimpleFeatureType retype( SimpleFeatureType original, String[] types ) {
-	    return retype(original, Arrays.asList(types));
-	}
-	
+    }
+
+    /**
+     * Create a SimpleFeatureType containing just the descriptors indicated.
+     * 
+     * @param original SimpleFeatureType
+     * @param types name of types to include in result
+     * @return SimpleFeatureType containing just the types indicated by name
+     */
+    public static SimpleFeatureType retype(SimpleFeatureType original, String[] types) {
+        return retype(original, Arrays.asList(types));
+    }
+
     public static SimpleFeatureType retype(SimpleFeatureType original, List<String> types) {
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
 
@@ -1114,6 +1116,7 @@ public class SimpleFeatureTypeBuilder {
 
         return b.buildFeatureType();
     }
+
 
 	/**
          * Create a SimpleFeatureType with the same content; just updating the geometry
@@ -1142,8 +1145,31 @@ public class SimpleFeatureTypeBuilder {
                     continue;
                 }
                 b.add( descriptor);
-            }            
+            }
             return b.buildFeatureType();
+        }
+
+        /**
+         * Configure expected 
+         * @param origional
+         * @param query
+         * @return
+         */
+        public static SimpleFeatureType retype(SimpleFeatureType origional, Query query) {
+            CoordinateReferenceSystem crs = null;
+            if( query.getCoordinateSystem() != null ){
+                crs = query.getCoordinateSystem();
+            }
+            if( query.getCoordinateSystemReproject() != null ){
+                crs = query.getCoordinateSystemReproject();
+            }
+            return retype( origional, query.getPropertyNames(), crs );
+        }
+        
+        private static SimpleFeatureType retype(SimpleFeatureType origional, String[] propertyNames,
+                CoordinateReferenceSystem crs) {
+            // TODO Auto-generated method stub
+            return null;
         }
 
         /**

--- a/modules/plugin/property/src/main/java/org/geotools/data/property/PropertyFeatureSource.java
+++ b/modules/plugin/property/src/main/java/org/geotools/data/property/PropertyFeatureSource.java
@@ -30,7 +30,6 @@ import org.geotools.data.QueryCapabilities;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.factory.Hints;
-import org.geotools.factory.Hints.Key;
 import org.geotools.feature.SchemaException;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.geometry.jts.WKTReader2;
@@ -60,9 +59,9 @@ public class PropertyFeatureSource extends ContentFeatureSource {
     }
     
     @Override
-    protected void addHints(Set<Key> hints) {
+    protected void addHints(Set<Hints.Key> hints) {
         // mark the features as detached, that is, the user can directly alter them
-        // without altering the state of the datastore
+        // without altering the state of the DataStore
         hints.add(Hints.FEATURE_DETACHED);
     }
     

--- a/modules/plugin/property/src/test/java/org/geotools/data/property/PropertyExamples.java
+++ b/modules/plugin/property/src/test/java/org/geotools/data/property/PropertyExamples.java
@@ -107,6 +107,7 @@ public class PropertyExamples {
         }
     }
     
+    @SuppressWarnings("unused")
     private static void featureStoreExample() throws Exception {
         System.out.println("featureStoreExample start\n");
         // featureStoreExample start
@@ -239,6 +240,7 @@ public class PropertyExamples {
         System.out.println("\nremoveAllExample end\n");
     }
     
+    @SuppressWarnings("unused")
     private void replaceAll() throws Exception {
         System.out.println("replaceAll start\n");
         // replaceAll start

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2007-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2007-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -17,6 +17,7 @@
 package org.geotools.data.shapefile;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureWriter;
@@ -29,6 +30,7 @@ import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureStore;
 import org.geotools.data.store.ContentState;
+import org.geotools.factory.Hints.Key;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
@@ -41,15 +43,15 @@ import org.opengis.filter.Filter;
  * 
  * @author Andrea Aime - GeoSolutions
  */
-@SuppressWarnings("rawtypes")
 class ShapefileFeatureStore extends ContentFeatureStore {
 
     ShapefileFeatureSource delegate;
 
+    @SuppressWarnings("unchecked")
     public ShapefileFeatureStore(ContentEntry entry, ShpFiles files) {
         super(entry, Query.ALL);
         this.delegate = new ShapefileFeatureSource(entry, files);
-        this.hints = delegate.getSupportedHints();
+        this.hints = (Set<Key>) (Set<?>) delegate.getSupportedHints();
     }
 
     @Override


### PR DESCRIPTION
The goal with ContentDataStore was to use objects, rather than Maps for organization. This refactor changes MemoryDataStore from Map<String,Map<String,Feature>> to a MemoryEntry managed by the ContentDataStore superclass.

Although this refactor is functionally identical changing to objects makes the logic easier to follow.

To enable this refactor ContentEntry is no longer a final class.