### PR TITLE
added test for GEOT-5176 - white space in column names

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -490,6 +490,10 @@ public class OracleDialect extends PreparedStatementSQLDialect {
         raw = raw.toUpperCase();
         if(raw.length() > 30)
             raw = raw.substring(0, 30);
+        // need to quote column names with spaces in
+        if (raw.contains(" ")) {
+            raw = "\"" + raw + "\"";
+        }
         sql.append(raw);
     }
     
@@ -498,6 +502,10 @@ public class OracleDialect extends PreparedStatementSQLDialect {
         raw = raw.toUpperCase();
         if(raw.length() > 30)
             raw = raw.substring(0, 30);
+        // need to quote table names with spaces in
+        if (raw.contains(" ")) {
+            raw = "\"" + raw + "\"";
+        }
         sql.append(raw);
     }
     

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/ColumnEncodingTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/ColumnEncodingTest.java
@@ -35,5 +35,16 @@ public class ColumnEncodingTest {
         dialect.encodeColumnName("name",buffer);
         assertEquals("NAME", buffer.toString());
     }
+    
+    /**
+     * test for GEOT-5176 Oracle can't handle spaces in column names
+     */
+    @Test
+    public void testspaces() {
+        StringBuffer buffer = new StringBuffer();
+        OracleDialect dialect = new OracleDialect(null);
+        dialect.encodeColumnName("name with space",buffer);
+        assertEquals("NAME WITH SPACE", buffer.toString());
+    }
 
 }

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/ColumnEncodingTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/ColumnEncodingTest.java
@@ -44,7 +44,7 @@ public class ColumnEncodingTest {
         StringBuffer buffer = new StringBuffer();
         OracleDialect dialect = new OracleDialect(null);
         dialect.encodeColumnName("name with space",buffer);
-        assertEquals("NAME WITH SPACE", buffer.toString());
+        assertEquals("\"NAME WITH SPACE\"", buffer.toString());
     }
 
 }


### PR DESCRIPTION
I believe that this bug was fixed by [PR1183](https://github.com/geotools/geotools/pull/1183), this PR adds a test, just needs a working Oracle instance for testing.