### PR TITLE
Use SI.getInstance() to clone si units

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/wkt/GeoToolsUnitFormat.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/wkt/GeoToolsUnitFormat.java
@@ -67,7 +67,7 @@ abstract class GeoToolsUnitFormat extends UnitFormat {
                 }
             }
             // clone si units
-            Set<Unit<?>> siUnits = NonSI.getInstance().getUnits();
+            Set<Unit<?>> siUnits = SI.getInstance().getUnits();
             for (Unit<?> unit : siUnits) {
                 String name = base.nameFor(unit);
                 if (name != null) {


### PR DESCRIPTION
The si units clone part used NonSI.getInstance() instead of SI.getInstance().