### PR TITLE
JP2K Improvments

### DIFF
--- a/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/Granule.java
+++ b/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/Granule.java
@@ -30,12 +30,12 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ImageReaderSpi;
-import javax.imageio.stream.ImageInputStream;
 import javax.media.jai.ImageLayout;
 import javax.media.jai.InterpolationNearest;
 import javax.media.jai.JAI;
@@ -103,7 +103,6 @@ class Granule {
 
 		final Rectangle rasterDimensions;
 		
-		
 		public AffineTransform getBaseToLevelTransform() {
 			return baseToLevelTransform;
 		}
@@ -144,7 +143,7 @@ class Granule {
 
 		public AffineTransform2D getGridToWorldTransform() {
 			return gridToWorldTransform;
-		}		
+		}
 
 		@Override
 		public String toString() {
@@ -161,47 +160,33 @@ class Granule {
 		}
 	}
 	
-	ReferencedEnvelope  granuleBBOX;
+	ReferencedEnvelope granuleBBOX;
 	
 	File granuleFile;
 	
 	final Map<Integer,Level> granuleLevels= Collections.synchronizedMap(new HashMap<Integer,Level>());
 	
 	AffineTransform baseGridToWorld;
-	
+
+	JP2KReader reader;
+
 	ImageReaderSpi cachedSPI;
 
-	public Granule(BoundingBox granuleBBOX, File granuleFile) {
-		super();
+	public Granule(BoundingBox granuleBBOX, File granuleFile, JP2KReader reader) {
+		this.reader = reader;
 		this.granuleBBOX = ReferencedEnvelope.reference(granuleBBOX);
 		this.granuleFile = granuleFile;
-		
+		ImageReader imageReader = reader.getImageReader();
+		this.cachedSPI = imageReader.getOriginatingProvider();
+
 		// create the base grid to world transformation
-		ImageInputStream inStream = null;
-		ImageReader reader = null;
 		try {
 			//
 			//get info about the raster we have to read
 			//
-			
-			// get a stream
-			inStream = Utils.getInputStream(granuleFile);
-			if(inStream == null)
-				throw new IllegalArgumentException("Unable to get an input stream for the provided file "+granuleFile.getAbsolutePath());
-			
-			// get a reader and try to cache the relevant SPI
-			if (cachedSPI == null){
-				reader = Utils.getReader( inStream);
-				if (reader != null)
-					cachedSPI = reader.getOriginatingProvider();
-			}
-			else
-				reader = cachedSPI.createReaderInstance();
-			if(reader == null)
-				throw new IllegalArgumentException("Unable to get an ImageReader for the provided file "+granuleFile.getAbsolutePath());
-			
+
 			//get selected level and base level dimensions
-			final Rectangle originalDimension = ImageUtilities.getDimension(0,inStream, reader);
+			final Rectangle originalDimension = new Rectangle(imageReader.getWidth(0), imageReader.getHeight(0));
 			
 			// build the g2W for this tile, in principle we should get it
 			// somehow from the tile itself or from the index, but at the moment
@@ -211,29 +196,17 @@ class Granule {
 					new GridEnvelope2D(originalDimension), granuleBBOX);
 			geMapper.setPixelAnchor(PixelInCell.CELL_CENTER);//this is the default behavior but it is nice to write it down anyway
 			this.baseGridToWorld = geMapper.createAffineTransform();
-			
+
 			// add the base level
 			this.granuleLevels.put(Integer.valueOf(0), new Level(1, 1, originalDimension.width, originalDimension.height));
 
-		} catch (IllegalStateException e) {
+		} catch (IllegalStateException|IOException e) {
 			throw new IllegalArgumentException(e);
-			
-		} catch (IOException e) {
-			throw new IllegalArgumentException(e);
-		} 
-		finally{
-			try{
-				if(inStream != null)
-					inStream.close();
+		} finally {
+			if(!JP2KFormatFactory.isImageReaderThreadSafe) {
+				Utils.disposeReaderAndInnerStream(imageReader);
 			}
-			catch (Throwable e) {
-				throw new IllegalArgumentException(e);
-			}
-			finally{
-				if(reader != null)
-					reader.dispose();
-			}
-		}	
+		}
 	}
 	
 	
@@ -244,50 +217,25 @@ class Granule {
 			final MathTransform2D worldToGrid,
 			final RasterLayerRequest request,
 			final Dimension tileDimension) throws IOException {
-		
-		if (LOGGER.isLoggable(java.util.logging.Level.FINE))
-			LOGGER.fine("Loading raster data for granule "+this.toString());
+	    if(LOGGER.isLoggable(java.util.logging.Level.FINE)) {
+            LOGGER.fine("Loading raster data for granule " + this.toString());
+        }
 
-		final ReferencedEnvelope bbox= new ReferencedEnvelope(granuleBBOX);
+		final ReferencedEnvelope bbox = new ReferencedEnvelope(granuleBBOX);
 		// intersection of this tile bound with the current crop bbox
 		final ReferencedEnvelope intersection = new ReferencedEnvelope(bbox.intersection(cropBBox), cropBBox.getCoordinateReferenceSystem());
 
-		ImageInputStream inStream=null;
-		ImageReader reader=null;
+		ImageReader imageReader = reader.getImageReader();
 		try {
-			//
-			//get info about the raster we have to read
-			//
-			
-			// get a stream
-			inStream = Utils.getInputStream(granuleFile);
-			if(inStream==null)
-				return null;
-	
-			// get a reader and try to cache the relevant SPI
-			if(cachedSPI==null){
-				reader = Utils.getReader( inStream);
-				if(reader!=null)
-					cachedSPI=reader.getOriginatingProvider();
-			}
-			else
-				reader=cachedSPI.createReaderInstance();
-			if(reader==null)
-			{
-				if (LOGGER.isLoggable(java.util.logging.Level.WARNING))
-					LOGGER.warning("Unable to get reader for granule "+this.toString()+ " with request "+request.toString());
-				return null;
-			}
-			
 			//get selected level and base level dimensions
 			final Level selectedlevel= getLevel(imageIndex);
-	
+
 			
 			// now create the crop grid to world which can be used to decide
 			// which source area we need to crop in the selected level taking
 			// into account the scale factors imposed by the selection of this
 			// level together with the base level grid to world transformation
-			MathTransform2D cropWorldToGrid=(MathTransform2D) PixelTranslation.translate(ProjectiveTransform.create(selectedlevel.gridToWorldTransform), PixelInCell.CELL_CENTER, PixelInCell.CELL_CORNER).inverse();		
+			MathTransform2D cropWorldToGrid=(MathTransform2D) PixelTranslation.translate(ProjectiveTransform.create(selectedlevel.gridToWorldTransform), PixelInCell.CELL_CENTER, PixelInCell.CELL_CORNER).inverse();
 			
 			// computing the crop source area which leaves straight into the
 			// selected level raster space, NOTICE that at the end we need to
@@ -298,14 +246,17 @@ class Granule {
 			XRectangle2D.intersect(sourceArea, selectedlevel.rasterDimensions, sourceArea);//make sure roundings don't bother us
 			// is it empty??
 			if (sourceArea.isEmpty()) {
-				if (LOGGER.isLoggable(java.util.logging.Level.FINE))
-					LOGGER.fine("Got empty area for granule "+this.toString()+ " with request "+request.toString());
+				if (LOGGER.isLoggable(java.util.logging.Level.FINE)) {
+                    LOGGER.fine("Got empty area for granule "+this.toString()+ " with request "+request.toString());
+                }
 				return null;
 
-			} else if (LOGGER.isLoggable(java.util.logging.Level.FINE))
+			} else if(LOGGER.isLoggable(java.util.logging.Level.FINE)) {
 				LOGGER.fine((new StringBuffer("Loading level ").append(
 						imageIndex).append(" with source region ").append(
 						sourceArea).toString()));
+			}
+
 			final int ssx = readParameters.getSourceXSubsampling();
 			final int ssy = readParameters.getSourceYSubsampling();
 			final int newSubSamplingFactor = ImageIOUtilities.getSubSamplingFactor2(ssx,ssy);
@@ -318,13 +269,15 @@ class Granule {
 			final RenderedImage raster;
 			try{
 				// read
-				raster= request.getReadType().read(readParameters,imageIndex, granuleFile, selectedlevel.rasterDimensions,tileDimension,cachedSPI);
+				raster= request.getReadType().read(readParameters,imageIndex, granuleFile, selectedlevel.rasterDimensions,tileDimension,cachedSPI, imageReader);
 				if (raster == null)
 					return null;
 			}
 			catch (Throwable e) {
-				if(LOGGER.isLoggable(java.util.logging.Level.FINE))
-					LOGGER.log(java.util.logging.Level.FINE,"Unable to load raster for granule "+this.toString()+ " with request "+request.toString(),e);
+                if (LOGGER.isLoggable(java.util.logging.Level.FINE)) {
+                    LOGGER.log(java.util.logging.Level.FINE,"Unable to load raster for granule "+this.toString()+
+                            " with request "+request.toString(),e);
+                }
 				return null;
 			}
 
@@ -403,28 +356,15 @@ class Granule {
 				return worker.getRenderedImage();
 			}
 		
-		} catch (IllegalStateException e) {
-			if (LOGGER.isLoggable(java.util.logging.Level.WARNING))
-				LOGGER.log(java.util.logging.Level.WARNING, "Unable to load raster for granule "+this.toString()+ " with request "+request.toString(), e);
+		} catch (IllegalStateException|TransformException e) {
+			if (LOGGER.isLoggable(java.util.logging.Level.FINE)) {
+                LOGGER.log(java.util.logging.Level.WARNING, "Unable to load raster for granule "+this.toString()+
+                        " with request "+request.toString(), e);
+            }
 			return null;
-		} 
-		catch (org.opengis.referencing.operation.NoninvertibleTransformException e) {
-			if (LOGGER.isLoggable(java.util.logging.Level.WARNING))
-				LOGGER.log(java.util.logging.Level.WARNING, "Unable to load raster for granule "+this.toString()+ " with request "+request.toString(), e);
-			return null;
-		} catch (TransformException e) {
-			if (LOGGER.isLoggable(java.util.logging.Level.WARNING))
-				LOGGER.log(java.util.logging.Level.WARNING, "Unable to load raster for granule "+this.toString()+ " with request "+request.toString(), e);
-			return null;
-		} 
-		finally{
-			try{
-				if(inStream!=null)
-					inStream.close();
-			}
-			finally{
-				if(reader!=null)
-					reader.dispose();
+		} finally {
+			if (!JP2KFormatFactory.isImageReaderThreadSafe) {
+				Utils.disposeReaderAndInnerStream(imageReader);
 			}
 		}
 	}
@@ -435,33 +375,13 @@ class Granule {
 				return granuleLevels.get(Integer.valueOf(index));
 			else
 			{
+				ImageReader imageReader = reader.getImageReader();
 				//load level
 				// create the base grid to world transformation
-				ImageInputStream inStream=null;
-				ImageReader reader=null;
 				try {
-					//
-					//get info about the raster we have to read
-					//
-					
-					// get a stream
-					inStream = Utils.getInputStream(granuleFile);
-					if(inStream==null)
-						throw new IllegalArgumentException();
-			
-					// get a reader and try to cache the relevant SPI
-					if(cachedSPI==null){
-						reader = Utils.getReader( inStream);
-						if(reader!=null)
-							cachedSPI=reader.getOriginatingProvider();
-					}
-					else
-						reader=cachedSPI.createReaderInstance();
-					if(reader==null)
-						throw new IllegalArgumentException("Unable to get an ImageReader for the provided file "+granuleFile.getAbsolutePath());					
-					
 					//get selected level and base level dimensions
-					final Rectangle levelDimension = ImageUtilities.getDimension(index,inStream, reader);
+
+					final Rectangle levelDimension = new Rectangle(imageReader.getWidth(index), imageReader.getHeight(index));
 					final Level baseLevel= granuleLevels.get(0);
 					final double scaleX=baseLevel.width/(1.0*levelDimension.width);
 					final double scaleY=baseLevel.height/(1.0*levelDimension.height);
@@ -470,29 +390,14 @@ class Granule {
 					final Level newLevel=new Level(scaleX,scaleY,levelDimension.width,levelDimension.height);
 					this.granuleLevels.put(Integer.valueOf(index),newLevel);
 					return newLevel;
-					
-
-				} catch (IllegalStateException e) {
+				} catch (IllegalStateException|IOException e) {
 					throw new IllegalArgumentException(e);
-					
-				} catch (IOException e) {
-					throw new IllegalArgumentException(e);
-				} 
-				finally{
-					try{
-						if(inStream!=null)
-							inStream.close();
+				} finally {
+					if(!JP2KFormatFactory.isImageReaderThreadSafe) {
+						Utils.disposeReaderAndInnerStream(imageReader);
 					}
-					catch (Throwable e) {
-						throw new IllegalArgumentException(e);
-					}
-					finally{
-						if(reader!=null)
-							reader.dispose();
-					}
-				}	
-			}			
-			
+				}
+			}
 		}
 	}
 
@@ -511,7 +416,7 @@ class Granule {
 			buffer.append("Description of level ").append(i++).append("\n");
 			buffer.append(level.toString()).append("\n");
 		}
-		return super.toString();
+
+		return buffer.toString();
 	}
-	
 }

--- a/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/JP2KFormat.java
+++ b/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/JP2KFormat.java
@@ -85,9 +85,7 @@ public final class JP2KFormat extends AbstractGridFormat implements Format {
      */
     public JP2KFormat() {
     	setInfo();
-        if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.fine("Creating a new JP2KFormat.");
-        }
+        LOGGER.fine("Creating a new JP2KFormat.");
     }
 
     /**
@@ -115,29 +113,20 @@ public final class JP2KFormat extends AbstractGridFormat implements Format {
     }
 
     /**
-     * @see org.geotools.data.coverage.grid.AbstractGridFormat#getReader(Object, Hints)
+     * @see org.geotools.coverage.grid.io.AbstractGridFormat#getReader(Object, Hints)
      */
     @Override
     public AbstractGridCoverage2DReader getReader(Object source, Hints hints) {
         try {
             return new JP2KReader(source, hints);
-        } catch (MismatchedDimensionException e) {
-        	if (LOGGER.isLoggable(Level.WARNING))
-        		LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
+        } catch (MismatchedDimensionException|IOException e) {
+            LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
         	return null;
-        } catch (DataSourceException e) {
-        	if (LOGGER.isLoggable(Level.WARNING))
-        		LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
-        	return null;
-        } catch (IOException e) {
-        	if (LOGGER.isLoggable(Level.WARNING))
-        		LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
-        	return null;
-		} 
+        }
     }
     
     /**
-     * @see org.geotools.data.coverage.grid.AbstractGridFormat#getReader(Object)
+     * @see org.geotools.coverage.grid.io.AbstractGridFormat#getReader(Object)
      */
     @Override
     public AbstractGridCoverage2DReader getReader( Object source ) {
@@ -145,7 +134,7 @@ public final class JP2KFormat extends AbstractGridFormat implements Format {
     }
     
     /**
-     * @see org.geotools.data.coverage.grid.AbstractGridFormat#createWriter(java.lang.Object
+     * @see org.geotools.coverage.grid.io.AbstractGridFormat#getWriter(java.lang.Object
      *      destination)
      * 
      * Actually, the plugin does not support write capabilities. The method
@@ -158,7 +147,7 @@ public final class JP2KFormat extends AbstractGridFormat implements Format {
     }
 
     /**
-     * @see org.geotools.data.coverage.grid.AbstractGridFormat#getDefaultImageIOWriteParameters
+     * @see org.geotools.coverage.grid.io.AbstractGridFormat#getDefaultImageIOWriteParameters
      * 
      * Actually, the plugin does not support write capabilities. The method
      * throws an {@code UnsupportedOperationException}.
@@ -170,7 +159,7 @@ public final class JP2KFormat extends AbstractGridFormat implements Format {
     }
 
     /**
-     * @see org.geotools.data.coverage.grid.AbstractGridFormat#createWriter(java.lang.Object
+     * @see org.geotools.coverage.grid.io.AbstractGridFormat#getWriter(java.lang.Object
      *      destination,Hints hints)
      * 
      * Actually, the plugin does not support write capabilities. The method
@@ -183,7 +172,7 @@ public final class JP2KFormat extends AbstractGridFormat implements Format {
     }
 
     /**
-     * @see org.geotools.data.coverage.grid.AbstractGridFormat#accepts(java.lang.Object input)
+     * @see org.geotools.coverage.grid.io.AbstractGridFormat#accepts(java.lang.Object input)
      */
     @Override
     public boolean accepts(Object input,Hints hints) {
@@ -205,9 +194,7 @@ public final class JP2KFormat extends AbstractGridFormat implements Format {
 			}
             return spi.canDecodeInput(stream);
         } catch (IOException e) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, e.getLocalizedMessage(), e);
-            }
+            LOGGER.log(Level.FINE, e.getLocalizedMessage(), e);
             return false;
         }
     }

--- a/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/RasterLayerRequest.java
+++ b/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/RasterLayerRequest.java
@@ -67,7 +67,7 @@ import org.opengis.referencing.operation.TransformException;
 
 /**
  * A class to handle coverage requests to a reader for a single 2D layer..
- * 
+ *
  * @author Daniele Romagnoli, GeoSolutions
  * @author Simone Giannecchini, GeoSolutions
  */
@@ -80,19 +80,19 @@ class RasterLayerRequest {
 
     /** The {@link BoundingBox} requested */
     private BoundingBox requestedBBox;
-    
+
     /** The {@link BoundingBox} of the portion of the coverage that intersects the requested bbox */
     private BoundingBox cropBBox;
-    
+
     /** The desired overview Policy for this request */
     private OverviewPolicy overviewPolicy;
 
     /** The region where to fit the requested envelope */
     private Rectangle requestedRasterArea;
-    
+
     /** The region of the destination area */
     private Rectangle destinationRasterArea;
-    
+
     /** Requesting a multithreading read */
     private boolean useMultithreading;
 
@@ -127,12 +127,12 @@ class RasterLayerRequest {
 
 	/**
      * Build a new {@code CoverageRequest} given a set of input parameters.
-     * 
+     *
      * @param params
      *                The {@code GeneralParameterValue}s to initialize this
      *                request
-     * @param baseGridCoverage2DReader 
-	 * @throws DataSourceException 
+     * @param baseGridCoverage2DReader
+	 * @throws DataSourceException
      */
     public RasterLayerRequest(final GeneralParameterValue[] params, final RasterManager rasterManager) throws DataSourceException {
 
@@ -143,8 +143,8 @@ class RasterLayerRequest {
         // //
     	this.rasterManager=rasterManager;
     	setDefaultParameterValues();
-    	
-    	
+
+
         // //
         //
         // Parsing parameter that can be used to control this request
@@ -153,7 +153,7 @@ class RasterLayerRequest {
         if (params != null) {
             for (GeneralParameterValue gParam : params) {
             	if(gParam instanceof ParameterValue<?>)
-            	{                
+            	{
             		final ParameterValue<?> param = (ParameterValue<?>) gParam;
                     final ReferenceIdentifier name = param.getDescriptor().getName();
                     extractParameter(param, name);
@@ -167,7 +167,7 @@ class RasterLayerRequest {
         // imageReadParams
         //
         // //
-        checkReadType();        
+        checkReadType();
         prepare();
     }
 
@@ -175,22 +175,21 @@ class RasterLayerRequest {
 	private void setDefaultParameterValues() {
     	final ParameterValueGroup readParams = this.rasterManager.parent.getFormat().getReadParameters();
     	if(readParams==null){
-    		if(LOGGER.isLoggable(Level.FINE))
-    			LOGGER.fine("No default values for the read parameters!");
+			LOGGER.fine("No default values for the read parameters!");
     		return;
     	}
     	final List<GeneralParameterDescriptor> parametersDescriptors = readParams.getDescriptor().descriptors();
     	for(GeneralParameterDescriptor descriptor:parametersDescriptors){
-    		
+
     		// we canc get the default vale only with the ParameterDescriptor class
     		if(!(descriptor instanceof ParameterDescriptor))
     			continue;
-    		
+
     		// get name and default value
     		final ParameterDescriptor desc=(ParameterDescriptor) descriptor;
 	    	final ReferenceIdentifier name = desc.getName();
 	    	final Object value= desc.getDefaultValue();
-	    	
+
 	        // //
 	        //
 	        // Requested GridGeometry2D parameter
@@ -200,14 +199,14 @@ class RasterLayerRequest {
 	        	if(value==null)
 	        		continue;
 	            final GridGeometry2D gg = (GridGeometry2D)value;
-	            
-	
+
+
 	            requestedBBox = new ReferencedEnvelope((Envelope) gg.getEnvelope2D());
 	            requestedRasterArea = gg.getGridRange2D().getBounds();
 	            requestedGridToWorld=(AffineTransform) gg.getGridToCRS2D();
 	            continue;
 	        }
-	
+
 	        // //
 	        //
 	        // Use JAI ImageRead parameter
@@ -219,7 +218,7 @@ class RasterLayerRequest {
 	            readType = ((Boolean)value)? ReadType.JAI_IMAGEREAD: ReadType.DIRECT_READ;
 	            continue;
 	        }
-	        
+
 	        // //
 	        //
 	        // Use Multithreading parameter
@@ -231,7 +230,7 @@ class RasterLayerRequest {
 	            useMultithreading = ((Boolean) value).booleanValue();
 	            continue;
 	        }
-	
+
 	        // //
 	        //
 	        // Overview Policy parameter
@@ -243,7 +242,7 @@ class RasterLayerRequest {
 	            overviewPolicy = (OverviewPolicy) value;
 	            continue;
 	        }
-	
+
 	        if (name.equals(JP2KFormat.INPUT_TRANSPARENT_COLOR.getName())) {
 	        	if(value==null)
 	        		continue;
@@ -251,12 +250,12 @@ class RasterLayerRequest {
 				// paranoiac check on the provided transparent color
 				inputTransparentColor = new Color(
 						inputTransparentColor.getRed(),
-						inputTransparentColor.getGreen(), 
+						inputTransparentColor.getGreen(),
 						inputTransparentColor.getBlue());
 				continue;
-	
-			} 
-	        
+
+			}
+
 	        // //
 	        //
 	        // Suggested tile size parameter. It must be specified with
@@ -266,11 +265,11 @@ class RasterLayerRequest {
 	        // //
 	        if (name.equals(JP2KFormat.SUGGESTED_TILE_SIZE.getName())) {
 	            final String suggestedTileSize = (String) value;
-	
+
 	            // Preliminary checks on parameter value
 	            if ((suggestedTileSize != null)
 	                    && (suggestedTileSize.trim().length() > 0)) {
-	
+
 	                if (suggestedTileSize
 	                        .contains(JP2KFormat.TILE_SIZE_SEPARATOR)) {
 	                    final String[] tilesSize = suggestedTileSize
@@ -282,22 +281,19 @@ class RasterLayerRequest {
 	                            final int tileHeight = Integer.valueOf(tilesSize[1].trim());
 	                            tileDimensions= new Dimension(tileWidth,tileHeight);
 	                        } catch (NumberFormatException nfe) {
-	                            if (LOGGER.isLoggable(Level.WARNING)) {
-	                                LOGGER.log(Level.WARNING, "Unable to parse "
-	                                        + "suggested tile size parameter");
-	                            }
+	                        	LOGGER.warning("Unable to parse suggested tile size parameter");
 	                        }
 	                    }
 	                }
 	            }
-	        }	
+	        }
     	}
-		
+
 	}
 
 	/**
      * Set proper fields from the specified input parameter.
-     * 
+     *
      * @param param
      *                the input {@code ParamaterValue} object
      * @param name
@@ -324,7 +320,7 @@ class RasterLayerRequest {
             requestedGridToWorld=(AffineTransform) gg.getGridToCRS2D();
             return;
         }
-        
+
         // //
         //
         // Use Multithreading parameter
@@ -370,12 +366,12 @@ class RasterLayerRequest {
 			// paranoiac check on the provided transparent color
 			inputTransparentColor = new Color(
 					inputTransparentColor.getRed(),
-					inputTransparentColor.getGreen(), 
+					inputTransparentColor.getGreen(),
 					inputTransparentColor.getBlue());
 			return;
 
-		} 
-       
+		}
+
         // //
         //
         // Suggested tile size parameter. It must be specified with
@@ -401,21 +397,19 @@ class RasterLayerRequest {
                             final int tileHeight = Integer.valueOf(tilesSize[1].trim());
                             tileDimensions= new Dimension(tileWidth,tileHeight);
                         } catch (NumberFormatException nfe) {
-                            if (LOGGER.isLoggable(Level.WARNING)) {
-                                LOGGER.log(Level.WARNING, "Unable to parse "
-                                        + "suggested tile size parameter");
-                            }
+                                LOGGER.warning("Unable to parse suggested tile size parameter");
+
                         }
                     }
                 }
             }
-        }		
+        }
     }
 
     /**
      * Compute this specific request settings all the parameters needed by a
      * visiting {@link RasterLayerResponse} object.
-     * @throws DataSourceException 
+     * @throws DataSourceException
      */
     private void prepare() throws DataSourceException {
             //
@@ -425,7 +419,7 @@ class RasterLayerRequest {
             // requested envelope with the bounds of this data set.
             //
             if (requestedBBox == null) {
-                    
+
                     //
                     // In case we have nothing to look at we should get the whole coverage
                     //
@@ -433,12 +427,12 @@ class RasterLayerRequest {
                     cropBBox=rasterManager.spatialDomainManager.coverageBBox;
                     requestedRasterArea=(Rectangle) rasterManager.spatialDomainManager.coverageRasterArea.clone();
                     destinationRasterArea=(Rectangle)rasterManager.spatialDomainManager.coverageRasterArea.clone();
-                    requestedResolution=rasterManager.spatialDomainManager.coverageFullResolution.clone();   
+                    requestedResolution=rasterManager.spatialDomainManager.coverageFullResolution.clone();
                     // TODO harmonize the various types of transformations
                     requestedGridToWorld=(AffineTransform) rasterManager.spatialDomainManager.coverageGridToWorld2D;
                     return;
             }
-            
+
             //
             // Adjust requested bounding box and source region in order to fall within the source coverage
             //
@@ -470,26 +464,26 @@ class RasterLayerRequest {
 				// can incorporate it into the requested grid to world
 	            //
 	            // we should not have any problems with regards to BBOX reprojection
-            		
+
                 // update the requested grid to world transformation by pre concatenating the destination to source transform
                 AffineTransform mutableTransform = (AffineTransform) requestedGridToWorld.clone();
                 mutableTransform.preConcatenate((AffineTransform) destinationToSourceTransform);
-            	
+
             	//update the requested envelope
             	try {
             		final MathTransform tempTransform = PixelTranslation.translate(
-            				ProjectiveTransform.create(requestedGridToWorld), 
+            				ProjectiveTransform.create(requestedGridToWorld),
             				PixelInCell.CELL_CENTER,
             				PixelInCell.CELL_CORNER);
 					requestedBBox=new ReferencedEnvelope(
 							CRS.transform( tempTransform,new GeneralEnvelope(requestedRasterArea)));
-					
+
 				} catch (MismatchedDimensionException e) {
 					throw new DataSourceException("Unable to inspect request CRS",e);
 				} catch (TransformException e) {
 					throw new DataSourceException("Unable to inspect request CRS",e);
 				}
-            	
+
 				// now clean up all the traces of the transformations
 				destinationToSourceTransform=null;
             }
@@ -499,7 +493,7 @@ class RasterLayerRequest {
      * Check the type of read operation which will be performed and return
      * {@code true} if a JAI imageRead operation need to be performed or
      * {@code false} if a simple read operation is needed.
-     * 
+     *
      * @return {@code true} if the read operation will use a JAI ImageRead
      *         operation instead of a simple {@code ImageReader.read(...)} call.
      */
@@ -543,28 +537,28 @@ class RasterLayerRequest {
     /**
      * Return a crop region from a specified envelope, leveraging on the grid to
      * world transformation.
-     * 
+     *
      * @param refinedRequestedBBox
      *                the crop envelope
      * @return a {@code Rectangle} representing the crop region.
      * @throws TransformException
      *                 in case a problem occurs when going back to raster space.
-     * @throws DataSourceException 
+     * @throws DataSourceException
      */
     private void computeCropRasterArea()
             throws  DataSourceException {
-    	
+
     	//we have nothing to crop
     	if(cropBBox==null)
     	{
     		destinationRasterArea=null;
     		return;
     	}
-    	
+
     	//
     	// We need to invert the requested gridToWorld and then adjust the requested raster area are accordingly
     	//
-    	
+
     	// invert the requested grid to world keeping into account the fact that it is related to cell center
     	// while the raster is related to cell corner
     	MathTransform2D requestedWorldToGrid;
@@ -573,24 +567,24 @@ class RasterLayerRequest {
 		} catch (NoninvertibleTransformException e) {
 			throw new DataSourceException(e);
 		}
-			
-		
+
+
     	if(destinationToSourceTransform==null||destinationToSourceTransform.isIdentity()){
 
-			
+
 			// now get the requested bbox which have been already adjusted and project it back to raster space
 			try {
-				destinationRasterArea = new GeneralGridEnvelope(CRS.transform(requestedWorldToGrid,new GeneralEnvelope(cropBBox)),PixelInCell.CELL_CORNER,false).toRectangle();
+			    destinationRasterArea = new GeneralGridEnvelope(CRS.transform(requestedWorldToGrid,new GeneralEnvelope(cropBBox)),PixelInCell.CELL_CORNER,false).toRectangle();
 			} catch (IllegalStateException e) {
 				throw new DataSourceException(e);
-			} catch (TransformException e) { 
+			} catch (TransformException e) {
 				throw new DataSourceException(e);
 			}
     	}
     	else
     	{
     		//
-    		// reproject the crop bbox back and then crop, notice that we are imposing 
+    		// reproject the crop bbox back and then crop, notice that we are imposing
     		//
     		try {
                 final GeneralEnvelope cropBBOXInRequestCRS = CRS.transform(cropBBox,
@@ -598,7 +592,7 @@ class RasterLayerRequest {
 				cropBBOXInRequestCRS.setCoordinateReferenceSystem(requestedBBox.getCoordinateReferenceSystem());
 				//make sure it falls within the requested envelope
 				cropBBOXInRequestCRS.intersect(requestedBBox);
-				
+
 				//now go back to raster space 
 				destinationRasterArea =  new GeneralGridEnvelope(CRS.transform(requestedWorldToGrid,cropBBOXInRequestCRS),PixelInCell.CELL_CORNER,false).toRectangle();
 				//intersect with the original requested raster space to be sure that we stay within the requested raster area
@@ -610,10 +604,8 @@ class RasterLayerRequest {
 			}
     	}
 		//is it empty??
-        if (destinationRasterArea.isEmpty()) 
-        {
-            if (LOGGER.isLoggable(Level.FINE)) 
-                LOGGER.log(Level.FINE, "Requested envelope too small resulting in empty cropped raster region");
+        if (destinationRasterArea.isEmpty()) {
+    	    LOGGER.log(Level.FINE, "Requested envelope too small resulting in empty cropped raster region");
             // TODO: Future versions may define a 1x1 rectangle starting
             // from the lower coordinate
             empty=true;
@@ -625,13 +617,13 @@ class RasterLayerRequest {
     /**
      * Evaluates the requested envelope and builds a new adjusted version of it
      * fitting this coverage envelope.
-     * 
+     *
      * <p>
      * While adjusting the requested envelope this methods also compute the
      * source region as a rectangle which is suitable for a successive read
      * operation with {@link ImageIO} to do crop-on-read.
-     * 
-     * 
+     *
+     *
      * @param requestedBBox
      *                is the envelope we are requested to load.
      * @param destinationRasterArea
@@ -649,13 +641,13 @@ class RasterLayerRequest {
      *         does not intersect the coverage envelope or in case the adjusted
      *         requested envelope is covered by a too small raster region (an
      *         empty region).
-     * @throws DataSourceException 
-     * 
+     * @throws DataSourceException
+     *
      * @throws DataSourceException
      *                 in case something bad occurs
      */
     private void computeRequestSpatialElements() throws DataSourceException{
-        
+
         //
 		// Inspect the request and precompute transformation between CRS. We
 		// also check if we can simply adjust the requested GG in case the
@@ -667,7 +659,7 @@ class RasterLayerRequest {
 		// operation to change CRS
         //
         inspectCoordinateReferenceSystems();
-            
+
         //
         // WE DO HAVE A REQUESTED AREA!
     	//
@@ -677,26 +669,24 @@ class RasterLayerRequest {
         //
         computeCropBBOX();
         if (empty||(cropBBox!=null&&cropBBox.isEmpty()))
-        {	  	
-            if (LOGGER.isLoggable(Level.FINE)) 
-                LOGGER.log(Level.FINE, "RequestedBBox empty or null");
+        {
+			LOGGER.log(Level.FINE, "RequestedBBox empty or null");
         	//this means that we do not have anything to load at all!
             empty=true;
             return;
         }
-        
+
         //
         // CROP SOURCE REGION using the refined requested envelope
         //
-        computeCropRasterArea();     
+        computeCropRasterArea();
         if (empty||(destinationRasterArea!=null&&destinationRasterArea.isEmpty()))
-        {	  	
-            if (LOGGER.isLoggable(Level.FINE)) 
-                LOGGER.log(Level.FINE, "CropRasterArea empty or null");
+        {
+			LOGGER.log(Level.FINE, "CropRasterArea empty or null");
         	//this means that we do not have anything to load at all!
             return;
-        }                
-        
+        }
+
         if (LOGGER.isLoggable(Level.FINE)) {
             StringBuffer sb = new StringBuffer(
                     "Adjusted Requested Envelope = ")
@@ -719,25 +709,25 @@ class RasterLayerRequest {
 	/**
 	 * Computes the requested resolution which is going to be used for selecting
 	 * overviews and or deciding decimation factors on the target coverage.
-	 * 
+	 *
 	 * <p>
 	 * In case the requested envelope is in the same
 	 * {@link CoordinateReferenceSystem} of the coverage we compute the
 	 * resolution using the requested {@link MathTransform}. Notice that it must
 	 * be a {@link LinearTransform} or else we fail.
-	 * 
+	 *
 	 * <p>
 	 * In case the requested envelope is not in the same {@link CoordinateReferenceSystem} of the coverage we 
-	 * 
+	 *
 	 * @throws DataSourceException
 	 *             in case something bad happens during reprojections and/or
 	 *             intersections.
 	 */
 	private void computeRequestedResolution() throws DataSourceException
 	{
-			
+
 		try{
-	
+
 			// let's try to get the resolution from the requested gridToWorld
 			if(requestedGridToWorld instanceof LinearTransform){
 
@@ -746,7 +736,7 @@ class RasterLayerRequest {
 				// same and the conversion is not , we can get the resolution from envelope + raster directly
 				//
 				if(destinationToSourceTransform!=null&&!destinationToSourceTransform.isIdentity()){
-					
+
 			        //
 			        // compute the approximated resolution in the request crs, notice that we are
 					// assuming a reprojection that keeps the raster area unchanged hence
@@ -777,14 +767,13 @@ class RasterLayerRequest {
 			else
 				// should not happen
 				throw new UnsupportedOperationException(Errors.format(ErrorKeys.UNSUPPORTED_OPERATION_$1,requestedGridToWorld.toString()));
-				
+
 			//leave
 			return;
 		}catch (Throwable e) {
-			if(LOGGER.isLoggable(Level.INFO))
-				LOGGER.log(Level.INFO,"Unable to compute requested resolution",e);
+			LOGGER.log(Level.INFO,"Unable to compute requested resolution",e);
 		}
-		
+
 		//
 		//use the coverage resolution since we cannot compute the requested one
 		//
@@ -804,8 +793,8 @@ class RasterLayerRequest {
 			// the coverage crs or the request bbox can be reprojected to that
 			// crs
         	//
-        	
-        	
+
+
             // STEP 1: reproject requested BBox to native CRS if needed
             if (!CRS.equalsIgnoreMetadata(requestCRS,rasterManager.spatialDomainManager.coverageCRS2D))
                 destinationToSourceTransform = CRS.findMathTransform(requestCRS,rasterManager.spatialDomainManager.coverageCRS2D, true);
@@ -816,7 +805,7 @@ class RasterLayerRequest {
                         rasterManager.spatialDomainManager.coverageCRS2D);
             	temp.setCoordinateReferenceSystem(rasterManager.spatialDomainManager.coverageCRS2D);
             	cropBBox= new ReferencedEnvelope(temp);
-            	
+
             }
             else
             {
@@ -827,8 +816,8 @@ class RasterLayerRequest {
             			requestedBBox.getMinY(),
             			requestedBBox.getMaxY(),
             			rasterManager.spatialDomainManager.coverageCRS2D);
-            	
-            }            
+
+            }
 
 
             //
@@ -843,21 +832,14 @@ class RasterLayerRequest {
             	return;
             }
             // TODO XXX Optimize when referenced envelope has intersection method that actually retains the CRS, this is the JTS one
-            cropBBox=new ReferencedEnvelope(((ReferencedEnvelope) cropBBox).intersection(rasterManager.spatialDomainManager.coverageBBox),rasterManager.spatialDomainManager.coverageCRS2D);   
-            
+            cropBBox=new ReferencedEnvelope(((ReferencedEnvelope) cropBBox).intersection(rasterManager.spatialDomainManager.coverageBBox),rasterManager.spatialDomainManager.coverageCRS2D);
+
             return;
-        } catch (TransformException te) {
+        } catch (TransformException|FactoryException e) {
             // something bad happened while trying to transform this
             // envelope. let's try with wgs84
-            if(LOGGER.isLoggable(Level.FINE))
-            	LOGGER.log(Level.FINE,te.getLocalizedMessage(),te);
-        } catch (FactoryException fe) {
-            // something bad happened while trying to transform this
-            // envelope. let's try with wgs84
-            if(LOGGER.isLoggable(Level.FINE))
-            	LOGGER.log(Level.FINE,fe.getLocalizedMessage(),fe);
+			LOGGER.log(Level.FINE,e.getLocalizedMessage(),e);
         }
-        
 
         try {
 
@@ -866,9 +848,9 @@ class RasterLayerRequest {
 			// we go back to reproject in the geographic crs of the native
 			// coverage since this usually happens for conversions between CRS
 			// whose area of definition is different
-	        //              
+	        //
 
-        	
+
         	// STEP 1 reproject the requested envelope to the coverage geographic bbox
 	        if(!CRS.equalsIgnoreMetadata(rasterManager.spatialDomainManager.coverageGeographicCRS2D, requestCRS)){
 	        	//try to convert the requested bbox to the coverage geocrs
@@ -881,8 +863,8 @@ class RasterLayerRequest {
 	        }
 	        if(requestedBBOXInCoverageGeographicCRS==null)
 	        	requestedBBOXInCoverageGeographicCRS= new GeneralEnvelope(requestCRS);
-	
-	
+
+
 	        // STEP 2 intersection with the geographic bbox for this coverage
 	        if (!requestedBBOXInCoverageGeographicCRS.intersects(rasterManager.spatialDomainManager.coverageGeographicBBox,true))
 	        {
@@ -894,28 +876,22 @@ class RasterLayerRequest {
 	        // note that for the moment we got to use general envelope since there is no intersection otherwise
 	        requestedBBOXInCoverageGeographicCRS.intersect(rasterManager.spatialDomainManager.coverageGeographicBBox);
 	        requestedBBOXInCoverageGeographicCRS.setCoordinateReferenceSystem(rasterManager.spatialDomainManager.coverageGeographicCRS2D);
-	        
+
 	        // now go back to the coverage native CRS in order to compute an approximate requested resolution
             approximateRequestedBBoInNativeCRS = CRS.transform(
                     requestedBBOXInCoverageGeographicCRS,
                     rasterManager.spatialDomainManager.coverageCRS2D);
 	    	approximateRequestedBBoInNativeCRS.setCoordinateReferenceSystem(rasterManager.spatialDomainManager.coverageCRS2D);
-	    	cropBBox = new ReferencedEnvelope(approximateRequestedBBoInNativeCRS);     
-	    	
-	    	
-        } catch (TransformException te) {
+	    	cropBBox = new ReferencedEnvelope(approximateRequestedBBoInNativeCRS);
+
+
+        } catch (TransformException|FactoryException  e) {
             // something bad happened while trying to transform this
             // envelope. let's try with wgs84
-            if(LOGGER.isLoggable(Level.FINE))
-            	LOGGER.log(Level.FINE,te.getLocalizedMessage(),te);
-        } catch (FactoryException fe) {
-            // something bad happened while trying to transform this
-            // envelope. let's try with wgs84
-            if(LOGGER.isLoggable(Level.FINE))
-            	LOGGER.log(Level.FINE,fe.getLocalizedMessage(),fe);
+			LOGGER.log(Level.FINE,e.getLocalizedMessage(),e);
         }
 
-        LOGGER.log(Level.INFO,"We did not manage to crop the requested envelope, we fall back onto loading the whole coverage.");
+        LOGGER.info("We did not manage to crop the requested envelope, we fall back onto loading the whole coverage.");
         cropBBox=null;
     }
 
@@ -963,7 +939,7 @@ class RasterLayerRequest {
 	public Dimension getTileDimensions() {
 		return tileDimensions;
 	}
-	
+
 	@Override
 	public String toString() {
 		final StringBuilder builder= new StringBuilder();
@@ -973,5 +949,5 @@ class RasterLayerRequest {
 		builder.append("\tRequestedGridToWorld=").append(requestedGridToWorld).append("\n");
 		builder.append("\tReadType=").append(readType);
 		return builder.toString();
-	}	
+	}
 }

--- a/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/ReadType.java
+++ b/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/ReadType.java
@@ -46,27 +46,20 @@ import org.geotools.resources.i18n.Errors;
  *
  */
 enum ReadType {
-	
     DIRECT_READ{
+    	@Override
     	RenderedImage read(
-    			final ImageReadParam readP,
-    			final int imageIndex, 
-    			final File rasterFile,
-    			final Rectangle readDimension,
-    			final Dimension tileDimension, // we just ignore in this case
-    			final ImageReaderSpi spi
-    			)throws IOException{
+                final ImageReadParam readP,
+                final int imageIndex,
+                final File rasterFile,
+                final Rectangle readDimension,
+                final Dimension tileDimension, // we just ignore in this case
+                final ImageReaderSpi spi,
+                ImageReader reader)throws IOException{
     		//
     		// Using ImageReader to load the data directly
     		//
-    		ImageInputStream inStream=null;
-    		ImageReader reader=null;
     		try{
-    			inStream = Utils.getInputStream(rasterFile);
-    			if(inStream==null)
-    				return null;
-    	
-    			reader=spi.createReaderInstance();
     			if(reader==null)
     			{
     				if (LOGGER.isLoggable(Level.WARNING))
@@ -74,10 +67,7 @@ enum ReadType {
     							+ rasterFile.getAbsolutePath());
     				return null;
     			}
-    			
-    			inStream.reset();
-    			reader.setInput(inStream);
-    			
+
     			//check source regione
     			if(CoverageUtilities.checkEmptySourceRegion(readP, readDimension))
     				return null;
@@ -92,22 +82,7 @@ enum ReadType {
     				LOGGER.log(Level.WARNING,"Unable to compute source area for file "
     						+ rasterFile.getAbsolutePath(),e);	
     			return null;
-    		} finally {
-    			//close everything
-    			try {
-    				// reader
-    				reader.dispose();
-    			} catch (Throwable t) {
-    				// swallow the exception, we are just trying to close as much stuff as possible
-    			} 
-    			
-    			try {
-    				// instream
-    				inStream.close();
-    			} catch (Throwable t) {
-    				// swallow the exception, we are just trying to close as much stuff as possible
-    			} 							
-    		}        		
+    		}
     	}
     }, 
     
@@ -115,67 +90,17 @@ enum ReadType {
     JAI_IMAGEREAD{
     	@Override
     	RenderedImage read(
-    			final ImageReadParam readP,
-    			final int imageIndex, 
-    			final File rasterFile,
-    			final Rectangle readDimension,
-    			final Dimension tileDimension,
-    			final ImageReaderSpi spi
-    			) throws IOException{
+                final ImageReadParam readP,
+                final int imageIndex,
+                final File rasterFile,
+                final Rectangle readDimension,
+                final Dimension tileDimension,
+                final ImageReaderSpi spi,
+                ImageReader reader) throws IOException{
     		
-      		///
-    		// Using ImageReader to load the data directly
-    		//
-    		ImageInputStream inStream=null;
-    		ImageReader reader=null;
-    		try{
-    			//get stream
-    			inStream = Utils.getInputStream(rasterFile);
-    			if(inStream==null)
-    				return null;
-    			// get a reader
-    			reader=spi.createReaderInstance();
-    			if(reader==null)
-    			{
-    				if (LOGGER.isLoggable(Level.WARNING))
-    					LOGGER.warning("Unable to get reader for file "
-    							+ rasterFile.getAbsolutePath());
-    				return null;
-    			}
-    			
-    			inStream.reset();
-    			reader.setInput(inStream);
+			if(CoverageUtilities.checkEmptySourceRegion(readP, readDimension))
+				return null;
 
-    			
-    			//check source region
-    			if(CoverageUtilities.checkEmptySourceRegion(readP, readDimension))
-    				return null;
-    			
-
-    		} catch (IOException e) {
-    			if (LOGGER.isLoggable(Level.WARNING))
-    				LOGGER.log(Level.WARNING,"Unable to compute source area for file "
-    						+ rasterFile.getAbsolutePath(),e);	
-    			return null;
-    		} finally {
-    			//close everything
-    			try {
-    				// reader
-    				if(reader!=null)
-    					reader.dispose();
-    			} catch (Throwable t) {
-    				// swallow the exception, we are just trying to close as much stuff as possible
-    			} 
-    			
-    			try {
-    				// instream
-    				if(inStream!=null)
-    					inStream.close();
-    			} catch (Throwable t) {
-    				// swallow the exception, we are just trying to close as much stuff as possible
-    			} 							
-    		}
-    		
 			// read data    	
 			final ParameterBlock pbjImageRead = new ParameterBlock();
 			pbjImageRead.add(rasterFile);
@@ -206,68 +131,19 @@ enum ReadType {
     JAI_IMAGEREAD_MT{
     	@Override
     	RenderedImage read(
-    			final ImageReadParam readP,
-    			final int imageIndex, 
-    			final File rasterFile,
-    			final Rectangle readDimension,
-    			final Dimension tileDimension,
-    			final ImageReaderSpi spi
-    			) throws IOException{
-    		
-      		///
-    		// Using ImageReader to load the data directly
-    		//
-    		ImageInputStream inStream=null;
-    		ImageReader reader=null;
-    		try{
-    			//get stream
-    			inStream = Utils.getInputStream(rasterFile);
-    			if(inStream==null)
-    				return null;
-    			// get a reader
-    			reader=spi.createReaderInstance();
-    			if(reader==null)
-    			{
-    				if (LOGGER.isLoggable(Level.WARNING))
-    					LOGGER.warning("Unable to get reader for file "
-    							+ rasterFile.getAbsolutePath());
-    				return null;
-    			}
-    			
-    			inStream.reset();
-    			reader.setInput(inStream);
+                final ImageReadParam readP,
+                final int imageIndex,
+                final File rasterFile,
+                final Rectangle readDimension,
+                final Dimension tileDimension,
+                final ImageReaderSpi spi,
+                ImageReader reader) throws IOException{
 
-    			
-    			//check source region
-    			if(CoverageUtilities.checkEmptySourceRegion(readP, readDimension))
-    				return null;
-    			
+			//check source region
+			if(CoverageUtilities.checkEmptySourceRegion(readP, readDimension))
+				return null;
 
-    		} catch (IOException e) {
-    			if (LOGGER.isLoggable(Level.WARNING))
-    				LOGGER.log(Level.WARNING,"Unable to compute source area for file "
-    						+ rasterFile.getAbsolutePath(),e);	
-    			return null;
-    		} finally {
-    			//close everything
-    			try {
-    				// reader
-    				if(reader!=null)
-    					reader.dispose();
-    			} catch (Throwable t) {
-    				// swallow the exception, we are just trying to close as much stuff as possible
-    			} 
-    			
-    			try {
-    				// instream
-    				if(inStream!=null)
-    					inStream.close();
-    			} catch (Throwable t) {
-    				// swallow the exception, we are just trying to close as much stuff as possible
-    			} 							
-    		}
-    		
-			// read data    	
+			// read data
 			final ParameterBlock pbjImageRead = new ParameterBlock();
 			pbjImageRead.add(rasterFile);
 			pbjImageRead.add(imageIndex);
@@ -298,13 +174,13 @@ enum ReadType {
 
     	@Override
 		RenderedImage read(
-    			final ImageReadParam readP,
-    			final int imageIndex, 
-    			final File rasterFile,
-    			final Rectangle readDimension,
-    			final Dimension tileDimension,
-    			final ImageReaderSpi spi
-    			)throws IOException{
+                final ImageReadParam readP,
+                final int imageIndex,
+                final File rasterFile,
+                final Rectangle readDimension,
+                final Dimension tileDimension,
+                final ImageReaderSpi spi,
+                ImageReader reader)throws IOException{
     		throw new UnsupportedOperationException(Errors.format(ErrorKeys.UNSUPPORTED_OPERATION_$1,"read"));
     	}
     };
@@ -336,20 +212,21 @@ enum ReadType {
 	 * @param tileDimension
 	 *            a {@link Dimension} object that can be used to suggest specific
 	 *            tile dimension for the raster to load. It can be <code>null</code>.
-	 * 
-	 * @return a {@link RenderedImage} instance that matches the provided
+	 *
+	 * @param reader
+     * @return a {@link RenderedImage} instance that matches the provided
 	 *         request parameters as close as possible.
 	 * 
 	 * @throws IOException
 	 *             in case something bad occurs during the decoding process.
 	 */
 	abstract RenderedImage read(
-			final ImageReadParam readParameters,
-			final int imageIndex, 
-			final File rasterFile,
-			final Rectangle readDimension, 
-			final Dimension tileDimension,
-			final ImageReaderSpi spi
-			) throws IOException;
+            final ImageReadParam readParameters,
+            final int imageIndex,
+            final File rasterFile,
+            final Rectangle readDimension,
+            final Dimension tileDimension,
+            final ImageReaderSpi spi,
+            ImageReader reader) throws IOException;
 	
 };

--- a/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/Utils.java
+++ b/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/Utils.java
@@ -118,33 +118,50 @@ class Utils {
 		// get a reader
 //		inStream.mark();
 		try {
+
 			if (inStream instanceof FileImageInputStreamExt){
+
 				final File file = ((FileImageInputStreamExt)inStream).getFile();
-				if (FILEFILTER.accept(file))
-					return JP2KFormatFactory.getCachedSpi().createReaderInstance();
+				if (FILEFILTER.accept(file)) {
+					ImageReader reader = JP2KFormatFactory.getCachedSpi().createReaderInstance();
+					reader.setInput(inStream);
+					return reader;
+				}
 			}
 			return null;
 			
 		} catch (IOException e) {
-			if (LOGGER.isLoggable(Level.WARNING))
-					LOGGER.warning(e.getLocalizedMessage());
+			LOGGER.warning(e.getLocalizedMessage());
 			return null;
+		}
+	}
+
+	static void disposeReaderAndInnerStream(ImageReader imageReader) {
+		if (imageReader == null) {
+			return;
+		}
+
+		ImageInputStream inStream = (ImageInputStream) imageReader.getInput();
+		imageReader.dispose();
+		if (inStream != null) {
+			try {
+				inStream.close();
+			}
+			catch (IOException e) {
+			}
 		}
 	}
 
 	/**
 	 * Retrieves an {@link ImageInputStream} for the provided input {@link File}
 	 * .
-	 * 
+	 *
 	 * @param file
 	 * @return
 	 * @throws IOException
 	 */
 	static ImageInputStream getInputStream(final File file) throws IOException {
-		final ImageInputStream inStream = ImageIO.createImageInputStream(file);
-		if (inStream == null)
-			return null;
-		return inStream;
+		return ImageIO.createImageInputStream(file);
 	}
 
 

--- a/modules/plugin/jp2k/src/test/java/org/geotools/coverageio/jp2k/GranuleTest.java
+++ b/modules/plugin/jp2k/src/test/java/org/geotools/coverageio/jp2k/GranuleTest.java
@@ -32,6 +32,9 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.test.TestData;
 import org.junit.Test;
 
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+
 /**
  * @author Daniele Romagnoli, GeoSolutions
  * @author Simone Giannecchini (simboss), GeoSolutions
@@ -45,20 +48,13 @@ import org.junit.Test;
 public final class GranuleTest extends BaseJP2K {
 
 	private final static Logger LOGGER = org.geotools.util.logging.Logging.getLogger(GranuleTest.class);
-    /**
-     * Creates a new instance of GranuleTest
-     *
-     * @param name
-     */
-    public GranuleTest() {
-    }
 
     @Test
     public void test() throws Exception {
     	if (!testingEnabled()) {
             return;
         }
-    	File file = null;
+    	File file;
         try{
              file = TestData.file(this, "sample.jp2");
          }catch (FileNotFoundException fnfe){
@@ -66,9 +62,10 @@ public final class GranuleTest extends BaseJP2K {
              return;
         }
          
-		final AbstractGridCoverage2DReader reader = new JP2KReader(file);
+		final JP2KReader reader = new JP2KReader(file);
 		final GeneralEnvelope envelope = reader.getOriginalEnvelope();
-		final Granule granule = new Granule(new ReferencedEnvelope(envelope), file);
+
+		final Granule granule = new Granule(new ReferencedEnvelope(envelope), file, reader);
 		final Level level = granule.getLevel(0);
 		if (level != null){
 			final AffineTransform btl = level.getBaseToLevelTransform();
@@ -88,8 +85,7 @@ public final class GranuleTest extends BaseJP2K {
 	         
 	    	final String levelS = level.toString();
 	    	if (TestData.isInteractiveTest()){
-	         	if (LOGGER.isLoggable(java.util.logging.Level.INFO))
-	         		LOGGER.info(levelS);
+				LOGGER.info(levelS);
 	        }
 	    }
     	

--- a/modules/plugin/jp2k/src/test/java/org/geotools/coverageio/jp2k/JP2KTest.java
+++ b/modules/plugin/jp2k/src/test/java/org/geotools/coverageio/jp2k/JP2KTest.java
@@ -57,14 +57,6 @@ import org.opengis.referencing.operation.MathTransform;
 public final class JP2KTest extends BaseJP2K {
 	
     private final static Logger LOGGER = org.geotools.util.logging.Logging.getLogger(JP2KTest.class);
-	
-    /**
-     * Creates a new instance of JP2KTest
-     *
-     * @param name
-     */
-    public JP2KTest() {
-    }
 
     @Test
     public void testTiledImageReadMT() throws Exception {

--- a/modules/plugin/jp2k/src/test/java/org/geotools/coverageio/jp2k/RasterLayerRequesTest.java
+++ b/modules/plugin/jp2k/src/test/java/org/geotools/coverageio/jp2k/RasterLayerRequesTest.java
@@ -25,15 +25,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.geotools.coverage.grid.GridGeometry2D;
-import org.geotools.coverageio.jp2k.JP2KFormat;
-import org.geotools.coverageio.jp2k.JP2KReader;
-import org.geotools.coverageio.jp2k.RasterLayerRequest;
-import org.geotools.coverageio.jp2k.RasterManager;
 import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.test.TestData;
 import org.junit.Test;
 import org.opengis.parameter.GeneralParameterValue;
 import org.opengis.parameter.ParameterValue;
+
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 
 /**
  * @author Daniele Romagnoli, GeoSolutions
@@ -48,20 +47,13 @@ import org.opengis.parameter.ParameterValue;
 public final class RasterLayerRequesTest extends BaseJP2K {
 	
     private final static Logger LOGGER = org.geotools.util.logging.Logging.getLogger(RasterLayerRequesTest.class);
-    /**
-     * Creates a new instance of GranuleTest
-     *
-     * @param name
-     */
-    public RasterLayerRequesTest() {
-    }
 
     @Test
     public void testRequest() throws Exception {
     	if (!testingEnabled()) {
             return;
         }
-   	 	File file = null;
+   	 	File file;
         try{
             file = TestData.file(this, "sample.jp2");
         }catch (FileNotFoundException fnfe){


### PR DESCRIPTION
Iv'e made performance improvements to the direct JP2K direct when using kakadu, mainly creating only one imageReader for every JP2KReader when using kakadu.
Since the kakadu imageReader is thread safe, it is possible to use one reader, and creating a reader per request was unnecessary, and caused a large performance decrease.
The other readers however aren't thread safe, so i needed to create a reader per request depending on the reader available.