### PR TITLE
modify numberFormat to take an optional language string (GEOT-5543)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat.java
@@ -16,20 +16,24 @@
  */
 package org.geotools.filter.function;
 
-
-import static org.geotools.filter.capability.FunctionNameImpl.*;
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.logging.Logger;
 
 import org.geotools.filter.FunctionExpressionImpl;
 import org.geotools.filter.capability.FunctionNameImpl;
+import org.geotools.util.logging.Logging;
 import org.opengis.filter.capability.FunctionName;
+import org.opengis.filter.expression.Expression;
 
 /**
- * Formats a number into a string given a certain pattern (specified in the format accepted
- * by {@link DecimalFormat}} 
+ * Formats a number into a string given a certain pattern (specified in the format accepted by {@link DecimalFormat}}
+ * 
  * @author Andrea Aime - OpenGeo
  *
  *
@@ -38,11 +42,22 @@ import org.opengis.filter.capability.FunctionName;
  * @source $URL$
  */
 public class FilterFunction_numberFormat extends FunctionExpressionImpl {
-    
+    static final Logger LOGGER = Logging.getLogger(FilterFunction_numberFormat.class);
+
+    static HashSet<String> languages = new HashSet<>();
+
+    Locale locale = Locale.ENGLISH;
+
+    static {
+        
+        for(Locale loc:Locale.getAvailableLocales()) {
+            languages.add(loc.getLanguage());
+        }
+    }
+
     public static FunctionName NAME = new FunctionNameImpl("numberFormat", String.class,
-            parameter("format", String.class),
-            parameter("number", Number.class));
-    
+            parameter("format", String.class), parameter("number", Number.class),
+            parameter("language", String.class, 0, 1));
 
     public FilterFunction_numberFormat() {
         super(NAME);
@@ -51,35 +66,47 @@ public class FilterFunction_numberFormat extends FunctionExpressionImpl {
     public Object evaluate(Object feature) {
         String format;
         Double number;
-
+        String localeString = "";
         try {
             // attempt to get value and perform conversion
-            format  = getExpression(0).evaluate(feature, String.class);
+            format = getExpression(0).evaluate(feature, String.class);
         } catch (Exception e) // probably a type error
         {
             throw new IllegalArgumentException(
-                    "Filter Function problem for function dateFormat argument #0 - expected type String");
+                    "Filter Function problem for function NumberFormat argument #0 - expected type String");
         }
 
         try { // attempt to get value and perform conversion
-            number = getExpression(1).evaluate(feature, Double.class); 
+            number = getExpression(1).evaluate(feature, Double.class);
         } catch (Exception e) // probably a type error
         {
             throw new IllegalArgumentException(
-                    "Filter Function problem for function dateFormat argument #1 - expected type java.util.Double");
+                    "Filter Function problem for function NumberFormat argument #1 - expected type java.util.Double");
         }
-        
-        if(format == null || number == null) {
+
+        if (format == null || number == null) {
             return null;
         }
-        Locale locale=Locale.getDefault();
-        
+        try { // attempt to get value and perform conversion
+            if (params.size() > 2) {
+                Expression second = getExpression(2);
+
+                localeString = second.evaluate(feature, String.class);
+            }
+        } catch (Exception e) // probably a type error
+        {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function NumberFormat argument #2 - expected type String");
+        }
+        if (localeString != null && !localeString.isEmpty() && languages.contains(localeString)) {
+            locale = Locale.forLanguageTag(localeString);
+
+        }
+
         DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(locale);
 
         DecimalFormat numberFormat = new DecimalFormat(format, decimalFormatSymbols);
         return numberFormat.format(number);
     }
-
-    
 
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat.java
@@ -101,6 +101,8 @@ public class FilterFunction_numberFormat extends FunctionExpressionImpl {
         if (localeString != null && !localeString.isEmpty() && languages.contains(localeString)) {
             locale = Locale.forLanguageTag(localeString);
 
+        } else {
+            throw new IllegalArgumentException("Unknown language code '"+localeString+"' in numberFormat function");
         }
 
         DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(locale);

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat.java
@@ -43,7 +43,6 @@ public class FilterFunction_numberFormat extends FunctionExpressionImpl {
             parameter("format", String.class),
             parameter("number", Number.class));
     
-    public static DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(Locale.ENGLISH);
 
     public FilterFunction_numberFormat() {
         super(NAME);
@@ -67,12 +66,15 @@ public class FilterFunction_numberFormat extends FunctionExpressionImpl {
         } catch (Exception e) // probably a type error
         {
             throw new IllegalArgumentException(
-                    "Filter Function problem for function dateFormat argument #1 - expected type java.util.Date");
+                    "Filter Function problem for function dateFormat argument #1 - expected type java.util.Double");
         }
         
         if(format == null || number == null) {
             return null;
         }
+        Locale locale=Locale.getDefault();
+        
+        DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(locale);
 
         DecimalFormat numberFormat = new DecimalFormat(format, decimalFormatSymbols);
         return numberFormat.format(number);

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat.java
@@ -98,11 +98,14 @@ public class FilterFunction_numberFormat extends FunctionExpressionImpl {
             throw new IllegalArgumentException(
                     "Filter Function problem for function NumberFormat argument #2 - expected type String");
         }
-        if (localeString != null && !localeString.isEmpty() && languages.contains(localeString)) {
-            locale = Locale.forLanguageTag(localeString);
+        if (languages.contains(localeString)) {
+            if (localeString != null && !localeString.isEmpty()) {
+                locale = Locale.forLanguageTag(localeString);
+            }
 
         } else {
-            throw new IllegalArgumentException("Unknown language code '"+localeString+"' in numberFormat function");
+            throw new IllegalArgumentException(
+                    "Unknown language code '" + localeString + "' in numberFormat function");
         }
 
         DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(locale);

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat2.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_numberFormat2.java
@@ -70,7 +70,7 @@ public class FilterFunction_numberFormat2 extends FunctionExpressionImpl {
         } catch (Exception e) // probably a type error
         {
             throw new IllegalArgumentException(
-                    "Filter Function problem for function dateFormat argument #1 - expected type java.util.Date");
+                    "Filter Function problem for function dateFormat argument #1 - expected type java.util.Double");
         }
         
         if(format == null || number == null) {

--- a/modules/library/main/src/test/java/org/geotools/filter/function/NumberFormatTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/NumberFormatTest.java
@@ -24,8 +24,19 @@ public class NumberFormatTest extends TestCase {
         Literal number = ff.literal("10.56789");
         
         Function f = ff.function("numberFormat", new Expression[]{pattern, number});
-        char ds = DecimalFormatSymbols.getInstance(Locale.ENGLISH).getDecimalSeparator();
+        char ds = DecimalFormatSymbols.getInstance(Locale.getDefault()).getDecimalSeparator();
         assertEquals("10" + ds + "57", f.evaluate(null , String.class));
+    }
+    public void testFormatFrenchDouble() {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.FRANCE);
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        Literal pattern = ff.literal("#.##");
+        Literal number = ff.literal("10.56789");
+        Function f = ff.function("numberFormat", new Expression[]{pattern, number});
+        char ds = DecimalFormatSymbols.getInstance(Locale.FRANCE).getDecimalSeparator();
+        assertEquals("10" + ds + "57", f.evaluate(null , String.class));
+        Locale.setDefault(defaultLocale);
     }
     
     public void testFormatInteger() {
@@ -34,7 +45,7 @@ public class NumberFormatTest extends TestCase {
         Literal number = ff.literal("123456");
         
         Function f = ff.function("numberFormat", new Expression[]{pattern, number});
-        char gs = DecimalFormatSymbols.getInstance(Locale.ENGLISH).getGroupingSeparator();
+        char gs = DecimalFormatSymbols.getInstance(Locale.getDefault()).getGroupingSeparator();
         assertEquals("123" + gs + "456", f.evaluate(null , String.class));
     }
     

--- a/modules/library/main/src/test/java/org/geotools/filter/function/NumberFormatTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/NumberFormatTest.java
@@ -24,19 +24,18 @@ public class NumberFormatTest extends TestCase {
         Literal number = ff.literal("10.56789");
         
         Function f = ff.function("numberFormat", new Expression[]{pattern, number});
-        char ds = DecimalFormatSymbols.getInstance(Locale.getDefault()).getDecimalSeparator();
+        char ds = DecimalFormatSymbols.getInstance(Locale.ENGLISH).getDecimalSeparator();
         assertEquals("10" + ds + "57", f.evaluate(null , String.class));
     }
     public void testFormatFrenchDouble() {
-        Locale defaultLocale = Locale.getDefault();
-        Locale.setDefault(Locale.FRANCE);
         FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
         Literal pattern = ff.literal("#.##");
         Literal number = ff.literal("10.56789");
-        Function f = ff.function("numberFormat", new Expression[]{pattern, number});
+        Literal lang = ff.literal("fr");
+        Function f = ff.function("numberFormat", new Expression[]{pattern, number, lang});
         char ds = DecimalFormatSymbols.getInstance(Locale.FRANCE).getDecimalSeparator();
         assertEquals("10" + ds + "57", f.evaluate(null , String.class));
-        Locale.setDefault(defaultLocale);
+       
     }
     
     public void testFormatInteger() {
@@ -45,7 +44,7 @@ public class NumberFormatTest extends TestCase {
         Literal number = ff.literal("123456");
         
         Function f = ff.function("numberFormat", new Expression[]{pattern, number});
-        char gs = DecimalFormatSymbols.getInstance(Locale.getDefault()).getGroupingSeparator();
+        char gs = DecimalFormatSymbols.getInstance(Locale.ENGLISH).getGroupingSeparator();
         assertEquals("123" + gs + "456", f.evaluate(null , String.class));
     }
     
@@ -104,6 +103,28 @@ public class NumberFormatTest extends TestCase {
         
         Function f = ff.function("numberFormat2", new Expression[]{pattern, number, minus, ds, gs});
         assertEquals(null, f.evaluate(null, String.class));
+    }
+    
+    public void testNumberFactoryLocaleParam() {
+        Locale[] locales = { Locale.CANADA, Locale.CANADA_FRENCH, Locale.GERMAN, Locale.KOREAN,
+                Locale.CHINESE, Locale.JAPANESE, Locale.ENGLISH, Locale.TRADITIONAL_CHINESE,
+                Locale.SIMPLIFIED_CHINESE };
+
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        Literal pattern = ff.literal("##.##");
+        Literal number = ff.literal("10.56789");
+        for (Locale locale : locales) {
+            Literal lang = ff.literal(locale.getLanguage());
+            Function f = ff.function("numberFormat", new Expression[] { pattern, number, lang });
+            char ds = DecimalFormatSymbols.getInstance(locale).getDecimalSeparator();
+            assertEquals("10" + ds + "57", f.evaluate(null, String.class));
+        }
+        
+        Literal lang = ff.literal("AnyLang");
+        Function f = ff.function("numberFormat", new Expression[] { pattern, number, lang });
+        char ds = DecimalFormatSymbols.getInstance(Locale.ENGLISH).getDecimalSeparator();
+        assertEquals("10" + ds + "57", f.evaluate(null, String.class));
+        
     }
 
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/function/NumberFormatTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/NumberFormatTest.java
@@ -123,8 +123,12 @@ public class NumberFormatTest extends TestCase {
         Literal lang = ff.literal("AnyLang");
         Function f = ff.function("numberFormat", new Expression[] { pattern, number, lang });
         char ds = DecimalFormatSymbols.getInstance(Locale.ENGLISH).getDecimalSeparator();
+        try {
         assertEquals("10" + ds + "57", f.evaluate(null, String.class));
-        
+        fail("Accepted unknown language code");
+        }catch (IllegalArgumentException e) {
+            //this is a good thing
+        }
     }
 
 }


### PR DESCRIPTION
Fix for [GEOT-5543](https://osgeo-org.atlassian.net/browse/GEOT-5543) takes current locale into account when formatting the number. This is more likely to be what the user is expecting.