### PR TITLE
Readability improvements to InterpolationFunction

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/FunctionImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/FunctionImpl.java
@@ -145,7 +145,7 @@ public class FunctionImpl extends ExpressionAbstract implements Function {
      */
     // Copied from FunctionExpressionImpl KS
     public String toString(){
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(getName());
         sb.append("(");
         List<org.opengis.filter.expression.Expression> params = getParameters();

--- a/modules/library/main/src/main/java/org/geotools/filter/function/InterpolateFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/InterpolateFunction.java
@@ -20,6 +20,7 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,6 +37,7 @@ import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.ExpressionVisitor;
 import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.Literal;
+import org.opengis.filter.expression.PropertyName;
 
 /**
  * This is an implemenation of the Interpolate function as defined by
@@ -433,7 +435,10 @@ public class InterpolateFunction implements Function {
             }
         }
     }
-
+    
+    /**
+     * Review parameters and generate {@link Mode} linear cosine, cubbic based on optional parameter.
+     */
     private void setMode() {
         boolean specified = false;
 
@@ -469,6 +474,9 @@ public class InterpolateFunction implements Function {
         modeSpecified = specified;
     }
 
+    /**
+     * Review parameters and generate {@link Method} numeric or color based on optional parameter.
+     */
     private void setMethod() {
         boolean specified = false;
 
@@ -635,6 +643,31 @@ public class InterpolateFunction implements Function {
     private double clamp(double x, double min, double max) {
         return Math.max(min, Math.min(max, x));
     }
-
+    
+    /**
+     * Creates a String representation of this Function with
+     * the function name and the arguments.
+     */
+    @Override
+    public String toString(){
+        StringBuilder sb = new StringBuilder();
+        sb.append(getName());
+        sb.append("(");
+        List<org.opengis.filter.expression.Expression> params = getParameters();
+        if(params != null){
+            org.opengis.filter.expression.Expression exp;
+            for(Iterator<org.opengis.filter.expression.Expression> it = params.iterator(); it.hasNext();){
+                exp = it.next();
+                sb.append("[");
+                sb.append(exp);
+                sb.append("]");
+                if(it.hasNext()){
+                    sb.append(", ");
+                }
+            }
+        }
+        sb.append(")");
+        return sb.toString();
+    }
 }
 

--- a/modules/library/main/src/test/java/org/geotools/filter/function/InterpolateFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/InterpolateFunctionTest.java
@@ -313,8 +313,6 @@ public class InterpolateFunctionTest extends SEFunctionTestBase {
 
     @Test
     public void testColorValuesNumericMethodMismatch() throws Exception {
-        System.out.println("   testColorValuesNumericMethodMismatch");
-
         /*
          * Set interpolation points but let the function default to
          * linear / numeric
@@ -334,8 +332,6 @@ public class InterpolateFunctionTest extends SEFunctionTestBase {
 
     @Test
     public void testNumericValuesColorMethodMismatch() throws Exception {
-        System.out.println("   testNumericValuesColorMethodMismatch");
-
         setupParameters(data, values);
         parameters.add(ff2.literal(InterpolateFunction.METHOD_COLOR));
 


### PR DESCRIPTION
Javadocs and toString implementation based on StringBuilder. This implementation does not extend any base class, causing it to miss out on a default toString implementation.