### PR TITLE
refactor MBObjectParser into an object for reuse of factories

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/styling/StyleFactory.java
+++ b/modules/library/api/src/main/java/org/geotools/styling/StyleFactory.java
@@ -423,15 +423,17 @@ public interface StyleFactory extends Factory, org.opengis.style.StyleFactory {
     ExternalMark externalMark(Icon inline);
 
     /**
+     * Direct FeatureTypeStyle creation (with no default SLD values applied). 
      * 
-     * @param name
-     * @param description
-     * @param definedFor
-     * @param featureTypeNames
-     * @param types
+     * @param name Name
+     * @param description Description with title and abstract information
+     * @param definedFor Currently unused
+     * @param featureTypeNames FeatureTypes this style applies to, use AbstractFeature to match all 
+     * @param types SemanticType 
      * @param rules
      *            May not be null or empty
-     * @return
+     * @return feature type style
+     * @see SimpleFe
      */
     FeatureTypeStyle featureTypeStyle(String name,
             org.opengis.style.Description description, Id definedFor, Set<Name> featureTypeNames,

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/FillMBLayer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/FillMBLayer.java
@@ -19,6 +19,7 @@ package org.geotools.mbstyle;
 
 import java.awt.Color;
 import java.awt.Point;
+import java.lang.reflect.Array;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -28,6 +29,8 @@ import org.opengis.style.Displacement;
 public class FillMBLayer extends MBLayer {
 
     private JSONObject paint;
+
+    private JSONObject layout;
 
     private static String type = "fill";
 
@@ -46,12 +49,8 @@ public class FillMBLayer extends MBLayer {
     public FillMBLayer(JSONObject json) {
         super(json);
 
-        if (json.get("paint") != null) {
-            paint = (JSONObject) json.get("paint");
-        } else {
-            paint = new JSONObject();
-        }
-
+        paint = paint();
+        layout = layout();
     }
 
     /**
@@ -60,7 +59,7 @@ public class FillMBLayer extends MBLayer {
      * Defaults to true.
      * 
      */
-    public Expression getFillAntialias() {        
+    public Expression getFillAntialias() {
         return parse.bool(paint, "fill-antialias", true);
     }
 
@@ -72,7 +71,17 @@ public class FillMBLayer extends MBLayer {
      * @throws MBFormatException 
      * 
      */
-    public Expression getFillOpacity() throws MBFormatException {
+    public Number getFillOpacity() throws MBFormatException {
+        return parse.optional(Double.class, paint, "fill-opacity", 1.0 );
+    }
+    
+    /**
+     * Access fill-opacity.
+     * 
+     * @return Access fill-opacity as literal or function expression, defaults to 1.
+     * @throws MBFormatException
+     */
+    public Expression fillOpacity() throws MBFormatException {
         return parse.percentage( paint, "fill-opacity", 1 );
     }
 
@@ -84,7 +93,12 @@ public class FillMBLayer extends MBLayer {
      * 
      * Defaults to #000000. Disabled by fill-pattern.
      */
-    public Expression getFillColor() {      
+    public Color getFillColor(){
+        return parse.optional(Color.class, paint, "fill-color", Color.BLACK );
+    }
+    
+    /** Access fill-color as literal or function expression, defaults to black. */
+    public Expression fillColor() {      
         return parse.color(paint, "fill-color", Color.BLACK);
     }
 
@@ -93,18 +107,32 @@ public class FillMBLayer extends MBLayer {
      * 
      * Matches the value of fill-color if unspecified. Disabled by fill-pattern.
      */
-    public Expression getFillOutlineColor() {
+    public Color getFillOutlineColor(){
         if (paint.get("fill-outline-color") != null) {
-            return parse.color(paint, "fill-outline-color", Color.BLACK );
+            return parse.optional(Color.class, paint, "fill-outline-color", Color.BLACK);
         } else {
             return getFillColor();
         }
     }
 
+    /** Access fill-outline-color as literal or function expression, defaults to black. */
+    public Expression fillOutlineColor() {
+        if (paint.get("fill-outline-color") != null) {
+            return parse.color(paint, "fill-outline-color", Color.BLACK);
+        } else {
+            return fillColor();
+        }
+    }
+
     /**
-     * (Optional) The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively. Units in pixels. Defaults to 0, 0.
+     * (Optional) The geometry's offset. Values are [x, y] where negatives indicate left and up,
+     * respectively. Units in pixels. Defaults to 0, 0.
      */
-    public Point getFillTranslate() {
+    public double[] getFillTranslate(){
+        return parse.array( paint, "fill-translate", new double[]{ 0.0, 0.0 } ); 
+    }
+     
+    public Point fillTranslate() {
         if (paint.get("fill-translate") != null) {
             JSONArray array = (JSONArray) paint.get("fill-translate");
             Number x = (Number) array.get(0);

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/FillMBLayer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/FillMBLayer.java
@@ -20,23 +20,16 @@ package org.geotools.mbstyle;
 import java.awt.Color;
 import java.awt.Point;
 
-import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.mbstyle.parse.MBObjectParser;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.opengis.filter.FilterFactory;
 import org.opengis.filter.expression.Expression;
 import org.opengis.style.Displacement;
-import org.opengis.style.StyleFactory;
 
-public class MBFillLayer extends MBLayer {
+public class FillMBLayer extends MBLayer {
 
-    private JSONObject paintJson;
+    private JSONObject paint;
 
     private static String type = "fill";
-
-    private static FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
-    private static StyleFactory sf = CommonFactoryFinder.getStyleFactory();
 
     /**
      * Controls the translation reference point.
@@ -50,13 +43,13 @@ public class MBFillLayer extends MBLayer {
         MAP, VIEWPORT
     }
 
-    public MBFillLayer(JSONObject json) {
+    public FillMBLayer(JSONObject json) {
         super(json);
 
         if (json.get("paint") != null) {
-            paintJson = (JSONObject) json.get("paint");
+            paint = (JSONObject) json.get("paint");
         } else {
-            paintJson = new JSONObject();
+            paint = new JSONObject();
         }
 
     }
@@ -68,7 +61,7 @@ public class MBFillLayer extends MBLayer {
      * 
      */
     public Expression getFillAntialias() {        
-        return MBObjectParser.bool(paintJson, "fill-antialias", true);
+        return parse.bool(paint, "fill-antialias", true);
     }
 
     /**
@@ -80,7 +73,7 @@ public class MBFillLayer extends MBLayer {
      * 
      */
     public Expression getFillOpacity() throws MBFormatException {
-        return MBObjectParser.percentage( paintJson, "fill-opacity", 1 );
+        return parse.percentage( paint, "fill-opacity", 1 );
     }
 
     /**
@@ -92,7 +85,7 @@ public class MBFillLayer extends MBLayer {
      * Defaults to #000000. Disabled by fill-pattern.
      */
     public Expression getFillColor() {      
-        return MBObjectParser.color(paintJson, "fill-color", Color.BLACK);
+        return parse.color(paint, "fill-color", Color.BLACK);
     }
 
     /**
@@ -101,8 +94,8 @@ public class MBFillLayer extends MBLayer {
      * Matches the value of fill-color if unspecified. Disabled by fill-pattern.
      */
     public Expression getFillOutlineColor() {
-        if (paintJson.get("fill-outline-color") != null) {
-            return MBObjectParser.color(paintJson, "fill-outline-color", Color.BLACK );
+        if (paint.get("fill-outline-color") != null) {
+            return parse.color(paint, "fill-outline-color", Color.BLACK );
         } else {
             return getFillColor();
         }
@@ -112,8 +105,8 @@ public class MBFillLayer extends MBLayer {
      * (Optional) The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively. Units in pixels. Defaults to 0, 0.
      */
     public Point getFillTranslate() {
-        if (paintJson.get("fill-translate") != null) {
-            JSONArray array = (JSONArray) paintJson.get("fill-translate");
+        if (paint.get("fill-translate") != null) {
+            JSONArray array = (JSONArray) paint.get("fill-translate");
             Number x = (Number) array.get(0);
             Number y = (Number) array.get(1);
             return new Point(x.intValue(), y.intValue());
@@ -133,7 +126,7 @@ public class MBFillLayer extends MBLayer {
      * 
      */
     public FillTranslateAnchor getFillTranslateAnchor() {
-        Object value = paintJson.get("fill-translate-anchor");
+        Object value = paint.get("fill-translate-anchor");
         if (value != null && "viewport".equalsIgnoreCase((String) value)) {
             return FillTranslateAnchor.VIEWPORT;
         } else {
@@ -146,7 +139,7 @@ public class MBFillLayer extends MBLayer {
      * 4, 8, ..., 512).
      */
     public Expression getFillPattern() {
-        return MBObjectParser.string(paintJson, "fill-pattern", null);
+        return parse.string(paint, "fill-pattern", null);
     }
 
     /**
@@ -168,15 +161,15 @@ public class MBFillLayer extends MBLayer {
      * @return
      */
     public Displacement toDisplacement() {
-        Object defn  = paintJson.get("filter-translate");
+        Object defn  = paint.get("filter-translate");
         if( defn == null ){
             return null;
         }
         else if (defn instanceof JSONArray){
             JSONArray array = (JSONArray) defn;
             return sf.displacement(
-                    MBObjectParser.number( array, 0, 0 ),
-                    MBObjectParser.number( array, 1, 0 ));
+                    parse.number( array, 0, 0 ),
+                    parse.number( array, 1, 0 ));
         }
         return null;
     }

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/LineMBLayer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/LineMBLayer.java
@@ -146,7 +146,7 @@ public class LineMBLayer extends MBLayer {
      * 
      */
     public Number getLineMiterLimit() {
-        if (paint.get("line-miter_limit") != null) {
+        if (paint.get("line-miter-limit") != null) {
             return (Number) paint.get("line-miter-limit");
         } else {
             return 2;
@@ -160,7 +160,7 @@ public class LineMBLayer extends MBLayer {
      * 
      */
     public Number getLineRoundLimit() {
-        if (paint.get("line-round_limit") != null) {
+        if (paint.get("line-round-limit") != null) {
             return (Number) paint.get("line-round-limit");
         } else {
             return 1.05;
@@ -174,11 +174,39 @@ public class LineMBLayer extends MBLayer {
      * 
      */
     public Number getLineOpacity() {
-        if (paint.get("line-opacity") != null) {
-            return (Number) paint.get("line-opacity");
+        if( paint.containsKey("line-opacity")){
+            Object lineOpacity = paint.get("line-opacity");
+            if( lineOpacity == null ){
+                return 1;
+            }
+            else if (lineOpacity instanceof JSONObject){
+                throw new UnsupportedOperationException("Functions not supported yet");
+            }
+            else if (lineOpacity instanceof Number){
+                return (Number) lineOpacity;
+            }
+            else if(lineOpacity instanceof String){
+                return Double.parseDouble((String)lineOpacity);
+            }
+            else {
+                throw new IllegalArgumentException(
+                        "json contents invalid, line-opacity value limited to Number, String, or JSONObject (function)"
+                        + lineOpacity.getClass().getSimpleName());
+            }
         } else {
             return 1;
         }
+    }
+    
+    /**
+     * The opacity at which the line will be drawn.
+     * 
+     * Defaults to 1.
+     * @return opacity for line (literal or function), defaults to 1.
+     * 
+     */
+    public Expression lineOpacity(){
+        return parse.number(paint, "line-opacity", 1 );
     }
 
     /**

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBFormatException.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBFormatException.java
@@ -1,3 +1,19 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
 package org.geotools.mbstyle;
 
 /**

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBLayer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBLayer.java
@@ -17,79 +17,268 @@
  */
 package org.geotools.mbstyle;
 
+import org.geotools.mbstyle.parse.MBObjectParser;
+import org.geotools.styling.StyleFactory2;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
 
+/**
+ * MBLayer wrapper (around one of the MBStyle layers).
+ * <p>
+ * All methods act as accessors on provided JSON layer, no other state is maintained. This allows
+ * modifications to be made ceanly with out chance of side-effect.
+ * </p>
+ * <p>
+ * In the normal course of events MBLayer is constructed as a flighweight object by MBStyle to
+ * provide easy access to its layers list.
+ * </p>
+ * 
+ * @author Torben Barsballe (Boundless)
+ */
 public abstract class MBLayer {
+    /** Helper class used to provide json access and expression / filter conversions */
+    final protected MBObjectParser parse;
 
-    protected JSONObject json;
+    /** Shared filter factory */
+    final protected FilterFactory2 ff;
 
-    protected String id;
+    /** Shared style factory */
+    final protected StyleFactory2 sf;
 
-    protected String source;
+    /** JSON layer being wrapped. */
+    final protected JSONObject json;
 
-    protected String sourceLayer;
+    /** field access for "id" key (due to its use in error messages) */
+    final protected String id;
 
-    protected Boolean visibility = true;
-
-    public MBLayer(JSONObject json) {        
-        super();
-        this.json = json;
-
-        this.id = (String) json.get("id");
-
-        if (json.containsKey("source")) {
-            this.source = (String) json.get("source");
-        }
-
-        if (json.containsKey("source-layer")) {
-            this.sourceLayer = (String) json.get("source-layer");
-        }
-
-        if (json.containsKey("visibility")) {
-            this.visibility = (Boolean) json.get("visibility");
-        }
+    public MBLayer(JSONObject json) {
+        this(json, new MBObjectParser());
     }
 
+    public MBLayer(JSONObject json, MBObjectParser parse) {
+        this.json = json;
+        this.parse = parse;
+        this.ff = parse.getFilterFactory();
+        this.sf = parse.getStyleFactory();
+        
+        this.id = (String) json.get("id");
+    }
+    //
+    // Factory methods
+    //
+    
+    /**
+     * Factory method creating the appropriate MBStyle based on the "type" indicated in the layer JSON.
+     */
+    public static MBLayer create(JSONObject layer ){
+        if( layer.containsKey("type") && layer.get("type") instanceof String){
+            String type = (String) layer.get("type");
+            switch( type ){
+            case "line": return new LineMBLayer(layer);
+            case "fill": return new FillMBLayer(layer);
+            case "raster": return new RasterMBLayer(layer);
+            default:
+                throw new MBFormatException("Could not create layer \""+type+"\"");
+            }
+        }
+        // technically we may be able to do this via a ref
+        throw new MBFormatException("\"type\" required to create layer.");
+    }
+    
+    /**
+     * Rendering type of this layer.
+     * <p>
+     * One of:
+     * <ul>
+     * <li>fill:A filled polygon with an optional stroked border.</li>
+     * <li>line: A stroked line.</li>
+     * <li>symbol: An icon or a text label.</li>
+     * <li>circle:A filled circle.</li>
+     * <li>fill-extrusion: An extruded (3D) polygon.</li>
+     * <li>raster: Raster map textures such as satellite imagery.</li>
+     * <li>background: The background color or pattern of the map.</li>
+     * </ul>
+     * 
+     * @return Optional field, one of fill, line, symbol, circle, fill-extrusion, raster,
+     *         background.
+     */
+    public abstract String getType();
+    
+    /**
+     * Arbitrary properties useful to track with the layer, but do not influence rendering.
+     * Properties should be prefixed to avoid collisions, like 'mapbox:' and 'gt:`.
+     * 
+     * @return Arbitrary properties useful to track with the layer. 
+     */
+    public JSONObject getMetadata(){
+        throw new UnsupportedOperationException(); 
+    }
+
+    /**
+     * References another layer to copy type, source, source-layer, minzoom, maxzoom, filter, and
+     * layout properties from. This allows the layers to share processing and be more efficient.
+     * 
+     * @return References another layer to copy type, source, source-layer, minzoom, maxzoom, filter, and
+     * layout properties from.
+     */
+    public String getRef(){
+        // We should update getType(), getSource(), getSourceLayer(), getMinZoom(), getMaxZoom(),
+        // getFilter() to look up value provided by getRef() if needed.
+        throw new UnsupportedOperationException();
+    }
+    
+    
     public JSONObject getJson() {
         return json;
     }
 
-    public void setJson(JSONObject json) {
-        this.json = json;
-    }
-
+    /**
+     * Unique layer name.
+     * @return layer name, required field
+     */
     public String getId() {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
+    /**
+     * Name of a source description to be used for this layer.
+     * <p>
+     * While this value is optional, it may be obtained via {@link #getRef()} if needed.
+     * </p>
+     * 
+     * @return name of source description to be used for this layer
+     */
     public String getSource() {
-        return source;
+        return parse.get(json,"source");
     }
 
-    public void setSource(String source) {
-        this.source = source;
-    }
-
+    /**
+     * Layer to use from a vector tile source. Required if the source supports multiple layers.
+     * <p>
+     * While this value is optional, it may be obtained via {@link #getRef()} if needed.
+     * </p>
+     * 
+     * @return layer to use from a vector tile source
+     */
     public String getSourceLayer() {
-        return sourceLayer;
+        return parse.get(json,"source-layer");
     }
 
-    public void setSourceLayer(String sourceLayer) {
-        this.sourceLayer = sourceLayer;
+    /**
+     * The minimum zoom level on which the layer gets parsed and appears on.
+     * 
+     * @return minimum zoom level, optional number may return null.
+     */
+    public Integer getMinZoom(){
+        return parse.optional(Integer.class, json, "minzoom", null);
+    }
+    
+    /**
+     * The maximum zoom level on which the layer gets parsed and appears on.
+     * 
+     * @return maximum zoom level, optional number may return null.
+     */
+    public Integer getMaxZoom(){
+        return parse.optional(Integer.class, json, "maxzoom", null);
+    }
+    
+    /**
+     * A JSONArray expression specifying conditions on source features. Only features that match the filter
+     * are displayed. This is available as a GeoTools {@link Filter} via {@link #filter()}.
+     * 
+     * @return JSONArray expression specifying conditions on source features, optional may return null.
+     */
+    public JSONArray getFilter(){
+        return parse.getJSONArray(json,"filter", null );
+    }
+    
+    /**
+     * The "filter" as a GeoTools {@link Filter} suitable for feature selection, as defined by
+     * {@link #getFilter()}.
+     * 
+     * @return Filter
+     */
+    public Filter filter(){
+        return Filter.INCLUDE; // TODO: Implemented based on getFilter, for now select everything
+    }
+    
+    /**
+     * Layout properties for the layer.
+     * <p>
+     * <em>Layout properties</em> appear in the layer's "layout" object. They are applied early in
+     * the rendering process and define how data for that layer is passed to the renderer. For
+     * efficiency, a layer can share layout properties with another layer via the "ref" layer
+     * property, and should do so where possible. This will decrease processing time and allow the
+     * two layers will share GPU memory and other resources associated with the layer.
+     * </p>
+     * 
+     * @return Layout properties for the layer, optional value may be empty.
+     */
+    public JSONObject getLayout(){
+        return parse.layout(json);
+    }
+    
+    /**
+     * Default paint properties for this layer.
+     * <p>
+     * <em>Paint properties</em> are applied later in the rendering process. A layer that shares layout
+     * properties with another layer can have independent paint properties. Paint properties appear
+     * in the layer's "paint" object.
+     * </p>
+     * 
+     * @return Default paint properties for this layer, optinal value may be empty.
+     */
+    public JSONObject getPaint(){
+        return parse.paint(json);
     }
 
-    public abstract String getType();
-
-    public Boolean getVisibility() {
-        return visibility;
+    /**
+     * Class-specific "paint.*" properties for this layer. The class name is the part after the first
+     * dot. 
+     * 
+     * @return class specific "paint.*" properties
+     * @deprecated style classes are deprecated and will be removed in the next version of this spec.
+     */
+    public JSONObject getPaintProperties(){
+        return new JSONObject();
+    }
+    
+    //
+    // Data Object based on wrapped json
+    //
+    
+    /** Hashcode based on wrapped {@link #json}. */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((json == null) ? 0 : json.hashCode());
+        return result;
     }
 
-    public void setVisibility(Boolean visibility) {
-        this.visibility = visibility;
+    /** Equality based on wrapped {@link #json}. */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        MBLayer other = (MBLayer) obj;
+        if (json == null) {
+            if (other.json != null)
+                return false;
+        } else if (!json.equals(other.json))
+            return false;
+        return true;
+    }
+    
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " id=" + id;
     }
 
 }

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBLayer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBLayer.java
@@ -28,8 +28,13 @@ import org.opengis.filter.FilterFactory2;
  * MBLayer wrapper (around one of the MBStyle layers).
  * <p>
  * All methods act as accessors on provided JSON layer, no other state is maintained. This allows
- * modifications to be made ceanly with out chance of side-effect.
- * </p>
+ * modifications to be made cleanly with out chance of side-effect.
+ * 
+ * <ul>
+ * <li>get methods: access the json directly</li>
+ * <li>query methods: provide logic / transforms to GeoTools classes as required.</li>
+ * </ul>
+ * 
  * <p>
  * In the normal course of events MBLayer is constructed as a flighweight object by MBStyle to
  * provide easy access to its layers list.
@@ -79,6 +84,12 @@ public abstract class MBLayer {
             case "line": return new LineMBLayer(layer);
             case "fill": return new FillMBLayer(layer);
             case "raster": return new RasterMBLayer(layer);
+            
+            case "symbol":
+            case "circle":
+            case "fill-extrusion":
+                throw new UnsupportedOperationException("MBLayer type "+type+" not yet implemented");
+                
             default:
                 throw new MBFormatException(("\"type\" " + type
                         + " is not a valid layer type. Must be one of: "
@@ -217,10 +228,19 @@ public abstract class MBLayer {
      * two layers will share GPU memory and other resources associated with the layer.
      * </p>
      * 
-     * @return Layout properties for the layer, optional value may be empty.
+     * @return Layout properties defined for layer, optional value may be empty.
      */
     public JSONObject getLayout(){
         return parse.layout(json);
+    }
+    
+    /**
+     * Query for layout information (making use of {@link #getRef()} if available).
+     * 
+     * @return Layout properties to use for this layer.
+     */
+    public JSONObject layout(){
+        return getLayout(); // TODO: Lookup ref
     }
     
     /**
@@ -235,6 +255,14 @@ public abstract class MBLayer {
      */
     public JSONObject getPaint(){
         return parse.paint(json);
+    }
+    /**
+     * Query for paint information (making use of {@link #getRef()} if available).
+     * 
+     * @return Paint properties to use for this layer.
+     */
+    public JSONObject paint(){
+        return getPaint(); // TODO: Lookup ref
     }
 
     /**

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBLayer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBLayer.java
@@ -80,7 +80,10 @@ public abstract class MBLayer {
             case "fill": return new FillMBLayer(layer);
             case "raster": return new RasterMBLayer(layer);
             default:
-                throw new MBFormatException("Could not create layer \""+type+"\"");
+                throw new MBFormatException(("\"type\" " + type
+                        + " is not a valid layer type. Must be one of: "
+                        + "background, fill, line, symbol, raster, circle, fill-extrusion"));
+
             }
         }
         // technically we may be able to do this via a ref

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBStyle.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBStyle.java
@@ -59,6 +59,23 @@ public class MBStyle {
     public MBStyle(JSONObject json) {
         this.json = json;
     }
+    /**
+     * Parse MBStyle for the provided json. 
+     * @param json Required to be a JSONObject
+     * @return MBStyle wrapping the provided json
+     * 
+     * @throws MBFormatException
+     */
+    public static MBStyle create(Object json) throws MBFormatException {
+        if (json instanceof JSONObject) {
+            return new MBStyle((JSONObject) json);
+        } else if (json == null) {
+            throw new MBFormatException("JSONObject required: null");
+        } else {
+            throw new MBFormatException("Root must be a JSON Object: " + json.toString());
+        }
+    }
+    
 
     public List<MBLayer> layers(){
         JSONArray layers = parse.getJSONArray(json, "layers");

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBStyle.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/MBStyle.java
@@ -27,8 +27,15 @@ import org.json.simple.JSONObject;
  * MapBox Style implemented as wrapper around parsed JSON file.
  * <p>
  * This class is responsible for presenting the wrapped JSON in an easy to use / navigate form for
- * Java developers. Access methods should return Java Objects, rather than generic maps. Additional
- * access methods to perform common queries are expected and encouraged.
+ * Java developers:
+ * </p>
+ * <ul>
+ * <li>get methods: access the json directly</li>
+ * <li>query methods: provide logic / transforms to GeoTools classes as required.</li>
+ * </ul>
+ * <p>
+ * Access methods should return Java Objects, rather than generic maps. Additional access methods to
+ * perform common queries are expected and encouraged.
  * </p>
  * <p>
  * This class works closely with {@link MBLayer} hierarchy used to represent the fill, line, symbol,

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/RasterMBLayer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/RasterMBLayer.java
@@ -17,17 +17,16 @@
  */
 package org.geotools.mbstyle;
 
-import org.geotools.mbstyle.parse.MBObjectParser;
 import org.json.simple.JSONObject;
 import org.opengis.filter.expression.Expression;
 
-public class MBRasterLayer extends MBLayer {
+public class RasterMBLayer extends MBLayer {
 
     private JSONObject paintJson;
 
     private static String type = "raster";
 
-    public MBRasterLayer(JSONObject json) {
+    public RasterMBLayer(JSONObject json) {
         super(json);
 
         if (json.get("paint") != null) {
@@ -44,7 +43,7 @@ public class MBRasterLayer extends MBLayer {
      * 
      */
     public Expression getOpacity() {
-        return MBObjectParser.percentage(paintJson, "raster-opacity", 1);
+        return parse.percentage(paintJson, "raster-opacity", 1);
     }
 
     /**
@@ -53,7 +52,7 @@ public class MBRasterLayer extends MBLayer {
      * Number. Units in degrees. Defaults to 0.
      */
     public Expression getHueRotate() {
-        return MBObjectParser.number(paintJson, "raster-hue-rotate", 0);
+        return parse.number(paintJson, "raster-hue-rotate", 0);
     }
 
     /**
@@ -62,7 +61,7 @@ public class MBRasterLayer extends MBLayer {
      * Number. Defaults to 0.
      */
     public Expression getBrightnessMin() {
-        return MBObjectParser.number(paintJson, "raster-brightness-min", 0);
+        return parse.number(paintJson, "raster-brightness-min", 0);
     }
 
     /**
@@ -71,7 +70,7 @@ public class MBRasterLayer extends MBLayer {
      * Number. Defaults to 1.
      */
     public Expression getBrightnessMax() {
-        return MBObjectParser.number(paintJson, "raster-brightness-max", 1);
+        return parse.number(paintJson, "raster-brightness-max", 1);
     }
 
     /**
@@ -80,7 +79,7 @@ public class MBRasterLayer extends MBLayer {
      * Number. Defaults to 0.
      */
     public Expression getSaturation() {
-        return MBObjectParser.number(paintJson, "raster-saturation", 0);
+        return parse.number(paintJson, "raster-saturation", 0);
     }
 
     /**
@@ -89,7 +88,7 @@ public class MBRasterLayer extends MBLayer {
      * Number. Defaults to 0.
      */
     public Expression getContrast() {
-        return MBObjectParser.number(paintJson, "raster-contrast", 0);
+        return parse.number(paintJson, "raster-contrast", 0);
     }
 
     /**
@@ -98,7 +97,7 @@ public class MBRasterLayer extends MBLayer {
      * Number. Units in milliseconds. Defaults to 300.
      */
     public Expression getFadeDuration() {
-        return MBObjectParser.number(paintJson, "raster-fade-duration", 300);
+        return parse.number(paintJson, "raster-fade-duration", 300);
     }
 
     /**

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -1,39 +1,349 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
 package org.geotools.mbstyle.parse;
 
 import java.awt.Color;
 
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.mbstyle.MBFillLayer;
+import org.geotools.mbstyle.FillMBLayer;
 import org.geotools.mbstyle.MBFormatException;
 import org.geotools.mbstyle.MBLayer;
 import org.geotools.mbstyle.MBStyle;
+import org.geotools.styling.StyleFactory2;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Expression;
 
 /**
- * Utility methods for parsing JSONObject values.
- * <p>
- * These utilities are used by the MBStyle to convert JSON to simple Java objects, process functions
- * and perform common JSON manipulation tasks.
- * </p>
- *
+ * Helper class used to perform JSON traverse {@link JSONObject} and perform Expression and Filter
+ * conversions. These utilities are used by the MBStyle to convert JSON to simple Java objects,
+ * process functions and perform common JSON manipulation tasks.
+ * 
+ * <h2>Acess methods</h2>
+ * Example of transformation to Expression, using the fallback value if provided:
+ * 
+ * <pre><code> MBObjectParser parse = new MBObjectParser( ff );
+ * 
+ * Expression fillOpacity = parse.percent( json, "fill-opacity", 1.0 );
+ * Expression fillColor = parse.color( json, "fill-color", Color.BLACK );
+ * </code></pre>
+ * 
+ * <h2>Get Methods</h2>
+ * 
+ * Generic "get" methods are also available for safely accessing required fields. These methods will throw a
+ * validation error if the required tag was is not available.
+ * 
+ * <pre><code> String id = parse.get("id");
+ * String visibility = parse.getBoolean("visibility");
+ * String source = parse.get("source");
+ * </code></pre>
+ * 
+ * Non generic "get" methods, like {@link #paint(JSONObject)}, are in position to provide an appropriate default value.
+ * <pre><code> JSONObject paint = parse.paint( layer );
+ * </code></pre>
+ * 
  * @author Torbien Barsballe (Boundless)
  */
 public class MBObjectParser {
-    static FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+    final FilterFactory2 ff;
+    final StyleFactory2 sf;
+    
+    public MBObjectParser() {
+        this(CommonFactoryFinder.getFilterFactory2(),
+                (StyleFactory2) CommonFactoryFinder.getStyleFactory());
+    }
+    
+    public MBObjectParser(FilterFactory2 filterFactory, StyleFactory2 styleFactory){
+        ff = filterFactory;
+        sf = styleFactory;
+    }
+    
+    //
+    // Utility methods for required lookup
+    //
+    // These methds throw a validation error if tag is not available
+    //
 
-    public static JSONObject parseJSONObect(Object obj) throws MBFormatException {
+    /** Safely look up paint in provided layer json.
+     * <p>
+     * Paint is optional, returning an empty JSONObject (to prevent the need for null checks).</p>
+     * @param layer
+     * @return paint definition, optional so may be an empty JSONObject
+     * @throws MBFormatException If paint is provided as an invalid type (such as boolean).
+     */
+    public JSONObject paint(JSONObject layer) {
+        if(layer.containsKey("paint")){
+            Object paint = layer.get("paint");
+            if( paint == null ){
+                String type = get( layer, "type", "layer");
+                throw new MBFormatException(  type + " paint rquires JSONOBject");
+            }
+            else if( paint instanceof JSONObject){
+                return (JSONObject) paint;
+            }
+            else {
+                String type = get( layer, "type", "layer");
+                throw new MBFormatException( type + " paint rquires JSONOBject");
+            }
+        }
+        else {
+            // paint is optional, having a value here prevents need for null checks
+            return new JSONObject(); 
+        }
+    }
+    /** Safely look up layout in provided layer json.
+     * <p>
+     * Layout is optional, returning an empty JSONObject (to prevent the need for null checks).</p>
+     * @param layer
+     * @return layout definition, optional so may be an empty JSONObject
+     * @throws MBFormatException If layout is provided as an invalid type (such as boolean).
+     */
+    public JSONObject layout(JSONObject layer) {
+        if(layer.containsKey("layout")){
+            Object layout = layer.get("layout");
+            if( layout == null ){
+                String type = get( layer, "type", "layer");
+                throw new MBFormatException(  type + " layout rquires JSONOBject");
+            }
+            else if( layout instanceof JSONObject){
+                return (JSONObject) layout;
+            }
+            else {
+                String type = get( layer, "type", "layer");
+                throw new MBFormatException( type + " paint rquires JSONOBject");
+            }
+        }
+        else {
+            // paint is optional, having a value here prevents need for null checks
+            return new JSONObject(); 
+        }
+    }
+
+    /**
+     * Access JSONObject for the indicated tag.
+     * <p>
+     * Confirms json contains the provided tag as a JSONObject, correctly
+     * throwing {@link MBFormatException} if not available.
+     * 
+     * @param json
+     * @param tag
+     * @return JSONObject 
+     * @throws MBFormatException If JSONObject not available for the provided tag
+     */
+    public JSONObject getJSONObject( JSONObject json, String tag ){
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        if (json.containsKey(tag) && json.get(tag) instanceof JSONObject) {
+            return (JSONObject) json.get(tag);
+        } else {
+            throw new MBFormatException("\""+tag+"\" requires JSONObject");
+        }
+    }
+    public JSONObject getJSONObject( JSONObject json, String tag, JSONObject fallback ){
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        if (json.containsKey(tag) && json.get(tag) instanceof JSONObject) {
+            return (JSONObject) json.get(tag);
+        } else {
+            return fallback;
+        }
+    }
+    /**
+     * Access json contains a JSONArray for the indicated tag.
+     * <p>
+     * Confirms json contains the provided tag as a JSONArray, correctly
+     * throwing {@link MBFormatException} if not available.
+     * 
+     * @param json
+     * @param tag
+     * @return JSONObject 
+     * @throws MBFormatException If JSONObject not available for the provided tag
+     */
+    public JSONArray getJSONArray( JSONObject json, String tag ){
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        if (json.containsKey(tag) && json.get(tag) instanceof JSONArray) {
+            return (JSONArray) json.get(tag);
+        } else {
+            throw new MBFormatException("\""+tag+"\" requires JSONArray");
+        }
+    }
+    public JSONArray getJSONArray( JSONObject json, String tag, JSONArray fallback ){
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        else if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        else if(!json.containsKey(tag) || json.get(tag)==null){
+            return fallback;
+        }
+        else if (json.containsKey(tag) && json.get(tag) instanceof JSONArray) {
+            return (JSONArray) json.get(tag);
+        } else {
+            throw new MBFormatException("\""+tag+"\" requires JSONArray");
+        }
+    }
+    
+    /**
+     * Quickly access required json tag.
+     * 
+     * @param tag
+     * @return required string
+     * @throws MBFormatException if required tag not available.
+     */
+    public String get(JSONObject json, String tag) {
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        if (json.containsKey(tag) && json.get(tag) instanceof String) {
+            return (String) json.get(tag);
+        } else {
+            throw new MBFormatException(
+                    getClass().getSimpleName() + " requires \"" + tag + "\" string field");
+        }
+    }
+    /**
+     * Quickly access required json tag.
+     * 
+     * @param json
+     * @param tag 
+     * @param fallback 
+     * @return required string, or fallback if unavailable
+     */
+    public String get(JSONObject json, String tag, String fallback) {
+        if (tag == null || json == null) {
+            return fallback;
+        }
+        else if(!json.containsKey(tag) || json.get(tag)==null){
+            return fallback;
+        }
+        if (json.containsKey(tag) && json.get(tag) instanceof String) {
+            return (String) json.get(tag);
+        } else {
+            throw new MBFormatException(
+                    getClass().getSimpleName() + " requires \"" + tag + "\" string field");
+        }
+    }
+
+    public Boolean getBoolean(JSONObject json, String tag) {
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        if (json.containsKey(tag) && json.get(tag) instanceof Boolean) {
+            return (Boolean) json.get(tag);
+        } else {
+            throw new MBFormatException(
+                    getClass().getSimpleName() + " requires \"" + tag + "\" boolean field");
+        }
+    }
+    /** Boolean lookup, using the fallback value if not provided. */
+    public Boolean getBoolean(JSONObject json, String tag, Boolean fallback) {
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        else if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        else if (!json.containsKey(tag) || json.get(tag)==null){
+            return fallback;
+        }
+        else if (json.get(tag) instanceof Boolean) {
+            return (Boolean) json.get(tag);
+        } else {
+            throw new MBFormatException(getClass().getSimpleName() + " requires \"" + tag + "\" boolean field");
+        }
+    }
+    public <T> T require( Class<T> type, JSONObject json, String tag ){
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        if (json.containsKey(tag) && type.isInstance(json.get(tag))) {
+            return type.cast(json.get(tag));
+        } else {
+            throw new MBFormatException(getClass().getSimpleName() + " requires \"" + tag + "\" "+type.getSimpleName()+" field");
+        }
+    }
+
+    /**
+     * Optional lookup, will return fallback if not avaialble.
+     * @param type Type to lookup
+     * @param json
+     * @param tag
+     * @param fallback
+     * @return value for the provided tag, or fallback if not available
+     * @throws MBFormatException If alue is found and is not the expected type
+     */
+    public <T> T optional( Class<T> type, JSONObject json, String tag, T fallback ){
+        if (json == null) {
+            throw new IllegalArgumentException("json required");
+        }
+        else if (tag == null) {
+            throw new IllegalArgumentException("tag required for json access");
+        }
+        else if (!json.containsKey(tag) || json.get(tag)==null){
+            return fallback;
+        }
+        if (json.containsKey(tag) && type.isInstance(json.get(tag))) {
+            return type.cast(json.get(tag));
+        } else {
+            throw new MBFormatException(getClass().getSimpleName() + " requires \"" + tag + "\" "+type.getSimpleName()+" field");
+        }
+    }
+    
+    /**
+     * Casts the provided obj to a JSONObject (safely reporting format exception 
+     * 
+     * @param obj
+     * @return JSONObject
+     * @throws MBFormatException 
+     */
+    public JSONObject jsonObject(Object obj) throws MBFormatException {
         return parseJSONObect(obj,
                 new MBFormatException("Not a JSON Object: " + toStringOrNull(obj)));
     }
 
-    public static JSONObject parseJSONObect(Object obj, String message) throws MBFormatException {
+    public JSONObject jsonObect(Object obj, String message) throws MBFormatException {
         return parseJSONObect(obj, new MBFormatException(message));
     }
 
-    public static JSONObject parseJSONObect(Object obj, MBFormatException exception)
+    public JSONObject parseJSONObect(Object obj, MBFormatException exception)
             throws MBFormatException {
         if (obj instanceof JSONObject) {
             return (JSONObject) obj;
@@ -41,16 +351,16 @@ public class MBObjectParser {
         throw exception;
     }
 
-    public static JSONArray parseJSONArray(Object obj) throws MBFormatException {
+    public JSONArray parseJSONArray(Object obj) throws MBFormatException {
         return parseJSONArray(obj,
                 new MBFormatException("Not a JSON Array: " + toStringOrNull(obj)));
     }
 
-    public static JSONArray parseJSONArray(Object obj, String message) throws MBFormatException {
+    public JSONArray parseJSONArray(Object obj, String message) throws MBFormatException {
         return parseJSONArray(obj, new MBFormatException(message));
     }
 
-    public static JSONArray parseJSONArray(Object obj, MBFormatException exception)
+    public JSONArray parseJSONArray(Object obj, MBFormatException exception)
             throws MBFormatException {
         if (obj instanceof JSONArray) {
             return (JSONArray) obj;
@@ -58,15 +368,15 @@ public class MBObjectParser {
         throw exception;
     }
 
-    public static String parseJSONString(Object obj) throws MBFormatException {
+    public String parseJSONString(Object obj) throws MBFormatException {
         return parseJSONString(obj, new MBFormatException("Not a String: " + toStringOrNull(obj)));
     }
 
-    public static String parseJSONString(Object obj, String message) throws MBFormatException {
+    public String parseJSONString(Object obj, String message) throws MBFormatException {
         return parseJSONString(obj, new MBFormatException(message));
     }
 
-    public static String parseJSONString(Object obj, MBFormatException exception)
+    public String parseJSONString(Object obj, MBFormatException exception)
             throws MBFormatException {
         if (obj instanceof String) {
             return (String) obj;
@@ -74,20 +384,19 @@ public class MBObjectParser {
         throw exception;
     }
 
-    public static MBStyle parseRoot(Object obj) throws MBFormatException {
+    public  MBStyle parseRoot(Object obj) throws MBFormatException {
         return new MBStyle(
-                parseJSONObect(obj, "Root must be a JSON Object: " + toStringOrNull(obj)));
+                jsonObect(obj, "Root must be a JSON Object: " + toStringOrNull(obj)));
     }
 
-    public static MBLayer parseLayer(Object obj) throws MBFormatException {
-        JSONObject layer = parseJSONObect(obj,
-                "Layer must be a JSON Object: " + toStringOrNull(obj));
+    public MBLayer parseLayer(Object obj) throws MBFormatException {
+        JSONObject layer = jsonObect(obj, "Layer must be a JSON Object: " + toStringOrNull(obj));
         String type = parseJSONString(layer.get("type"),
                 "\"type\" must be a String: " + toStringOrNull(obj));
         if ("background".equals(type)) {
             throw new UnsupportedOperationException("\"type\" background is not supported");
         } else if ("fill".equals(type)) {
-            return new MBFillLayer(layer);
+            return new FillMBLayer(layer);
         } else if ("line".equals(type)) {
             throw new UnsupportedOperationException("\"type\" background is not supported");
         } else if ("symbol".equals(type)) {
@@ -104,7 +413,7 @@ public class MBObjectParser {
                         + "background, fill, line, symbol, raster, circle, fill-extrusion"));
     }
 
-    public static String toStringOrNull(Object obj) {
+    public String toStringOrNull(Object obj) {
         return obj == null ? "null" : obj.toString();
     }
 
@@ -115,7 +424,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or null if not provided
      * @throws MBFormatException
      */
-    public static Expression percentage(JSONObject json, String tag) throws MBFormatException {
+    public  Expression percentage(JSONObject json, String tag) throws MBFormatException {
         return percentage(json, tag, null);
     }
 
@@ -127,7 +436,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or literal if json was null.
      * @throws MBFormatException
      */
-    public static Expression percentage(JSONObject json, String tag, Number fallback)
+    public Expression percentage(JSONObject json, String tag, Number fallback)
             throws MBFormatException {
         if (json == null) {
             return fallback == null ? null : ff.literal(fallback);
@@ -158,7 +467,7 @@ public class MBObjectParser {
     //
     // NUMBER
     //
-    private static Expression number(String context, Object obj, Number fallback) {
+    private Expression number(String context, Object obj, Number fallback) {
         if (obj == null) {
             return fallback == null ? null : ff.literal(fallback);
         }
@@ -192,7 +501,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or null
      * @throws MBFormatException
      */
-    public static Expression number(JSONArray json, int index) throws MBFormatException {
+    public  Expression number(JSONArray json, int index) throws MBFormatException {
         return number(json, index, null);
     }
 
@@ -205,7 +514,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or literal if json was null.
      * @throws MBFormatException
      */
-    public static Expression number(JSONArray json, int index, Number fallback)
+    public  Expression number(JSONArray json, int index, Number fallback)
             throws MBFormatException {
         if (json == null) {
             return fallback == null ? null : ff.literal(fallback);
@@ -222,7 +531,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or null
      * @throws MBFormatException
      */
-    public static Expression number(JSONObject json, String tag) throws MBFormatException {
+    public  Expression number(JSONObject json, String tag) throws MBFormatException {
         return number(json, tag, null);
     }
 
@@ -235,7 +544,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or literal if json was null.
      * @throws MBFormatException
      */
-    public static Expression number(JSONObject json, String tag, Number fallback)
+    public  Expression number(JSONObject json, String tag, Number fallback)
             throws MBFormatException {
         if (json == null) {
             return ff.literal(fallback);
@@ -247,7 +556,7 @@ public class MBObjectParser {
     //
     // STRING
     //
-    private static Expression string(String context, Object obj, String fallback) {
+    private  Expression string(String context, Object obj, String fallback) {
         if (obj == null) {
             return fallback == null ? null : ff.literal(fallback);
         }
@@ -280,7 +589,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or literal if json was null.
      * @throws MBFormatException
      */
-    public static Expression string(JSONObject json, String tag, String fallback)
+    public  Expression string(JSONObject json, String tag, String fallback)
             throws MBFormatException {
         if (json == null) {
             return fallback == null ? null : ff.literal(fallback);
@@ -298,7 +607,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or literal if json was null.
      * @throws MBFormatException
      */
-    public static Expression color(JSONObject json, String tag, Color fallback)
+    public  Expression color(JSONObject json, String tag, Color fallback)
             throws MBFormatException {
         if (json.get(tag) == null) {
             return fallback == null ? null : ff.literal(fallback);
@@ -307,7 +616,7 @@ public class MBObjectParser {
         return color( "\""+tag+"\"", obj, fallback );
     }
 
-    private static Expression color(String context, Object obj, Color fallback) {
+    private  Expression color(String context, Object obj, Color fallback) {
         if (obj == null) {
             return fallback == null ? null : ff.literal(fallback);
         } else if (obj instanceof String) {
@@ -336,7 +645,7 @@ public class MBObjectParser {
      * @return Expression based on provided json, or literal if json was null.
      * @throws MBFormatException
      */
-    public static Expression bool(JSONObject json, String tag, boolean fallback)
+    public Expression bool(JSONObject json, String tag, boolean fallback)
             throws MBFormatException {
         if (json.get(tag) == null) {
             return ff.literal(fallback);
@@ -363,5 +672,14 @@ public class MBObjectParser {
                     + "\" value limited to String, Boolean or JSONObject but was "
                     + obj.getClass().getSimpleName());
         }
+    }
+
+    /** Shared FilterFactory */
+    public FilterFactory2 getFilterFactory() {
+        return this.ff;
+    }
+    /** Shared StyleFactory */
+    public StyleFactory2 getStyleFactory() {
+        return sf;
     }
 }

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -17,6 +17,7 @@
 package org.geotools.mbstyle.parse;
 
 import java.awt.Color;
+import java.lang.reflect.Array;
 
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.mbstyle.MBFormatException;
@@ -636,5 +637,40 @@ public class MBObjectParser {
     /** Shared StyleFactory */
     public StyleFactory2 getStyleFactory() {
         return sf;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T[] array(Class<T> type, JSONObject json, String tag, T[] fallback) {
+        if( json.containsKey(tag)){
+            Object obj = json.get(tag);
+            if( obj instanceof JSONArray){
+                JSONArray array = (JSONArray) obj;
+                return (T[]) Array.newInstance(type, array.size());
+            }
+            else {
+                throw new MBFormatException("\"" + tag + "\" required as JSONArray of "
+                        + type.getSimpleName() + ": Unexpected " + obj.getClass().getSimpleName());
+            }
+        }
+        return fallback;
+    }
+    /** Convert to doublep[] */
+    public double[] array(JSONObject json, String tag, double[] fallback) {
+        if (json.containsKey(tag)) {
+            Object obj = json.get(tag);
+            if (obj instanceof JSONArray) {
+                JSONArray array = (JSONArray) obj;
+                double result[] = new double[array.size()];
+                for (int i = 0; i < array.size(); i++) {
+                    result[i] = ((Number) array.get(i)).doubleValue();
+                }
+                return result;
+            } else {
+                throw new MBFormatException(
+                        "\"" + tag + "\" required as JSONArray of Number: Unexpected "
+                                + obj.getClass().getSimpleName());
+            }
+        }
+        return fallback;
     }
 }

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -19,9 +19,7 @@ package org.geotools.mbstyle.parse;
 import java.awt.Color;
 
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.mbstyle.FillMBLayer;
 import org.geotools.mbstyle.MBFormatException;
-import org.geotools.mbstyle.MBLayer;
 import org.geotools.mbstyle.MBStyle;
 import org.geotools.styling.StyleFactory2;
 import org.json.simple.JSONArray;
@@ -335,82 +333,39 @@ public class MBObjectParser {
      * @throws MBFormatException 
      */
     public JSONObject jsonObject(Object obj) throws MBFormatException {
-        return parseJSONObect(obj,
-                new MBFormatException("Not a JSON Object: " + toStringOrNull(obj)));
+        if( obj instanceof JSONObject){
+            return (JSONObject) obj;
+        }
+        else {
+            throw new MBFormatException("Not a JSONObject: " + toStringOrNull(obj));
+        }
     }
 
     public JSONObject jsonObect(Object obj, String message) throws MBFormatException {
-        return parseJSONObect(obj, new MBFormatException(message));
-    }
-
-    public JSONObject parseJSONObect(Object obj, MBFormatException exception)
-            throws MBFormatException {
-        if (obj instanceof JSONObject) {
+        if( obj instanceof JSONObject){
             return (JSONObject) obj;
         }
-        throw exception;
+        else {
+            throw new MBFormatException(message);
+        }
     }
 
-    public JSONArray parseJSONArray(Object obj) throws MBFormatException {
-        return parseJSONArray(obj,
-                new MBFormatException("Not a JSON Array: " + toStringOrNull(obj)));
-    }
-
-    public JSONArray parseJSONArray(Object obj, String message) throws MBFormatException {
-        return parseJSONArray(obj, new MBFormatException(message));
-    }
-
-    public JSONArray parseJSONArray(Object obj, MBFormatException exception)
-            throws MBFormatException {
-        if (obj instanceof JSONArray) {
+    public JSONArray jsonArray(Object obj) throws MBFormatException {
+        if( obj instanceof JSONArray){
             return (JSONArray) obj;
         }
-        throw exception;
-    }
-
-    public String parseJSONString(Object obj) throws MBFormatException {
-        return parseJSONString(obj, new MBFormatException("Not a String: " + toStringOrNull(obj)));
-    }
-
-    public String parseJSONString(Object obj, String message) throws MBFormatException {
-        return parseJSONString(obj, new MBFormatException(message));
-    }
-
-    public String parseJSONString(Object obj, MBFormatException exception)
-            throws MBFormatException {
-        if (obj instanceof String) {
-            return (String) obj;
+        else {
+            throw new MBFormatException("Not a JSONArray: " + toStringOrNull(obj));
         }
-        throw exception;
     }
 
-    public  MBStyle parseRoot(Object obj) throws MBFormatException {
-        return new MBStyle(
-                jsonObect(obj, "Root must be a JSON Object: " + toStringOrNull(obj)));
-    }
-
-    public MBLayer parseLayer(Object obj) throws MBFormatException {
-        JSONObject layer = jsonObect(obj, "Layer must be a JSON Object: " + toStringOrNull(obj));
-        String type = parseJSONString(layer.get("type"),
-                "\"type\" must be a String: " + toStringOrNull(obj));
-        if ("background".equals(type)) {
-            throw new UnsupportedOperationException("\"type\" background is not supported");
-        } else if ("fill".equals(type)) {
-            return new FillMBLayer(layer);
-        } else if ("line".equals(type)) {
-            throw new UnsupportedOperationException("\"type\" background is not supported");
-        } else if ("symbol".equals(type)) {
-            throw new UnsupportedOperationException("\"type\" background is not supported");
-        } else if ("raster".equals(type)) {
-            throw new UnsupportedOperationException("\"type\" background is not supported");
-        } else if ("circle".equals(type)) {
-            throw new UnsupportedOperationException("\"type\" background is not supported");
-        } else if ("fill-extrusion".equals(type)) {
-            throw new UnsupportedOperationException("\"type\" background is not supported");
+    public JSONArray jsonArray(Object obj, String message) throws MBFormatException {
+        if( obj instanceof JSONArray){
+            return (JSONArray) obj;
         }
-        throw new MBFormatException(
-                ("\"type\" " + type + " is not a valid layer type. Must be one of: "
-                        + "background, fill, line, symbol, raster, circle, fill-extrusion"));
+        else {
+            throw new MBFormatException(message);
+        }
     }
 
     public String toStringOrNull(Object obj) {

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBStyleParser.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBStyleParser.java
@@ -27,27 +27,71 @@ import org.geotools.mbstyle.MBStyle;
 
 
 /**
- * Given JSON input (as a {@link String} or {@link Reader}, parses and returns a {@link MBStyle}
- *
- * @author tbarsballe
+ * Given JSON input (as a {@link String} or {@link Reader}, parses and returns a {@link MBStyle}.
+ * 
+ * @author Torbien Barsballe (Boundless)
  */
 public class MBStyleParser {
 
-    JSONParser parser;
-
+    JSONParser jsonParser;
+    MBObjectParser parse = new MBObjectParser();
+    
     public MBStyleParser() {
-        parser = new JSONParser();
+        jsonParser = new JSONParser();
     }
 
+    /**
+     * Parse the provided json into MBStyle. 
+     * <p>
+     * Please be aware that {@link MBStyle}.is a thin wrapper around the provided
+     * json and will lazily parse map box style contents as required.
+     * 
+     * @param json String
+     * @return MBStyle
+     * @throws ParseException If JSON is not well formed
+     * @throws MBFormatException If MapBox Style is obviously not well formed
+     */
     public MBStyle parse(String json) throws ParseException, MBFormatException {
-        return MBObjectParser.parseRoot(parser.parse(json));
+        return parse.parseRoot(jsonParser.parse(json));
     }
 
+    /**
+     * Parse the provided json into MBStyle. 
+     * <p>
+     * Please be aware that {@link MBStyle}.is a thin wrapper around the provided
+     * json and will lazily parse map box style contents as required.
+     * 
+     * @param json Reader
+     * @return MBStyle
+     * @throws ParseException If JSON is not well formed
+     * @throws IOException If json reader cannot be read
+     * @throws MBFormatException If MapBox Style is obviously not well formed
+     */
     public MBStyle parse(Reader json) throws ParseException, IOException, MBFormatException {
-        return MBObjectParser.parseRoot(parser.parse(json));
+        try {
+            return parse.parseRoot(jsonParser.parse(json));
+        }
+        finally {
+            json.close();
+        }
     }
 
+    /**
+     * Parse the provided json into MBStyle. 
+     * <p>
+     * Please be aware that {@link MBStyle}.is a thin wrapper around the provided
+     * json and will lazily parse map box style contents as required.
+     * 
+     * @param json InputStream
+     * @return MBStyle
+     * @throws ParseException If JSON is not well formed
+     * @throws IOException If json input stream cannot be read
+     * @throws MBFormatException If MapBox Style is obviously not well formed
+     */
     public MBStyle parse(InputStream json) throws ParseException, IOException, MBFormatException {
-        return MBObjectParser.parseRoot(parser.parse(new InputStreamReader(json)));
+        try (Reader reader = new InputStreamReader(json)){ // auto close
+            Object obj = jsonParser.parse( reader );
+            return parse.parseRoot( obj );
+        }
     }
 }

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBStyleParser.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBStyleParser.java
@@ -52,7 +52,7 @@ public class MBStyleParser {
      * @throws MBFormatException If MapBox Style is obviously not well formed
      */
     public MBStyle parse(String json) throws ParseException, MBFormatException {
-        return parse.parseRoot(jsonParser.parse(json));
+        return MBStyle.create(jsonParser.parse(json));
     }
 
     /**
@@ -69,7 +69,7 @@ public class MBStyleParser {
      */
     public MBStyle parse(Reader json) throws ParseException, IOException, MBFormatException {
         try {
-            return parse.parseRoot(jsonParser.parse(json));
+            return MBStyle.create(jsonParser.parse(json));
         }
         finally {
             json.close();
@@ -91,7 +91,7 @@ public class MBStyleParser {
     public MBStyle parse(InputStream json) throws ParseException, IOException, MBFormatException {
         try (Reader reader = new InputStreamReader(json)){ // auto close
             Object obj = jsonParser.parse( reader );
-            return parse.parseRoot( obj );
+            return MBStyle.create( obj );
         }
     }
 }

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/transform/MBStyleTransformer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/transform/MBStyleTransformer.java
@@ -81,7 +81,7 @@ public class MBStyleTransformer {
         
         // stroke from fill outline color and opacity
         Stroke stroke = sf.stroke(
-                layer.getFillOutlineColor(),
+                layer.fillOutlineColor(),
                 ff.literal(1),
                 ff.literal(1),
                 ff.literal("miter"),
@@ -92,10 +92,10 @@ public class MBStyleTransformer {
         // from fill pattern or fill color
         Fill fill; 
         if( layer.getFillPattern() != null ){
-            fill = sf.fill(null,null, layer.getFillOpacity());
+            fill = sf.fill(null,null, layer.fillOpacity());
         }
         else {
-            fill = sf.fill(null,  layer.getFillColor(),  layer.getFillOpacity());
+            fill = sf.fill(null,  layer.fillColor(),  layer.fillOpacity());
         }
         // String name, Expression geometry,
         symbolizer = sf.polygonSymbolizer(

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/transform/MBStyleTransformer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/transform/MBStyleTransformer.java
@@ -23,12 +23,11 @@ import java.util.List;
 import javax.measure.unit.NonSI;
 
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.mbstyle.MBFillLayer;
+import org.geotools.mbstyle.FillMBLayer;
 import org.geotools.mbstyle.MBStyle;
 import org.geotools.styling.Fill;
 import org.geotools.styling.PolygonSymbolizer;
 import org.geotools.styling.Stroke;
-import org.geotools.styling.StyleBuilder;
 import org.geotools.styling.StyleFactory;
 import org.geotools.styling.StyledLayerDescriptor;
 import org.geotools.styling.UserLayer;
@@ -51,12 +50,9 @@ public class MBStyleTransformer {
 
     private StyleFactory sf;
 
-    private StyleBuilder builder;
-
     public MBStyleTransformer() {
         ff = CommonFactoryFinder.getFilterFactory2();
         sf = CommonFactoryFinder.getStyleFactory();
-        builder = new StyleBuilder(sf, ff);
     }
 
     /**
@@ -79,7 +75,7 @@ public class MBStyleTransformer {
      * @param layer Describing polygon fill styling
      * @return FeatureTypeStyle 
      */
-    FeatureTypeStyle transform(MBFillLayer layer) {
+    FeatureTypeStyle transform(FillMBLayer layer) {
         PolygonSymbolizer symbolizer;
         // use of factory is more verbose, but we supply every value (no defaults)
         

--- a/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/transform/MapBoxStyleTest.java
+++ b/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/transform/MapBoxStyleTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.mbstyle.MBFillLayer;
+import org.geotools.mbstyle.FillMBLayer;
 import org.geotools.mbstyle.MBLayer;
 import org.geotools.mbstyle.MBStyle;
 import org.json.simple.JSONObject;
@@ -63,8 +63,8 @@ public class MapBoxStyleTest {
         assertEquals(1, layers.size());
 
         // Find the MBFillLayer and assert it contains the correct FeatureTypeStyle.
-        assertTrue(layers.get(0) instanceof MBFillLayer);
-        MBFillLayer mbFill = (MBFillLayer) layers.get(0);
+        assertTrue(layers.get(0) instanceof FillMBLayer);
+        FillMBLayer mbFill = (FillMBLayer) layers.get(0);
         FeatureTypeStyle fts = new MBStyleTransformer().transform(mbFill);
 
         assertEquals(1, fts.rules().size());


### PR DESCRIPTION
MBObjectParser now has a naming convention to distingish between get methods for json access and  query methods which can transform into Expression and Filter as required.

Also a "quick" review of MBLayer implementations against geotools code conventions and the mapbox specificiation (mostly resulting in more javadocs).