### PR TITLE
[GEOT-5398] ECQL: format property name ID as "ID"

### DIFF
--- a/modules/library/cql/src/main/java/org/geotools/filter/text/commons/ExpressionToText.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/commons/ExpressionToText.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2006-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -19,16 +19,12 @@ package org.geotools.filter.text.commons;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.SimpleTimeZone;
 import java.util.TimeZone;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
@@ -244,6 +240,7 @@ public class ExpressionToText implements ExpressionVisitor {
                 new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         reservedWords.addAll(Arrays.asList("NOT", "AND", "OR", "LIKE", "IS", 
                 "NULL", "EXISTS", "DOES-NOT-EXIST", "DURING", "AFTER", "BEFORE",
+                "ID", // deprecated but accepted by the parser
                 "IN", "INCLUDE", "EXCLUDE", "TRUE", "FALSE", "EQUALS", 
                 "DISJOINT", "INTERSECTS", "TOUCHES", "CROSSES", "WITHIN", 
                 "CONTAINS", "OVERLAPS", "RELATE", "DWITHIN", "BEYOND", "POINT", 

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/ecql/ECQLIDPredicateTest.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/ecql/ECQLIDPredicateTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -246,5 +246,37 @@ public class ECQLIDPredicateTest {
     	Filter filter = ECQL.toFilter("ID IN ('river.1', 'river.2')");
     
     	Assert.assertTrue(filter instanceof Id);
+    }
+    
+    /**
+     * Keyword ID is deprecated but still accepted by the parser.
+     * 
+     */
+    @Test
+    public void propertyNameIdIsBeingDelimited() {
+
+        try { ECQL.toFilter("id = 'river.3'"); Assert.fail(); } catch (CQLException e) {}
+        try { ECQL.toFilter("Id = 'river.3'"); Assert.fail(); } catch (CQLException e) {}
+        try { ECQL.toFilter("iD = 'river.3'"); Assert.fail(); } catch (CQLException e) {}
+        try { ECQL.toFilter("ID = 'river.3'"); Assert.fail(); } catch (CQLException e) {}
+        assertToFilterToECQLEquals("\"id\" = 'river.3'");
+        assertToFilterToECQLEquals("\"Id\" = 'river.3'");
+        assertToFilterToECQLEquals("\"iD\" = 'river.3'");
+        assertToFilterToECQLEquals("\"ID\" = 'river.3'");
+    }
+    
+    /**
+     * Parse ecql, format ecql, and compare result to input.
+     * 
+     */
+    private static void assertToFilterToECQLEquals(final String ecqlPredicate) 
+    {
+        
+        try {
+            final Filter filter = ECQL.toFilter(ecqlPredicate);
+            Assert.assertTrue(ecqlPredicate.equals(ECQL.toCQL(filter)));
+        } catch (CQLException e) {
+            Assert.fail();
+        }
     }
 }


### PR DESCRIPTION
The ECQL parser still accepts the deprecated keyword ID. Thus property
names ID, iD, Id, id must be delimited, and hence will be delimited.