### PR TITLE
[GEOT-5520] Make grid coverage renderer bands selection setup update a copy of the channels

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRenderer.java
@@ -80,6 +80,7 @@ import org.geotools.resources.image.ImageUtilities;
 import org.geotools.styling.ChannelSelection;
 import org.geotools.styling.RasterSymbolizer;
 import org.geotools.styling.SelectedChannelType;
+import org.geotools.styling.SelectedChannelTypeImpl;
 import org.jaitools.imageutils.ImageLayout2;
 import org.jaitools.imageutils.ROIGeometry;
 import org.opengis.coverage.grid.GridCoverage;
@@ -1330,17 +1331,18 @@ public final class GridCoverageRenderer {
     public static RasterSymbolizer setupSymbolizerForBandsSelection(
             RasterSymbolizer symbolizer) {
         ChannelSelection selection = symbolizer.getChannelSelection();
-        final SelectedChannelType[] channels = selection.getSelectedChannels();
-        if (channels != null) {
+        final SelectedChannelType[] originalChannels = selection.getSelectedChannels();
+        if (originalChannels != null) {
             int i = 0;
-            for (SelectedChannelType channel : channels) {
+            SelectedChannelType[] channels = new SelectedChannelType[originalChannels.length];
+            for (SelectedChannelType originalChannel : originalChannels) {
                 // Remember, channel indices start from 1
+                SelectedChannelTypeImpl channel = new SelectedChannelTypeImpl();
                 channel.setChannelName(Integer.toString(i + 1));
+                channel.setContrastEnhancement(originalChannel.getContrastEnhancement());
                 i++;
             }
-
-            ChannelSelectionUpdateStyleVisitor channelsUpdateVisitor = new ChannelSelectionUpdateStyleVisitor(
-                    channels);
+            ChannelSelectionUpdateStyleVisitor channelsUpdateVisitor = new ChannelSelectionUpdateStyleVisitor(channels);
             symbolizer.accept(channelsUpdateVisitor);
             return (RasterSymbolizer) channelsUpdateVisitor.getCopy();
         }

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/GridCoverageRendererTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/GridCoverageRendererTest.java
@@ -79,13 +79,7 @@ import org.geotools.referencing.operation.DefaultMathTransformFactory;
 import org.geotools.referencing.operation.projection.MapProjection;
 import org.geotools.renderer.lite.gridcoverage2d.GridCoverageRenderer;
 import org.geotools.resources.image.ImageUtilities;
-import org.geotools.styling.ColorMap;
-import org.geotools.styling.ContrastEnhancement;
-import org.geotools.styling.RasterSymbolizer;
-import org.geotools.styling.SelectedChannelType;
-import org.geotools.styling.Style;
-import org.geotools.styling.StyleBuilder;
-import org.geotools.styling.StyleFactory;
+import org.geotools.styling.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1077,9 +1071,18 @@ public class GridCoverageRendererTest  {
         
         GridCoverageRenderer renderer = new GridCoverageRenderer(DefaultGeographicCRS.WGS84, mapExtent,
                 new Rectangle(0, 0, 100, 100), null);
-        RenderedImage image = renderer.renderImage(reader, null, buildChannelSelectingSymbolizer(3), Interpolation.getInstance(Interpolation.INTERP_NEAREST), Color.BLACK, 256, 256);
+        // keeping a reference to the raster symbolizer so we can check we has not altered
+        // during the band setup the raster symbolizer channel selection needs to be rearranged
+        // but the original raster symbolizer should not be altered
+        RasterSymbolizer rasterSymbolizer = buildChannelSelectingSymbolizer(3);
+        RenderedImage image = renderer.renderImage(reader, null, rasterSymbolizer, Interpolation.getInstance(Interpolation.INTERP_NEAREST), Color.BLACK, 256, 256);
         assertEquals(1, image.getSampleModel().getNumBands());
         assertEquals(255, new ImageWorker(image).getMinimums()[0], 0d);
+        // test that raster symbolizer was not altered
+        RasterSymbolizer expectedRasterSymbolizer = buildChannelSelectingSymbolizer(3);
+        // during the copy method contrast enhancement NULL options are converted to an empty HashMap
+        expectedRasterSymbolizer.getContrastEnhancement().setOptions(Collections.emptyMap());
+        assertEquals(rasterSymbolizer, expectedRasterSymbolizer);
         ImageUtilities.disposeImage(image);
         
     }


### PR DESCRIPTION
This fix the aliasing issue and extend test testBandSelectionSupportingReader to check raster symbolizer immutability between runs.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOT-5520