### PR TITLE
[GEOT-5630] add pom support to jaiext 1.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <test.args></test.args>
     <src.output>${basedir}/target</src.output>
     <imageio.ext.version>1.1.17</imageio.ext.version>
-    <jaiext.version>1.0.12</jaiext.version>
+    <jaiext.version>1.0.13</jaiext.version>
     <netcdf.version>4.6.6</netcdf.version>
     <jt.version>1.4.0</jt.version>
     <java.awt.headless>true</java.awt.headless>


### PR DESCRIPTION
The issue GEOT-5629 has been split in two steps. First step: GEOT-5630 (this one) updates the pom to support JAI-EXT 1.0.13; second step: GEOT-5631 to fix the imports of ROIGeometry, ImageLayout2.