### PR TITLE
add scroll wheel zoom in/out to JMapPanes and JMapFrames

### DIFF
--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/JMapFrame.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/JMapFrame.java
@@ -37,8 +37,6 @@ import javax.swing.JSplitPane;
 import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
 
-import net.miginfocom.swing.MigLayout;
-
 import org.geotools.map.MapContent;
 import org.geotools.swing.action.InfoAction;
 import org.geotools.swing.action.NoToolAction;
@@ -47,6 +45,9 @@ import org.geotools.swing.action.ResetAction;
 import org.geotools.swing.action.ZoomInAction;
 import org.geotools.swing.action.ZoomOutAction;
 import org.geotools.swing.control.JMapStatusBar;
+import org.geotools.swing.tool.ScrollWheelTool;
+
+import net.miginfocom.swing.MigLayout;
 
 /**
  * A Swing frame containing a map display pane and (optionally) a toolbar,
@@ -120,7 +121,12 @@ public class JMapFrame extends JFrame {
         /**
          * The zoom display cursor tools.
          */
-        ZOOM;
+        ZOOM, 
+        /**
+         * The map should zoom with the mouse wheel.
+         * No button shown for this.
+         */    
+        SCROLLWHEEL;
     }
 
     private boolean showToolBar;
@@ -351,7 +357,9 @@ public class JMapFrame extends JFrame {
 
             JButton btn;
             ButtonGroup cursorToolGrp = new ButtonGroup();
-            
+            if(toolSet.contains(Tool.SCROLLWHEEL)) {
+               mapPane.addMouseListener(new ScrollWheelTool(mapPane));
+            }
             if (toolSet.contains(Tool.POINTER)) {
                 btn = new JButton(new NoToolAction(mapPane));
                 btn.setName(TOOLBAR_POINTER_BUTTON_NAME);

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ScrollWheelTool.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ScrollWheelTool.java
@@ -1,0 +1,80 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.swing.tool;
+
+import java.awt.Cursor;
+import java.awt.Rectangle;
+
+import javax.swing.JComponent;
+
+import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.Envelope2D;
+import org.geotools.swing.JMapPane;
+import org.geotools.swing.event.MapMouseEvent;
+/**
+ * Allow scrolling with the mouse wheel.
+ * 
+ * @author Ian Turton
+ * @since 2.15
+ *
+ */
+public class ScrollWheelTool extends AbstractZoomTool {
+
+    public ScrollWheelTool(JMapPane mapPane) {
+        setMapPane(mapPane);
+    }
+
+    @Override
+    public Cursor getCursor() {
+        return null;
+    }
+
+    @Override
+    public void onMouseWheelMoved(MapMouseEvent ev) {
+
+        Rectangle paneArea = ((JComponent) getMapPane()).getVisibleRect();
+
+        DirectPosition2D mapPos = ev.getWorldPos();
+
+        double scale = getMapPane().getWorldToScreenTransform().getScaleX();
+        int clicks = ev.getWheelAmount();
+
+        double actualZoom = 1;
+        // positive clicks are down - zoom out
+
+        if (clicks > 0) {
+            actualZoom = -1.0 / (clicks * getZoom());
+        } else {
+            actualZoom = clicks * getZoom();
+
+        }
+        double newScale = scale * actualZoom;
+
+        DirectPosition2D corner = new DirectPosition2D(
+                mapPos.getX() - 0.5d * paneArea.getWidth() / newScale,
+                mapPos.getY() + 0.5d * paneArea.getHeight() / newScale);
+
+        //I would prefer to offset the new map based on the cursor but this matches
+        //the current zoom in/out tools.
+        
+        Envelope2D newMapArea = new Envelope2D();
+        newMapArea.setFrameFromCenter(mapPos, corner);
+        getMapPane().setDisplayArea(newMapArea);
+
+    }
+}


### PR DESCRIPTION
Allow users to zoom in and out of Swing based GeoTools maps using their mouse scroll wheel.
See [[GEOT-5289]](https://osgeo-org.atlassian.net/browse/GEOT-5412)