### PR TITLE
[GEOT-5558][GEOS-7524] Ignore no matching properties (backport 15.x)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -1860,7 +1860,13 @@ public class DataUtilities {
         tb.setName(featureType.getName());
         tb.setCRS(null); // not interested in warnings from this simple method
         for (int i = 0; i < properties.length; i++) {
-            tb.add(featureType.getDescriptor(properties[i]));
+            // let's get the attribute descriptor corresponding to the current property
+            AttributeDescriptor attributeDescriptor = featureType.getDescriptor(properties[i]);
+            if (attributeDescriptor != null) {
+                // if the property doesn't map to an attribute descriptor we ignore it
+                // an attribute descriptor may be omitted for security proposes for example
+                tb.add(attributeDescriptor);
+            }
         }
         setDefaultGeometry(tb, properties, featureType);
         return tb.buildFeatureType();

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -647,6 +647,16 @@ public class DataUtilitiesTest extends DataTestCase {
         assertEquals("the_geom2", after.getGeometryDescriptor().getLocalName());
     }
 
+    public void testCreateSubTypeWithPropertyNotMatchingAnAttributeDescriptor() throws Exception {
+        // creating a sub type with a property that doesn't map to an attribute descriptor
+        SimpleFeatureType before = DataUtilities.createType("cities","the_geom:Point:srid=4326,name:String");
+        SimpleFeatureType after = DataUtilities.createSubType(before, new String[] { "the_geom", "name", "not_existing" });
+        // the not_existing property should have been ignored
+        assertEquals(2, after.getAttributeCount());
+        assertNotNull(after.getDescriptor("the_geom"));
+        assertNotNull(after.getDescriptor("name"));
+    }
+
     public void testSource() throws Exception {
         SimpleFeatureSource s = DataUtilities.source(roadFeatures);
         assertEquals(3, s.getCount(Query.ALL));


### PR DESCRIPTION
When creating a sub type using DataUtilies if one of the provided properties doesn't map to an attribute descriptor a NULL attribute descriptor will be added to the new sub type attributes descriptors list.

Since the typical code assumes that the attributes descriptors of a feature type are not NULL this may provoke a NULL pointer exception. A situation like this happens for example when a provided property is valid but the corresponding attribute descriptor is hidden by a security rule (read only attributes for example).

This pull request fix this issue and adds a test case.

Associated issues:
- https://osgeo-org.atlassian.net/browse/GEOT-5558
- https://osgeo-org.atlassian.net/browse/GEOS-7524

This is a backport of this pull request: https://github.com/geotools/geotools/pull/1367
