### PR TITLE
[GEOT-5580] Use imageio EnhancedImageReadParam instead of ExtendedImageParam (backport 16.x)

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/resources/image/ExtendedImageParam.java
+++ b/modules/library/coverage/src/main/java/org/geotools/resources/image/ExtendedImageParam.java
@@ -20,7 +20,9 @@ import javax.imageio.ImageReadParam;
 
 /**
  * Utility class that should be used to pass extra parameters to the NetCdf image reader machinery.
+ * @deprecated use {@link it.geosolutions.imageio.imageioimpl.EnhancedImageReadParam}
  */
+@Deprecated
 public class ExtendedImageParam extends ImageReadParam {
 
     // the bands parameter define the order and which bands should be returned

--- a/modules/library/coverage/src/main/java/org/geotools/resources/image/ImageUtilities.java
+++ b/modules/library/coverage/src/main/java/org/geotools/resources/image/ImageUtilities.java
@@ -63,6 +63,7 @@ import javax.media.jai.RenderedImageAdapter;
 import javax.media.jai.RenderedOp;
 import javax.media.jai.WritableRenderedImageAdapter;
 
+import it.geosolutions.imageio.imageioimpl.EnhancedImageReadParam;
 import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.image.ImageWorker;
@@ -867,7 +868,7 @@ public final class ImageUtilities {
     	// in which there is not a special ImageReadparam used.
     
     	// Create a new ImageReadParam instance.
-    	ExtendedImageParam newParam = new ExtendedImageParam();
+    	EnhancedImageReadParam newParam = new EnhancedImageReadParam();
     
     	// Set all fields which need to be set.
     
@@ -902,8 +903,8 @@ public final class ImageUtilities {
     			.getSubsamplingYOffset());
 
         // check if need to copy extra parameters
-        if (param instanceof ExtendedImageParam) {
-            newParam.setBands(((ExtendedImageParam) param).getBands());
+        if (param instanceof EnhancedImageReadParam) {
+            newParam.setBands(((EnhancedImageReadParam) param).getBands());
         }
 
     	// Replace the local variable with the new ImageReadParam.

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFResponse.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFResponse.java
@@ -54,7 +54,7 @@ import org.geotools.coverage.io.range.RangeType;
 import org.geotools.data.DataSourceException;
 import org.geotools.data.Query;
 import org.geotools.factory.Hints;
-import org.geotools.resources.image.ExtendedImageParam;
+import it.geosolutions.imageio.imageioimpl.EnhancedImageReadParam;
 import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.image.ImageWorker;
@@ -115,7 +115,7 @@ class NetCDFResponse extends CoverageResponse{
 
     private URL datasetURL;
 
-    private ExtendedImageParam baseReadParameters = new ExtendedImageParam();
+    private EnhancedImageReadParam baseReadParameters = new EnhancedImageReadParam();
 
     private boolean oversampledRequest;
 
@@ -377,7 +377,7 @@ class NetCDFResponse extends CoverageResponse{
     private void prepareParams() throws DataSourceException {
 
         try {
-            baseReadParameters = new ExtendedImageParam();
+            baseReadParameters = new EnhancedImageReadParam();
             performDecimation(baseReadParameters);
 
             // === extract bbox

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/NetCDFImageReader.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/NetCDFImageReader.java
@@ -44,7 +44,7 @@ import org.geotools.coverage.io.catalog.CoverageSlice;
 import org.geotools.coverage.io.catalog.CoverageSlicesCatalog;
 import org.geotools.coverage.io.catalog.DataStoreConfiguration;
 import org.geotools.gce.imagemosaic.RasterLayerRequest;
-import org.geotools.resources.image.ExtendedImageParam;
+import it.geosolutions.imageio.imageioimpl.EnhancedImageReadParam;
 import org.geotools.coverage.io.range.FieldType;
 import org.geotools.coverage.io.range.RangeType;
 import org.geotools.data.DefaultTransaction;
@@ -587,8 +587,8 @@ public class NetCDFImageReader extends GeoSpatialImageReader implements FileSetM
 
         // let's see if we have some extra parameters
         int[] bands = null;
-        if (param instanceof ExtendedImageParam) {
-            bands = ((ExtendedImageParam) param).getBands();
+        if (param instanceof EnhancedImageReadParam) {
+            bands = ((EnhancedImageReadParam) param).getBands();
         }
 
         /*

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterLayerResponse.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterLayerResponse.java
@@ -76,7 +76,7 @@ import org.geotools.resources.coverage.FeatureUtilities;
 import org.geotools.resources.geometry.XRectangle2D;
 import org.geotools.resources.i18n.Vocabulary;
 import org.geotools.resources.i18n.VocabularyKeys;
-import org.geotools.resources.image.ExtendedImageParam;
+import it.geosolutions.imageio.imageioimpl.EnhancedImageReadParam;
 import org.geotools.resources.image.ImageUtilities;
 import org.geotools.util.NumberRange;
 import org.geotools.util.SimpleInternationalString;
@@ -445,7 +445,7 @@ public class RasterLayerResponse {
 
     private int imageChoice = 0;
 
-    private ExtendedImageParam baseReadParameters = new ExtendedImageParam();
+    private EnhancedImageReadParam baseReadParameters = new EnhancedImageReadParam();
 
     private boolean multithreadingAllowed;
 


### PR DESCRIPTION
Backport of pull request: https://github.com/geotools/geotools/pull/1392

This pull request substitute the usage of ```EnhancedImageReadParam``` by by the new imageio```ExtendedImageParam```.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOT-5580