### PR TITLE
Remove warning associated with DEFAULT_COORDINATE_REFERENCE_SYSTEM use

### DIFF
--- a/modules/plugin/arcgrid/src/main/java/org/geotools/gce/arcgrid/ArcGridReader.java
+++ b/modules/plugin/arcgrid/src/main/java/org/geotools/gce/arcgrid/ArcGridReader.java
@@ -151,7 +151,7 @@ public final class ArcGridReader extends AbstractGridCoverage2DReader implements
                 final Object tempCRS = this.hints.get(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM);
                 if (tempCRS != null) {
                     this.crs=(CoordinateReferenceSystem) tempCRS;
-                    LOGGER.log(Level.WARNING,"Using default coordinate reference system ");
+                    LOGGER.log(Level.FINE,"Using default coordinate reference system ");
                 } else {         
                     initCoordinateReferenceSystem();
                 }

--- a/modules/plugin/imageio-ext-gdal/src/main/java/org/geotools/coverageio/gdal/BaseGDALGridCoverage2DReader.java
+++ b/modules/plugin/imageio-ext-gdal/src/main/java/org/geotools/coverageio/gdal/BaseGDALGridCoverage2DReader.java
@@ -146,7 +146,7 @@ public abstract class BaseGDALGridCoverage2DReader extends
         final Object tempCRS = this.hints.get(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM);
         if (tempCRS != null) {
             this.crs=(CoordinateReferenceSystem) tempCRS;
-            LOGGER.log(Level.WARNING,"Using default coordinate reference system ");
+            LOGGER.log(Level.FINE,"Using default coordinate reference system ");
         } else{
             
             // //


### PR DESCRIPTION
The DEFAULT_COORDINATE_REFERENCE_SYSTEM is explicitly provided and should not produce a WARNING when used correctly.