### PR TITLE
[GEOT-5534] Make streaming renderer map the default geometry attribute to the real geometry attribute name

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -33,14 +33,7 @@ import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 import java.io.IOException;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -1608,12 +1601,21 @@ public class StreamingRenderer implements GTRenderer {
         }
 
         try {
-            // DJB:geos-469 if the default geometry was used in the style, we
-            // need to grab it.
+            // DJB:geos-469 if the default geometry was used in the style, we need to grab it.
+            // we substitute the default geometry attribute "" with the proper geometry attribute name (this will help us avoid
+            // situations were the geometry is not read because of the default geometry attribute "" not being taken in account)
             if (sae.getDefaultGeometryUsed()
-                    && !attributeNames.contains(schema.getGeometryDescriptor().getName().toString())
-                    && !attributeNames.contains("")) {
+                    && !attributeNames.contains(schema.getGeometryDescriptor().getName().toString())) {
                 atts.add(filterFactory.property ( schema.getGeometryDescriptor().getName() ));
+            }
+            // the geometry attribute name was added above, we need to remove the default geometry attribute "" if present
+            for (Iterator<PropertyName> it = atts.iterator(); it.hasNext();){
+                PropertyName propertyName = it.next();
+                if (propertyName.getPropertyName().equals("")) {
+                    // well the default geometry attribute name "" is present, so let's remove it
+                    it.remove();
+                    break;
+                }
             }
         } catch (Exception e) {
             // might not be a geometry column. That will cause problems down the

--- a/modules/library/render/src/test/resources/org/geotools/renderer/lite/test-data/genericLines.properties
+++ b/modules/library/render/src/test/resources/org/geotools/renderer/lite/test-data/genericLines.properties
@@ -1,0 +1,5 @@
+_=geom:Geometry:4326,name:String
+line.1=LINESTRING(-1  1, -1 -1)|line1
+line.2=LINESTRING(-1 -1,  1 -1)|line2
+line.3=LINESTRING( 1 -1,  1  1)|line3
+line.4=LINESTRING( 1  1, -1  1)|line4

--- a/modules/library/render/src/test/resources/org/geotools/renderer/lite/test-data/genericLines.sld
+++ b/modules/library/render/src/test/resources/org/geotools/renderer/lite/test-data/genericLines.sld
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <Name>LineWidth</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:Function name="isValid">
+                                <ogc:PropertyName> </ogc:PropertyName>
+                            </ogc:Function>
+                            <ogc:Literal>true</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#0000FF</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-5534

This pull request also adds a test case for this.