### PR TITLE
[GEOT-5556] Add mosaic config to config map when updating mosaic

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicConfigHandler.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicConfigHandler.java
@@ -1292,6 +1292,7 @@ public class ImageMosaicConfigHandler {
             // Get the manager for this coverage so it can be updated
             rasterManager = getParentReader().getRasterManager(targetCoverageName);
             mosaicConfiguration = rasterManager.getConfiguration();
+            this.configurations.put(mosaicConfiguration.getName(), mosaicConfiguration);
         }
 
         // STEP 2


### PR DESCRIPTION
It looks like when the mosaic is being updated, the MosaicConfiguration is never put in the "configurations" map. During normal operation this isn't an issue, but with a reprojecting mosaic this is needed because it needs info from that config. 