### PR TITLE
Numbers with decimals in ShapefileDataStore always less than 10

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
@@ -378,7 +378,8 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
                 header.addColumn(colName, 'N', Math.min(fieldLen, 33), 0);
             } else if (Number.class.isAssignableFrom(colType)) {
                 int l = Math.min(fieldLen, 33);
-                int d = Math.max(l - 2, 0);
+                // Number length is split to have same chars number before and after decimal point.
+                int d = (int) Math.floor(Math.max(l / 2, 0));
                 header.addColumn(colName, 'N', l, d);
                 // This check has to come before the Date one or it is never reached
                 // also, this field is only activated with the following system property:

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
@@ -376,10 +376,19 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
                 header.addColumn(colName, 'N', Math.min(fieldLen, 19), 0);
             } else if (colType == BigInteger.class) {
                 header.addColumn(colName, 'N', Math.min(fieldLen, 33), 0);
+            } else if (colType == Float.class) {
+                int l = Math.min(fieldLen, 24);
+                // GDAL format default is 15 decimal places of precision
+                // http://www.gdal.org/drv_shapefile.html
+                int d = Math.min(Math.max(l - 2, 0), 15);
+                header.addColumn(colName, 'N', l, d);
+            } else if (colType == Double.class) {
+                int l = Math.min(fieldLen, 33);
+                int d = Math.min(Math.max(l - 2, 0), 15);
+                header.addColumn(colName, 'N', l, d);
             } else if (Number.class.isAssignableFrom(colType)) {
                 int l = Math.min(fieldLen, 33);
-                // Number length is split to have same chars number before and after decimal point.
-                int d = (int) Math.floor(Math.max(l / 2, 0));
+                int d = Math.max(l - 2, 0);
                 header.addColumn(colName, 'N', l, d);
                 // This check has to come before the Date one or it is never reached
                 // also, this field is only activated with the following system property:

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileQuadTreeReadWriteTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileQuadTreeReadWriteTest.java
@@ -57,7 +57,7 @@ import com.vividsolutions.jts.geom.Geometry;
  */
 public class ShapefileQuadTreeReadWriteTest extends TestCaseSupport {
     final String[] files = { "shapes/statepop.shp", "shapes/polygontest.shp",
-            "shapes/pointtest.shp", "shapes/holeTouchEdge.shp", "shapes/stream.shp" };
+            "shapes/pointtest.shp", "shapes/holeTouchEdge.shp", "shapes/streams.shp" };
 
     boolean readStarted = false;
 


### PR DESCRIPTION
With the current code, shapefile columns can't be bigger than 9.999... In Qgis, columns are truncated and information is modified.
My proposition is to split the chars number to define the same length before and after the decimal point.
