### PR TITLE
Added processes for convolve and normalizing a coverage

### DIFF
--- a/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/ConvolveCoverageProcess.java
+++ b/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/ConvolveCoverageProcess.java
@@ -1,0 +1,71 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.process.raster;
+
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.processing.CoverageProcessor;
+import org.geotools.process.ProcessException;
+import org.geotools.process.factory.DescribeParameter;
+import org.geotools.process.factory.DescribeProcess;
+import org.geotools.process.factory.DescribeResult;
+import org.jaitools.media.jai.kernel.KernelFactory;
+import org.opengis.parameter.ParameterValueGroup;
+
+import javax.media.jai.KernelJAI;
+import java.io.IOException;
+
+@DescribeProcess(title = "Convolve Coverage", description = "Returns a convoluted version of a given raster")
+public class ConvolveCoverageProcess implements RasterProcess {
+
+    private final CoverageProcessor PROCESSOR = new CoverageProcessor();
+
+    @DescribeResult(name = "result", description = "Convoluted raster")
+    public GridCoverage2D execute(
+            @DescribeParameter(name = "data", description = "Input raster") GridCoverage2D coverage,
+            @DescribeParameter(name = "kernel", description = "Convolution kernel", min = 0) KernelJAI kernel,
+            @DescribeParameter(name = "kernelRadius", description = "Radius for a circular kernel", min = 0) Integer kernelRadius,
+            @DescribeParameter(name = "kernelWidth", description = "Width for rectangular kernel", min = 0) Integer kernelWidth,
+            @DescribeParameter(name = "kernelHeight", description = "Height for rectangular kernel", min = 0) Integer kernelHeight
+    ) throws IOException {
+        final ParameterValueGroup param = PROCESSOR.getOperation("Convolve").getParameters();
+
+        param.parameter("Source").setValue(coverage);
+
+        if (kernel == null) {
+            if (kernelRadius != null && kernelRadius > 0) {
+                // circular kernel
+                kernel = KernelFactory.createCircle(kernelRadius);
+            }
+            else if (kernelWidth != null) {
+                if (kernelHeight == null) {
+                    kernelHeight = kernelWidth;
+                }
+
+                kernel = KernelFactory.createRectangle(kernelWidth, kernelHeight);
+            }
+        }
+
+        if (kernel == null) {
+            throw new ProcessException("No kernel argument specified"); 
+        }
+
+        param.parameter("kernel").setValue(kernel);
+
+        return (GridCoverage2D) PROCESSOR.doOperation(param);
+    }
+
+}

--- a/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/NormalizeCoverageProcess.java
+++ b/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/NormalizeCoverageProcess.java
@@ -1,0 +1,70 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.process.raster;
+
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.processing.CoverageProcessor;
+import org.geotools.process.factory.DescribeParameter;
+import org.geotools.process.factory.DescribeProcess;
+import org.geotools.process.factory.DescribeResult;
+import org.geotools.util.Converters;
+import org.opengis.parameter.ParameterValueGroup;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+
+@DescribeProcess(title = "Normalize Coverage", description = "Normalizes a coverage by dividing values by the max value")
+public class NormalizeCoverageProcess implements RasterProcess {
+
+    private final CoverageProcessor PROCESSOR = new CoverageProcessor();
+
+    @DescribeResult(name = "result", description = "Normalized raster")
+    public GridCoverage2D execute(
+        @DescribeParameter(name = "data", description = "Input raster") GridCoverage2D coverage
+    ) throws IOException {
+        
+        ParameterValueGroup param = PROCESSOR.getOperation("Extrema").getParameters();
+        param.parameter("Source").setValue(coverage);
+
+        GridCoverage2D extrema = (GridCoverage2D) PROCESSOR.doOperation(param);
+        Object max = extrema.getProperty("maximum");
+
+        // handle zero case
+        boolean allZero = true;
+        for (int i = 0; i < Array.getLength(max); i++) {
+            Object num = Array.get(max, i);
+            boolean isZero = num instanceof Number && ((Number)num).doubleValue() == 0d;
+
+            allZero = allZero && isZero;
+            if (isZero) {
+                Array.set(max, i, Converters.convert(1, num.getClass()));
+            }
+        }
+
+        if (allZero) {
+            // no need to do anything
+            return coverage;
+        }
+
+        param = PROCESSOR.getOperation("DivideByConst").getParameters();
+        param.parameter("source").setValue(coverage);
+        param.parameter("constants").setValue(max);
+    
+        return (GridCoverage2D) PROCESSOR.doOperation(param);
+    }
+
+}

--- a/modules/unsupported/process-raster/src/main/resources/META-INF/services/org.geotools.process.raster.RasterProcess
+++ b/modules/unsupported/process-raster/src/main/resources/META-INF/services/org.geotools.process.raster.RasterProcess
@@ -13,4 +13,6 @@ org.geotools.process.raster.RasterAsPointCollectionProcess
 org.geotools.process.raster.RasterZonalStatistics
 org.geotools.process.raster.RasterZonalStatistics2
 org.geotools.process.raster.ScaleCoverage 
-org.geotools.process.raster.StyleCoverageorg.geotools.process.raster.ConvolveCoverageProcess
+org.geotools.process.raster.StyleCoverage
+org.geotools.process.raster.ConvolveCoverageProcess
+org.geotools.process.raster.NormalizeCoverageProcess

--- a/modules/unsupported/process-raster/src/main/resources/META-INF/services/org.geotools.process.raster.RasterProcess
+++ b/modules/unsupported/process-raster/src/main/resources/META-INF/services/org.geotools.process.raster.RasterProcess
@@ -13,4 +13,4 @@ org.geotools.process.raster.RasterAsPointCollectionProcess
 org.geotools.process.raster.RasterZonalStatistics
 org.geotools.process.raster.RasterZonalStatistics2
 org.geotools.process.raster.ScaleCoverage 
-org.geotools.process.raster.StyleCoverage
+org.geotools.process.raster.StyleCoverageorg.geotools.process.raster.ConvolveCoverageProcess

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/ConvolveCoverageProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/ConvolveCoverageProcessTest.java
@@ -1,0 +1,89 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.process.raster;
+
+import org.geotools.coverage.CoverageFactoryFinder;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridCoverageFactory;
+import org.geotools.factory.GeoTools;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.awt.image.Raster;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ConvolveCoverageProcessTest {
+
+    float[][] covData;
+    GridCoverage2D cov;
+
+    @Before
+    public void setUp() {
+        covData = new float[][] {
+            {1,2,3,4},
+            {5,6,8,9},
+            {8,7,6,5},
+            {4,3,2,1},
+        };
+
+        GridCoverageFactory covFactory = CoverageFactoryFinder.getGridCoverageFactory(GeoTools.getDefaultHints());
+        cov = covFactory.create("test", covData, new ReferencedEnvelope(0,10,0,10, DefaultGeographicCRS.WGS84));
+    }
+
+    @Test
+    public void testConvolveRect() throws Exception {
+        ConvolveCoverageProcess p = new ConvolveCoverageProcess();
+
+        // identity
+        GridCoverage2D result = p.execute(cov, null, 0, 1, 1);
+        float[] grid = data(result);
+        assertEquals(covData[0][0], grid[0], 0.1);
+
+        // do something
+        result = p.execute(cov, null, 0, 2, 2);
+        grid = data(result);
+
+        assertNotEquals(covData[0][0], grid[0], 0.1);
+    }
+
+    @Test
+    public void testConvolveCircle() throws Exception {
+        ConvolveCoverageProcess p = new ConvolveCoverageProcess();
+        GridCoverage2D result = p.execute(cov, null, 1, 0, 0);
+
+        float[] grid = data(result);
+
+        assertNotEquals(0d, grid[5], 0.1);
+        assertNotEquals(covData[1][0], grid[5], 0.1);
+    }
+
+    float[] data(GridCoverage2D cov) {
+        Raster data = cov.getRenderedImage().getData();
+        int w = data.getWidth();
+        int h = data.getHeight();
+
+        float[] grid = new float[w*h];
+        data.getDataElements(0, 0, w, h, grid);
+
+        return grid;
+    }
+}

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/NormalizeCoverageProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/NormalizeCoverageProcessTest.java
@@ -1,0 +1,86 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.process.raster;
+
+import org.geotools.coverage.CoverageFactoryFinder;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridCoverageFactory;
+import org.geotools.factory.GeoTools;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.awt.image.Raster;
+
+import static org.junit.Assert.assertEquals;
+
+public class NormalizeCoverageProcessTest {
+
+    GridCoverageFactory covFactory;
+    
+    @Before
+    public void setUp() {
+        covFactory = CoverageFactoryFinder.getGridCoverageFactory(GeoTools.getDefaultHints());
+    }
+
+    @Test
+    public void test() throws Exception {
+        float[][] grid = new float[][] {
+            {1,2,3,4},
+            {5,6,8,9},
+            {10,11,12,13},
+            {14,15,16,17},
+        };
+
+        GridCoverage2D cov = covFactory.create("test", grid, new ReferencedEnvelope(0,10,0,10, DefaultGeographicCRS.WGS84));
+        NormalizeCoverageProcess p = new NormalizeCoverageProcess();
+        GridCoverage2D norm = p.execute(cov);
+
+        float[] data = data(norm);
+        for (int i = 0; i < data.length; i++) {
+            assertEquals(grid[i/grid.length][i%grid.length]/17f, data[i], 1E-9);
+        }
+    }
+
+    @Test
+    public void testZeroCoverage() throws Exception {
+        float[][] grid = new float[][] {
+            {0,0},
+            {0,0},
+        };
+
+        GridCoverage2D cov = covFactory.create("test", grid, new ReferencedEnvelope(0,10,0,10, DefaultGeographicCRS.WGS84));
+        NormalizeCoverageProcess p = new NormalizeCoverageProcess();
+        GridCoverage2D norm = p.execute(cov);
+
+        float[] data = data(norm);
+        for (int i = 0; i < data.length; i++) {
+            assertEquals(0f, data[i], 1E-9);
+        }
+    }
+    float[] data(GridCoverage2D cov) {
+        Raster data = cov.getRenderedImage().getData();
+        int w = data.getWidth();
+        int h = data.getHeight();
+
+        float[] grid = new float[w*h];
+        data.getDataElements(0, 0, w, h, grid);
+
+        return grid;
+    }
+}


### PR DESCRIPTION
- Convolve process simply exposes the Convolve raster operation
- The normalize process takes a raster, computes its max value, and then involves the divide operation by the max to produce a raster with values between [0,1], "normalizing" the values within it