### PR TITLE
[GEOT-5513] Changes for supporting AbstractGridFormat.BANDS parameter 

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridFormat.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridFormat.java
@@ -181,6 +181,19 @@ public abstract class AbstractGridFormat implements Format {
      */
     public static final DefaultParameterDescriptor<String> SUGGESTED_TILE_SIZE = new DefaultParameterDescriptor<String>(
         		SUGGESTED_TILESIZE, String.class, null, "512,512");
+    
+    /**
+     * This {@link GeneralParameterValue} can be provided to the
+     * {@link GridCoverageReader}s through the
+     * {@link GridCoverageReader#read(GeneralParameterValue[])} method to specify 
+     * the band indices of the input grid coverage that are going to be in the 
+     * resulting coverage. The order of the bands on the output coverage 
+     * is the order of the indices in the parameter. Value should be an integer 
+     * array (int[]) containing the band indices in the desired order. 
+     * Duplicate or multiple appearances of the same band index are allowed.
+     */
+    public static final DefaultParameterDescriptor<int[]> BANDS = new DefaultParameterDescriptor<int[]>(
+        		"Bands", int[].class, null, null);
 
     public static final String TILE_SIZE_SEPARATOR = ",";
 

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/ChannelSelectionUpdateStyleVisitor.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/ChannelSelectionUpdateStyleVisitor.java
@@ -1,0 +1,108 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.renderer.lite.gridcoverage2d;
+
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.styling.ChannelSelection;
+import org.geotools.styling.ColorMap;
+import org.geotools.styling.ContrastEnhancement;
+import org.geotools.styling.RasterSymbolizer;
+import org.geotools.styling.SelectedChannelType;
+import org.geotools.styling.ShadedRelief;
+import org.geotools.styling.Symbolizer;
+import org.geotools.styling.visitor.DuplicatingStyleVisitor;
+import org.opengis.filter.expression.Expression;
+
+/**
+ * ChannelSelectionUpdateStyleVisitor is a {@link DuplicatingStyleVisitor} that is used 
+ * to "reset" style symbolizer's selection channel order when the GridCoverageReader 
+ * used to read a coverage supports band selection. If a reader supports band selection
+ * then channel ordering is done by band selection from the reader, so symbolizer does
+ * not need to re-apply selection channel order.
+ * 
+ * Also, see {@link AbstractGridFormat#BANDS} for the reader band selection parameter 
+ * description.
+ * 
+ * @source $URL$
+ * @version $Id$
+ *
+ */
+
+public class ChannelSelectionUpdateStyleVisitor extends DuplicatingStyleVisitor{
+
+    private SelectedChannelType[] channels;
+    
+    public ChannelSelectionUpdateStyleVisitor(SelectedChannelType[] channels){
+        super();
+        this.channels = channels;
+    }
+    
+    @Override
+    public void visit(RasterSymbolizer raster) {
+
+        ChannelSelection channelSelection = createChannelSelection();
+
+        ColorMap colorMap = copy(raster.getColorMap());
+        ContrastEnhancement ce = copy(raster.getContrastEnhancement());
+        String geometryProperty = raster.getGeometryPropertyName();
+        Symbolizer outline = copy(raster.getImageOutline());
+        Expression overlap = copy(raster.getOverlap());
+        ShadedRelief shadedRelief = copy(raster.getShadedRelief());
+
+        Expression opacity = copy(raster.getOpacity());
+
+        RasterSymbolizer copy = sf.createRasterSymbolizer(geometryProperty, opacity,
+                channelSelection, overlap, colorMap, ce,
+                shadedRelief, outline);
+        if (STRICT && !copy.equals(raster)) {
+            throw new IllegalStateException("Was unable to duplicate provided raster:" + raster);
+        }
+        pages.push(copy);
+    }
+
+    private ChannelSelection createChannelSelection() {
+        if (channels.length != 3) {
+            return sf.createChannelSelection(new SelectedChannelType[]{channels[0]});
+        } else {
+            return sf.createChannelSelection(channels);
+        }
+    }
+    
+    /**
+     * Returns an int[] containing the indices of the coverage bands that are used for the
+     * symbolizer's selection channels
+     * @param symbolizer The input symbolizer
+     * @return the band indices array (null if no channel selection was present in symbolizer)
+     */
+    
+    public static int[] getBandIndicesFromSelectionChannels(RasterSymbolizer symbolizer){
+        int[] bandIndices = null;
+        ChannelSelection channelSelection = symbolizer.getChannelSelection();
+        if (channelSelection!=null){
+            SelectedChannelType[] channels = channelSelection.getSelectedChannels();
+            if (channels!=null){
+                    bandIndices = new int[channels.length];
+                    for (int i=0;i<channels.length;i++){
+                        //Note that in channel selection, channels start at index 1
+                        bandIndices[i]= Integer.parseInt(channels[i].getChannelName())-1;
+                    }
+            }
+        }
+        return bandIndices;
+    }
+}

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRenderer.java
@@ -32,6 +32,7 @@ import java.awt.image.RenderedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -56,12 +57,14 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.factory.Hints;
 import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.image.ImageWorker;
+import org.geotools.parameter.Parameter;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.operation.builder.GridToEnvelopeMapper;
 import org.geotools.referencing.operation.matrix.XAffineTransform;
@@ -74,13 +77,17 @@ import org.geotools.resources.i18n.ErrorKeys;
 import org.geotools.resources.i18n.Errors;
 import org.geotools.resources.image.ColorUtilities;
 import org.geotools.resources.image.ImageUtilities;
+import org.geotools.styling.ChannelSelection;
 import org.geotools.styling.RasterSymbolizer;
+import org.geotools.styling.SelectedChannelType;
 import org.jaitools.imageutils.ImageLayout2;
 import org.jaitools.imageutils.ROIGeometry;
 import org.opengis.coverage.grid.GridCoverage;
+import org.opengis.coverage.grid.GridCoverageReader;
 import org.opengis.geometry.BoundingBox;
 import org.opengis.metadata.spatial.PixelOrientation;
 import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.parameter.ParameterValue;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.datum.PixelInCell;
@@ -970,11 +977,21 @@ public final class GridCoverageRenderer {
             }
         }
         
+        RasterSymbolizer finalSymbolizer = symbolizer;
+        
+        // Check if reader supports band selection, and rearrange raster channels order in
+        // symbolizer. Reader should have taken care o proper channel order, based on initial
+        // symbolizer channel definition
+        if (isBandsSelectionApplicable(reader, symbolizer)){
+            applyBandsSelectionParameter(reader, readParams, symbolizer);
+            finalSymbolizer = setupSymbolizerForBandsSelection(symbolizer);
+        }
+
         // symbolize each bit (done here to make sure we can perform the warp/affine reduction)
         List<GridCoverage2D> symbolizedCoverages = new ArrayList<>();
         int ii = 0;
         for (GridCoverage2D displaced : displacedCoverages) {
-            GridCoverage2D symbolized = symbolize(displaced, symbolizer,
+            GridCoverage2D symbolized = symbolize(displaced, finalSymbolizer,
                     bgValues);
             symbolizedCoverages.add(symbolized);
             ii++;
@@ -1164,8 +1181,17 @@ public final class GridCoverageRenderer {
 
         setupInterpolationHints(interpolation);
         
+        RasterSymbolizer finalSymbolizer = symbolizer;
+        //
+        // Band selection
+        //
+        if (isBandsSelectionApplicable(gridCoverageReader, symbolizer)){
+            applyBandsSelectionParameter(gridCoverageReader, readParams, symbolizer);
+            finalSymbolizer = setupSymbolizerForBandsSelection(symbolizer);
+        }
+
         // Build the final image and the transformation
-        RenderedImage finalImage = renderImage(gridCoverageReader, readParams, symbolizer,
+        RenderedImage finalImage = renderImage(gridCoverageReader, readParams, finalSymbolizer,
                 interpolation, background);
         if (finalImage != null) {
             try {
@@ -1279,6 +1305,53 @@ public final class GridCoverageRenderer {
                 graphics.setRenderingHints(oldHints);
             }
         }
+    }
+    
+    private GeneralParameterValue[] applyBandsSelectionParameter(
+            GridCoverageReader reader,
+            GeneralParameterValue[] readParams, 
+            RasterSymbolizer symbolizer
+            ){
+        int[] bandIndices = 
+                ChannelSelectionUpdateStyleVisitor.getBandIndicesFromSelectionChannels(symbolizer);
+        Parameter<int[]> bandIndicesParam = null;
+        bandIndicesParam = (Parameter<int[]>) AbstractGridFormat.BANDS.createValue();
+        bandIndicesParam.setValue(bandIndices);
+        List<GeneralParameterValue> paramList = new ArrayList<GeneralParameterValue>();
+        paramList.addAll(Arrays.asList(readParams));
+        paramList.add(bandIndicesParam);
+        return paramList.toArray(new GeneralParameterValue[paramList.size()]);
+    }
+    
+    public static RasterSymbolizer setupSymbolizerForBandsSelection(
+            RasterSymbolizer symbolizer) {
+        int[] bandIndices = ChannelSelectionUpdateStyleVisitor
+                .getBandIndicesFromSelectionChannels(symbolizer);
+        ChannelSelection selection = symbolizer.getChannelSelection();
+        final SelectedChannelType[] channels = selection.getSelectedChannels();
+        if (channels != null) {
+            int i = 0;
+            for (SelectedChannelType channel : channels) {
+                // Remember, channel indices start from 1
+                channel.setChannelName(Integer.toString(i + 1));
+                i++;
+            }
+
+            ChannelSelectionUpdateStyleVisitor channelsUpdateVisitor = new ChannelSelectionUpdateStyleVisitor(
+                    channels);
+            symbolizer.accept(channelsUpdateVisitor);
+            return (RasterSymbolizer) channelsUpdateVisitor.getCopy();
+        }
+        return symbolizer;
+    }
+    
+    public static boolean isBandsSelectionApplicable(GridCoverageReader reader,
+            RasterSymbolizer symbolizer){
+        int[] bandIndices = ChannelSelectionUpdateStyleVisitor
+                .getBandIndicesFromSelectionChannels(symbolizer);
+        return reader.getFormat() != null && reader.getFormat().getReadParameters().getDescriptor()
+                .descriptors().contains(AbstractGridFormat.BANDS) && bandIndices != null;
+        
     }
 
 }


### PR DESCRIPTION
[GEOT-5513](https://osgeo-org.atlassian.net/browse/GEOT-5513)

Adding a BANDS parameter in AbstractGridFormat. Also, changes include adjustments on GridCoverageRenderer  for supporting readers using this parameter and  "resetting" of selection channels on raster symbolizers (when necessary) so as to use bands defined by the BANDS parameter.