### PR TITLE
[GEOT-5416] Fix so SortOrder.DESCENDING works

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2003-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2003-2016, Open Source Geospatial Foundation (OSGeo)
  *    
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -116,6 +116,7 @@ import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
 import org.opengis.geometry.BoundingBox;
 import org.opengis.metadata.citation.Citation;
 import org.opengis.referencing.FactoryException;
@@ -2395,6 +2396,7 @@ public class DataUtilities {
             };
         } else {
             final PropertyName PROPERTY = sortBy.getPropertyName();
+            final SortOrder ORDER = sortBy.getSortOrder();
             return new Comparator<SimpleFeature>() {
                 @SuppressWarnings("unchecked")
                 public int compare(SimpleFeature f1, SimpleFeature f2) {
@@ -2404,7 +2406,11 @@ public class DataUtilities {
                         return 0; // cannot perform comparison
                     }
                     if (value1 instanceof Comparable && value1.getClass().isInstance(value2)) {
-                        return ((Comparable<Object>) value1).compareTo(value2);
+                        if(ORDER == SortOrder.ASCENDING) {
+                            return ((Comparable<Object>) value1).compareTo(value2);
+                        }else {
+                            return ((Comparable<Object>) value2).compareTo(value1);
+                        }
                     } else {
                         return 0; // cannot perform comparison
                     }

--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -2395,20 +2395,20 @@ public class DataUtilities {
                 }
             };
         } else {
-            final PropertyName PROPERTY = sortBy.getPropertyName();
-            final SortOrder ORDER = sortBy.getSortOrder();
+            final PropertyName propertyName = sortBy.getPropertyName();
+            final SortOrder sortOrder = sortBy.getSortOrder();
             return new Comparator<SimpleFeature>() {
                 @SuppressWarnings("unchecked")
                 public int compare(SimpleFeature f1, SimpleFeature f2) {
-                    Object value1 = PROPERTY.evaluate(f1, Comparable.class);
-                    Object value2 = PROPERTY.evaluate(f2, Comparable.class);
+                    Object value1 = propertyName.evaluate(f1, Comparable.class);
+                    Object value2 = propertyName.evaluate(f2, Comparable.class);
                     if (value1 == null || value2 == null) {
                         return 0; // cannot perform comparison
                     }
                     if (value1 instanceof Comparable && value1.getClass().isInstance(value2)) {
-                        if(ORDER == SortOrder.ASCENDING) {
+                        if (sortOrder == SortOrder.ASCENDING) {
                             return ((Comparable<Object>) value1).compareTo(value2);
-                        }else {
+                        } else {
                             return ((Comparable<Object>) value2).compareTo(value1);
                         }
                     } else {

--- a/modules/library/main/src/test/java/org/geotools/data/collection/SortedFeatureCollectionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/collection/SortedFeatureCollectionTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/main/src/test/java/org/geotools/data/collection/SortedFeatureCollectionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/collection/SortedFeatureCollectionTest.java
@@ -50,6 +50,7 @@ public class SortedFeatureCollectionTest extends FeatureCollectionWrapperTestSup
                 new SortBy[] { sort });
         checkSorted(sorted, DataUtilities.sortComparator(sort));
     }
+    
     public void testSortAttributeDescending() throws Exception {
         SortBy sort = ff.sort("someAtt", SortOrder.DESCENDING);
         SortedSimpleFeatureCollection sorted = new SortedSimpleFeatureCollection(delegate,

--- a/modules/library/main/src/test/java/org/geotools/data/collection/SortedFeatureCollectionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/collection/SortedFeatureCollectionTest.java
@@ -50,6 +50,12 @@ public class SortedFeatureCollectionTest extends FeatureCollectionWrapperTestSup
                 new SortBy[] { sort });
         checkSorted(sorted, DataUtilities.sortComparator(sort));
     }
+    public void testSortAttributeDescending() throws Exception {
+        SortBy sort = ff.sort("someAtt", SortOrder.DESCENDING);
+        SortedSimpleFeatureCollection sorted = new SortedSimpleFeatureCollection(delegate,
+                new SortBy[] { sort });
+        checkSorted(sorted, DataUtilities.sortComparator(sort));
+    }
 
     private void checkSorted(SortedSimpleFeatureCollection sorted,
             Comparator<SimpleFeature> comparator) {


### PR DESCRIPTION
[GEOT-5416](https://osgeo-org.atlassian.net/browse/GEOT-5416) - Currently SortOrder.DESCENDING is handled in the same way as SortOrder.ASCENDING which is clearly wrong. This PR Fixes the issue.
