### PR TITLE
[GEOT-5445] Add alias handling to ScalarValidator

### DIFF
--- a/modules/unsupported/ysld/src/main/java/org/geotools/ysld/validate/ScalarValidator.java
+++ b/modules/unsupported/ysld/src/main/java/org/geotools/ysld/validate/ScalarValidator.java
@@ -17,10 +17,15 @@
  */
 package org.geotools.ysld.validate;
 
+import org.yaml.snakeyaml.events.AliasEvent;
 import org.yaml.snakeyaml.events.ScalarEvent;
 
 public abstract class ScalarValidator extends YsldValidateHandler {
-
+    @Override
+    public void alias(AliasEvent evt, YsldValidateContext context) {
+        //TODO: Validate alias
+        context.pop();
+    }
     @Override
     public void scalar(ScalarEvent evt, YsldValidateContext context) {
         String message = validate(evt.getValue(), evt, context);

--- a/modules/unsupported/ysld/src/test/java/org/geotools/ysld/validate/YsldValidateTest.java
+++ b/modules/unsupported/ysld/src/test/java/org/geotools/ysld/validate/YsldValidateTest.java
@@ -780,4 +780,50 @@ public class YsldValidateTest {
         List<MarkedYAMLException> errors = validate(builder.toString());
         assertThat(errors, empty());
     }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testColourAsVariable() throws Exception {
+        // GEOT-5445 - Try each permutation of variables with fill-color and stroke-color.
+        // This tests the known validator issue, plus any potential unknown related issues.
+        StringBuilder builder =  new StringBuilder();
+        builder.append("define: &color '#ff9900'\n");
+        builder.append("symbolizers:\n");
+        builder.append("- polygon:\n");
+        builder.append("    fill-color: *color\n");
+        builder.append("    stroke-color: '#000000'\n");
+        
+        List<MarkedYAMLException> errors = validate(builder.toString());
+        assertThat(errors, empty());
+        
+        builder =  new StringBuilder();
+        builder.append("define: &color '#ff9900'\n");
+        builder.append("symbolizers:\n");
+        builder.append("- polygon:\n");
+        builder.append("    fill-color: *color\n");
+        builder.append("    stroke-color: '#000000'\n");
+        
+        errors = validate(builder.toString());
+        assertThat(errors, empty());
+        
+        builder =  new StringBuilder();
+        builder.append("define: &color '#000000'\n");
+        builder.append("symbolizers:\n");
+        builder.append("- polygon:\n");
+        builder.append("    fill-color: '#ff9900'\n");
+        builder.append("    stroke-color: *color\n");
+        
+        errors = validate(builder.toString());
+        assertThat(errors, empty());
+        
+        builder =  new StringBuilder();
+        builder.append("define: &color '#000000'\n");
+        builder.append("symbolizers:\n");
+        builder.append("- polygon:\n");
+        builder.append("    stroke-color: *color\n");
+        builder.append("    fill-color: '#ff9900'\n");
+        
+        errors = validate(builder.toString());
+        assertThat(errors, empty());
+    }
 }


### PR DESCRIPTION
PR for https://osgeo-org.atlassian.net/browse/GEOT-5445

While this is fix is an improvement,, there should really be some sort of validation for Aliases. However, this does not seem to be implemented anywhere in the YSLD validators currently and implementation appears to be nontrivial.