### PR TITLE
[GEOT-5434] Upgrade to NetCDF-Java 4.6.6

### DIFF
--- a/modules/plugin/coverage-multidim/grib/src/test/java/org/geotools/coverage/io/grib/GribTest.java
+++ b/modules/plugin/coverage-multidim/grib/src/test/java/org/geotools/coverage/io/grib/GribTest.java
@@ -196,7 +196,7 @@ public class GribTest extends Assert{
         // Selection of the input file
         final File file = TestData.file(this, "sampleGrib.grb2");
         // Testing the 2 points
-        testGribFile(file, new Point2D.Double(-56, 8), new Point2D.Double(-56, 4));
+        testGribFile(file, new Point2D.Double(304, 8), new Point2D.Double(304, 4));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <src.output>${basedir}/target</src.output>
     <imageio.ext.version>1.1.13</imageio.ext.version>
     <jaiext.version>1.0.9</jaiext.version>
-    <netcdf.version>4.6.2</netcdf.version>
+    <netcdf.version>4.6.6</netcdf.version>
     <jt.version>1.4.0</jt.version>
     <jvm.opts></jvm.opts>
     <maven.build.timestamp.format>dd-MMM-yyyy HH:mm</maven.build.timestamp.format>


### PR DESCRIPTION
[GEOT-5434] Upgrade to NetCDF-Java 4.6.6
https://osgeo-org.atlassian.net/browse/GEOT-5434

[GEOT-5395] Build failure in gt-grib with -Dnetcdf.version=4.6.4 or later
https://osgeo-org.atlassian.net/browse/GEOT-5395

Must be merged at the same time as https://github.com/geoserver/geoserver/pull/1640