### PR TITLE
Fix ServiceException initCause() [GEOT-5533]

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/ows/ServiceException.java
+++ b/modules/library/main/src/main/java/org/geotools/ows/ServiceException.java
@@ -81,7 +81,9 @@ public class ServiceException extends SAXException {
 	private String code = "";
     private String locator = null;
     private ServiceException next; //So they can be chained
-
+    protected Throwable cause;
+    
+    @SuppressWarnings("unused")
     private ServiceException() {
         super("");
     	// should not be called
@@ -114,6 +116,28 @@ public class ServiceException extends SAXException {
         this.locator = locator;
     }
 
+    @Override
+    public synchronized Throwable initCause(Throwable cause) {
+        this.cause = cause;
+        
+        return super.initCause(cause);
+    }
+
+    @Override
+    public Throwable getCause() {
+        if (this.cause != null) {
+            return this.cause;
+        }
+        return super.getCause();
+    }
+
+    @Override
+    public Exception getException() {
+        if ( this.cause instanceof Exception){
+            return (Exception) cause;
+        }
+        return super.getException();
+    }
     /**
      * @return String the error code, such as 404-Not Found
      */

--- a/modules/library/main/src/test/java/org/geotools/ows/ServiceExceptionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/ows/ServiceExceptionTest.java
@@ -1,0 +1,48 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2016, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.ows;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import jdk.internal.org.xml.sax.SAXException;
+
+/**
+ * Tests service exception handling of Java 5 initCause.
+ */
+public class ServiceExceptionTest {
+    @Test
+    public void testCause() {
+        Exception throwable = new Exception("Placeholder");
+        
+        // Problem with SAX - cause and exception can only be provided via constructor
+        SAXException sax1 = (SAXException) new SAXException().initCause(throwable);
+        assertNull( sax1.getCause());
+        assertNull( sax1.getException());
+        
+        SAXException sax2 = new SAXException(throwable);
+        assertSame( throwable, sax2.getCause());
+        assertSame( throwable, sax2.getException());
+        
+        // Workaround with ServiceException
+        ServiceException serviceException1 = (ServiceException) new ServiceException("example").initCause(throwable);
+        assertSame( throwable, serviceException1.getCause());
+        assertSame( throwable, serviceException1.getException());
+    }
+
+}

--- a/modules/library/main/src/test/java/org/geotools/ows/ServiceExceptionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/ows/ServiceExceptionTest.java
@@ -19,8 +19,7 @@ package org.geotools.ows;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-
-import jdk.internal.org.xml.sax.SAXException;
+import org.xml.sax.SAXException;
 
 /**
  * Tests service exception handling of Java 5 initCause.


### PR DESCRIPTION
See: https://osgeo-org.atlassian.net/browse/GEOT-5533

Add a field for ServiceException.cause, overriding initCause, getCause and getException as appropriate. A better fix (passing in the cause via constructor requires an api change) after the code freeze is complete (See https://github.com/DBlasby/geotools/commit/01969ee209d5f0236818de1b2b8d7cadb22d6027 )
