### PR TITLE
[GEOT-5669] Make GMLEncodingUtils take in account GML 3.2 geometries types names (backport 17.x)

### DIFF
--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/bindings/GMLEncodingUtils.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/bindings/GMLEncodingUtils.java
@@ -17,12 +17,14 @@
 package org.geotools.gml2.bindings;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
@@ -291,24 +293,28 @@ public class GMLEncodingUtils {
                             .qName("PointPropertyType")));
                 }
                 else if ( LineString.class.isAssignableFrom( binding ) ) {
-                    element.setTypeDefinition(schemaIndex.getTypeDefinition(gml
-                            .qName("LineStringPropertyType")));
+                    // check both GML 3.1 and GML 3.2 types names
+                    element.setTypeDefinition(searchType(schemaIndex,
+                            "LineStringPropertyType", "CurvePropertyType"));
                 }
                 else if ( Polygon.class.isAssignableFrom( binding) ) {
-                    element.setTypeDefinition(schemaIndex.getTypeDefinition(gml
-                            .qName("PolygonPropertyType")));
+                    // check both GML 3.1 and GML 3.2 types names
+                    element.setTypeDefinition(searchType(schemaIndex,
+                            "PolygonPropertyType", "SurfacePropertyType"));
                 }
                 else if ( MultiPoint.class.isAssignableFrom( binding ) ) {
                     element.setTypeDefinition(schemaIndex.getTypeDefinition(gml
                             .qName("MultiPointPropertyType")));
                 }
                 else if ( MultiLineString.class.isAssignableFrom( binding ) ) {
-                    element.setTypeDefinition(schemaIndex.getTypeDefinition(gml
-                            .qName("MultiLineStringPropertyType")));
+                    // check both GML 3.1 and GML 3.2 types names
+                    element.setTypeDefinition(searchType(schemaIndex,
+                            "MultiLineStringPropertyType", "MultiCurvePropertyType"));
                 }
                 else if ( MultiPolygon.class.isAssignableFrom( binding) ) {
-                    element.setTypeDefinition(schemaIndex.getTypeDefinition(gml
-                            .qName("MultiPolygonPropertyType")));
+                    // check both GML 3.1 and GML 3.2 types names
+                    element.setTypeDefinition(searchType(schemaIndex,
+                            "MultiPolygonPropertyType", "MultiSurfacePropertyType"));
                 }
                 else {
                     element.setTypeDefinition(schemaIndex.getTypeDefinition(gml
@@ -336,6 +342,25 @@ public class GMLEncodingUtils {
         particle.setElement( dom.createElementNS( XSDConstants.SCHEMA_FOR_SCHEMA_URI_2001, "sequence") );
         type.setContent(particle);
         return type;
+    }
+
+    /**
+     * Return the first XSD type definition found in the schema index for
+     * the provided GML types names. NULL is returned if no XSD type
+     * definition is found.
+     */
+    private XSDTypeDefinition searchType(SchemaIndex schemaIndex, String... typesNames) {
+        for (String typeName : typesNames) {
+            XSDTypeDefinition type = schemaIndex.getTypeDefinition(gml.qName(typeName));
+            if (type != null) {
+                // we found a matching XSD type
+                return type;
+            }
+        }
+        // no matching XSD type found
+        LOGGER.fine(String.format("No type definition found for types [%s].",
+                Arrays.stream(typesNames).collect(Collectors.joining(", "))));
+        return null;
     }
     
     /**

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/GML3EncodingUtilsTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/GML3EncodingUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gml3.bindings;
+
+import org.eclipse.xsd.XSDElementDeclaration;
+import org.eclipse.xsd.XSDFeature;
+import org.eclipse.xsd.XSDNamedComponent;
+import org.eclipse.xsd.XSDTypeDefinition;
+import org.geotools.data.DataUtilities;
+import org.geotools.gml2.bindings.GMLEncodingUtils;
+import org.geotools.gml3.GML;
+import org.geotools.gml3.GMLConfiguration;
+import org.geotools.xml.Configuration;
+import org.geotools.xml.SchemaIndex;
+import org.geotools.xml.Schemas;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test GML 3.1 encoding utilities. Most of the work is delegate
+ * on {@link GMLEncodingUtils}.
+ */
+public class GML3EncodingUtilsTest {
+
+    @Test
+    public void testGeometriesGML3FeatureEncoding() throws Exception {
+        // create a schema index for GML 3.1
+        Configuration configuration = new GMLConfiguration();
+        SchemaIndex index = Schemas.findSchemas(configuration);
+        // create a simple feature type with multi lines and multi polygons
+        SimpleFeatureType featureType = DataUtilities.createType("feature",
+                "geometry1:LineString,geometry2:MultiLineString,geometry3:Polygon," +
+                        "geometry4:MultiPolygon,geometry5:Point,geometry6:MultiPoint");
+        // both GML 3.1 and GML 3.2 encoding utils delegate most of the work on the GML encoding utils
+        GMLEncodingUtils encoder = new GMLEncodingUtils(GML.getInstance());
+        // create the XSD type definition for our feature type
+        XSDTypeDefinition type = encoder.createXmlTypeFromFeatureType(featureType, index, Collections.emptySet());
+        // get the XSD elements representing our geometries attributes
+        List<XSDElementDeclaration> elements = Schemas.getChildElementDeclarations(type, false);
+        assertThat(elements, notNullValue());
+        assertThat(elements.size(), is(6));
+        // extract the type names and ignore the NULL values
+        List<String> typesNames = elements.stream()
+                .map(XSDFeature::getType)
+                .filter(elementType -> elementType != null)
+                .map(XSDNamedComponent::getName)
+                .collect(Collectors.toList());
+        // check that our geometries have the correct type
+        assertThat(typesNames.size(), is(6));
+        assertThat(typesNames, hasItems("LineStringPropertyType", "MultiLineStringPropertyType", "PolygonPropertyType",
+                "MultiPolygonPropertyType", "PointPropertyType", "MultiPointPropertyType"));
+    }
+}

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/bindings/GML32EncodingUtilsTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/bindings/GML32EncodingUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gml3.v3_2.bindings;
+
+import org.eclipse.xsd.XSDElementDeclaration;
+import org.eclipse.xsd.XSDFeature;
+import org.eclipse.xsd.XSDNamedComponent;
+import org.eclipse.xsd.XSDTypeDefinition;
+import org.geotools.data.DataUtilities;
+import org.geotools.gml2.bindings.GMLEncodingUtils;
+import org.geotools.gml3.v3_2.GML;
+import org.geotools.gml3.v3_2.GMLConfiguration;
+import org.geotools.xml.Configuration;
+import org.geotools.xml.SchemaIndex;
+import org.geotools.xml.Schemas;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test GML 3.2 encoding utilities. Most of the work is delegate
+ * on {@link GMLEncodingUtils}.
+ */
+public class GML32EncodingUtilsTest {
+
+    @Test
+    public void testGeometriesGML32FeatureEncoding() throws Exception {
+        // create a schema index for GML 3.2
+        Configuration configuration = new GMLConfiguration();
+        SchemaIndex index = Schemas.findSchemas(configuration);
+        // create a simple feature type with multi lines and multi polygons
+        SimpleFeatureType featureType = DataUtilities.createType("feature",
+                "geometry1:LineString,geometry2:MultiLineString,geometry3:Polygon," +
+                        "geometry4:MultiPolygon,geometry5:Point,geometry6:MultiPoint");
+        // both GML 3.1 and GML 3.2 encoding utils delegate most of the work on the GML encoding utils
+        GMLEncodingUtils encoder = new GMLEncodingUtils(GML.getInstance());
+        // create the XSD type definition for our feature type
+        XSDTypeDefinition type = encoder.createXmlTypeFromFeatureType(featureType, index, Collections.emptySet());
+        // get the XSD elements representing our geometries attributes
+        List<XSDElementDeclaration> elements = Schemas.getChildElementDeclarations(type, false);
+        assertThat(elements, notNullValue());
+        assertThat(elements.size(), is(6));
+        // extract the type names and ignore the NULL values
+        List<String> typesNames = elements.stream()
+                .map(XSDFeature::getType)
+                .filter(elementType -> elementType != null)
+                .map(XSDNamedComponent::getName)
+                .collect(Collectors.toList());
+        // check that our geometries have the correct type
+        assertThat(typesNames.size(), is(6));
+        assertThat(typesNames, hasItems("CurvePropertyType", "MultiCurvePropertyType", "SurfacePropertyType",
+                "MultiSurfacePropertyType", "PointPropertyType", "MultiPointPropertyType"));
+    }
+}


### PR DESCRIPTION
Backport of this PR: #1504

GMLEncodingUtils will take in account GML 3.2 geometries types names when creating the XSD type for a feature type.

This PR also adds test cases for this.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOT-5669