### PR TITLE
[GEOT-5602] Better concurrent SoftValueHashMap

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/SoftValueHashMap.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/SoftValueHashMap.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2006-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -21,11 +21,12 @@ import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Queue;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,11 +45,9 @@ import org.geotools.util.logging.Logging;
  * collection. The amount of entries to retain by hard reference is specified at {@linkplain
  * #SoftValueHashMap(int) construction time}.
  * <p>
- * This map is thread-safe. It accepts the null key, but doesn't accepts null values. Usage
- * of {@linkplain #values value}, {@linkplain #keySet key} or {@linkplain #entrySet entry}
- * collections are supported except for direct usage of their iterators, which may throw
- * {@link java.util.ConcurrentModificationException} randomly depending on the garbage collector
- * activity.
+ * This map is thread-safe. It accepts the null key; it does not accept the null value. Usage 
+ * of {@linkplain #values value}, {@linkplain #keySet key} or {@linkplain #entrySet entry} 
+ * collections are supported. The iterator on the {@linkplain ConcurrentHashMap} is weakly consistent.
  *
  * @param <K> The type of keys in the map.
  * @param <V> The type of values in the map.
@@ -60,6 +59,7 @@ import org.geotools.util.logging.Logging;
  * @version $Id$
  * @author Simone Giannecchini
  * @author Martin Desruisseaux
+ * @author Ugo Moschini
  */
 public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
     static final Logger LOGGER = Logging.getLogger(SoftValueHashMap.class);
@@ -73,13 +73,14 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      * The map of hard or soft references. Values are either direct reference to the objects,
      * or wrapped in a {@code Reference} object.
      */
-    private final Map<K,Object> hash = new HashMap<K,Object>();
+    private final Map<K,Object> hash = new ConcurrentHashMap<K,Object>();
 
     /**
      * The FIFO list of keys to hard references. Newest elements are first, and latest elements
-     * are last. This list should never be longer than {@link #hardReferencesCount}.
+     * are last. Note that in a highly concurrent environments the exact total number of strong
+     * references may differ slightly from {@link #hardReferencesCount}.
      */
-    private final LinkedList<K> hardCache = new LinkedList<K>();
+    private final Queue<K> hardCache = new ConcurrentLinkedQueue<K>();
 
     /**
      * The number of hard references to hold internally.
@@ -129,7 +130,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      * @return
      */
     public int getHardReferencesCount() {
-    	return this.hardReferencesCount;
+       return this.hardReferencesCount;
     }
 
     /**
@@ -142,13 +143,12 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
     }
 
     /**
-     * Performs a consistency check on this map. This method is used for tests and
-     * assertions only.
+     * Performs a consistency check on this map. This method must be used for tests and
+     * assertions only in single-threaded environments.
      */
     final boolean isValid() {
         int count=0, size=0;
-        synchronized (hash) {
-            for (final Map.Entry<K,?> entry : hash.entrySet()) {
+         for (final Map.Entry<K,?> entry : hash.entrySet()) {
                 if (entry.getValue() instanceof Reference) {
                     count++;
                 } else {
@@ -158,7 +158,6 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
             }
             assert size == hash.size();
             assert hardCache.size() == Math.min(size, hardReferencesCount);
-        }
         return count == Math.max(size - hardReferencesCount, 0);
     }
 
@@ -167,19 +166,16 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      */
     @Override
     public int size() {
-        synchronized (hash) {
-            return hash.size();
-        }
+        return hash.size();
     }
+    
 
     /**
      * Returns {@code true} if this map contains a mapping for the specified key.
      */
     @Override
     public boolean containsKey(final Object key) {
-        synchronized (hash) {
-            return hash.containsKey(key);
-        }
+            return hash.containsKey(replaceNull(key));
     }
 
     /**
@@ -188,13 +184,11 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
     @Override
     public boolean containsValue(final Object value) {
         ensureNotNull(value);
-        synchronized (hash) {
             /*
              * We must rely on the super-class default implementation, not on HashMap
              * implementation, because some references are wrapped into SoftReferences.
              */
             return super.containsValue(value);
-        }
     }
 
     /**
@@ -204,45 +198,43 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      * @param key key whose associated value is to be returned.
      * @return the value to which this map maps the specified key, or {@code null} if none.
      */
+    @SuppressWarnings("unchecked")
     @Override
     public V get(final Object key) {
-        synchronized (hash) {
-            Object value = hash.get(key);
-            if (value instanceof Reference) {
-                /*
-                 * The value is a soft reference only if it was not used for a while and the map
-                 * contains more than 'hardReferenceCount' entries. Otherwise, it is an ordinary
-                 * reference and is returned directly. See the 'retainStrongly' method.
-                 *
-                 * If the value is a soft reference, get the referent and clear it immediately
-                 * for avoiding the reference to be enqueded. We abandon the soft reference and
-                 * reinject the referent as a strong reference in the hash map, since we try to
-                 * keep the last entries by strong references.
-                 */
-                value = ((Reference) value).getAndClear();
-                if (value != null) {
-                    /*
-                     * Transforms the soft reference into a hard one. The cast should be safe
-                     * because hash.get(key) should not have returned a non-null value if the
-                     * key wasn't valid.
-                     */
-                    @SuppressWarnings("unchecked")
-                    final K k = (K) key;
-                    hash.put(k, value);
-                    retainStrongly(k);
-                } else {
-                    // The value has already been garbage collected.
-                    hash.remove(key);
-                }
-            }
+        Object value = hash.get(replaceNull(key));
+        if (value instanceof Reference) {
             /*
-             * The safety of this cast depends only on this implementation, not on users.
-             * It should be safe if there is no bug in the way this class manages 'hash'.
+             * The value is a soft reference only if it was not used for a while and the map
+             * contains more than 'hardReferenceCount' entries. Otherwise, it is an ordinary
+             * reference and is returned directly. See the 'retainStrongly' method.
+             *
+             * If the value is a soft reference, get the referent and clear it immediately
+             * for avoiding the reference to be enqueued. We abandon the soft reference and
+             * reinject the referent as a strong reference in the hash map, since we try to
+             * keep the last entries by strong references.
              */
-            @SuppressWarnings("unchecked")
-            final V v = (V) value;
-            return v;
+             value = ((Reference<K, V>) value).getAndClear();
+             if (value != null) {
+                /*
+                 * Transforms the soft reference into a hard one. The cast should be safe
+                 * because hash.get(key) should not have returned a non-null value if the
+                 * key wasn't valid.
+                 */
+                 final K k = (K) key;
+                 hash.put(k, value);
+                 retainStrongly((K) replaceNull(k));
+             } else {
+                 // The value has already been garbage collected.
+                 hash.remove(replaceNull(key));
+             }
         }
+        /*
+         * The safety of this cast depends only on this implementation, not on users.
+         * It should be safe if there is no bug in the way this class manages 'hash'.
+         */
+        @SuppressWarnings("unchecked")
+        final V v = (V) value;
+        return v;
     }
 
     /**
@@ -250,21 +242,23 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      * If there is already {@link #hardReferencesCount} hard references, then this method
      * replaces the oldest hard reference by a soft one.
      */
+    @SuppressWarnings("unchecked")
     private void retainStrongly(final K key) {
-        assert Thread.holdsLock(hash);
-        assert !hardCache.contains(key) : key;
-        hardCache.addFirst(key);
-        if (hardCache.size() > hardReferencesCount) {
-            // Remove the last entry if list longer than hardReferencesCount
-            final K toRemove = hardCache.removeLast();
-            final Object value = hash.get(toRemove);
-            assert value!=null && !(value instanceof Reference) : toRemove;
-            @SuppressWarnings("unchecked")
-            final V v = (V) value;
-            hash.put(toRemove, new Reference<K,V>(hash, toRemove, v, cleaner));
-            assert hardCache.size() == hardReferencesCount;
-        }
-        assert isValid();
+        /*
+         * In highly concurrent environments, fields' values (e.g. the size of 'hardCache')
+         *  may differ slightly from what expected.
+         */
+        hardCache.add((K) replaceNull(key));
+            if (hardCache.size() > hardReferencesCount) {
+                // Remove the last entry if list longer than hardReferencesCount
+                final K toRemove = hardCache.poll();
+                final Object value = hash.get(replaceNull(toRemove));
+                final V v = (V) value;
+                if(v instanceof Reference) // check if v is already a Reference: it can happen in concurrent environments
+                    hash.put((K) replaceNull(toRemove), v);
+                else
+                    hash.put((K) replaceNull(toRemove), new Reference<K, V>(hash, (K) replaceNull(toRemove), v, cleaner));
+             }
     }
 
     /**
@@ -274,34 +268,32 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      * @param value Value to be associated with the specified key. The value can't be null.
      *
      * @return Previous value associated with specified key, or {@code null}
-     *	       if there was no mapping for key.
+     *        if there was no mapping for key.
      */
+    @SuppressWarnings("unchecked")
     @Override
     public V put(final K key, final V value) {
         ensureNotNull(value);
-        synchronized (hash) {
-            Object oldValue = hash.put(key, value);
+        Object oldValue = hash.put((K) replaceNull(key), value);
             if (oldValue instanceof Reference) {
                 oldValue = ((Reference) oldValue).getAndClear();
             } else if (oldValue != null) {
                 /*
                  * The value was retained by hard reference, which implies that the key must be in
                  * the hard-cache list. Removes the key from the list, since we want to reinsert it
-                 * at the begining of the list in order to mark the value as the most recently used.
-                 * This method performs a linear search, which may be quite ineficient. But it still
+                 * at the beginning of the list in order to mark the value as the most recently used.
+                 * This method performs a linear search, which may be quite inefficient. But it still
                  * efficient enough if the key was recently used, in which case it appears near the
-                 * begining of the list. We assume that this is a common case. We may revisit later
+                 * beginning of the list. We assume that this is a common case. We may revisit later
                  * if profiling show that this is a performance issue.
-                 */
-                if (!hardCache.remove(key)) {
-                    throw new AssertionError(key);
-                }
+                 * 
+                 * In highly concurrent environments, key could have been already removed.
+                 */                 
+                 hardCache.remove((K) replaceNull(key));
             }
-            retainStrongly(key);
-            @SuppressWarnings("unchecked")
+            retainStrongly((K) replaceNull(key));
             final V v = (V) oldValue;
             return v;
-        }
     }
 
     /**
@@ -311,9 +303,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      */
     @Override
     public void putAll(final Map<? extends K, ? extends V> map) {
-        synchronized (hash) {
             super.putAll(map);
-        }
     }
 
     /**
@@ -321,26 +311,23 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      *
      * @param  key Key whose mapping is to be removed from the map.
      * @return previous value associated with specified key, or {@code null}
-     *	       if there was no entry for key.
+     *        if there was no entry for key.
      */
     @Override
     public V remove(final Object key) {
-        synchronized (hash) {
-            Object oldValue = hash.remove(key);
+        Object oldValue = hash.remove(replaceNull(key));
             if (oldValue instanceof Reference) {
                 oldValue = ((Reference) oldValue).getAndClear();
             } else if (oldValue != null) {
                 /*
                  * See the comment in the 'put' method.
+                 * In highly concurrent environments, key could have been already removed.
                  */
-                if (!hardCache.remove(key)) {
-                    throw new AssertionError(key);
-                }
+                hardCache.remove(replaceNull(key));
             }
             @SuppressWarnings("unchecked")
             final V v = (V) oldValue;
             return v;
-        }
     }
 
     /**
@@ -348,16 +335,13 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      */
     @Override
     public void clear() {
-        synchronized (hash) {
-            for (final Iterator it=hash.values().iterator(); it.hasNext();) {
-                final Object value = it.next();
+            for(Object value:hash.values()){
                 if (value instanceof Reference) {
-                	((Reference) value).getAndClear();
+                       ((Reference) value).getAndClear();
                 }
             }
             hash.clear();
             hardCache.clear();
-        }
     }
 
     /**
@@ -365,12 +349,10 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      */
     @Override
     public Set<Map.Entry<K,V>> entrySet() {
-        synchronized (hash) {
             if (entries == null) {
                 entries = new Entries();
             }
             return entries;
-        }
     }
 
     /**
@@ -380,9 +362,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      */
     @Override
     public boolean equals(final Object object) {
-        synchronized (hash) {
             return super.equals(object);
-        }
     }
 
     /**
@@ -390,9 +370,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      */
     @Override
     public int hashCode() {
-        synchronized (hash) {
             return super.hashCode();
-        }
     }
 
     /**
@@ -400,9 +378,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      */
     @Override
     public String toString() {
-        synchronized (hash) {
             return super.toString();
-        }
     }
 
     /**
@@ -413,9 +389,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          * Returns an iterator over the elements contained in this collection.
          */
         public Iterator<Map.Entry<K,V>> iterator() {
-            synchronized (hash) {
                 return new Iter<K,V>(hash);
-            }
         }
 
         /**
@@ -430,9 +404,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public boolean contains(final Object entry) {
-            synchronized (hash) {
                 return super.contains(entry);
-            }
         }
 
         /**
@@ -440,9 +412,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public Object[] toArray() {
-            synchronized (hash) {
                 return super.toArray();
-            }
         }
 
         /**
@@ -450,9 +420,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public <T> T[] toArray(final T[] array) {
-            synchronized (hash) {
                 return super.toArray(array);
-            }
         }
 
         /**
@@ -461,9 +429,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public boolean remove(final Object entry) {
-            synchronized (hash) {
                 return super.remove(entry);
-            }
         }
 
         /**
@@ -472,9 +438,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public boolean containsAll(final Collection<?> collection) {
-            synchronized (hash) {
                 return super.containsAll(collection);
-            }
         }
 
         /**
@@ -482,9 +446,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public boolean addAll(final Collection<? extends Map.Entry<K,V>> collection) {
-            synchronized (hash) {
                 return super.addAll(collection);
-            }
         }
 
         /**
@@ -493,9 +455,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public boolean removeAll(final Collection<?> collection) {
-            synchronized (hash) {
                 return super.removeAll(collection);
-            }
         }
 
         /**
@@ -504,9 +464,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public boolean retainAll(final Collection<?> collection) {
-            synchronized (hash) {
                 return super.retainAll(collection);
-            }
         }
 
         /**
@@ -522,9 +480,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @Override
         public String toString() {
-            synchronized (hash) {
                 return super.toString();
-            }
         }
     }
 
@@ -532,11 +488,6 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
      * The iterator to be returned by {@link Entries}.
      */
     private static final class Iter<K,V> implements Iterator<Map.Entry<K,V>> {
-        /**
-         * A copy of the {@link SoftValueHashMap#hash} field.
-         */
-        private final Map<K,Object> hash;
-
         /**
          * The iterator over the {@link #hash} entries.
          */
@@ -552,7 +503,6 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          * Creates an iterator for the specified {@link SoftValueHashMap#hash} field.
          */
         Iter(final Map<K,Object> hash) {
-            this.hash = hash;
             this.iterator = hash.entrySet().iterator();
         }
 
@@ -562,17 +512,16 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          */
         @SuppressWarnings("unchecked")
         private boolean findNext() {
-            assert Thread.holdsLock(hash);
             while (iterator.hasNext()) {
                 final Map.Entry<K,Object> candidate = iterator.next();
                 Object value = candidate.getValue();
                 if (value instanceof Reference) {
-                    value = ((Reference) value).get();
-                    entry = new MapEntry<K,V>(candidate.getKey(), (V) value);
+                    value = ((Reference<K, V>) value).get();
+                    entry = new MapEntry<K,V>((K) SoftValueHashMap.resolveNull(candidate.getKey()), (V) value);
                     return true;
                 }
                 if (value != null) {
-                    entry = (Map.Entry<K,V>) candidate;
+                    entry = new MapEntry<K,V>((K) SoftValueHashMap.resolveNull(candidate.getKey()), (V) value);
                     return true;
                 }
             }
@@ -583,35 +532,29 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          * Returns {@code true} if this iterator can return more value.
          */
         public boolean hasNext() {
-            synchronized (hash) {
                 return entry!=null || findNext();
-            }
         }
 
         /**
          * Returns the next value. If some value were garbage collected after the
-         * iterator was created, they will not be returned. Note however that a
-         * {@link ConcurrentModificationException} may be throw if the iteration
-         * is not synchronized on {@link #hash}.
+         * iterator was created, they will not be returned. A
+         * {@link ConcurrentModificationException} is not thrown since a
+         * ConcurrentHashMap is used.
          */
         public Map.Entry<K,V> next() {
-            synchronized (hash) {
                 if (entry==null && !findNext()) {
                     throw new NoSuchElementException();
                 }
                 final Map.Entry<K,V> next = entry;
                 entry = null; // Flags that a new entry will need to be lazily fetched.
                 return next;
-            }
         }
 
         /**
          * Removes the last entry.
          */
         public void remove() {
-            synchronized (hash) {
                 iterator.remove();
-            }
         }
     }
 
@@ -660,7 +603,6 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          * or is about to be removed.</li>
          */
         final Object getAndClear() {
-            assert Thread.holdsLock(hash);
             final Object value = get();
             super.clear();
             return value;
@@ -677,7 +619,7 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
                 final Object value = get();
                 if(value != null) {
                     try {
-                        cleaner.clean(key, value);
+                        cleaner.clean(replaceNull(key), value);
                     } catch(Throwable t) {
                         // never let a bad implementation break soft reference cleaning
                         LOGGER.log(Level.SEVERE, "Exception occurred while cleaning soft referenced object", t);
@@ -686,20 +628,19 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
             }
             
             super.clear();
-            synchronized (hash) {
-                final Object old = hash.remove(key);
-                /*
-                 * If the entry was used for an other value, then put back the old value. This
-                 * case may occurs if a new value was set in the hash map before the old value
-                 * was garbage collected.
-                 */
-                if (old != this && old != null) {
-                    hash.put(key, old);
-                }
-            }
+            final Object old = hash.remove(replaceNull(key));
+            /*
+             * If the entry was used for an other value, then put back the old value. This
+             * case may occurs if a new value was set in the hash map before the old value
+             * was garbage collected.
+             */
+            if (old != this && old != null) {
+            hash.put((K) replaceNull(key), old);
+           }
         }
     }
     
+
     /**
      * A delegate that can be used to perform clean up operation, such as resource closing,
      * before the values cached in soft part of the cache gets disposed of
@@ -712,5 +653,23 @@ public class SoftValueHashMap<K,V> extends AbstractMap<K,V> {
          * @param object
          */
         public void clean(Object key, Object object);
+    }
+    
+    /**
+     * Define placeholder to deal with null key values
+     */
+    private enum Null { PLACEHOLDER }
+
+    /**
+     * Replaces null with placeholder.
+     */
+    private static Object replaceNull(Object o) {
+      return o == null ? Null.PLACEHOLDER : o;
+    }
+    /**
+     * Resolves placeholder.
+     */
+    private static Object resolveNull(Object value) {
+      return value == Null.PLACEHOLDER ? null : value;
     }
 }

--- a/modules/library/metadata/src/test/java/org/geotools/util/SoftValueHashMapTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/SoftValueHashMapTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2006-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2016, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -17,9 +17,11 @@
 package org.geotools.util;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Random;
-import java.util.ConcurrentModificationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import org.junit.*;
@@ -34,12 +36,16 @@ import static org.junit.Assert.*;
  * @source $URL$
  * @version $Id$
  * @author Martin Desruisseaux
+ * @author Ugo Moschini
  */
 public final class SoftValueHashMapTest {
     /**
      * The size of the test sets to be created.
      */
     private static final int SAMPLE_SIZE = 200;
+    private static int NUMTHREADS = 16;
+    private static int THREAD_CYCLES= (int)1E1;
+    private static int TEST_CYCLES = (int) 1E1;
 
     /**
      * Tests the {@link SoftValueHashMap} using strong references. The tested
@@ -54,8 +60,11 @@ public final class SoftValueHashMapTest {
             final SoftValueHashMap<Integer,Integer> softMap = new SoftValueHashMap<Integer,Integer>(SAMPLE_SIZE);
             final HashMap<Integer,Integer>        strongMap = new HashMap<Integer,Integer>();
             for (int i=0; i<SAMPLE_SIZE; i++) {
-                final Integer key   = random.nextInt(SAMPLE_SIZE);
+                Integer key   = random.nextInt(SAMPLE_SIZE);
                 final Integer value = random.nextInt(SAMPLE_SIZE);
+                if (random.nextBoolean()) // test from time to time with the null key
+                    key = null;
+                
                 assertEquals("containsKey:",   strongMap.containsKey(key),
                                                  softMap.containsKey(key));
                 assertEquals("containsValue:", strongMap.containsValue(value),
@@ -72,15 +81,16 @@ public final class SoftValueHashMapTest {
                     assertSame("remove:", strongMap.remove(key),
                                             softMap.remove(key));
                 }
+                
                 assertEquals("equals:", strongMap, softMap);
-            }
+            }          
         }
     }
 
     /**
      * Tests the {@link SoftValueHashMap} using soft references.
      * In this test, we have to keep in mind than some elements
-     * in {@code softMap} may disaspear at any time.
+     * in {@code softMap} may disappear at any time.
      */
     @Test
     public void testSoftReferences() throws InterruptedException {
@@ -93,8 +103,11 @@ public final class SoftValueHashMapTest {
             strongMap.clear();
             for (int i=0; i<SAMPLE_SIZE; i++) {
                 // We really want new instances below.
-                final Integer key   = new Integer(random.nextInt(SAMPLE_SIZE));
+                Integer key   = new Integer(random.nextInt(SAMPLE_SIZE));
                 final Integer value = new Integer(random.nextInt(SAMPLE_SIZE));
+                if (random.nextBoolean()) // test from time to time with the null key
+                    key = null;
+                
                 if (random.nextBoolean()) {
                     /*
                      * Test addition.
@@ -126,7 +139,8 @@ public final class SoftValueHashMapTest {
                     }
                 }
                 assertTrue("containsAll:", softMap.entrySet().containsAll(strongMap.entrySet()));
-            }
+            }            
+            
             // Do our best to lets GC finish its work.
             for (int i=0; i<20; i++) {
                 Runtime.getRuntime().gc();
@@ -138,23 +152,133 @@ public final class SoftValueHashMapTest {
              * Make sure that all values are of the correct type. More specifically, we
              * want to make sure that we didn't forget to convert some Reference object.
              */
-            for (final Iterator it=softMap.values().iterator(); it.hasNext();) {
-                final Object value;
-                try {
-                    value = it.next();
-                } catch (ConcurrentModificationException e) {
-                    break;
-                }
+            for(Object value : softMap.values()) {
                 assertTrue(value instanceof Integer);
                 assertNotNull(value);
             }
         }
     }
     
+    /**
+     * Tests the {@link SoftValueHashMap} with threads performing a sequence of put
+     *  and get operations on the cache.
+     * @throws InterruptedException 
+     */
+    @Test
+    public void testGetPutInMultithreadEnv() throws InterruptedException
+    {
+        final Random random = getRandom();
+        SoftValueHashMap<Integer, Integer> cache = new SoftValueHashMap<Integer, Integer>();
+        
+        // create threads
+        ExecutorService executor = Executors.newFixedThreadPool(NUMTHREADS);      
+        
+        for (int iter = 0; iter < TEST_CYCLES; iter++) {           
+            final CountDownLatch latch = new CountDownLatch(NUMTHREADS);
+            for(int i=0; i < NUMTHREADS; i++) {
+                Runnable th = new CacheTestThreadGetPut(cache, random,latch);
+                executor.execute(th);
+            }           
+            latch.await();  
+        }
+        
+        executor.shutdown();
+        executor.awaitTermination(3, TimeUnit.SECONDS);        
+    }
+    
+    /**
+     * Tests the {@link SoftValueHashMap} with threads that perform a sequence of put and get
+     * and threads that access elements in cache through the iterator
+     * @throws InterruptedException 
+     */
+    @Test
+    public void testGetPutIteratorsInMultithreadEnv() throws InterruptedException {
+        final Random random = getRandom();
+        SoftValueHashMap<Integer, Integer> cache = new SoftValueHashMap<Integer, Integer>();
+       
+        // create threads
+        ExecutorService executor = Executors.newFixedThreadPool(NUMTHREADS);        
+        
+        for (int iter = 0; iter < TEST_CYCLES; iter++) {
+           
+            final CountDownLatch latch = new CountDownLatch(NUMTHREADS);
+            
+            // Threads that fill the cache with random values
+            for(int i=0; i < NUMTHREADS/2; i++) {
+                Runnable th = new CacheTestThreadGetPut(cache, random,latch);
+                executor.execute(th);
+            }
+            
+            // Threads that use the iterator on the cache
+            for(int i=0; i < NUMTHREADS/2; i++) {
+                Runnable th = new CacheTestThreadIterators(cache, latch);
+                executor.execute(th);
+            }
+            
+            latch.await();     
+        }
+        
+        executor.shutdown();
+        executor.awaitTermination(3, TimeUnit.SECONDS);
+    }
+    
+    private class CacheTestThreadGetPut implements Runnable{
+
+        private SoftValueHashMap<Integer, Integer> cache;
+        private Random random;
+        private CountDownLatch latch;
+        
+        public CacheTestThreadGetPut(SoftValueHashMap<Integer, Integer> cache, Random random, CountDownLatch latch) {
+            this.cache = cache;
+            this.random = random;
+            this.latch=latch;
+        }
+        
+        public void run() {
+            for(int i=0; i<THREAD_CYCLES; i++) {
+                final Integer key   = new Integer(random.nextInt(SAMPLE_SIZE));
+                final Integer value = new Integer(random.nextInt(SAMPLE_SIZE));
+                if (random.nextBoolean()) {
+                    Object o = cache.put(key, value);
+                    if(o!= null)
+                        assertTrue("Put in multithread", o instanceof Integer);                    
+                } else {
+                    Object o = cache.get(key);
+                    if(o!= null)
+                        assertTrue("Get in multithread", o instanceof Integer);
+                }                
+            }    
+            latch.countDown();
+       } 
+    }
+    
+    private class CacheTestThreadIterators implements Runnable{
+
+        private SoftValueHashMap<Integer, Integer> cache;
+        private CountDownLatch latch;
+        
+        public CacheTestThreadIterators(SoftValueHashMap<Integer, Integer> cache, CountDownLatch latch) {
+            this.cache = cache;
+            this.latch=latch;
+        }
+        
+        public void run() {
+            for(int i=0; i<THREAD_CYCLES; i++) {
+                for(Object value : cache.values()) {
+                    if(value != null){
+                        assertTrue("Value from iterator:", value instanceof Integer);
+                    }
+                }              
+            }    
+            latch.countDown();
+        } 
+    }
+    
+    
     private Random getRandom() {
-    	long seed = System.currentTimeMillis() + hashCode();
-    	Random random = new Random(seed);
-    	Logger.getLogger(this.getClass().getName()).info("Using Random Seed: "+seed);
-    	return random;
+        long seed = System.currentTimeMillis() + hashCode();
+        Random random = new Random(seed);
+        Logger.getLogger(this.getClass().getName()).info("Using Random Seed: "+seed);
+        return random;
     }
 }


### PR DESCRIPTION
SoftValueHashMap that uses data structures to scale better in concurrent environments. Unit tests were added to test the behaviour in multithreaded environments. Fixed the issue present in previous (reverted) PR ( https://github.com/geotools/geotools/pull/1431 ): inside the method retainStrongly, it is checked that if the value returned by hash.get(replaceNull(toRemove)) has already been wrapped in a Reference, it must not be wrapped again before insertion in the map.