### PR TITLE
[GEOT-5636] fixed imageio-ext-gdalgeotiff.jar classpath conflicts

### DIFF
--- a/modules/plugin/imageio-ext-gdal/pom.xml
+++ b/modules/plugin/imageio-ext-gdal/pom.xml
@@ -150,6 +150,12 @@
       <groupId>it.geosolutions.imageio-ext</groupId>
       <artifactId>imageio-ext-gdalvrt</artifactId>
       <!-- The version number is specified in the parent POM. -->
+      <exclusions>
+        <exclusion>
+          <groupId>it.geosolutions.imageio-ext</groupId>
+          <artifactId>imageio-ext-gdalgeotiff</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>it.geosolutions.imageio-ext</groupId>


### PR DESCRIPTION
The imageio-ext-gdalgeotiff.jar can cause classpath loading problems: only classes in imageio-ext-tiff.jar should be loaded.
See related issue on geoserver https://osgeo-org.atlassian.net/browse/GEOS-7981