### PR TITLE
Fix possible NPE in CompoundCurve [GEOT-5508]

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/geometry/jts/CompoundCurve.java
+++ b/modules/library/api/src/main/java/org/geotools/geometry/jts/CompoundCurve.java
@@ -374,7 +374,7 @@ public class CompoundCurve extends LineString implements CompoundCurvedGeometry<
      */
 
     public boolean isRectangle() {
-        return linearized.isRectangle();
+        return linearize().isRectangle();
     }
 
     public Coordinate[] getCoordinates() {

--- a/modules/library/api/src/test/java/org/geotools/geometry/jts/CurvedGeometryTest.java
+++ b/modules/library/api/src/test/java/org/geotools/geometry/jts/CurvedGeometryTest.java
@@ -223,6 +223,8 @@ public class CurvedGeometryTest {
         CompoundCurve curve = new CompoundCurve(Arrays.asList(cs, ls), GEOMETRY_FACTORY,
                 Double.MAX_VALUE);
 
+        assertFalse("Check that this should not be a rectangle.", curve.isRectangle());
+
         // envelope check
         Envelope env = curve.getEnvelopeInternal();
         assertEnvelopeEquals(new Envelope(-10, 10, 0, 20), env);


### PR DESCRIPTION
In this PR:

  - [x] add a call to the failing `isRectangle()` method to illustrate GEOT-5508 (e862c1755f8e8a6d06b3163897d51d2e8df34620)
  - [x] provide a fix by calling `linearize().isRectangle()` instead (06399d6a4804ccf0e15e96f1b8ec24ca98346c0a)


fixes [GEOT-5508](https://osgeo-org.atlassian.net/browse/GEOT-5508)


