### PR TITLE
[GEOT-5601] Import of SoftValueHashMap fixed

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/egr/Tile.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/egr/Tile.java
@@ -49,7 +49,7 @@ import org.geotools.util.logging.Logging;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Polygon;
 
-import it.geosolutions.imageio.utilities.SoftValueHashMap;
+import org.geotools.util.SoftValueHashMap;
 import it.geosolutions.jaiext.iterators.RandomIterFactory;
 
 /**


### PR DESCRIPTION
The class imports the SoftValueHashMap in GT (not in imageio-ext)