### PR TITLE
[GEOT-5606] Fixed invalid GML3 GeometryCollection encoding.

### DIFF
--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML3FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML3FeatureCollectionEncoderDelegate.java
@@ -41,6 +41,7 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.xml.sax.helpers.AttributesImpl;
 
+import com.vividsolutions.jts.geom.GeometryCollection;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.MultiLineString;
@@ -193,6 +194,7 @@ public class GML3FeatureCollectionEncoderDelegate extends
             encoders.put(CompoundCurve.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
             encoders.put(CircularRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
             encoders.put(CompoundRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(GeometryCollection.class, new GeometryCollectionEncoder(encoder, gmlPrefix, gmlUri));
         }
 
         @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
@@ -30,36 +30,37 @@ import org.xml.sax.helpers.AttributesImpl;
  * 
  * @author 
  */
-public class GeometryCollectionEncoder extends GeometryEncoder<GeometryCollection> {
+class GeometryCollectionEncoder extends GeometryEncoder<GeometryCollection> {
 
-    static final QualifiedName GEOMETRY_COLLECTION = new QualifiedName(
-        GML.NAMESPACE, "GeometryCollection", "gml");
+    static final QualifiedName MULTI_GEOMETRY = new QualifiedName(
+        GML.NAMESPACE, "MultiGeometry", "gml");
 
-    QualifiedName element;
-    static Encoder encoder;
+    static final QualifiedName GEOMETRY_MEMBER = new QualifiedName(
+        GML.NAMESPACE, "geometryMember", "gml");
 
-    public GeometryCollectionEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
-        this(encoder, GEOMETRY_COLLECTION.derive(gmlPrefix, gmlUri));
-    }
+    QualifiedName multiGeometry;
 
-    public GeometryCollectionEncoder(Encoder encoder, QualifiedName name) {
+    QualifiedName geometryMember;
+
+    GenericGeometryEncoder gge;
+
+    protected GeometryCollectionEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
-        GeometryCollectionEncoder.encoder = encoder;
+        gge = new GenericGeometryEncoder(encoder, gmlPrefix, gmlUri);
+        multiGeometry = MULTI_GEOMETRY.derive(gmlPrefix, gmlUri);
+        geometryMember = GEOMETRY_MEMBER.derive(gmlPrefix, gmlUri);
     }
+
     @Override
-    public void encode(GeometryCollection geometry, AttributesImpl atts,
-        GMLWriter handler) throws Exception {
-        handler.startElement(GEOMETRY_COLLECTION, atts);
-        if (geometry.getNumGeometries() < 1) {
-            throw new Exception("More than 1 geometry required!");
-        } else {
-            GenericGeometryEncoder gec = new GenericGeometryEncoder(
-                GeometryCollectionEncoder.encoder);
-            for (int i = 0; i < geometry.getNumGeometries(); i++) {
-                gec.encode(geometry.getGeometryN(i), atts, handler);
-            }
+    public void encode(GeometryCollection geometry, AttributesImpl atts, GMLWriter handler)
+            throws Exception {
+        handler.startElement(multiGeometry, atts);
+        for (int i = 0; i < geometry.getNumGeometries(); i++) {
+            handler.startElement(geometryMember, null);
+            gge.encode(geometry.getGeometryN(i), atts, handler);
+            handler.endElement(geometryMember);
         }
-        handler.endElement(GEOMETRY_COLLECTION);
+        handler.endElement(multiGeometry);
     }
 
 }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryCollectionEncoderTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryCollectionEncoderTest.java
@@ -39,12 +39,12 @@ public class GeometryCollectionEncoderTest extends GeometryEncoderTestSupport {
             xpath.getMatchingNodes("//gml:LineString", doc).getLength());
         assertEquals(2, xpath.getMatchingNodes("//gml:Point", doc).getLength());
         assertEquals(1,
-            xpath.getMatchingNodes("//gml:GeometryCollection", doc).getLength());
+            xpath.getMatchingNodes("//gml:MultiGeometry", doc).getLength());
         assertEquals("180 200 160 180",
             xpath.evaluate(
-                "//gml:GeometryCollection/gml:LineString/gml:posList", doc));
+                "//gml:MultiGeometry/gml:geometryMember/gml:LineString/gml:posList", doc));
         assertEquals("19 19",
             xpath.evaluate(
-                "//gml:GeometryCollection/gml:Point/gml:pos", doc));
+                "//gml:MultiGeometry/gml:geometryMember/gml:Point/gml:pos", doc));
     }
 }


### PR DESCRIPTION
Fixed invalid GML3 GeometryCollection encoding and updated the unit test.  Also applying the GEOT-5360 GeometryCollection encoding fix for GML 3.2 to GML 3.1.

https://osgeo-org.atlassian.net/browse/GEOT-5606
https://osgeo-org.atlassian.net/browse/GEOT-5360

This patch can be backported to 15.x and 16.x