### PR TITLE
[GEOT-5419] Fix NetCDFImageReaderSpi file dispose

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/NetCDFImageReaderSpi.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/NetCDFImageReaderSpi.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2007-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2007-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -21,6 +21,7 @@ import it.geosolutions.imageio.stream.input.FileImageInputStreamExtImpl;
 import it.geosolutions.imageio.stream.input.URIImageInputStream;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -251,11 +252,15 @@ public class NetCDFImageReaderSpi extends ImageReaderSpi {
         return canDecode;
     }
 
-    private boolean isNcML(File input) throws IOException {
-        final StreamSource streamSource = new StreamSource(input);
+    private boolean isNcML(File file) throws IOException {
+        FileInputStream input = null;
+        StreamSource streamSource = null;
         XMLStreamReader reader = null;
         try {
-            reader = XMLInputFactory.newInstance().createXMLStreamReader(streamSource);
+            input  = new FileInputStream(file);
+            streamSource = new StreamSource(input);
+            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            reader = inputFactory.createXMLStreamReader(streamSource);
             reader.nextTag();
             if ("netcdf".equals(reader.getName().getLocalPart())) {
                 return true;
@@ -265,6 +270,9 @@ public class NetCDFImageReaderSpi extends ImageReaderSpi {
         } catch (FactoryConfigurationError e) {
 
         } finally {
+            if (input != null) {
+                input.close();
+            }
             if (reader != null) {
                 if (streamSource.getInputStream() != null) {
                     streamSource.getInputStream().close();

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/imageio/netcdf/NetCDFImageReaderSpiTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/imageio/netcdf/NetCDFImageReaderSpiTest.java
@@ -1,0 +1,49 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.imageio.netcdf;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public final class NetCDFImageReaderSpiTest {
+
+    @Test
+    public void testFileIsProperlyClosed() throws Exception {
+        // create a temporary file and write some random bytes on it
+        Path path = Files.createTempFile(UUID.randomUUID().toString(), ".txt");
+        byte[] content = new byte[100];
+        Random random = new Random();
+        random.nextBytes(content);
+        Files.write(path, content);
+        // invoking the reader that will not be able to read the file
+        File file = path.toFile();
+        NetCDFImageReaderSpi reader = new NetCDFImageReaderSpi();
+        reader.canDecodeInput(file);
+        // check if the file as some lock on it
+        assertThat(file.delete(), is(true));
+    }
+}


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOT-5419
JAXB's unmarhsaller is not properly releasing the file when an error happens. 
To solve this I use an InputStream instead of a File so we can properly close it.

I create a test for this situation, although this seems to be only reproducible in Windows.