### PR TITLE
GEOT-5430 Check for empty or null geometry before doing offset

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometryClipper.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometryClipper.java
@@ -94,7 +94,7 @@ public class GeometryClipper {
      * @param g
      * @param ensureValid
      * @param scale Scale used to snap geometry to precision model, 0 to disable
-     * @return clipped geometry, or original geometry if clipping failed.
+     * @return a clipped geometry, which may be empty, or null
      */
     public Geometry clipSafe(Geometry g, boolean ensureValid, double scale) {
         try {

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2004-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -2561,7 +2561,8 @@ public class StreamingRenderer implements GTRenderer {
                     Geometry g = clipper.clipSafe(shape.getGeometry(), preserveTopology, 1);
                     
                     // handle perpendincular offset as needed
-                    if(style instanceof LineStyle2D && ((LineStyle2D) style).getPerpendicularOffset() != 0) {
+                    if(style instanceof LineStyle2D && ((LineStyle2D) style).getPerpendicularOffset() != 0
+                            && g != null && !g.isEmpty()) {
                         LineStyle2D ls = (LineStyle2D) style;
                         double offset = ls.getPerpendicularOffset();
                         // people applying an offset on a polygon really expect a buffer instead,

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/LineTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/LineTest.java
@@ -218,7 +218,6 @@ public class LineTest {
     }
 
     @Test
-    @Ignore
     public void testPerpendicularOffsetNPE() throws Exception {
         StreamingRenderer renderer = setupMap(fsAround, RendererBaseTest.loadStyle(this, "linePerpendicularOffsetSmall.sld"));
 


### PR DESCRIPTION
[GEOT-5430]

Unfortunately I haven't been able create a test case for this due to the nature of the issue. I'm all ears for suggestions. The issue boils down to the following:

- StreamingRenderer clips a MultiPolygon that's actually out of the envelope bounds. This produces an empty polygon.
- Offset code then attempts to offset the vector, but fails since the geometry is empty

Except in most cases the code shouldn't even make it this far, since features outside the bounds should be filtered out anyway. I'm not sure why it doesn't happen in the case of the data in the ticket, it could have something to do with the projection?

In any case, this is a pretty innocuous null + empty check anyway, and test coverage is already pretty good there anyway, so maybe we could merge this without a specific test case? 