### PR TITLE
[GEOT-5575] Relax the XML encoder to be able to encode nested complex types that don't respect the GML object-property model

### DIFF
--- a/docs/user/library/xml/internal/overview.rst
+++ b/docs/user/library/xml/internal/overview.rst
@@ -140,3 +140,5 @@ During encoding an xml schema is used to determine how various objects should be
    * All the contents of the "PurchaseOrderType" have been completed, the "purchaseOrder" element is closed. Being the root element of the document there is no containing type and the encoding process is stopped.
      
      .. image:: /images/xml/encoderExecution9.png
+
+There are some situations where the encoder will try to encode complex features against a complex type that is not completely valid. This happens for example when mapping nested entities against a complex type that doesn't respect GML object-property model. The Java configuration property ``encoder.relaxed`` can be set to ``false`` to disable this behavior.  


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-5575

GeoServer side pull requests that add app-schema test case with complex features:
https://github.com/geoserver/geoserver/pull/1976