### PR TITLE
Fixed GEOT-5336

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
@@ -643,7 +643,12 @@ public final class RendererUtilities {
             int qMaxX=1;
             int qMinY=-1;
             int qMaxY=1;
-           
+            //we must consider at least a pair of quadrants in each direction other wise lines which don't cross both the equator and prime meridian are
+            //measured as 0 length. But for some cases we need to consider still more hemispheres.
+            qMinX = Math.min(qMinX, (int) (Math.signum(env.getMinX()) * Math.ceil(Math.abs(env.getMinX() / 180.0))));
+            qMaxX = Math.max(qMaxX, (int) (Math.signum(env.getMaxX()) * Math.ceil(Math.abs(env.getMaxX() / 180.0))));
+            qMinY = Math.min(qMinY, (int) (Math.signum(env.getMinY()) * Math.ceil(Math.abs((env.getMinY() + 90) / 180.0))));
+            qMaxY = Math.max(qMaxY, (int) (Math.signum(env.getMaxY()) * Math.ceil(Math.abs((env.getMaxY() + 90) / 180.0))));
             for (int i = qMinX; i < qMaxX; i++) {
                 for (int j = qMinY; j < qMaxY; j++) {
                     double minX = i * 180.0;

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
@@ -639,10 +639,11 @@ public final class RendererUtilities {
             GeometryFactory gf = new GeometryFactory();
             LineString ls = gf.createLineString(new Coordinate[] {new Coordinate(env.getMinX(), env.getMinY()), 
                     new Coordinate(env.getMaxX(), env.getMaxY())});
-            int qMinX = (int) (Math.signum(env.getMinX()) * Math.ceil(Math.abs(env.getMinX() / 180.0)));
-            int qMaxX = (int) (Math.signum(env.getMaxX()) * Math.ceil(Math.abs(env.getMaxX() / 180.0)));
-            int qMinY = (int) (Math.signum(env.getMinY()) * Math.ceil(Math.abs((env.getMinY() + 90) / 180.0)));
-            int qMaxY = (int) (Math.signum(env.getMaxY()) * Math.ceil(Math.abs((env.getMaxY() + 90) / 180.0)));
+            int qMinX=-1;
+            int qMaxX=1;
+            int qMinY=-1;
+            int qMaxY=1;
+           
             for (int i = qMinX; i < qMaxX; i++) {
                 for (int j = qMinY; j < qMaxY; j++) {
                     double minX = i * 180.0;

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderUtilitiesTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderUtilitiesTest.java
@@ -245,4 +245,40 @@ public class RenderUtilitiesTest extends TestCase {
         double expected = groundDistance / pixelDistance;
         assertEquals(expected, scale, expected * 0.05); // no projection deformation here!
     }
+    
+    /**
+     * Test from GEOT-5336,
+     * RenderUtilities was miss calculating the quadrants for large maps
+     * 
+     * 
+     */
+    public void testHemisphereCrossing() throws Exception {
+        CoordinateReferenceSystem wgs84 = CRS.decode("EPSG:4326", true);
+        
+        //First cross equator and prime meridian
+        ReferencedEnvelope re = new ReferencedEnvelope(new Envelope(-72.0, 132.0, -4.0, 70.0), wgs84);
+        double scale = RendererUtilities.calculateScale(re, 1000, 500, 75);
+        assertTrue(scale > 1.0d);
+        
+        //Then prime meridian in North
+        re = new ReferencedEnvelope(new Envelope(-72.0, 132.0, 4.0, 70.0), wgs84);
+        scale = RendererUtilities.calculateScale(re, 1000, 500, 75);
+        assertTrue(scale > 1.0d);
+        
+        //Then prime meridian in South
+        re = new ReferencedEnvelope(new Envelope(-72.0, 132.0, -4.0, -70.0), wgs84);
+        scale = RendererUtilities.calculateScale(re, 1000, 500, 75);
+        assertTrue(scale > 1.0d);
+        
+        //Then equator in West
+        re = new ReferencedEnvelope(new Envelope(-72.0, -132.0, -90.0, 90.0), wgs84);
+        scale = RendererUtilities.calculateScale(re, 1000, 500, 75);
+        assertTrue(scale > 1.0d);
+        
+        //Then Equator in East
+        re = new ReferencedEnvelope(new Envelope(72.0, 132.0, -90.0, 90.0), wgs84);
+        scale = RendererUtilities.calculateScale(re, 1000, 500, 75);
+        assertTrue(scale > 1.0d);
+        
+    }
 }


### PR DESCRIPTION
The code was miss calculating the quadrants to compare to when dealing with
diagaonals greater than 180 degrees.