### PR TITLE
[GEOT-724] backport for 15.x

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -585,7 +585,7 @@ public class OracleDialect extends PreparedStatementSQLDialect {
 
         // Handle the null geometry case.
         // Surprisingly, using setNull(column, Types.OTHER) does not work...
-        if (g == null) {
+        if (g == null||g.isEmpty()) {
             ps.setNull(column, Types.STRUCT, "MDSYS.SDO_GEOMETRY");
             return;
         }

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/SDO11OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/SDO11OracleDialect.java
@@ -75,7 +75,7 @@ class SDO11OracleDialect extends OracleDialect {
             int column) throws SQLException {
         // Handle the null geometry case.
         // Surprisingly, using setNull(column, Types.OTHER) does not work...
-        if (g == null) {
+        if (g == null || g.isEmpty()) {
             ps.setNull(column, Types.STRUCT, "MDSYS.SDO_GEOMETRY");
             return;
         }

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/SDOOracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/SDOOracleDialect.java
@@ -70,7 +70,7 @@ class SDOOracleDialect extends OracleDialect {
             int column) throws SQLException {
         // Handle the null geometry case.
         // Surprisingly, using setNull(column, Types.OTHER) does not work...
-        if (g == null) {
+        if (g == null || g.isEmpty()) {
             ps.setNull(column, Types.STRUCT, "MDSYS.SDO_GEOMETRY");
             return;
         }

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/GeometryConverter.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/GeometryConverter.java
@@ -153,7 +153,7 @@ public class GeometryConverter {
      * @see net.refractions.jspatial.Converter#toDataType(java.lang.Object)
      */
     public STRUCT toSDO(Geometry geom, int srid) throws SQLException {
-        if( geom == null) return asEmptyDataType();
+        if( geom == null || geom.isEmpty()) return asEmptyDataType();
         
         int gtype = SDO.gType( geom );
         NUMBER SDO_GTYPE = new NUMBER( gtype );

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/SDO.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/SDO.java
@@ -147,6 +147,8 @@ public final class SDO {
 
         if (f instanceof CoordinateAccessFactory) {
             return ((CoordinateAccessFactory) f).getDimension();
+        } else if(geom==null ||geom.getCoordinate() == null || geom.isEmpty()){
+        	return 2;
         } else {
             //return 3;
             return Double.isNaN(geom.getCoordinate().z) ? 2 : 3;
@@ -464,13 +466,14 @@ public final class SDO {
 
         for (int i = 0; i < polys.getNumGeometries(); i++) {
             poly = (Polygon) polys.getGeometryN(i);
-            addElemInfo(elemInfoList, poly, offset, GTYPE);
-            if( isRectangle( poly )){
-                offset += (2 * LEN);                
-            }
-            else {
-                offset += (poly.getNumPoints() * LEN);                
-            }            
+			if (poly!=null&&!poly.isEmpty()) {
+				addElemInfo(elemInfoList, poly, offset, GTYPE);
+				if (isRectangle(poly)) {
+					offset += (2 * LEN);
+				} else {
+					offset += (poly.getNumPoints() * LEN);
+				}
+			}
         }
     }
 
@@ -1096,33 +1099,40 @@ public final class SDO {
      */
     private static void addCoordinatesInterpretation1(List list, Polygon polygon) {
         int holes = polygon.getNumInteriorRing();
-
-        addCoordinates(list,
-            counterClockWise(polygon.getFactory().getCoordinateSequenceFactory(),
-                polygon.getExteriorRing().getCoordinateSequence()));
-
-        for (int i = 0; i < holes; i++) {
+        if (!polygon.isEmpty()) {
             addCoordinates(list,
-                clockWise(polygon.getFactory().getCoordinateSequenceFactory(),
-                    polygon.getInteriorRingN(i).getCoordinateSequence()));
+                    counterClockWise(polygon.getFactory().getCoordinateSequenceFactory(),
+                            polygon.getExteriorRing().getCoordinateSequence()));
+
+            for (int i = 0; i < holes; i++) {
+                addCoordinates(list, clockWise(polygon.getFactory().getCoordinateSequenceFactory(),
+                        polygon.getInteriorRingN(i).getCoordinateSequence()));
+            }
         }
     }
 
     private static void addCoordinates(List list, MultiPoint points) {
         for (int i = 0; i < points.getNumGeometries(); i++) {
-            addCoordinates(list, (Point) points.getGeometryN(i));
+            Geometry geometryN = points.getGeometryN(i);
+            if(geometryN!=null && !geometryN.isEmpty())
+            	addCoordinates(list, (Point) geometryN);
         }
     }
 
     private static void addCoordinates(List list, MultiLineString lines) {
         for (int i = 0; i < lines.getNumGeometries(); i++) {
-            addCoordinates(list, (LineString) lines.getGeometryN(i));
+            Geometry geometryN = lines.getGeometryN(i);
+            if(geometryN!=null && !geometryN.isEmpty())
+            	addCoordinates(list, (LineString) geometryN);
         }
     }
 
     private static void addCoordinates(List list, MultiPolygon polys) {
         for (int i = 0; i < polys.getNumGeometries(); i++) {
-            addCoordinates(list, (Polygon) polys.getGeometryN(i));
+        	
+            Geometry geometryN = polys.getGeometryN(i);
+            if(geometryN!=null && !geometryN.isEmpty())
+            	addCoordinates(list, (Polygon) geometryN);
         }
     }
 
@@ -1131,7 +1141,8 @@ public final class SDO {
 
         for (int i = 0; i < geoms.getNumGeometries(); i++) {
             geom = geoms.getGeometryN(i);
-
+            if(geom==null || geom.isEmpty())
+            	continue;
             if (geom instanceof Point) {
                 addCoordinates(list, (Point) geom);
             } else if (geom instanceof LineString) {

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleGeometryOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleGeometryOnlineTest.java
@@ -16,14 +16,29 @@
  */
 package org.geotools.data.oracle;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.geotools.data.DataUtilities;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureStore;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.jdbc.JDBCGeometryOnlineTest;
 import org.geotools.jdbc.JDBCGeometryTestSetup;
 import org.geotools.referencing.CRS;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.filter.identity.FeatureId;
 
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.CoordinateSequence;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.Point;
@@ -48,6 +63,45 @@ public class OracleGeometryOnlineTest extends JDBCGeometryOnlineTest {
         assertEquals(LineString.class, checkGeometryType(LinearRing.class));
     }
     
+    public void testInsertEmptyGeometry() throws Exception {
+        ContentFeatureSource source = dataStore.getFeatureSource("COLA_MARKETS_CS");
+        if (!(source instanceof SimpleFeatureStore)) {
+            fail("store not writable");
+        }
+        GeometryFactory gf = new GeometryFactory();
+        ArrayList<SimpleFeature> list = new ArrayList<>();
+        SimpleFeatureBuilder builder = new SimpleFeatureBuilder(source.getSchema());
+        
+        builder.add("empty point");
+        builder.add(gf.createPoint((Coordinate)null));
+        SimpleFeature f = builder.buildFeature(null);
+        list.add(f);
+        builder.add("empty line");
+        builder.add(gf.createLineString((CoordinateSequence)null));
+        f = builder.buildFeature(null);
+        list.add(f);
+        builder.add("empty polygon");
+        builder.add(gf.createPolygon(null,null));
+        f = builder.buildFeature(null);
+        list.add(f);
+        FeatureCollection<SimpleFeatureType, SimpleFeature> collection = DataUtilities
+                .collection(list);
+        SimpleFeatureStore store = (SimpleFeatureStore) source;
+        Transaction transaction = new DefaultTransaction("create");
+        store.setTransaction(transaction);
+
+        try {
+            //GEOT-724 https://osgeo-org.atlassian.net/browse/GEOT-724 
+        	//throws exception here
+        	List<FeatureId> ids = store.addFeatures(collection);
+            
+            transaction.commit();
+        } finally {
+            transaction.close();
+        }
+        
+
+    }
     public void testComplexGeometryFallback() throws Exception {
         SimpleFeatureIterator fi = dataStore.getFeatureSource("COLA_MARKETS_CS").getFeatures().features();
         assertTrue(fi.hasNext());


### PR DESCRIPTION
fixes "Oracle DataStore is unable to add empty geometries"

Applies patches for [GEOT-724](https://osgeo-org.atlassian.net/browse/GEOT-724) provided in #1228 to 15.x branch