### PR TITLE
Oracle will fail to create spatial metadata entry correctly for CRS that report 0 dimensions [GEOT-5455]

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -1119,8 +1119,9 @@ public class OracleDialect extends PreparedStatementSQLDialect {
                     String[] axisNames;
                     if(geom.getCoordinateReferenceSystem() != null) {
                         CoordinateSystem cs = geom.getCoordinateReferenceSystem().getCoordinateSystem();
-                        if(geom.getUserData().get(Hints.COORDINATE_DIMENSION) != null) {
-                            dims = ((Number) geom.getUserData().get(Hints.COORDINATE_DIMENSION)).intValue();
+                        Object userDims = geom.getUserData().get(Hints.COORDINATE_DIMENSION);
+                        if(userDims != null && ((Number) userDims).intValue()> 0) {
+                            dims = ((Number) userDims).intValue();
                         } else {
                             dims = cs.getDimension();
                         }

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDataStoreOnlineTest.java
@@ -50,6 +50,21 @@ public class OracleDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
         return new OracleTestSetup();
     }
     
+    public void testCreateSchemaOSGBCrs() throws Exception {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName(tname("ft2"));
+        builder.setNamespaceURI(dataStore.getNamespaceURI());
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:27700");
+        builder.setCRS(crs);
+        builder.add(aname("geometry"), Geometry.class);
+        builder.add(aname("intProperty"), Integer.class);
+        builder.add(aname("dateProperty"), Date.class);
+
+        SimpleFeatureType featureType = builder.buildFeatureType();
+        // used to fail here - with index creation error
+        dataStore.createSchema(featureType);
+    }
+    
     public void testCreateSchemaWktCrs() throws Exception {
         SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
         builder.setName(tname("ft2"));

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
       <name>Ian Turton</name>
       <id>ianturton</id>
       <email>ianturton@users.sourceforge.net</email>
-      <organization>Envitia Ltd</organization>
+      <organization>Astun Technology</organization>
       <roles>
         <role>Java Developer</role>
         <role>Project Management Committee (PMC) Member</role>


### PR DESCRIPTION
Allow users to create tables in Oracle (10g) DB even if the CRS declares 0 dimensions. 