### PR TITLE
Fix copy/paste error in GeoToolsUnitFormat.java

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/styling/SLDTransformer.java
+++ b/modules/library/main/src/main/java/org/geotools/styling/SLDTransformer.java
@@ -83,6 +83,11 @@ public class SLDTransformer extends TransformerBase {
      * Additional namespace mappings to emit in the start element of the generated. Each entry has a URI key and an associated prefix string value.
      */
     final private Map uri2prefix;
+    
+    /**
+     * don't suppress the export of default values
+     */
+    private boolean exportDefaultValues = false;
 
     /**
      * Construct a new instance of <code>SLDTransformer</code> with the default namespace mappings usually found in a simple Styled Layer Descriptor
@@ -118,6 +123,20 @@ public class SLDTransformer extends TransformerBase {
         }
     }
 
+    /**
+     * @return the exportDefaultValues
+     */
+    public boolean isExportDefaultValues() {
+        return exportDefaultValues;
+    }
+
+    /**
+     * @param exportDefaultValues the exportDefaultValues to set
+     */
+    public void setExportDefaultValues(boolean exportDefaultValues) {
+        this.exportDefaultValues = exportDefaultValues;
+    }
+    
     public Translator createTranslator(ContentHandler handler) {
         Translator result = new SLDTranslator(handler);
         // add pre-configured namespace mappings
@@ -135,8 +154,10 @@ public class SLDTransformer extends TransformerBase {
                 }
             }
         }
+        ((SLDTranslator)result).setExportDefaultValues(isExportDefaultValues());
         return result;
     }
+
 
     /**
      * Currently does nothing.
@@ -170,7 +191,9 @@ public class SLDTransformer extends TransformerBase {
          * Handles any Filters used in our data structure.
          */
         FilterTransformer.FilterTranslator filterTranslator;
-
+        
+        private boolean exportDefaultValues = false;
+        
         /**
          * Translates into the default of prefix "sld" for "http://www.opengis.net/sld".
          * 
@@ -179,7 +202,6 @@ public class SLDTransformer extends TransformerBase {
         public SLDTranslator(ContentHandler handler) {
             this(handler, "sld", "http://www.opengis.net/sld");
         }
-
         /**
          * Translates
          * 
@@ -204,6 +226,9 @@ public class SLDTransformer extends TransformerBase {
         }
 
         boolean isDefault(Expression expr, Object defaultValue) {
+            if (isExportDefaultValues()) {
+                return false;
+            }
             if (defaultValue == null)
                 return isNull(expr);
 
@@ -222,6 +247,26 @@ public class SLDTransformer extends TransformerBase {
             }
             return false;
         }
+
+        /**
+         * @param exportDefaultValues
+         */
+        public void setExportDefaultValues(boolean exportDefaultValues) {
+          this.exportDefaultValues = exportDefaultValues; 
+            
+        }
+
+        /**
+         * @return the exportDefaultValues
+         */
+        public boolean isExportDefaultValues() {
+            return exportDefaultValues;
+        }
+
+
+
+
+       
 
         /**
          * Utility method used to quickly package up the provided expression.
@@ -279,7 +324,7 @@ public class SLDTransformer extends TransformerBase {
             if (expr instanceof Literal) {
                 if (defaultValue != null) {
                     Object value = expr.evaluate(null, defaultValue.getClass());
-                    if (value != null && !value.equals(defaultValue)) {
+                    if (value != null && (!value.equals(defaultValue)||isExportDefaultValues())) {
                         element(element, value.toString(), atts);
                     }
                 } else {
@@ -832,7 +877,7 @@ public class SLDTransformer extends TransformerBase {
         public void visit(Mark mark) {
             start("Mark");
             if (mark.getWellKnownName() != null
-                    && !"square".equals(mark.getWellKnownName().evaluate(null))) {
+                    && (!"square".equals(mark.getWellKnownName().evaluate(null))||isExportDefaultValues())) {
                 encodeValue("WellKnownName", null, mark.getWellKnownName(), null);
             }
 
@@ -1235,15 +1280,16 @@ public class SLDTransformer extends TransformerBase {
             if (expression == null) {
                 return; // protect ourselves from things like a null Stroke Color
             }
-
-            // skip encoding if we are using the default value
-            if (expression instanceof Literal && defaultValue != null) {
-                Object value = expression.evaluate(null, defaultValue.getClass());
-                if (value != null && value.equals(defaultValue)) {
-                    return;
+            
+            if (!isExportDefaultValues()) {
+                // skip encoding if we are using the default value
+                if (expression instanceof Literal && defaultValue != null) {
+                    Object value = expression.evaluate(null, defaultValue.getClass());
+                    if (value != null && value.equals(defaultValue)) {
+                        return;
+                    }
                 }
             }
-
             if (atts == null) {
                 atts = NULL_ATTS;
             }

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/wkt/GeoToolsUnitFormatTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/wkt/GeoToolsUnitFormatTest.java
@@ -1,0 +1,52 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.referencing.wkt;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import javax.measure.unit.SI;
+import javax.measure.unit.Unit;
+import javax.measure.unit.UnitFormat;
+
+import org.geotools.metadata.iso.citation.Citations;
+import org.junit.Test;
+
+/**
+ * @author ian
+ *
+ */
+public class GeoToolsUnitFormatTest {
+
+    private UnitFormat unitFormat = GeoToolsUnitFormat.getInstance(Citations.EPSG);
+
+    /**
+     * Test method for {@link javax.measure.unit.UnitFormat#format(javax.measure.unit.Unit, java.lang.Appendable)}.
+     * 
+     * @throws IOException
+     */
+    @Test
+    public void testFormatUnitOfQAppendable() throws IOException {
+
+        Unit<?> u = SI.CELSIUS;
+        Appendable appendable = new StringBuilder();
+        unitFormat.format(u, appendable);
+        assertEquals("Missing symbol formats", u.toString(), appendable.toString());
+    }
+
+}


### PR DESCRIPTION
Means that SI units weren't necessarily labeled correctly
extends and replaces https://github.com/geotools/geotools/pull/1427
