### PR TITLE
[GEOT-5527] PostgreSQL 9.6 breaks ASC_OR_DESC for index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <postgresql.jdbc.version>9.4-1201-jdbc41</postgresql.jdbc.version>
+    <postgresql.jdbc.version>9.4.1211</postgresql.jdbc.version>
     <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>
   </properties>
 


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5527

This pull request targets 15.x.