### PR TITLE
[GEOT-5670] MongoDB Fix 'And' filter

### DIFF
--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
@@ -189,17 +189,17 @@ public class FilterToMongo implements FilterVisitor, ExpressionVisitor {
     // logical
     //
 
-    // Expressions like ((A == 1) AND (B == 2)) are basically
-    // implied. So just build up all sub expressions
     @Override
     public Object visit(And filter, Object extraData) {
         BasicDBObject output = asDBObject(extraData);
-
         List<Filter> children = filter.getChildren();
+        BasicDBList andList = new BasicDBList();
         if (children != null) {
             for (Filter child : children) {
-                child.accept(this, output);
+                BasicDBObject item = (BasicDBObject) child.accept(this, null);
+                andList.add(item);
             }
+            output.put("$and", andList);
         }
 
         return output;

--- a/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
+++ b/modules/unsupported/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
@@ -24,6 +24,7 @@ import junit.framework.TestCase;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.opengis.filter.And;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsEqualTo;
@@ -32,6 +33,7 @@ import org.opengis.filter.PropertyIsLessThan;
 import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.spatial.BBOX;
 
+import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.vividsolutions.jts.geom.Point;
 
@@ -136,6 +138,19 @@ public class FilterToMongoTest extends TestCase {
         assertNotNull(filter);
         assertEquals(MongoTestSetup.parseDate(LOWER_BOUND), filter.get("$gte"));
         assertEquals(MongoTestSetup.parseDate(UPPER_BOUND), filter.get("$lte"));
+    }
+    
+    public void testAndComparison() {
+        PropertyIsGreaterThan greaterThan = ff.greater(ff.property("property"), ff.literal(0));
+        PropertyIsLessThan lessThan = ff.less(ff.property("property"), ff.literal(10));
+        And and = ff.and(greaterThan, lessThan);
+        BasicDBObject obj = (BasicDBObject) and.accept(filterToMongo, null);
+        assertNotNull(obj);
+        System.out.println(obj.toJson());
+        
+        BasicDBList andFilter = (BasicDBList) obj.get("$and");
+        assertNotNull(andFilter);
+        assertEquals(andFilter.size(), 2);  
     }
 
 }


### PR DESCRIPTION
* The And filter builder had this comment 'Expressions like ((A == 1) AND (B == 2)) are basically implied. So just build up all sub expressions'.
  Which is true for an AND expressions with 2 different properties, however for an AND on the same property '((A > 1) AND (A <= 2))'
  this expression will overwrite the first expression with the second since the key is the same.
  IE { "A" : { "$lte" : 2 } }, rather than the correct expression { "$and" : [{ "A" : { "$gt" : "0" } }, { "A" : { "$lt" : "10" } }] }