### PR TITLE
Fix link to FeatureCollection in swing faq

### DIFF
--- a/docs/user/unsupported/swing/faq.rst
+++ b/docs/user/unsupported/swing/faq.rst
@@ -35,4 +35,4 @@ in addition to converting your rasters into an efficient format (anything is bet
 
 References:
 
-* `FeatureCollection Performance </library/main/collection>`_
+* :doc:`FeatureCollection Performance </library/main/collection>`


### PR DESCRIPTION
Crossing my fingers this syntax for linking to other docs works (?). I borrowed it from another geotools rst example.

The link was sending the user here:
http://docs.geotools.org/library/main/collection

Instead of here:
http://docs.geotools.org/latest/userguide/library/main/collection.html