### PR TITLE
Default to use of GeoTools ENTITY_RESOLVER hint [GEOT-5514]

### DIFF
--- a/docs/user/library/metadata/geotools.rst
+++ b/docs/user/library/metadata/geotools.rst
@@ -10,9 +10,16 @@ It also provides the version number of the library, in case you want to check at
 Hints
 ^^^^^
 
-Hints are used to configure the GeoTools library for use in your application. The method GeoTools.getDefaultHints() can be configured as part of your application startup.
+Hints are used to configure the GeoTools library for use in your application. The value provided by GeoTools.getDefaultHints() can be configured as part of your application startup:
 
-In addition the following following bindings to system properties are defined:
+.. code-block:: java
+
+   Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+   Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+
+GeoTools Hints are similar to a Map<GeoTools.Key,Object>, the GeoTools.Key instances each provide javadocs, and some control over the values that may be used. For example the Hints.ENTITY_RESOLVER values must be an instance of EntityResolver.
+
+By contrast java system properties are similar to a Map<String,String> and may be specified programmatically or on the command line. The following bindings to system properties are defined (each as static constants in the GeoTools class):
 
 ================================= ===============================================
 CRS_AUTHORITY_EXTRA_DIRECTORY     org.geotools.referencing.crs-directory
@@ -20,7 +27,16 @@ EPSG_DATA_SOURCE                  org.geotools.referencing.epsg-datasource
 FORCE_LONGITUDE_FIRST_AXIS_ORDER  org.geotools.referencing.forceXY
 LOCAL_DATE_TIME_HANDLING          org.geotools.localDateTimeHandling
 RESAMPLE_TOLERANCE                org.geotools.referencing.resampleTolerance
+ENTITY_RESOLVER                   org.xml.sax.EntityResolver
 ================================= ===============================================
+
+The bound system properties can also be used to configure Hints:
+
+.. code-block:: java
+   
+   // Allow access to local dtd and xsd files
+   System.getProperties.put(GeoTools.ENTITY_RESOLVER, "org.geotools.xml.NullEntityResolver");
+   Hints.scanSystemProperties();
 
 Plug-ins
 ^^^^^^^^
@@ -38,10 +54,37 @@ In rare cases, such as OSGi plug-in system, adding additional jars to the CLASSP
 JNDI
 ^^^^
 
-If you are working in a Java Enterprise Edition environment, and would like to configure GeoTools to look up services in a specific
-context use the following::
+If you are working in a Java Enterprise Edition environment, and would like to configure GeoTools to look up services in a specific context use the following::
   
   GeoTools.init( applicationContext ); // JNDI configuration
+
+GeoTools uses names of the format "jdbc:EPSG" internally these are adapted for use with your applicationContext using the GeoTools fixName methods::
+
+  String name = GeoTools.fixName("jdbc.EPSG");
+
+XML
+^^^
+
+When embedding GeoTools in your own application you may wish to configure the library to use a specific EntityResolver (to access any XML Schema files included in your application, or to restrict access based on security policies).
+
+GeoTools uses a range of XML technologies when implementing both format and protocol support - where possible these are configured based on the Hints.ENTITY_RESOLVER described above.
+
+To access the configured ENTITY_RESOLVER:
+
+.. code-block:: java
+   
+   parser.setEntityResolver( GeoTools.getEntityResolver(hints) );
+
+GeoTools also includes two EntityResolver implementations:
+
+* PreventLocalEntityResolver: For use when working with external XML documents, only allows DTD and XML Schema references to remote resources
+* NullEntityResolver: Placeholder allowing the default SAXParser access-anything behaviour.
+
+The library uses PreventLocalEntityResolver by default, if you wish to work with a local XML file (referencing local DTD and XMLSchema) please use the following during application setup:
+
+.. code-block:: java
+
+   Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
 
 Logging
 ^^^^^^^
@@ -116,3 +159,4 @@ If you would like to check this bootstrapping process use the system property `-
 To completely filter JAI messages from your application set `javax.media.jai` group to Level.WARNING::
    
    Logging.getLogger("javax.media.jai").setLevel(Level.WARNING);
+

--- a/modules/library/metadata/src/main/java/org/geotools/factory/Hints.java
+++ b/modules/library/metadata/src/main/java/org/geotools/factory/Hints.java
@@ -1121,8 +1121,8 @@ public class Hints extends RenderingHints {
          * provided there is no concurrent changes in an other thread.
          */
         @SuppressWarnings("unchecked")
-        Map<RenderingHints.Key, Object> filtered = (Map) hints;
-        for (final Iterator it=hints.keySet().iterator(); it.hasNext();) {
+        Map<RenderingHints.Key, Object> filtered = (Map<RenderingHints.Key, Object>) hints;
+        for (final Iterator<?> it=hints.keySet().iterator(); it.hasNext();) {
             final Object key = it.next();
             if (!(key instanceof RenderingHints.Key)) {
                 if (filtered == hints) {

--- a/modules/library/metadata/src/main/java/org/geotools/xml/NullEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/xml/NullEntityResolver.java
@@ -24,7 +24,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.ext.EntityResolver2;
 
 /**
- * NullObject implementation for {@link EntityResolver2} as an alternative to null checks.
+ * NullObject implementation for {@link EntityResolver2} (used as an alternative to null checks).
  * <p>
  * This implementation returns {@code null} to request that the parser open a regular URI connection
  * to the system identifier.

--- a/modules/library/metadata/src/main/java/org/geotools/xml/PreventLocalEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/xml/PreventLocalEntityResolver.java
@@ -17,10 +17,12 @@
 package org.geotools.xml;
 
 import java.io.IOException;
+
 import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.geotools.factory.GeoTools;
 import org.geotools.util.logging.Logging;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -32,6 +34,9 @@ import org.xml.sax.ext.EntityResolver2;
  * 
  * When parsing an XML entity reference to a local file a SAXException is thrown, which can be
  * handled appropriately.
+ * 
+ * This implementation is both recommended and the default returned by
+ * {@link GeoTools#getEntityResolver()}.
  * 
  * @author Davide Savazzi - geo-solutions.it
  */

--- a/modules/library/metadata/src/test/java/org/geotools/factory/GeoToolsTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/factory/GeoToolsTest.java
@@ -209,9 +209,29 @@ public final class GeoToolsTest {
         assertEquals("jdbc/EPSG",  GeoTools.fixName(null, "jdbc/EPSG"));
     }
     @Test
-    public void testDefaultResolver() {
+    public void testEntityResolver() {
+        
+        // confirm instantiate works
+        EntityResolver resolver;
+        
+        resolver = GeoTools.instantiate("org.geotools.factory.PlaceholderEntityResolver",
+                EntityResolver.class, PreventLocalEntityResolver.INSTANCE);
+        assertTrue(resolver instanceof PlaceholderEntityResolver);
+
+        resolver = GeoTools.instantiate("org.geotools.xml.NullEntityResolver", EntityResolver.class,
+                PreventLocalEntityResolver.INSTANCE);
+        assertTrue(resolver instanceof NullEntityResolver);
+
+        resolver = GeoTools.instantiate("invalid.class.reference", EntityResolver.class,
+                PreventLocalEntityResolver.INSTANCE);
+        assertTrue(resolver instanceof PreventLocalEntityResolver);
+
+        resolver = GeoTools.instantiate(null, EntityResolver.class,
+                PreventLocalEntityResolver.INSTANCE);
+        assertTrue(resolver instanceof PreventLocalEntityResolver);
+        
+        // confirm system hints work
         try {
-            // confirm system hint works
             Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
             assertSame(NullEntityResolver.INSTANCE, GeoTools.getEntityResolver(null));
             
@@ -228,10 +248,10 @@ public final class GeoToolsTest {
 
             // test system property functions with INSTANCE field constructor
             System.getProperties().put(GeoTools.ENTITY_RESOLVER,
-                    "org.geotools.xml.PreventLocalEntityResolver");
+                    "org.geotools.xml.NullEntityResolver");
             Hints.scanSystemProperties();
             entityResolver = GeoTools.getEntityResolver(null);
-            assertTrue(entityResolver instanceof PreventLocalEntityResolver);
+            assertTrue(entityResolver instanceof NullEntityResolver);
         } finally {
             System.clearProperty(GeoTools.ENTITY_RESOLVER);
             Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);

--- a/modules/library/metadata/src/test/java/org/geotools/factory/PlaceholderEntityResolver.java
+++ b/modules/library/metadata/src/test/java/org/geotools/factory/PlaceholderEntityResolver.java
@@ -14,7 +14,7 @@
  *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *    Lesser General Public License for more details.
  */
-package org.geotools.renderer.style;
+package org.geotools.factory;
 
 import java.io.IOException;
 import java.util.Map;

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLHandlerHints.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLHandlerHints.java
@@ -21,6 +21,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.geotools.factory.GeoTools;
+import org.geotools.factory.Hints;
+import org.xml.sax.EntityResolver;
+
 /**
  * Hint object with known parameters for XML parsing.
  * 
@@ -45,7 +49,7 @@ public class XMLHandlerHints implements Map<String,Object> {
     /** Sets the level of compliance that the filter encoder should use */
     public static final String FILTER_COMPLIANCE_STRICTNESS = "org.geotools.xml.filter.FILTER_COMPLIANCE_STRICTNESS";
     /** Supplied {@link EntityResolver} for Schema and/or DTD validation */
-    public final static String ENTITY_RESOLVER ="org.xml.sax.EntityResolver";
+    public final static String ENTITY_RESOLVER = GeoTools.ENTITY_RESOLVER;
     /** Supplied {@link SaxParserFactory}  */
     public final static String SAX_PARSER_FACTORY ="javax.xml.parsers.SAXParserFactory";
 
@@ -180,8 +184,26 @@ public class XMLHandlerHints implements Map<String,Object> {
     public Collection<Object> values() {
         return map.values();
     }
-    
-    
-    
+
+    /**
+     * Looks up {@link #ENTITY_RESOLVER} instance in provided hints, defaulting to setting provided
+     * by {@link GeoTools#getEntityResolver(org.geotools.factory.Hints)} (usually
+     * {@link PreventLocalEntityResolver} unless otherwise configured).
+     * 
+     * @param hints
+     * @return EntityResolver provided by hints, or non-null default provided by
+     *         {@link Hints#ENTITY_RESOLVER}.
+     */
+    public static EntityResolver toEntityResolver(Map<String, Object> hints) {
+        if (hints != null && hints.containsKey(Hints.ENTITY_RESOLVER)) {
+            Object resolver = hints.get(Hints.ENTITY_RESOLVER);
+            if (resolver == null) { // use null instance rather than check each time
+                return NullEntityResolver.INSTANCE;
+            } else if (resolver instanceof EntityResolver) {
+                return (EntityResolver) resolver;
+            }
+        }
+        return GeoTools.getEntityResolver(null);
+    }
 
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLSAXHandler.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLSAXHandler.java
@@ -166,18 +166,16 @@ public class XMLSAXHandler extends DefaultHandler {
      *
      * @param hints Hints as per {@link {@link XMLHandlerHints}
      */
-    public XMLSAXHandler(Map hints) {
+    public XMLSAXHandler(Map<String,Object> hints) {
         init(hints);
         logger.setLevel(level);
     }
-    protected void init(Map hints){
+    protected void init(Map<String,Object> hints){
         if( hints == null ){
             hints = new HashMap<String,Object>();
         }
         this.hints = hints;
-        if( hints.containsKey(XMLHandlerHints.ENTITY_RESOLVER)){
-            setEntityResolver( (EntityResolver) hints.get(XMLHandlerHints.ENTITY_RESOLVER));;
-        }
+        setEntityResolver(XMLHandlerHints.toEntityResolver(hints));
     }
     /**
      * Implementation of endDocument.

--- a/modules/plugin/svg/src/main/java/org/geotools/renderer/style/SVGGraphicFactory.java
+++ b/modules/plugin/svg/src/main/java/org/geotools/renderer/style/SVGGraphicFactory.java
@@ -117,30 +117,8 @@ public class SVGGraphicFactory implements Factory, ExternalGraphicFactory {
             }
         }
         else {
-            this.resolver = defaultResolver();
+            this.resolver = GeoTools.getEntityResolver(null);
         }
-    }
-    private static final Logger LOGGER = org.geotools.util.logging.Logging.getLogger("org.geotools.renderer.style.SVGGraphicFactory");
-    protected static EntityResolver defaultResolver() {
-        Hints hints = GeoTools.getDefaultHints();
-        if( hints != null && hints.containsKey(Hints.ENTITY_RESOLVER)){
-            Object hint = hints.get(Hints.ENTITY_RESOLVER);
-            if( hint instanceof EntityResolver){
-                return (EntityResolver) hint;
-            }
-            if( hint instanceof String ){
-                try {
-                    Class<?> type = Class.forName((String)hint);
-                    Object value = type.newInstance();
-                    if( value instanceof EntityResolver){
-                        return (EntityResolver) value;
-                    }
-                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-                    LOGGER.log(Level.FINER, "Unable to instantiate ENTITY_RESOLVER: "+ e.getMessage(), e);
-                }
-            }
-        }
-        return PreventLocalEntityResolver.INSTANCE;
     }
 
     @Override

--- a/modules/plugin/svg/src/test/java/org/geotools/renderer/style/SVGGraphicFactoryTest.java
+++ b/modules/plugin/svg/src/test/java/org/geotools/renderer/style/SVGGraphicFactoryTest.java
@@ -101,22 +101,6 @@ public class SVGGraphicFactoryTest extends TestCase {
         assertNotNull(icon);
     }
 
-    public void testDefaultResolver() {
-        try {
-            Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
-            assertSame(NullEntityResolver.INSTANCE, SVGGraphicFactory.defaultResolver());
-
-            Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
-            assertSame(PreventLocalEntityResolver.INSTANCE, SVGGraphicFactory.defaultResolver());
-
-            System.getProperties().put(GeoTools.ENTITY_RESOLVER,
-                    "org.geotools.renderer.style.PlaceholderEntityResolver");
-            Hints.scanSystemProperties();
-            assertTrue(SVGGraphicFactory.defaultResolver() instanceof PlaceholderEntityResolver);
-        }        finally {
-            Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
-        }
-    }
     public void testNaturalSize() throws Exception {
         SVGGraphicFactory svg = new SVGGraphicFactory();
         URL url = SVGGraphicFactory.class.getResource("gradient.svg");

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetCapabilitiesRequest.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetCapabilitiesRequest.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.data.wfs.internal;
 
+import java.beans.XMLEncoder;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
@@ -54,9 +55,8 @@ public class GetCapabilitiesRequest extends AbstractGetCapabilitiesRequest {
     public Response createResponse(HTTPResponse response) throws ServiceException, IOException {
         Map<String, Object> hints = getRequestHints();
         EntityResolver resolver = null;
-        if(hints != null) {
-            GeoTools.getEntityResolver(
-            resolver = GeoTools.getEntityResolver(hints);
+        if (hints != null) {
+            resolver = XMLHandlerHints.toEntityResolver(hints);
         }
         return new GetCapabilitiesResponse(response, resolver);
     }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetCapabilitiesRequest.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetCapabilitiesRequest.java
@@ -24,6 +24,7 @@ import org.geotools.data.ows.AbstractGetCapabilitiesRequest;
 import org.geotools.data.ows.HTTPResponse;
 import org.geotools.data.ows.Request;
 import org.geotools.data.ows.Response;
+import org.geotools.factory.GeoTools;
 import org.geotools.ows.ServiceException;
 import org.geotools.xml.XMLHandlerHints;
 import org.xml.sax.EntityResolver;
@@ -54,7 +55,8 @@ public class GetCapabilitiesRequest extends AbstractGetCapabilitiesRequest {
         Map<String, Object> hints = getRequestHints();
         EntityResolver resolver = null;
         if(hints != null) {
-            resolver = (EntityResolver) hints.get(XMLHandlerHints.ENTITY_RESOLVER);
+            GeoTools.getEntityResolver(
+            resolver = GeoTools.getEntityResolver(hints);
         }
         return new GetCapabilitiesResponse(response, resolver);
     }

--- a/modules/unsupported/wps/src/main/java/org/geotools/data/wps/response/WPSGetCapabilitiesResponse.java
+++ b/modules/unsupported/wps/src/main/java/org/geotools/data/wps/response/WPSGetCapabilitiesResponse.java
@@ -68,9 +68,7 @@ public class WPSGetCapabilitiesResponse extends AbstractWPSGetCapabilitiesRespon
             // hints.put(DocumentFactory.VALIDATION_HINT, Boolean.FALSE);
             Configuration config = new WPSConfiguration();
             Parser parser = new Parser(config);
-            if(hints != null && hints.get(XMLHandlerHints.ENTITY_RESOLVER) != null) {
-                parser.setEntityResolver((EntityResolver) hints.get(XMLHandlerHints.ENTITY_RESOLVER));
-            }
+            parser.setEntityResolver(XMLHandlerHints.toEntityResolver(hints));
 
             Object object;
             excepResponse = null;


### PR DESCRIPTION
This allows use od PreventLocalEntityResolver to be used as a default library wide, while allowing configuration with NullEntityResolver in the event access to local files is required.