### PR TITLE
[GEOT-5626] Add mbstyle.rst to fix docs build

### DIFF
--- a/docs/user/unsupported/mbstyle.rst
+++ b/docs/user/unsupported/mbstyle.rst
@@ -1,0 +1,32 @@
+Mapbox Styles Module
+--------------------
+
+The **gt-mbstyle** module is an unsupported module that provides a parser/encoder to convert between Mapbox Styles and GeoTools style objects. These docs are under active development, along with the module itself.
+
+References:
+
+* https://www.mapbox.com/mapbox-gl-style-spec
+
+Code Example
+^^^^^^^^^^^^
+
+Quick example of module usage (API change):
+
+.. code-block:: java
+
+    StyledLayerDescriptor style = MapBoxStyle.parse( reader );
+
+Internally the extension provides greater access to the parsed style:
+
+.. code-block:: java
+  
+    MBStyle mbstyle = MapBoxStyleParser.parse( reader );
+
+    // pull back all layers for a provided source
+    List<MBLayer> layers = mbstyle.layers( "mapbox://mapbox.mapbox-streets-v6" );
+
+    // pull back selected layers for a provided source
+    List<MBLayer> layers = mbstyle.layers( "mapbox://mapbox.mapbox-streets-v6", "water" ); 
+
+    //Which can be used to Generate Styler Layer Descriptor:
+    StyleLayerDescriptor sld = MBStyleTransformer.transform( layers );


### PR DESCRIPTION
Add a stub mbstyle.rst file to support the new mapbox styles unsupported module.