### PR TITLE
[GEOT-5563] DefaultRenderingExecutor stops working after a layer fail

### DIFF
--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/DefaultRenderingExecutor.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/DefaultRenderingExecutor.java
@@ -296,10 +296,10 @@ public class DefaultRenderingExecutor implements RenderingExecutor {
                 }
 
                 RenderingExecutorEvent event = new RenderingExecutorEvent(this, info.id);
+                tasksLatch.countDown();
                 if (!result) {
                     info.listener.onRenderingFailed(event);
                 } else {
-                    tasksLatch.countDown();
                     if (tasksLatch.getCount() == 0) {
                         currentTasks.remove(info);
                         info.listener.onRenderingCompleted(event);

--- a/modules/unsupported/swing/src/test/java/org/geotools/swing/DefaultRenderingExecutorTest.java
+++ b/modules/unsupported/swing/src/test/java/org/geotools/swing/DefaultRenderingExecutorTest.java
@@ -17,9 +17,19 @@
 
 package org.geotools.swing;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Color;
+import java.awt.image.WritableRaster;
+import java.util.concurrent.CancellationException;
+
+import org.geotools.map.MapContent;
+import org.geotools.swing.testutils.MockRenderer;
+import org.geotools.swing.testutils.WaitingRenderingExecutorListener;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Tests for SingleTaskRenderingExecutor.
@@ -67,4 +77,97 @@ public class DefaultRenderingExecutorTest extends RenderingExecutorTestBase {
         assertEquals(poll, executor.getPollingInterval());
     }
     
+    /**
+     * GEOT-5563
+     * 
+     * Tests that the renderer continue to work on subsequent submits after a single
+     * submit has failed due to a layer failure.
+     * 
+     */
+    @Test
+    public void testContinuedOperationAfterLayerFail() {
+        createSubmitObjects();
+        //Test requires that a map is _actually_ drawn, so cannot use the MockRenderer - replace it here
+        class FailableMockRenderer extends MockRenderer {
+            boolean mockFail;
+            public FailableMockRenderer(MapContent map) {
+                super(map);
+            }
+            public void setFail(boolean fail) {
+                this.mockFail = fail;
+            }
+            //Just fill the graphics with red ... our test will be looking for this
+            @Override
+            protected void pretendToPaint() {
+                graphics.setColor(Color.red);
+                graphics.fill(PANE);
+                //Do the locking/waiting bit
+                super.pretendToPaint();
+                //And now fail if we're told to.  Note that this fail is _after_ the render
+                //which simulate the actual behaviour if the map has multiple layers, only
+                //one of which fails.
+                if (mockFail) {
+                    listeners.forEach(listener->listener.errorOccurred(new RuntimeException("Simulated layer rendering failure")));
+                }
+            }
+        };
+ 
+        FailableMockRenderer failableRenderer = new FailableMockRenderer(mapContent);
+        this.renderer = failableRenderer;
+        renderer.setPaintTime(10);
+        
+        //Execute with no problems
+        clearGraphics();
+        listener.setExpected(WaitingRenderingExecutorListener.Type.STARTED);
+        listener.setExpected(WaitingRenderingExecutorListener.Type.COMPLETED);
+        executor.submit(mapContent, renderer, graphics, listener);
+        int timeoutMillis = 1000;
+        listener.await(WaitingRenderingExecutorListener.Type.STARTED, timeoutMillis);
+        listener.await(WaitingRenderingExecutorListener.Type.COMPLETED, timeoutMillis);
+        assertTrue(listener.eventReceived(WaitingRenderingExecutorListener.Type.STARTED));
+        assertTrue(listener.eventReceived(WaitingRenderingExecutorListener.Type.COMPLETED));
+        checkGraphicsWasPainted();
+        
+        //Now deliberately fail the render
+        clearGraphics();
+        listener.setExpected(WaitingRenderingExecutorListener.Type.STARTED);
+        listener.setExpected(WaitingRenderingExecutorListener.Type.FAILED);
+        failableRenderer.setFail(true);
+        executor.submit(mapContent, renderer, graphics, listener);
+        listener.await(WaitingRenderingExecutorListener.Type.STARTED, timeoutMillis);
+        listener.await(WaitingRenderingExecutorListener.Type.FAILED, timeoutMillis);
+        assertTrue(listener.eventReceived(WaitingRenderingExecutorListener.Type.STARTED));
+        assertTrue(listener.eventReceived(WaitingRenderingExecutorListener.Type.FAILED));
+        //Actual failed submission still paints as expected
+        checkGraphicsWasPainted();
+        
+        //Now remove the failure and submit again
+        clearGraphics();
+        listener.setExpected(WaitingRenderingExecutorListener.Type.STARTED);
+        listener.setExpected(WaitingRenderingExecutorListener.Type.COMPLETED);
+        failableRenderer.setFail(false);
+        executor.submit(mapContent, renderer, graphics, listener);
+        listener.await(WaitingRenderingExecutorListener.Type.STARTED, timeoutMillis);
+        listener.await(WaitingRenderingExecutorListener.Type.COMPLETED, timeoutMillis);
+        assertTrue(listener.eventReceived(WaitingRenderingExecutorListener.Type.STARTED));
+        assertTrue(listener.eventReceived(WaitingRenderingExecutorListener.Type.COMPLETED));
+        checkGraphicsWasPainted();             //Prior to fix, nothing is drawn
+       
+        
+    }
+
+    private void checkGraphicsWasPainted() {
+        WritableRaster raster = image.getRaster();
+        
+        int[] pixel = new int[4];
+        raster.getPixel(1, 1, pixel);
+        assertEquals("Pixel at (1,1) was not renderered", 255, pixel[0]);
+        assertEquals("Pixel at (1,1) was not renderered", 0, pixel[1]);
+        assertEquals("Pixel at (1,1) was not renderered", 0, pixel[2]);
+    }
+
+    private void clearGraphics() {
+        graphics.setColor(Color.white);
+        graphics.fill(PANE);
+    }
 }

--- a/modules/unsupported/swing/src/test/java/org/geotools/swing/testutils/MockRenderer.java
+++ b/modules/unsupported/swing/src/test/java/org/geotools/swing/testutils/MockRenderer.java
@@ -17,12 +17,13 @@
 
 package org.geotools.swing.testutils;
 
-import com.vividsolutions.jts.geom.Envelope;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,8 @@ import org.geotools.map.MapContext;
 import org.geotools.renderer.GTRenderer;
 import org.geotools.renderer.RenderListener;
 
+import com.vividsolutions.jts.geom.Envelope;
+
 /**
  * A simple mock GTRenderer.
  * 
@@ -46,6 +49,8 @@ import org.geotools.renderer.RenderListener;
  * @version $Id$
  */
 public class MockRenderer implements GTRenderer {
+    protected List<RenderListener> listeners = new ArrayList<RenderListener>();
+    
     private MapContent mapContent;
     private long paintTime;
     private boolean verbose;
@@ -87,10 +92,12 @@ public class MockRenderer implements GTRenderer {
 
     @Override
     public void addRenderListener(RenderListener listener) {
+        this.listeners.add(listener);
     }
 
     @Override
     public void removeRenderListener(RenderListener listener) {
+        this.listeners.remove(listener);
     }
 
     @Override
@@ -156,7 +163,7 @@ public class MockRenderer implements GTRenderer {
         pretendToPaint();
     }
 
-    private void pretendToPaint() {
+    protected void pretendToPaint() {
         lock.lock();
         try {
             if (verbose) {


### PR DESCRIPTION
After a rendering failure on any layer, DefaultRenderingExecutor will not issue any more rendering requests, even if the offending layer is removed from the MapContent.  This is caused because the task counter is not decremented on a failure. 

DefaultRenderingExecutor modified to decrement the tasks latch on both fail and completion, thus clearing it's own internals and allow subsequent submissions to be rendered correctly.