### PR TITLE
[GEOT-5623]: dynamic stroke-dasharray improvements 

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_listMultiply.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_listMultiply.java
@@ -1,0 +1,89 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+import org.opengis.filter.capability.FunctionName;
+import org.opengis.filter.expression.Expression;
+
+/**
+ * Filter function to multiply a text list of numbers with a given factor.
+ *
+ * "1 2 3" * 2 = "2 4 6"
+ *
+ * @author Tobias Warneke
+ */
+public class FilterFunction_listMultiply extends FunctionExpressionImpl {
+
+    public static FunctionName NAME = new FunctionNameImpl("listMultiply", String.class,
+            parameter("factor", Number.class),
+            parameter("list", String.class));
+
+    public FilterFunction_listMultiply() {
+        super(NAME);
+    }
+
+    @Override
+    public Object evaluate(Object feature) {
+        Number arg0;
+        String arg1;
+
+        try { // attempt to get value and perform conversion
+            Object o = getExpression(0).evaluate(feature);
+            if (o instanceof String) 
+                arg0 = Double.valueOf((String)o);
+            else
+                arg0 = (Number) o;
+        } catch (Exception e) // probably a type error
+        {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function listMultiply argument #0 - expected type Double");
+        }
+
+        try {
+            // attempt to get value and perform conversion
+            final Expression exprArg1 = getExpression(1);
+            if (exprArg1 == null) {
+                return null;
+            }
+
+            arg1 = (String) exprArg1.evaluate(feature);
+        } catch (Exception e) // probably a type error
+        {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function listMultiply argument #1 - expected type String");
+        }
+
+        if (arg1 == null || arg1.length()==0) {
+            return null;
+        }
+
+        String[] values = arg1.split(" ");
+        StringBuilder b = new StringBuilder();
+
+        for (int i = 0; i < values.length; i++) {
+            if (b.length() != 0) {
+                b.append(" ");
+            }
+            b.append(Double.valueOf(values[i]) * arg0.doubleValue());
+        }
+
+        return b.toString();
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/styling/visitor/UomRescaleStyleVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/styling/visitor/UomRescaleStyleVisitor.java
@@ -52,21 +52,21 @@ import org.opengis.style.GraphicalSymbol;
  * This visitor extends {@link DuplicatingStyleVisitor} and as such yields a copy of the original
  * Style. Usage is simply to call the desired visit() method and then call getCopy() to retrieve the
  * result.
- * 
+ *
  * @author milton
  * @author Andrea Aime - GeoSolutions
- * 
- * 
+ *
+ *
  * @source $URL$
  */
 public class UomRescaleStyleVisitor extends DuplicatingStyleVisitor {
 
-    double mapScale;
+    double mapScale; 
 
     /**
      * Constructor: requires the current mapScale to inform the window to viewport (world to screen)
-     * relation in order to correctly rescale sizes according to units of measure given in world
-     * units (e.g., SI.METER, NonSI.FOOT, etc).
+ relation in order to correctly rescaleDashArray sizes according to units of measure given in world
+ units (e.g., SI.METER, NonSI.FOOT, etc).
      * 
      * @param mapScale The specified map scale, given in pixels per meter.
      */
@@ -79,8 +79,8 @@ public class UomRescaleStyleVisitor extends DuplicatingStyleVisitor {
     }
 
     /**
-     * Used to rescale the provided unscaled value.
-     * 
+     * Used to rescaleDashArray the provided unscaled value.
+     *
      * @param unscaled the unscaled value.
      * @param mapScale the mapScale in pixels per meter.
      * @param uom the unit of measure that will be used to scale.
@@ -98,20 +98,28 @@ public class UomRescaleStyleVisitor extends DuplicatingStyleVisitor {
     /**
      * Rescale a list of expressions, can handle null.
      */
-    protected List<Expression> rescale(List<Expression> expressions, Unit<Length> uom) {
-        if(expressions == null || expressions.isEmpty()) {
+    protected List<Expression> rescaleDashArray(List<Expression> expressions, Unit<Length> uom) {
+        if (expressions == null || expressions.isEmpty()) {
             return expressions;
         }
         List<Expression> rescaled = new ArrayList<>(expressions.size());
-        for(Expression expression: expressions) {
-            rescaled.add(rescale(expression, uom));
+        if (expressions.size() == 1) {
+            final Expression expr = expressions.get(0);
+            Expression rescale = ff.function("listMultiply", rescale(ff.literal(1), uom), expr);
+            
+            String constant = (String) rescale.evaluate(null);
+            rescaled.add(ff.literal(constant));
+        } else {
+            for (Expression expression : expressions) {
+                rescaled.add(rescale(expression, uom));
+            }
         }
         return rescaled;
     }
 
     /**
-     * Used to rescale the provided unscaled value.
-     * 
+     * Used to rescaleDashArray the provided unscaled value.
+     *
      * @param unscaled the unscaled value.
      * @param mapScale the mapScale in pixels per meter.
      * @param uom the unit of measure that will be used to scale.
@@ -127,8 +135,8 @@ public class UomRescaleStyleVisitor extends DuplicatingStyleVisitor {
     }
 
     /**
-     * Used to rescale the provided stroke.
-     * 
+     * Used to rescaleDashArray the provided stroke.
+     *
      * @param stroke the unscaled stroke, which will be modified in-place.
      * @param mapScale the mapScale in pixels per meter.
      * @param uom the unit of measure that will be used to scale.
@@ -136,7 +144,7 @@ public class UomRescaleStyleVisitor extends DuplicatingStyleVisitor {
     protected void rescaleStroke(Stroke stroke, Unit<Length> uom) {
         if (stroke != null) {
             stroke.setWidth(rescale(stroke.getWidth(), uom));
-            stroke.setDashArray(rescale(stroke.dashArray(), uom));
+            stroke.setDashArray(rescaleDashArray(stroke.dashArray(), uom));
             stroke.setDashOffset(rescale(stroke.getDashOffset(), uom));
             rescale(stroke.getGraphicFill(), uom);
             rescale(stroke.getGraphicStroke(), uom);
@@ -219,7 +227,7 @@ public class UomRescaleStyleVisitor extends DuplicatingStyleVisitor {
         for (Font font : copy.fonts()) {
             font.setSize(rescale(font.getSize(), uom));
         }
-        
+
         // rescales label placement
         LabelPlacement placement = copy.getLabelPlacement();
         if (placement instanceof PointPlacement) {
@@ -286,7 +294,7 @@ public class UomRescaleStyleVisitor extends DuplicatingStyleVisitor {
             options.put(optionName, sb.toString());
         }
     }
-    
+
     String toInt(String value) {
         Double dv = Double.valueOf(value);
         return String.valueOf(dv.intValue());

--- a/modules/library/main/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/modules/library/main/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -172,5 +172,6 @@ org.geotools.filter.function.math.PiFunction
 org.geotools.filter.function.string.ConcatenateFunction
 org.geotools.filter.function.string.URLEncodeFunction
 org.geotools.filter.function.JenksNaturalBreaksFunction
+org.geotools.filter.function.FilterFunction_listMultiply
 org.geotools.filter.function.FilterFunction_list
 org.geotools.styling.visitor.RescaleToPixelsFunction

--- a/modules/library/main/src/test/java/org/geotools/filter/function/FilterFunction_listMultiplyTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/FilterFunction_listMultiplyTest.java
@@ -1,0 +1,133 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ * 
+ *    (C) 2005-2008, Open Source Geospatial Foundation (OSGeo)
+ *    
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import org.geotools.data.DataStore;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.capability.FunctionName;
+
+/**
+ *
+ * @author Tobias Warneke
+ */
+public class FilterFunction_listMultiplyTest {
+
+    private FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+    protected SimpleFeatureType dataType;
+    protected SimpleFeature[] testFeatures;
+    protected SimpleFeatureCollection featureCollection;
+    private String[] dashArrays = null;
+    private String[] expectedDashArrays = null;
+
+    @Before
+    public void setUp() throws Exception {
+        dataType = DataUtilities.createType("listMultiply.test1",
+                "id:0,geom:Point,dynamic_dasharray:String");
+
+        dashArrays = new String[]{"5 10", "15 30"};
+        expectedDashArrays = new String[]{"10.0 20.0", "30.0 60.0"};
+
+        testFeatures = new SimpleFeature[dashArrays.length];
+        GeometryFactory fac = new GeometryFactory();
+
+        for (int i = 0; i < dashArrays.length; i++) {
+            testFeatures[i] = SimpleFeatureBuilder.build(dataType,
+                    new Object[]{i + 1, fac.createPoint(new Coordinate(i, i)), dashArrays[i]}, "obj:" + i);
+        }
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testFunctionMetaInfo() {
+        FunctionName functionName = ff.functionName("listMultiply", 2);
+        assertNotNull(functionName);
+    }
+
+    /**
+     * Test of evaluate method, of class FilterFunction_listMultiply.
+     */
+    @Test
+    public void testEvaluate() {
+        FilterFunction_listMultiply func = (FilterFunction_listMultiply) ff.function("listMultiply", ff.literal(2), ff.literal("1 2 3"));
+        Object evaluate = func.evaluate(null);
+        assertTrue(evaluate instanceof String);
+        assertEquals("2.0 4.0 6.0", evaluate.toString());
+    }
+
+    @Test
+    public void testEvaluate2() {
+        FilterFunction_listMultiply func = (FilterFunction_listMultiply) ff.function("listMultiply", ff.literal(2.5), ff.literal("1 2 3"));
+        Object evaluate = func.evaluate(null);
+        assertTrue(evaluate instanceof String);
+        assertEquals("2.5 5.0 7.5", evaluate.toString());
+    }
+
+    @Test
+    public void testEvaluateNull() {
+        FilterFunction_listMultiply func = (FilterFunction_listMultiply) ff.function("listMultiply", ff.literal(2.5), ff.literal((String) null));
+        Object evaluate = func.evaluate(null);
+        assertNull(evaluate);
+    }
+
+    @Test
+    public void testEvaluate4() {
+        FilterFunction_listMultiply func = (FilterFunction_listMultiply) ff.function("listMultiply", ff.literal(1), ff.literal("1 2 3"));
+        Object evaluate = func.evaluate(null);
+        assertTrue(evaluate instanceof String);
+        assertEquals("1.0 2.0 3.0", evaluate.toString());
+    }
+
+    @Test
+    public void testEvaluate5() {
+        FilterFunction_listMultiply func = (FilterFunction_listMultiply) ff.function("listMultiply", ff.literal(2), ff.property("dynamic_dasharray"));
+
+        for (int i = 0; i < testFeatures.length; i++) {
+            Object evaluate = func.evaluate(testFeatures[i]);
+            assertTrue(evaluate instanceof String);
+            assertEquals(expectedDashArrays[i], evaluate.toString());
+        }
+    }
+
+    @Test
+    public void testEvaluateNullDasharray() {
+        FilterFunction_listMultiply func = (FilterFunction_listMultiply) ff.function("listMultiply", ff.literal(2.5), null);
+        Object evaluate = func.evaluate(null);
+        assertNull(evaluate);
+    }
+
+    @Test
+    public void testEvaluateEmptyDasharray() {
+        FilterFunction_listMultiply func = (FilterFunction_listMultiply) ff.function("listMultiply", ff.literal(2.5), ff.literal(""));
+        Object evaluate = func.evaluate(null);
+        assertNull(evaluate);
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/styling/SLDStyleTest.java
+++ b/modules/library/main/src/test/java/org/geotools/styling/SLDStyleTest.java
@@ -13,9 +13,9 @@
  *    but WITHOUT ANY WARRANTY; without even the implied warranty of
  *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *    Lesser General Public License for more details.
- */
+ */ 
 package org.geotools.styling;
-
+ 
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -215,6 +215,14 @@ public class SLDStyleTest extends TestCase {
         assertTrue("not expected expression", expressions.get(2).equals(ff.property("stroke2")));
         assertTrue("not expected expression", expressions.get(3).equals(ff.literal(2.0)));
     }
+    
+    public void testDashArray3_dynamic() throws Exception {
+        java.net.URL surl = TestData.getResource(this, "dasharray3_dynamic.sld");
+        SLDParser stylereader = new SLDParser(sf, surl);
+        StyledLayerDescriptor sld = stylereader.parseSLD();
+        
+        validateDynamicDashArrayStyle(sld);
+    }
 
     private Stroke validateDashArrayStyle(StyledLayerDescriptor sld) {
         assertEquals(1, ((UserLayer) sld.getStyledLayers()[0]).getUserStyles().length);
@@ -234,6 +242,23 @@ public class SLDStyleTest extends TestCase {
         assertNotNull("stroke dasharray is null", stroke.dashArray());
 
         return stroke;
+    }
+    
+    private void validateDynamicDashArrayStyle(StyledLayerDescriptor sld) {
+        assertEquals(1, ((UserLayer) sld.getStyledLayers()[0]).getUserStyles().length);
+        Style style = ((UserLayer) sld.getStyledLayers()[0]).getUserStyles()[0];
+        List<FeatureTypeStyle> fts = style.featureTypeStyles();
+        assertEquals(1, fts.size());
+        List<Rule> rules = fts.get(0).rules();
+        assertEquals(1, rules.size());
+        List<Symbolizer> symbolizers = rules.get(0).symbolizers();
+        assertEquals(1, symbolizers.size());
+        
+        LineSymbolizer ls = (LineSymbolizer) symbolizers.get(0);
+		assertNotNull(ls.getStroke().dashArray());
+		List<Expression> e = ls.getStroke().dashArray();
+        assertEquals(1, e.size());
+        assertEquals("2.0 1.0 4.0 1.0", e.get(0).evaluate(null));
     }
 
     public void testSLDParserWithWhitespaceIsTrimmed() throws Exception {

--- a/modules/library/main/src/test/java/org/geotools/styling/visitor/RescaleStyleVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/styling/visitor/RescaleStyleVisitorTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.awt.Color;
+import java.util.Arrays;
 
 import javax.measure.unit.SI;
 
@@ -44,6 +45,7 @@ import org.geotools.styling.TextSymbolizer;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.Expression;
 
 
 /**
@@ -141,6 +143,20 @@ public class RescaleStyleVisitorTest {
         assertEquals(4.0d, clone.getWidth().evaluate(null, Double.class), 0d);
         assertEquals(10.0f, clone.getDashArray()[0], 0d);
         assertEquals(20.0f, clone.getDashArray()[1], 0d);
+    }
+    
+    @Test
+    public void testDynamicStroke() throws Exception {
+        Stroke original = sb.createStroke(Color.RED, 2);
+        original.setDashArray(Arrays.asList((Expression)ff.literal("5 10")));
+        
+        original.accept(visitor);
+        Stroke clone = (Stroke) visitor.getCopy();
+
+        assertEquals(4.0d, Double.valueOf((String)clone.getWidth().evaluate(null)), 0.001);
+        assertNotNull(original.dashArray());
+        assertEquals(1, original.dashArray().size());
+        assertEquals("10.0 20.0", ((Expression) clone.dashArray().get(0)).evaluate(null));
     }
     
     @Test

--- a/modules/library/main/src/test/java/org/geotools/styling/visitor/UomRescaleStyleVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/styling/visitor/UomRescaleStyleVisitorTest.java
@@ -63,6 +63,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
+import java.util.Arrays;
 
 
 /**
@@ -293,6 +294,38 @@ public class UomRescaleStyleVisitorTest
         }
     }
     
+    protected void visitLineSymbolizerTestDynamicDashArray(double scaleMetersToPixel, Unit<Length> uom)
+    {
+        try
+        {
+            UomRescaleStyleVisitor visitor = null;
+            double size = 1;
+			double expectedRescaledSize = Math.floor(computeExpectedRescaleSize(size, scaleMetersToPixel, uom) * 10000.0) / 10000.0;
+			FilterFactory2 filterFactory  = new FilterFactoryImpl();
+            Expression func = filterFactory.function("listMultiply", filterFactory.literal(expectedRescaledSize), filterFactory.literal("5 10"));
+			String expectedDashArray = (String)func.evaluate(null);
+			
+			            StyleBuilder styleBuilder = new StyleBuilder();
+
+            LineSymbolizerImpl lineSymb = (LineSymbolizerImpl) styleBuilder.createLineSymbolizer();
+            lineSymb.setUnitOfMeasure(uom);
+			lineSymb.getStroke().setDashArray(Arrays.asList(filterFactory.literal("5.0 10.0")));
+
+            visitor = new UomRescaleStyleVisitor(scaleMetersToPixel);
+
+            lineSymb.accept(visitor);
+            LineSymbolizer rescaledLineSymb = (LineSymbolizer) visitor.getCopy();
+            String rescaledDynamicDashArray = (String)((Expression)rescaledLineSymb.getStroke().dashArray().get(0)).evaluate(null);
+            
+            assertEquals(expectedDashArray, rescaledDynamicDashArray);
+            assertNotSame(rescaledLineSymb, lineSymb);
+        }
+        catch (Exception e2)
+        {
+            e2.printStackTrace();
+            fail(e2.getClass().getSimpleName() + " should not be thrown.");
+        }
+    }
 
     // POINT SYMBOLIZER TESTS
     
@@ -370,6 +403,41 @@ public class UomRescaleStyleVisitorTest
         visitLineSymbolizerTest(10, NonSI.FOOT);
     }
     
+    // LINE SYMBOLIZER TESTS with dynamic dash arrays
+	public void testVisitLineSymbolizerDynamicDashArray_ScalePixelNull()
+    {
+        visitLineSymbolizerTestDynamicDashArray(10, null);
+    }
+    
+    
+    public void testVisitLineSymbolizerDynamicDashArray_ScalePixelExplicit()
+    {
+        visitLineSymbolizerTestDynamicDashArray(10, NonSI.PIXEL);
+    }
+    
+    
+    public void testVisitLineSymbolizerDynamicDashArray_ScaleMeter1()
+    {
+        visitLineSymbolizerTestDynamicDashArray(1, SI.METER);
+    }
+    
+    
+    public void testVisitLineSymbolizerDynamicDashArray_ScaleMeter10()
+    {
+        visitLineSymbolizerTestDynamicDashArray(10, SI.METER);
+    }
+    
+    
+    public void testVisitLineSymbolizerDynamicDashArray_ScaleFoot1()
+    {
+        visitLineSymbolizerTestDynamicDashArray(1, NonSI.FOOT);
+    }
+    
+    
+    public void testVisitLineSymbolizerDynamicDashArray_ScaleFoot10()
+    {
+        visitLineSymbolizerTestDynamicDashArray(10, NonSI.FOOT);
+    }
     
     // POLYGON SYMBOLIZER TESTS
     @Test

--- a/modules/library/main/src/test/resources/org/geotools/styling/test-data/dasharray3_dynamic.sld
+++ b/modules/library/main/src/test/resources/org/geotools/styling/test-data/dasharray3_dynamic.sld
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+					   xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink"
+					   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+					   xsi:schemaLocation="http://www.opengis.net/sld
+F:\projects\schema\sld\1.0.0\StyledLayerDescriptor.xsd"
+					   version="1.0.0">
+	<Name>My Layer</Name>
+	<Title>A layer by me</Title>
+	<Abstract>this is a sample layer</Abstract>
+	<UserLayer>
+		<LayerFeatureConstraints>
+			<FeatureTypeConstraint />
+		</LayerFeatureConstraints>
+		<UserStyle>
+			<Name>My User Style</Name>
+			<Title>A style by me</Title>
+			<Abstract>this is a sample style</Abstract>
+			<IsDefault>true</IsDefault>
+			<FeatureTypeStyle>
+				<Rule>
+					<LineSymbolizer>
+						<Stroke>
+							<CssParameter name="stroke">
+								<ogc:Literal>#000044</ogc:Literal>
+							</CssParameter>
+							<CssParameter name="stroke-width">
+								<ogc:Literal>3</ogc:Literal>
+							</CssParameter>
+							<CssParameter name="stroke-offset">
+								<ogc:Literal>0</ogc:Literal>
+							</CssParameter>
+							<CssParameter name="stroke-dasharray">
+								<!-- to force single value mapping -->
+								<ogc:Function name="listMultiply">
+									<ogc:Literal>1</ogc:Literal>
+									<ogc:Literal>2.0 1.0 4.0 1.0</ogc:Literal>
+								</ogc:Function>
+							</CssParameter>
+						</Stroke>
+					</LineSymbolizer>
+				</Rule>
+			</FeatureTypeStyle>
+		</UserStyle>
+	</UserLayer>
+</StyledLayerDescriptor>

--- a/modules/library/render/src/main/java/org/geotools/renderer/style/DynamicLineStyle2D.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/DynamicLineStyle2D.java
@@ -78,15 +78,7 @@ public class DynamicLineStyle2D extends org.geotools.renderer.style.LineStyle2D 
         capCode = SLDStyleFactory.lookUpCap(capType);
 
         // get the other properties needed for the stroke
-        float[] dashes = null;
-        if(stroke.dashArray() != null) {
-            dashes = new float[stroke.dashArray().size()];
-            int index = 0;
-            for (Expression expression : stroke.dashArray()) {
-                dashes[index] = expression.evaluate(feature, Float.class);
-                index++;
-            }
-        }
+        float[] dashes = SLDStyleFactory.evaluateDashArray(stroke, feature);
         float width = ((Float) stroke.getWidth().evaluate(feature, Float.class)).floatValue();
         float dashOffset = ((Float) stroke.getDashOffset().evaluate(feature, Float.class)).floatValue();
 

--- a/modules/library/render/src/main/java/org/geotools/renderer/style/SLDStyleFactory.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/SLDStyleFactory.java
@@ -1004,15 +1004,7 @@ public class SLDStyleFactory {
 		}
 
 		// get the other properties needed for the stroke
-        float[] dashes = null;
-        if(stroke.dashArray() != null) {
-            dashes = new float[stroke.dashArray().size()];
-            int index = 0;
-            for (Expression expression : stroke.dashArray()) {
-                dashes[index] = expression.evaluate(feature, Float.class);
-                index++;
-            }
-        }
+        float[] dashes = evaluateDashArray(stroke, feature);
 		float width = evalToFloat(stroke.getWidth(), feature, 1);
 		float dashOffset = evalToFloat(stroke.getDashOffset(), feature, 0);
 
@@ -1035,6 +1027,30 @@ public class SLDStyleFactory {
 
 		return stroke2d;
 	}
+
+    public static float[] evaluateDashArray(org.geotools.styling.Stroke stroke, Object feature) throws NumberFormatException {
+        float[] dashes = null;
+        if(stroke.dashArray() != null) {
+            if (stroke.dashArray().size()==1) {
+                String dashString = stroke.dashArray().get(0).evaluate(feature, String.class);
+                if (dashString!=null && !"".equals(dashString)) {
+                    String[] strok = dashString.split(" ");
+                    dashes = new float[strok.length];
+                    for (int l = 0; l < dashes.length; l++) {
+                        dashes[l] = Float.parseFloat(strok[l]);
+                    }
+                }
+            } else {
+                dashes = new float[stroke.dashArray().size()];
+                int index = 0;
+                for (Expression expression : stroke.dashArray()) {
+                    dashes[index] = expression.evaluate(feature, Float.class);
+                    index++;
+                }
+            }
+        }
+        return dashes;
+    }
 
 	private Paint getStrokePaint(org.geotools.styling.Stroke stroke, Object feature) {
 		if (stroke == null) {


### PR DESCRIPTION
Hopefully, now I got the EOLs correct. 

This patch makes GeoTools able to process a complete stroke-dasharray from database. 

The implementation of GeoTools so far relies on getting single numbers from a stroke-dasharray from expression. Internally a stroke-dasharray is converted to a list of expressions. For this type of stroke-dasharray there must be more than one expression to be correct.

This patch introduces for the "edge" case "only one expression for a stroke-dasharray" to get the whole dasharray from one expression.