### PR TITLE
DB2 updates

### DIFF
--- a/modules/plugin/jdbc/jdbc-db2/src/main/java/org/geotools/data/db2/DB2FilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-db2/src/main/java/org/geotools/data/db2/DB2FilterToSQL.java
@@ -24,7 +24,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.logging.Logger;
 
 import org.geotools.filter.FilterCapabilities;
@@ -334,7 +333,10 @@ public class DB2FilterToSQL extends PreparedFilterToSQL {
             }
             out.write(comparisonOperator);
             out.write(toMeters(filter.getDistance(), filter.getDistanceUnits()));
-            addSelectivity();
+            if (!isValidUnit(distanceUnits)) {
+            	addSelectivity(); // Selectivity clause can not be used with distance units
+            }            
+            
             return extraData;
         } catch (IOException ex) {
             throw new RuntimeException(ex);

--- a/modules/plugin/jdbc/jdbc-db2/src/main/java/org/geotools/data/db2/DB2FilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-db2/src/main/java/org/geotools/data/db2/DB2FilterToSQL.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2011-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2011-2017, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -137,21 +137,21 @@ public class DB2FilterToSQL extends PreparedFilterToSQL {
         {
             put("kilometers", 1000.0);
             put("kilometer", 1000.0);
-			put("meters", 1.0);
-			put("meter", 1.0);
+            put("meters", 1.0);
+            put("meter", 1.0);
             put("mm", 0.001);
             put("millimeter", 0.001);
             put("mi", 1609.344);
             put("statute miles", 1609.344);
-			put("miles", 1609.344);
-			put("mile", 1609.344);
-			put("nautical miles", 1852.0);
+            put("miles", 1609.344);
+            put("mile", 1609.344);
+            put("nautical miles", 1852.0);
             put("NM", 1852d);
             put("feet", 0.3048);
             put("ft", 0.3048);
             put("in", 0.0254);
         }
-    };	
+    };  
 
     boolean functionEncodingEnabled = false;
 
@@ -299,29 +299,29 @@ public class DB2FilterToSQL extends PreparedFilterToSQL {
         }
     }
 
-	private boolean isValidUnit(String unit) {
-		if (UNITS_MAP.get(unit) != null) {
-			return true;
-		}
-		return false;
-	}
+    private boolean isValidUnit(String unit) {
+        if (UNITS_MAP.get(unit) != null) {
+            return true;
+        }
+        return false;
+    }
 
-	private String toMeters(double distance, String unit) {
-		Double conversion = UNITS_MAP.get(unit);
-		if (conversion != null) {
-			return String.valueOf(distance * conversion);
-		}
-		// in case unknown unit use as-is
-		return String.valueOf(distance);
-	}
-	
+    private String toMeters(double distance, String unit) {
+        Double conversion = UNITS_MAP.get(unit);
+        if (conversion != null) {
+            return String.valueOf(distance * conversion);
+        }
+        // in case unknown unit use as-is
+        return String.valueOf(distance);
+    }
+    
     Object visitDistanceSpatialOperator(DistanceBufferOperator filter, PropertyName property,
             Literal geometry, boolean swapped, Object extraData) {
         try {
-			String comparisonOperator = ") < ";
-			if ((filter instanceof DWithin && swapped) 
-				|| (filter instanceof Beyond && !swapped)) {
-			  comparisonOperator = ") > ";
+            String comparisonOperator = ") < ";
+            if ((filter instanceof DWithin && swapped) 
+                || (filter instanceof Beyond && !swapped)) {
+              comparisonOperator = ") > ";
             }
                 out.write("db2gse.ST_Distance(");
                 property.accept(this, extraData);
@@ -329,12 +329,12 @@ public class DB2FilterToSQL extends PreparedFilterToSQL {
                 geometry.accept(this, extraData);
             String distanceUnits = filter.getDistanceUnits();
             if (isValidUnit(distanceUnits)) {
-            	out.write(",'METER'");
+                out.write(",'METER'");
             }
             out.write(comparisonOperator);
             out.write(toMeters(filter.getDistance(), filter.getDistanceUnits()));
             if (!isValidUnit(distanceUnits)) {
-            	addSelectivity(); // Selectivity clause can not be used with distance units
+                addSelectivity(); // Selectivity clause can not be used with distance units
             }            
             
             return extraData;

--- a/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2SpatialFiltersOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2SpatialFiltersOnlineTest.java
@@ -61,7 +61,7 @@ public class DB2SpatialFiltersOnlineTest extends JDBCSpatialFiltersOnlineTest {
 	      	        
 	        int SRID = 4326;
 	        GeometryFactory gf = new GeometryFactory(precisionModel, SRID);
-	        Coordinate[] points = { new Coordinate(30, 40), new Coordinate(50, 60) };
+	        Coordinate[] points = { new Coordinate(1, 1), new Coordinate(50, 60) };
 	        LineString[] geometries = new LineString[2];
 	        geometries [0] = gf.createLineString(points);
 	        Coordinate[] points2 = { new Coordinate(40, 30), new Coordinate(70, 40) };
@@ -81,7 +81,8 @@ public class DB2SpatialFiltersOnlineTest extends JDBCSpatialFiltersOnlineTest {
 	        DWithin dwithinGeomCo  = ((FilterFactory2) ff).dwithin(p, collect, 5, "meter");
 	        Query dq = new Query(tname("road"), dwithinGeomCo);
 	        SimpleFeatureCollection features = dataStore.getFeatureSource(tname("road")).getFeatures(dq);
-	        assertEquals(0, features.size());
+			int numFeatures = features.size();
+	        assertEquals(2, numFeatures);
       }
 	
     public void testBboxFilter() throws Exception {

--- a/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2SpatialFiltersOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2SpatialFiltersOnlineTest.java
@@ -30,6 +30,7 @@ import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.spatial.BBOX;
+import org.opengis.filter.spatial.Beyond;
 import org.opengis.filter.spatial.DWithin;
 
 import com.vividsolutions.jts.geom.Coordinate;
@@ -83,6 +84,12 @@ public class DB2SpatialFiltersOnlineTest extends JDBCSpatialFiltersOnlineTest {
 	        SimpleFeatureCollection features = dataStore.getFeatureSource(tname("road")).getFeatures(dq);
 			int numFeatures = features.size();
 	        assertEquals(2, numFeatures);
+	        
+	        Beyond beyondGeomCo  = ((FilterFactory2) ff).beyond(p, collect, 5, "meter");
+	        dq = new Query(tname("road"), beyondGeomCo);
+	        features = dataStore.getFeatureSource(tname("road")).getFeatures(dq);
+			numFeatures = features.size();
+	        assertEquals(1, numFeatures);
       }
 	
     public void testBboxFilter() throws Exception {

--- a/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2SpatialFiltersOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-db2/src/test/java/org/geotools/data/db2/DB2SpatialFiltersOnlineTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2017, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General 
@@ -51,47 +51,47 @@ public class DB2SpatialFiltersOnlineTest extends JDBCSpatialFiltersOnlineTest {
         return new DB2DataStoreAPITestSetup();
     }
 
-	@Override
-	protected void connect() throws Exception {
-		super.connect();
-		dataStore.setDatabaseSchema("geotools");
-	}
-	
-	public void testGeometryCollection() throws Exception{
-	        PrecisionModel precisionModel = new PrecisionModel();
-	      	        
-	        int SRID = 4326;
-	        GeometryFactory gf = new GeometryFactory(precisionModel, SRID);
-	        Coordinate[] points = { new Coordinate(1, 1), new Coordinate(50, 60) };
-	        LineString[] geometries = new LineString[2];
-	        geometries [0] = gf.createLineString(points);
-	        Coordinate[] points2 = { new Coordinate(40, 30), new Coordinate(70, 40) };
-	        geometries[1] = gf.createLineString(points2);
-	        
-	        // TODO, DB2 does not support instantiating a geometry collection from wkb, 
-	        // wkb type 7, replace GeometryCollection with MultiLineString	        
-	        // code in superclass: GeometryCollection geometry = new GeometryCollection(geometries, factory );
-	        // For DB2, we must use the following line of code
-	        MultiLineString ml = gf.createMultiLineString(geometries);
-	        
-	        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
-	        
-	        PropertyName p = ff.property(aname("geom"));        
-	        Literal collect = ff.literal(ml);
-	      
-	        DWithin dwithinGeomCo  = ((FilterFactory2) ff).dwithin(p, collect, 5, "meter");
-	        Query dq = new Query(tname("road"), dwithinGeomCo);
-	        SimpleFeatureCollection features = dataStore.getFeatureSource(tname("road")).getFeatures(dq);
-			int numFeatures = features.size();
-	        assertEquals(2, numFeatures);
-	        
-	        Beyond beyondGeomCo  = ((FilterFactory2) ff).beyond(p, collect, 5, "meter");
-	        dq = new Query(tname("road"), beyondGeomCo);
-	        features = dataStore.getFeatureSource(tname("road")).getFeatures(dq);
-			numFeatures = features.size();
-	        assertEquals(1, numFeatures);
+    @Override
+    protected void connect() throws Exception {
+        super.connect();
+        dataStore.setDatabaseSchema("geotools");
+    }
+    
+    public void testGeometryCollection() throws Exception{
+            PrecisionModel precisionModel = new PrecisionModel();
+                    
+            int SRID = 4326;
+            GeometryFactory gf = new GeometryFactory(precisionModel, SRID);
+            Coordinate[] points = { new Coordinate(1, 1), new Coordinate(50, 60) };
+            LineString[] geometries = new LineString[2];
+            geometries [0] = gf.createLineString(points);
+            Coordinate[] points2 = { new Coordinate(40, 30), new Coordinate(70, 40) };
+            geometries[1] = gf.createLineString(points2);
+            
+            // TODO, DB2 does not support instantiating a geometry collection from wkb, 
+            // wkb type 7, replace GeometryCollection with MultiLineString          
+            // code in superclass: GeometryCollection geometry = new GeometryCollection(geometries, factory );
+            // For DB2, we must use the following line of code
+            MultiLineString ml = gf.createMultiLineString(geometries);
+            
+            FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+            
+            PropertyName p = ff.property(aname("geom"));        
+            Literal collect = ff.literal(ml);
+          
+            DWithin dwithinGeomCo  = ((FilterFactory2) ff).dwithin(p, collect, 5, "meter");
+            Query dq = new Query(tname("road"), dwithinGeomCo);
+            SimpleFeatureCollection features = dataStore.getFeatureSource(tname("road")).getFeatures(dq);
+            int numFeatures = features.size();
+            assertEquals(2, numFeatures);
+            
+            Beyond beyondGeomCo  = ((FilterFactory2) ff).beyond(p, collect, 5, "meter");
+            dq = new Query(tname("road"), beyondGeomCo);
+            features = dataStore.getFeatureSource(tname("road")).getFeatures(dq);
+            numFeatures = features.size();
+            assertEquals(1, numFeatures);
       }
-	
+    
     public void testBboxFilter() throws Exception {
         FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
         // should  match  "r2" and "r3"
@@ -99,7 +99,7 @@ public class DB2SpatialFiltersOnlineTest extends JDBCSpatialFiltersOnlineTest {
         FeatureCollection features = dataStore.getFeatureSource(tname("road")).getFeatures(bbox);
         assertEquals(2, features.size());
     }
-	    
+        
     public void testBboxFilterDefault() throws Exception {
         FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
         // should  match  "r2" and "r3"
@@ -107,7 +107,7 @@ public class DB2SpatialFiltersOnlineTest extends JDBCSpatialFiltersOnlineTest {
         FeatureCollection features = dataStore.getFeatureSource(tname("road")).getFeatures(bbox);
         assertEquals(2, features.size());
     }
-	
+    
 
     @Override
     protected HashMap createDataStoreFactoryParams() throws Exception {


### PR DESCRIPTION
Fix DB2 SQL generation to use units like METER for DWITHIN and BEYOND. Previously, units were ignored and distance was treated as being in the coordinate system units.

Updated online testcase to correctly test DWITHIN and BEYOND.