### PR TITLE
integration of checkstyle into geotools build process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,9 +214,17 @@
                         <checkstyleRules>
                             <module name="Checker">
                                 <module name="FileTabCharacter" />
+                                <!-- git checkout may change linefeeds on the fly
                                 <module name="RegexpMultiline">
                                     <property name="format" value="(?s:(\r\n|\r).*)"/>
                                     <property name="message" value="CRLF and CR line endings are prohibited, but this file uses them."/>
+                                </module>
+                                -->
+                                <module name="TreeWalker">
+                                    <module name="ConstantName" />
+                                    <module name="EmptyStatement" />
+                                    <module name="NeedBraces" />
+                                    <module name="UnnecessaryParentheses" />
                                 </module>
                             </module>
                         </checkstyleRules>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,10 @@
                         <checkstyleRules>
                             <module name="Checker">
                                 <module name="FileTabCharacter" />
+                                <module name="RegexpMultiline">
+                                    <property name="format" value="(?s:(\r\n|\r).*)"/>
+                                    <property name="message" value="CRLF and CR line endings are prohibited, but this file uses them."/>
+                                </module>
                             </module>
                         </checkstyleRules>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,35 @@
         </site>
       </distributionManagement>
     </profile>
+    <profile>
+        <id>check.sources</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>2.17</version>
+                    <executions>
+                        <execution>
+                            <id>verify-style</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <logViolationsToConsole>true</logViolationsToConsole>
+                        <checkstyleRules>
+                            <module name="Checker">
+                                <module name="FileTabCharacter" />
+                            </module>
+                        </checkstyleRules>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
   </profiles>
 
 


### PR DESCRIPTION
As for I am having so much difficulties to produce correct code for geotools, mainly in setting up my coding environment to the right standards, it would be nice to have a checkstyle check, rightly configured to match geotools standards.

For now this simple integration only checks for tab characters within source code files. 

It is integrated within a separat non active profile **check.sources**.

One could start it at every submodule of geotools to get the validation or violation of the rules by

checkstyle:check -Pcheck.sources

As for now there are many "old" sources that do not follow geotools own coding convention (e.g. tab characters). But if it does, this checking style could be a part of the main build.