### PR TITLE
Upgrade EhCache to latest 2.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1046,7 +1046,7 @@
       <dependency>
         <groupId>net.sf.ehcache</groupId>
         <artifactId>ehcache</artifactId>
-        <version>1.6.2</version>
+        <version>2.10.3</version>
       </dependency>
 
       <!-- Tests or legacy -->


### PR DESCRIPTION
This one is a little selfish, but we have some conflicts internally with the version of EhCache used in GeoTools and the latest 2.x version. I figure this upgrade is fairly safe in that

- it's only used by ImageMosaic
- there are no code changes required to do the upgrade.

I'd consider upgrading even further, but EhCache 3.x is a significant departure both in API and capabilities.