### PR TITLE
Upgrade to Mongo module to fix GEOT-5492

### DIFF
--- a/modules/unsupported/mongodb/pom.xml
+++ b/modules/unsupported/mongodb/pom.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- =======================================================================    
-        Maven Project Configuration File                                        
-                                                                                
-        The Geotools Project                                                    
-            http://www.geotools.org/                                            
-                                                                                
+<!-- =======================================================================
+        Maven Project Configuration File
+
+        The Geotools Project
+            http://www.geotools.org/
+
         Version: $Id: pom.xml 2014-03-21 13:32:49Z tkunicki $
      ======================================================================= -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.geotools</groupId>
     <artifactId>unsupported</artifactId>
     <version>16-SNAPSHOT</version>
   </parent>
-  
+
   <groupId>org.geotools</groupId>
   <artifactId>gt-mongodb</artifactId>
   <packaging>jar</packaging>
   <name>MongoDB DataStore</name>
   <description>MongoDB DataStore</description>
-  
+
   <developers>
     <developer>
       <id>jodygarnett</id>
@@ -45,7 +45,7 @@
       </roles>
     </developer>
   </developers>
-  
+
   <contributors>
     <contributor>
       <name>Tom Kunicki</name>
@@ -67,7 +67,7 @@
       </roles>
     </contributor>
   </contributors>
-  
+
     <dependencies>
         <!--   GeoTools modules   -->
         <dependency>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>2.11.3</version>
+            <version>3.3.0</version>
             <type>jar</type>
             <optional>false</optional>
         </dependency>

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
@@ -114,7 +114,7 @@ public class MongoDataStore extends ContentDataStore {
     final MongoClient createMongoClient(MongoClientURI mongoClientURI) {
         try {
             return new MongoClient(mongoClientURI);
-        } catch (UnknownHostException e) {
+        } catch (Exception e) {
             throw new IllegalArgumentException("Unknown mongodb host(s)", e);
         }
     }
@@ -221,7 +221,7 @@ public class MongoDataStore extends ContentDataStore {
         incoming.getUserData().put(KEY_collection, incoming.getTypeName());
         
         // Collection needs to exist (with index) so that it's returned with createTypeNames()
-        dataStoreDB.createCollection(incoming.getTypeName(), new BasicDBObject()).ensureIndex(new BasicDBObject(geometryMapping, "2dsphere"));
+        dataStoreDB.createCollection(incoming.getTypeName(), new BasicDBObject()).createIndex(new BasicDBObject(geometryMapping, "2dsphere"));
        
         // Store FeatureType instance since it can't be inferred (no documents)
         ContentEntry entry = entry (incoming.getName());

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureWriter.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureWriter.java
@@ -69,7 +69,7 @@ public class MongoFeatureWriter implements SimpleFeatureWriter {
     
     @Override
     public void close() throws IOException {
-        collection.ensureIndex(new BasicDBObject(mapper.getGeometryPath(), "2dsphere"));
+        collection.createIndex(new BasicDBObject(mapper.getGeometryPath(), "2dsphere"));
     }
 
 }

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoSchemaDBStore.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoSchemaDBStore.java
@@ -60,7 +60,7 @@ public class MongoSchemaDBStore implements MongoSchemaStore {
             collectionName = DEFAULT_collectionName;
         }
         collection = database.getCollection(collectionName);
-        collection.ensureIndex(
+        collection.createIndex(
                 new BasicDBObject(FeatureTypeDBObject.KEY_typeName, 1),
                 new BasicDBObject("unique", true));
     }

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -89,8 +89,8 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
             .pop()
         .get());
 
-        ft1.ensureIndex(new BasicDBObject("geometry", "2dsphere"));
-        ft1.ensureIndex(new BasicDBObject("properties.listProperty.value", 1));
+        ft1.createIndex(new BasicDBObject("geometry", "2dsphere"));
+        ft1.createIndex(new BasicDBObject("properties.listProperty.value", 1));
 
         DBCollection ft2 = db.getCollection("ft2");
         ft2.drop();

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/integration/MongoTestUtil.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/integration/MongoTestUtil.java
@@ -120,7 +120,7 @@ public class MongoTestUtil {
       }
       bdoBuilder.pop();
       coll.insert(bdoBuilder.get());
-      coll.ensureIndex(new BasicDBObject("geometry", "2dsphere"));
+      coll.createIndex(new BasicDBObject("geometry", "2dsphere"));
     }
   }
   


### PR DESCRIPTION
Fixes GEOT-5492 by:
-upgrade version of mongo-java-driver to 3.3.0 in pom.xml
-replacing usages of “ensureIndex” (deprecated) with “createIndex” in various classes
-UnknownHostException not explicitly thrown


Unit tests remain valid and functional tests pass in GeoServer