### PR TITLE
[GEOT-5650] fix for sorting

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
@@ -244,9 +244,15 @@ public class WFSClient extends AbstractOpenWebService<WFSGetCapabilities, QName>
         return true;
     }
 
-    public boolean canSort() {
-        return true;
+  public boolean canSort() {
+    final Version capsVersion = new Version(capabilities.getVersion());
+    //currently on version 1.1.0 supports native sorting
+    if (Versions.v1_1_0.equals(capsVersion)) {
+      return true;
+    } else {
+      return false;
     }
+  }
     
     public boolean supportsStoredQueries() {
         return getStrategy().supportsOperation(WFSOperationType.LIST_STORED_QUERIES, HttpMethod.POST) ||


### PR DESCRIPTION
Since the sortby code is commented out in org.geotools.data.wfs.internal.v2_0.StrictWFS_2_0_Strategy line 381, and seems not to work in 1.0.0 either (despite being coded) modify the client to return false to canSort() for those versions.