### PR TITLE
Fix redundant check argument

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/SDO.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/sdo/SDO.java
@@ -2655,7 +2655,7 @@ public final class SDO {
         ensure("ETYPE {0} must be expected POLYGON or POLYGON_EXTERIOR (one of {1})", eTYPE,
                 new int[] { ETYPE.COMPOUND_POLYGON_EXTERIOR, ETYPE.COMPOUND_POLYGON, ETYPE.POLYGON,
                         ETYPE.POLYGON_EXTERIOR,
-                        ETYPE.FACE_EXTERIOR, ETYPE.FACE_EXTERIOR });
+                        ETYPE.FACE_EXTERIOR });
         if ((eTYPE != ETYPE.COMPOUND_POLYGON_EXTERIOR) && (eTYPE != ETYPE.COMPOUND_POLYGON)
                 && ((INTERPRETATION < 1) || (INTERPRETATION > 4))) {
             LOGGER.warning("Could not create JTS Polygon with INTERPRETATION "
@@ -2759,7 +2759,7 @@ public final class SDO {
         ensure("ETYPE {0} must be expected POLYGON or POLYGON_EXTERIOR (one of {1})", eTYPE,
                 new int[] { ETYPE.COMPOUND_POLYGON, ETYPE.COMPOUND_POLYGON_EXTERIOR,
                         ETYPE.COMPOUND_POLYGON_INTERIOR, ETYPE.POLYGON, ETYPE.POLYGON_EXTERIOR,
-                        ETYPE.POLYGON_INTERIOR, ETYPE.FACE_EXTERIOR, ETYPE.FACE_EXTERIOR });
+                        ETYPE.POLYGON_INTERIOR, ETYPE.FACE_EXTERIOR });
         if ((eTYPE != ETYPE.COMPOUND_POLYGON_EXTERIOR) && (eTYPE != ETYPE.COMPOUND_POLYGON)
                 && (eTYPE != ETYPE.COMPOUND_POLYGON_INTERIOR)
                 && ((INTERPRETATION < 1) || (INTERPRETATION > 4))) {


### PR DESCRIPTION
The array with allowed ETypes contains the type `ETYPE.FACE_EXTERIOR` twice, which isn't usefull. This PR removes the redundant argument.