### PR TITLE
[GEOT-5686] Shapefile dumper throws a NPE on NULL geometry values (backport 17.x)

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDumper.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDumper.java
@@ -221,6 +221,11 @@ public class ShapefileDumper {
             while (it.hasNext()) {
                 SimpleFeature f = it.next();
 
+                // skip features with NULL geometries
+                if (f.getDefaultGeometry() == null) {
+                    continue;
+                }
+
                 StoreWriter storeWriter = getStoreWriter(f, writers, multiWriter);
                 // try to write, the shapefile size limits could be reached
                 try {

--- a/modules/plugin/shapefile/src/test/resources/org/geotools/data/shapefile/test-data/dumper/AllTypesWithNull.properties
+++ b/modules/plugin/shapefile/src/test/resources/org/geotools/data/shapefile/test-data/dumper/AllTypesWithNull.properties
@@ -1,0 +1,9 @@
+_=name:String,geom:Geometry
+AllTypes.f001=f001|POLYGON((0 60.5,0 64,6.25 64,6.25 60.5,0 60.5))
+AllTypes.f002=f002|MULTIPOLYGON(((0 60,1 61,2 60,0 60)), ((4 60,5 61,6 60,4 60)))
+AllTypes.f003=f003|LINESTRING(0 0,1 2,3 4)
+AllTypes.f004=f004|MULTILINESTRING((0 0,1 2,3 4), (0 0,-1 -2,-3 -4))
+AllTypes.f005=f005|POINT(0 0)
+AllTypes.f006=f006|MULTIPOINT(0 0, 1 1)
+AllTypes.f007=f007|null
+AllTypes.f008=f008|null


### PR DESCRIPTION
Backport of this PR: https://github.com/geotools/geotools/pull/1517

This PR fix the dump of features to shapefiles that don't have a geometry type defined (they use the generic Geometry type) and have NULL geometries.

A test case was improved a new test case added.

Associated issue: https://osgeo-org.atlassian.net/browse/GEOT-5686