### PR TITLE
Return null instead of throwing exception when parsing empty dates [GEOT-5435]

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/xml/xsi/XSISimpleTypes.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/xsi/XSISimpleTypes.java
@@ -1169,7 +1169,7 @@ public class XSISimpleTypes {
          */
         public Object getValue(Element element, ElementValue[] value,
             Attributes attrs, Map hints) throws SAXException {
-            if ((value.length == 1) && (value[0].getValue() != null)) {
+            if ((value.length == 1) && (value[0].getValue() != null) && (!"".equals(value[0].getValue()))) {
                 java.lang.String svalue = (java.lang.String) value[0].getValue();
                 java.sql.Date parsed = Converters.convert(svalue, java.sql.Date.class);
                 if (null == parsed) {
@@ -1218,7 +1218,7 @@ public class XSISimpleTypes {
          */
         public Object getValue(Element element, ElementValue[] value,
             Attributes attrs, Map hints) throws SAXException {
-            if ((value.length == 1) && (value[0].getValue() != null)) {
+            if ((value.length == 1) && (value[0].getValue() != null) && (!"".equals(value[0].getValue()))) {
                 java.lang.String svalue = (java.lang.String) value[0].getValue();
                 Timestamp parsed = Converters.convert(svalue, java.sql.Timestamp.class);
                 if (null == parsed) {
@@ -1267,7 +1267,7 @@ public class XSISimpleTypes {
          */
         public Object getValue(Element element, ElementValue[] value,
             Attributes attrs, Map hints) throws SAXException {
-            if ((value.length == 1) && (value[0].getValue() != null)) {
+            if ((value.length == 1) && (value[0].getValue() != null) && (!"".equals(value[0].getValue()))) {
                 int year;
                 int month;
                 int day;
@@ -1648,7 +1648,7 @@ public class XSISimpleTypes {
          */
         public Object getValue(Element element, ElementValue[] value,
             Attributes attrs, Map hints) throws SAXException {
-            if ((value.length == 1) && (value[0].getValue() != null)) {
+            if ((value.length == 1) && (value[0].getValue() != null) && (!"".equals(value[0].getValue()))) {
                 java.lang.String svalue = (java.lang.String) value[0].getValue();
                 java.sql.Time parsed = Converters.convert(svalue, java.sql.Time.class);
                 if (null == parsed) {

--- a/modules/library/xml/src/test/java/org/geotools/xml/xsi/XSISimpleTypesTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/xsi/XSISimpleTypesTest.java
@@ -50,6 +50,11 @@ public class XSISimpleTypesTest extends TestCase {
         assertEquals(expected.getClass().getName() + "[" + expected + "] : "
                 + actual.getClass().getName() + "[" + actual + "]", expected, actual);
 
+        sval = "";
+        value = new ElementValue[] { new ElementValueGT(null, sval) };
+        actual = dateBinding.getValue(element, value, attrs, hints);
+        assertNull(actual);
+
         sval = "10:53:24.255+03:00";
         value = new ElementValue[] { new ElementValueGT(null, sval) };
         try {
@@ -102,6 +107,11 @@ public class XSISimpleTypesTest extends TestCase {
         assertEquals(expected.getClass().getName() + "[" + expected + "] : "
                 + actual.getClass().getName() + "[" + actual + "]", expected, actual);
 
+        sval = "";
+        value = new ElementValue[] { new ElementValueGT(null, sval) };
+        actual = dateTimeBinding.getValue(element, value, attrs, hints);
+        assertNull(actual);
+
         sval = "10:53:24.255+03:00";
         value = new ElementValue[] { new ElementValueGT(null, sval) };
         try {
@@ -146,6 +156,11 @@ public class XSISimpleTypesTest extends TestCase {
         assertEquals(expected.getClass().getName() + "[" + expected + "] : "
                 + actual.getClass().getName() + "[" + actual + "]", expected, actual);
 
+        sval = "";
+        value = new ElementValue[] { new ElementValueGT(null, sval) };
+        actual = timeBinding.getValue(element, value, attrs, hints);
+        assertNull(actual);
+
         sval = "2012-02-14";
         value = new ElementValue[] { new ElementValueGT(null, sval) };
         try {
@@ -153,5 +168,21 @@ public class XSISimpleTypesTest extends TestCase {
         } catch (SAXException e) {
             assertTrue(true);
         }
+    }
+
+
+    public void testParseDuration() throws Exception {
+        SimpleType durationBinding = XSISimpleTypes.Duration.getInstance();
+
+        Element element = null;
+        Map hints = null;
+        Attributes attrs = null;
+        ElementValue[] value;
+        String sval = "";
+        Object actual;
+
+        value = new ElementValue[]{new ElementValueGT(null, sval)};
+        actual = durationBinding.getValue(element, value, attrs, hints);
+        assertNull(actual);
     }
 }


### PR DESCRIPTION
For all types (eg. Double) a check is made on ```""``` and return null in this case. Apply similar approach to empty date/dateTime/time/duration types instead of throwing SAXException.

Let me know if this is relevant or not.

Related discussion http://osgeo-org.1560.x6.nabble.com/WFS-feature-with-empty-date-td5268563.html