### PR TITLE
[DOCS] added note about needing svg module to draw svg icons

### DIFF
--- a/docs/user/library/render/faq.rst
+++ b/docs/user/library/render/faq.rst
@@ -77,3 +77,10 @@ is crossed.
 This feature can be enabled/disabled using the related method
 *setAdvancedProjectionHandlingEnabled()* in the same class.
 
+Q: Why does my SVG external graphic display as a gray square?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+GeoTools uses a plugable External Graphics factory system to render an icon
+(see :doc:`/library/render/icon` for more details) 
+onto the screen. To render SVG files as icons it needs access to the
+SVGExternalGraphics factory which is included in the :doc:`/library/render/svg`.

--- a/docs/user/library/render/svg.rst
+++ b/docs/user/library/render/svg.rst
@@ -23,3 +23,4 @@ Here is the example fillHouse.sld:
 
 .. literalinclude:: /../../modules/plugin/svg/src/test/resources/org/geotools/renderer/lite/test-data/fillHouse.sld
      :language: xml
+


### PR DESCRIPTION
In answering [this question](https://gis.stackexchange.com/questions/201282/externalgraphics-gray-squares-instead) I discovered it isn't obvious that you need to add the svg module to be able to render svg graphics. So this adds a note to that effect to the rendering faq.