### PR TITLE
Improving thread safety of SimpleFeatureTypeImpl.getTypes

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeImpl.java
@@ -76,10 +76,11 @@ public class SimpleFeatureTypeImpl extends FeatureTypeImpl implements
         if (types == null) {
             synchronized (this) {
                 if (types == null) {
-                    types = new ArrayList<AttributeType>();
+                    ArrayList<AttributeType> temp = new ArrayList<AttributeType>();
                     for (AttributeDescriptor ad : getAttributeDescriptors()) {
-                        types.add(ad.getType());
+                        temp.add(ad.getType());
                     }
+                    types = temp;
                 }
             }
         }

--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeImpl.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2009, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
* Avoids the chance of a second thread seeing a partially filled type list

I didn't add a unit test as thread safety is hard to test reliably, but it should be evident how the old code could result in a second thread seeing a non-null but empty or partially filled type list.

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>