### PR TITLE
Improve GeoTools Release Guide

### DIFF
--- a/docs/developer/procedures/release.rst
+++ b/docs/developer/procedures/release.rst
@@ -47,25 +47,11 @@ Since we don't make any release from master, ensure you select the right CITE te
 Release in JIRA
 ---------------
 
-Run the `geotools-release-jira <http://ares.boundlessgeo.com/jenkins/job/geotools-release-jira/>`_ job in Jenkins. The job takes the following parameters:
+1. Navigate to the `GeoTools project page <https://osgeo-org.atlassian.net/projects/GEOT?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page&status=released-unreleased>`_ in JIRA.
 
-**VERSION**
+2. Click ``Manage Versions``. Create a new version for the next version to be released after the current release (For example, if you are releasing GeoTools 15.1, create version 15.2).
 
-  The version to release, same as in the previous section. This version must match a version in JIRA.
-
-**NEXT_VERSION**
-
-  The next version in the series. All unresolved issues currently fils against ``VERSION`` will be transitioned to this version.
-
-**JIRA_USER** 
-
-  A JIRA user name that has release privileges. This user  will be used to perform the release in JIRA, via the SOAP api.
-
-**JIRA_PASSWD**
-
-  The password for the ``JIRA_USER``.
-     
-This job will perform the tasks in JIRA to release ``VERSION``. Navigate to `JIRA <https://osgeo-org.atlassian.net/projects/GEOT>`_ and verify that the version has actually been released.
+3. Return to the project page, and click on the version you are releasing. Click the ``Release`` button, and enter the release date when prompted. If there are still unsolved issues remaining in this release, you will be prompted to move them to an unreleased version. If so, choose the new version you created in step 2.
 
 If you are cutting the first RC of a series, create the stable branch
 ---------------------------------------------------------------------
@@ -176,7 +162,7 @@ This job will rsync all the artifacts located at::
 
      http://ares.boundlessgeo.com/geotools/release/<RELEASE>
 
-to the SourceForge FRS server.
+to the SourceForge FRS server, and also deploy the artifacts to the public geotools maven repository.
 
 #. Navigate to `Sourceforge <http://sourceforge.net/projects/geotools/>`__ and verify that the artifacts have been uploaded properly.
 #. If this is the latest stable release, make its ``-bin.zip`` the default download for all platforms (use the "i" button).
@@ -228,33 +214,3 @@ Cut and paste from the blog post to the following:
    
    * To: news_item@osgeo.org
    * Subject: GeoTools 8.0-RC1 Released
-
-Tell More of the World!
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Well that was not very much of the world was it? Lets do freshmeat, sf.net, geotools.org and freegis.
-
-#. Do it in the Morning
-   
-   Please don't announce releases on a Friday or weekend. And try to make it in the mornings as
-   well. If it's late then just finish it up the next day. This will ensure that a lot more
-   people will see the announcements.
-  
-   http://freshmeat.net/projects/geotools/
-
-#. Add release: http://freshmeat.net/projects/geotools/
-   
-   * Branch: GT2
-   * Version: 2.6-M4
-   * Changes: Grab the notes from the above release anouncement
-   * You can also update the screen snapshot to reflect a current GeoTools application.
-     GeoServer and UDIG have been highlighted in the past. If you are making the release
-     to support a project this is your big chance!
-
-#. http://freegis.org/
-   
-   Email Jan-Oliver Wagner
-   
-   * To: jan@intevation.de
-   * Subject: GeoTools update for FreeGIS site
-


### PR DESCRIPTION
After doing the GeoTools 15-RC1 release, I found that the release guide was rather out-of-date. This intends to remedy the problems I found:

**Add manual JIRA release instructions**

The current release instructions rely on the `geotools-release-jira` job on the ares jenkins server. This job has not been working for about a yer. Until someone finds the time to fix the JIRA release scripts, the Release Guide should be updated with manual release steps.

**Indicate `geotools-release-publish` is also responsible for deploying artifacts to maven.**

This is not made clear anywhere in the existing release guide, and caused some confusion when trying to start the GeoWebCache release after the artifacts had been built by the `geotools-release` job.
 
**Remove deprecated news sites**

A number of the sites in the "Announce the release" section have not been used in 2+ years. These have been removed.