### PR TITLE
Changed references to JDK 7 to be JDK 8

### DIFF
--- a/docs/user/build/install/mvn.rst
+++ b/docs/user/build/install/mvn.rst
@@ -19,9 +19,9 @@ Download and Install Maven
    
    If you do not have an unzip program may we recommend: http://www.7-zip.org/
 
-3. You need to have the following environmental variables set for maven to work:
+3. You need to have the following environmental variables set for maven to work (note your paths may differ based on Java or Maven revision numbers):
    
-   * JAVA_HOME = C:\Program Files\java\jdk1.7.0_51\
+   * JAVA_HOME = C:\Program Files\java\jdk1.8.0_91\
     
      Location of your JDK installation
    
@@ -38,81 +38,15 @@ Download and Install Maven
      > mvn -version
      Apache Maven 3.0.5 (r01de14724cdef164cd33c7c8c2fe155faf9602da; 2013-02-20 00:51:28+1100)
      Maven home: /opt/apache-maven-3.0.5
-     Java version: 1.7.0_51, vendor: Oracle Corporation
-     Java home: /Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home/jre
+     Java version: 1.8.0_91, vendor: Oracle Corporation
+     Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_91.jdk/Contents/Home/jre
      Default locale: en_US, platform encoding: UTF-8
      OS name: "mac os x", version: "10.9.3", arch: "x86_64", family: "mac"
 
-Do not use Apt-Get
-^^^^^^^^^^^^^^^^^^
+Maven and Apt-Get
+^^^^^^^^^^^^^^^^^
 
-It is very tempting to use apt-get to install maven, Ubuntu users I am looking at you!
+Current versions of Ubuntu provide Maven 3; however if you're using an older version or you'd like to use the very latest, please
+install the latest version manually by following the `official installation instructions <https://maven.apache.org/install.html>`_.
 
-Please be careful of the maven provided out of the box by Ubuntu::
-   
-   Apache Maven 2.2.1 (rdebian-1)
 
-It is not actually apache maven as provided by apache; and it has a build failure with::
-   
-   [INFO] ------------------------------------------------------------------------
-   [INFO] Building Cross-modules javadoc
-   [INFO]    task-segment: [install]
-   [INFO] ------------------------------------------------------------------------
-   [INFO] [plugin:descriptor {execution: default-descriptor}]
-   [WARNING] Using platform encoding (UTF-8 actually) to read mojo metadata, i.e. build is platform dependent!
-   [INFO] Applying mojo extractor for language: java
-   [INFO] Mojo extractor for language: java found 0 mojo descriptors.
-   [INFO] Applying mojo extractor for language: bsh
-   [INFO] Mojo extractor for language: bsh found 0 mojo descriptors.
-   [INFO] ------------------------------------------------------------------------
-   [ERROR] BUILD ERROR
-   [INFO] ------------------------------------------------------------------------
-   [INFO] Error extracting plugin descriptor: 'No mojo definitions were found for plugin: org.geotools.maven:javadoc.
-
-Kenneth Gulbrandsoy has supplied the following notes on Ubuntu:
-
-References:
-
-* http://usingmaven.bachew.net/manually-install-maven-on-linux
-
-1. Download apache-maven-3.2.1-bin.tar.gz
-   
-   * http://mirror.mel.bkb.net.au/pub/apache/maven/maven-3/3.2.1/binaries/apache-maven-3.2.1-bin.tar.gz
-
-2. Unpack into /usr/local/lib (or any other path you choose)::
-     
-     > cd /usr/local/lib
-     > sudo tar -xzf apache-maven-3.2.1-bin.tar.gz
-
-   This unpacks the folder apache-maven-3.2.1 to pwd
-
-   ..note::
-     
-     At this point > usr/local/lib/apache-maven-3.2.1/bin/mvn --version will complain::
-   
-       Warning: JAVA_HOME environment variable is not set. 
-
-     Step 4 solves this using a application specific environment (profile.d) script. This script
-     also set the M2_HOME and PATH variables. Note that step 5 registers the script with
-     current session.
-
-3. Link apache-maven-3.2.1 to apache-maven (optional)::
-     
-     > ln -sT apache-maven-3.2.1 apache-maven
-     
-   This makes it easier to upgrade later on
-
-4. Add maven script that set environment variables (su required)::
-     
-     > cat > /etc/profile.d/apache-maven.sh
-     export JAVA_HOME=/usr/lib/jvm/java-6-sun/jre
-     export M2_HOME=/usr/local/lib/apache-maven
-     export PATH=$PATH:$M2_HOME/bin
-     <Ctrl-D>
-     > . /etc/profile 
-
-5. Test Maven. The following command should not produce any warnings::
-     
-     > mvn --version
-
-If you still need to use the packaged version, install "maven3", not "maven".

--- a/docs/user/tutorial/datastore/intro.rst
+++ b/docs/user/tutorial/datastore/intro.rst
@@ -116,7 +116,7 @@ Time to create a new project making use of this library:
       :start-after: </dependencies>
       :end-before: <build>
 
-#. Finally we get to switch to Java 7:
+#. Finally we get to switch to Java 8:
 
    .. literalinclude:: artifacts/pom.xml
       :language: xml

--- a/docs/user/tutorial/quickstart/artifacts/pom.xml
+++ b/docs/user/tutorial/quickstart/artifacts/pom.xml
@@ -11,7 +11,7 @@
     <url>http://maven.apache.org</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <geotools.version>13.2</geotools.version>
+        <geotools.version>14.3</geotools.version>
     </properties>
     <dependencies>
         <dependency>
@@ -43,4 +43,18 @@
           <url>http://download.osgeo.org/webdav/geotools/</url>
       </repository>
     </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <inherited>true</inherited>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/docs/user/tutorial/quickstart/artifacts/pom2.xml
+++ b/docs/user/tutorial/quickstart/artifacts/pom2.xml
@@ -52,5 +52,20 @@
           <url>http://repo.boundlessgeo.com/main</url>
         </repository>
     </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <inherited>true</inherited>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>
 

--- a/docs/user/tutorial/quickstart/eclipse.rst
+++ b/docs/user/tutorial/quickstart/eclipse.rst
@@ -245,7 +245,7 @@ such as GeoTools publish their work.
 5. We are going to add a dependence to GeoTools :file:`gt-main` and :file:`gt-swing` jars. Note we
    are making use of the geotools.version defined above.
    
-.. literalinclude:: artifacts/pom.xml
+   .. literalinclude:: artifacts/pom.xml
         :language: xml
         :start-after: </properties>
         :end-before: <repositories>
@@ -256,16 +256,24 @@ such as GeoTools publish their work.
    .. literalinclude:: artifacts/pom.xml
         :language: xml
         :start-after: </dependencies>
-        :end-before: </project>
+        :end-before: </build>
 
    If you are using a nightly build (such as |branch|-SNAPSHOT) and add a reference to the snapshot repository.
    
    .. literalinclude:: artifacts/pom2.xml
      :language: xml
      :start-after: </dependencies>
-     :end-before: </project>
+     :end-before: <build>
 
-7. For comparison here is the completed :download:`pom.xml <artifacts/pom.xml>` file for download.
+7. If you'd like to use Java 8 language level features (eg. lambdas), you need to tell Maven to use the 1.8 source level
+
+
+   .. literalinclude:: artifacts/pom2.xml
+      :language: xml
+      :start-after: </repositories>
+      :end-before: </project>
+
+8. For comparison here is the completed :download:`pom.xml <artifacts/pom.xml>` file for download.
 
    You may find cutting and pasting to be easier than typing, you can choose Source --> Format to
    fix indentation

--- a/docs/user/tutorial/quickstart/maven.rst
+++ b/docs/user/tutorial/quickstart/maven.rst
@@ -112,7 +112,7 @@ Installing Maven
       Apache Maven 3.2.3 (33f8c3e1027c3ddde99d3cdebad2656a31e8fdf4; 2014-08-11T13:58:10-07:00)
       Maven home: C:\java\apache-maven-3.2.3
       Java version: 1.8.0_66, vendor: Oracle Corporation
-      Java home: C:\Program Files (x86)\Java\jdk1.7.0_67\jre
+      Java home: C:\Program Files (x86)\Java\jdk1.8.0_66\jre
       Default locale: en_US, platform encoding: Cp1252
       OS name: "windows 7", version: "6.1", arch: "x86", family: "windows"
 
@@ -188,19 +188,26 @@ Creating a new project
         :start-after: </properties>
         :end-before: <repositories>
 
-#. Finally, we tell maven which repositories to download jars from:
+#. We tell maven which repositories to download jars from:
    
    .. literalinclude:: artifacts/pom.xml
         :language: xml
         :start-after: </dependencies>
-        :end-before: </project>
+        :end-before: <build>
 
    If you are using a nightly build (such as |branch|-SNAPSHOT) and add a reference to the snapshot repository.
    
    .. literalinclude:: artifacts/pom2.xml
      :language: xml
      :start-after: </dependencies>
-     :end-before: </project>
+     :end-before: <build>
+
+#. If you'd like to use Java 8 language level features (eg. lambdas), you need to tell Maven to use the 1.8 source level
+
+   .. literalinclude:: artifacts/pom2.xml
+        :language: xml
+        :start-after: </repositories>
+        :end-before: <project>
      
 #. Return to the command line and get maven to download the required jars for your project with this
    command::

--- a/docs/user/tutorial/quickstart/netbeans.rst
+++ b/docs/user/tutorial/quickstart/netbeans.rst
@@ -45,12 +45,12 @@ Imaging and Java Image IO section – both of these libraries are used by GeoToo
    
 #. At the time of writing the latest JDK was:
    
-   jdk-7u1-windows-i586.exe
+   jdk-8u91-windows-i586.exe
    
 #. Click through the installer you will need to set an acceptance a license agreement and so forth.
    By default this will install to:     
    
-   C:\\Program Files\\Java\\jdk1.7.0\\
+   C:\\Program Files\\Java\\jdk1.8.0_91\\
      
 #. Optional: Java Advanced Imaging is used by GeoTools for raster support. If you install JAI 1.1.3 
    performance will be improved:   
@@ -206,22 +206,29 @@ such as GeoTools publish their work.
    .. literalinclude:: artifacts/pom.xml
         :language: xml
         :start-after: </dependencies>
-        :end-before: </project>
+        :end-before: <build>
 
    If you are using a nightly build (such as |branch|-SNAPSHOT) and add a reference to the snapshot repository.
    
    .. literalinclude:: artifacts/pom2.xml
      :language: xml
      :start-after: </dependencies>
-     :end-before: </project>
+     :end-before: <build>
+
+5. If you'd like to use Java 8 language level features (eg. lambdas), you need to tell Maven to use the 1.8 source level
+
+   .. literalinclude:: artifacts/pom2.xml
+      :language: xml
+      :start-after: </repositories>
+      :end-before: </project>
     
-5. You can now right click on Libraries in the Projects window, then Download missing Dependencies
+6. You can now right click on Libraries in the Projects window, then Download missing Dependencies
    from the pop-up menu. When downloading it will check the repositories we have listed
    above.
 
-6. We will continue to add dependencies on different parts of the GeoTools library as we work through these exercises; this fine grain control and the ability to download exactly what is needed is one of the advantages of using Maven.
+7. We will continue to add dependencies on different parts of the GeoTools library as we work through these exercises; this fine grain control and the ability to download exactly what is needed is one of the advantages of using Maven.
 
-7. Here is what the completed :file:`pom.xml` looks like:
+8. Here is what the completed :file:`pom.xml` looks like:
 
    .. literalinclude:: artifacts/pom.xml
         :language: xml


### PR DESCRIPTION
- Updated a few references to JDK 7 in some documentation
- Removed warning about Maven and Apt-Get. Ubuntu repositories contain Maven 3 since at least 14. Added a reference to official maven install guide if user's would like the most up-to-date version.