### PR TITLE
[GEOT-5690] Make MongoDB usable as a data store in app-schema

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/FeatureTypeMapping.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/FeatureTypeMapping.java
@@ -388,4 +388,7 @@ public class FeatureTypeMapping {
         this.isDenormalised = isDenormalised;
     }
 
+    public void setSource(FeatureSource<? extends FeatureType, ? extends Feature> source) {
+        this.source = source;
+    }
 }

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
@@ -54,6 +54,7 @@ import org.geotools.data.complex.NestedAttributeMapping;
 import org.geotools.data.complex.filter.XPath;
 import org.geotools.data.complex.filter.XPathUtil.Step;
 import org.geotools.data.complex.filter.XPathUtil.StepList;
+import org.geotools.data.complex.spi.CustomImplementationsFinder;
 import org.geotools.data.complex.xml.XmlFeatureSource;
 import org.geotools.data.joining.JoiningNestedAttributeMapping;
 import org.geotools.factory.Hints;
@@ -406,7 +407,12 @@ public class AppSchemaDataAccessConfigurator {
                     sourceFieldSteps = XPath.steps(root, sourceField, namespaces);
                 }
                 // a nested feature
-                if (isJoining() && isJDBC) {
+                NestedAttributeMapping customNestedMapping = CustomImplementationsFinder.find(this, idExpression, sourceExpression,
+                        targetXPathSteps, isMultiValued, clientProperties, elementExpr,
+                        sourceFieldSteps, namespaces);
+                if (customNestedMapping != null) {
+                    attMapping = customNestedMapping;
+                } else if (isJoining() && isJDBC) {
                     attMapping = new JoiningNestedAttributeMapping(idExpression, sourceExpression,
                             targetXPathSteps, isMultiValued, clientProperties, elementExpr,
                             sourceFieldSteps, namespaces);

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/spi/CustomAttributeExpressionFactory.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/spi/CustomAttributeExpressionFactory.java
@@ -1,0 +1,31 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.complex.spi;
+
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.NestedAttributeMapping;
+import org.geotools.data.complex.filter.XPathUtil;
+import org.opengis.filter.expression.Expression;
+
+/**
+ * Allow extensions to build custom nested expressions for chained entities.
+ */
+public interface CustomAttributeExpressionFactory {
+
+    Expression createNestedAttributeExpression(FeatureTypeMapping mappings, XPathUtil.StepList xpath,
+                                               NestedAttributeMapping nestedMapping);
+}

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/spi/CustomImplementationsFinder.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/spi/CustomImplementationsFinder.java
@@ -1,0 +1,84 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.complex.spi;
+
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.NestedAttributeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
+import org.geotools.data.complex.filter.XPathUtil;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.expression.Expression;
+import org.xml.sax.helpers.NamespaceSupport;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * Helper class used to find implementations for extensions points.
+ */
+public final class CustomImplementationsFinder {
+
+    private static List<CustomMappingFactory> mappingsFactories = new ArrayList<>();
+    private static List<CustomAttributeExpressionFactory> attributesFactories = new ArrayList<>();
+
+    static {
+        mappingsFactories = initFactories(CustomMappingFactory.class);
+        attributesFactories = initFactories(CustomAttributeExpressionFactory.class);
+    }
+
+    private CustomImplementationsFinder() {
+    }
+
+    private static <T> List<T> initFactories(Class<T> type) {
+        ServiceLoader<T> loader = ServiceLoader.load(type);
+        loader.reload();
+        List<T> factories = new ArrayList<>();
+        for (T aLoader : loader) {
+            factories.add(aLoader);
+        }
+        return factories;
+    }
+
+    public static NestedAttributeMapping find(AppSchemaDataAccessConfigurator configuration,
+                                              Expression idExpression, Expression parentExpression,
+                                              XPathUtil.StepList targetXPath, boolean isMultiValued,
+                                              Map<Name, Expression> clientProperties, Expression sourceElement,
+                                              XPathUtil.StepList sourcePath, NamespaceSupport namespaces) {
+        for (CustomMappingFactory factory : mappingsFactories) {
+            NestedAttributeMapping mapping = factory.createNestedAttributeMapping(configuration, idExpression,
+                    parentExpression, targetXPath, isMultiValued, clientProperties,
+                    sourceElement, sourcePath, namespaces);
+            if (mapping != null) {
+                return mapping;
+            }
+        }
+        return null;
+    }
+
+    public static Expression find(FeatureTypeMapping mappings, XPathUtil.StepList xpath,
+                                  NestedAttributeMapping nestedMapping) {
+        for (CustomAttributeExpressionFactory factory : attributesFactories) {
+            Expression attributeExpression = factory.createNestedAttributeExpression(mappings, xpath, nestedMapping);
+            if (attributeExpression != null) {
+                return attributeExpression;
+            }
+        }
+        return null;
+    }
+}

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/spi/CustomMappingFactory.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/spi/CustomMappingFactory.java
@@ -1,0 +1,35 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.complex.spi;
+
+import org.geotools.data.complex.NestedAttributeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
+import org.geotools.data.complex.filter.XPathUtil;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.expression.Expression;
+import org.xml.sax.helpers.NamespaceSupport;
+
+import java.util.Map;
+
+public interface CustomMappingFactory {
+
+    NestedAttributeMapping createNestedAttributeMapping(AppSchemaDataAccessConfigurator configuration,
+                                                        Expression idExpression, Expression parentExpression,
+                                                        XPathUtil.StepList targetXPath, boolean isMultiValued,
+                                                        Map<Name, Expression> clientProperties, Expression sourceElement,
+                                                        XPathUtil.StepList sourcePath, NamespaceSupport namespaces);
+}

--- a/modules/unsupported/mongodb/pom.xml
+++ b/modules/unsupported/mongodb/pom.xml
@@ -125,6 +125,21 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.geotools.xsd</groupId>
+          <artifactId>gt-xsd-core</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.geotools.xsd</groupId>
+          <artifactId>gt-xsd-core</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.geotools</groupId>
+          <artifactId>gt-app-schema</artifactId>
+          <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
   <build>

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/AbstractCollectionMapper.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/AbstractCollectionMapper.java
@@ -32,6 +32,8 @@ import org.opengis.feature.type.AttributeDescriptor;
  */
 public abstract class AbstractCollectionMapper implements CollectionMapper {
 
+    public static final String MONGO_OBJECT_FEATURE_KEY = "MONGO_OBJECT_FEATURE";
+
     @Override
     public SimpleFeature buildFeature(DBObject rootDBO, SimpleFeatureType featureType) {
 
@@ -50,6 +52,9 @@ public abstract class AbstractCollectionMapper implements CollectionMapper {
                         .getBinding()));
             }
         }
-        return new MongoFeature(values.toArray(), featureType, rootDBO.get("_id").toString());
+        SimpleFeature feature = new MongoFeature(rootDBO, values.toArray(), featureType, rootDBO.get("_id").toString());
+        // we store a reference to the original feature in the user data
+        feature.getUserData().put(MONGO_OBJECT_FEATURE_KEY, feature);
+        return feature;
     }
 }

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
@@ -141,6 +141,14 @@ public class MongoDataStore extends ContentDataStore {
             } catch (IOException e) {
                 LOGGER.log(Level.SEVERE, "Unable to create mongodb-based schema store with URI \"" + schemaStoreURI + "\"", e);
             }
+        } else {
+            try {
+                return new MongoSchemaFileStore("file:" + schemaStoreURI);
+            } catch (URISyntaxException e) {
+                LOGGER.log(Level.SEVERE, "Unable to create file-based schema store with URI \"" + schemaStoreURI + "\"", e);
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Unable to create file-based schema store with URI \"" + schemaStoreURI + "\"", e);
+            }
         }
         LOGGER.log(Level.SEVERE, "Unsupported URI \"{0}\" for schema store", schemaStoreURI);
         return null;

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeature.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeature.java
@@ -17,14 +17,31 @@
  */
 package org.geotools.data.mongodb;
 
+import com.mongodb.DBObject;
 import org.geotools.feature.simple.SimpleFeatureImpl;
 import org.geotools.filter.identity.FeatureIdImpl;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 public class MongoFeature extends SimpleFeatureImpl {
 
+    private final DBObject mongoObject;
+    private final Object[] values;
+
     public MongoFeature(Object[] values, SimpleFeatureType featureType, String id) {
-        super(values, featureType, new FeatureIdImpl(id), false);
+        this(null, values, featureType, id);
     }
 
+    public MongoFeature(DBObject mongoObject, Object[] values, SimpleFeatureType featureType, String id) {
+        super(values, featureType, new FeatureIdImpl(id), false);
+        this.values = values;
+        this.mongoObject = mongoObject;
+    }
+
+    public DBObject getMongoObject() {
+        return mongoObject;
+    }
+
+    public Object[] getValues() {
+        return values;
+    }
 }

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoInferredMapper.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/MongoInferredMapper.java
@@ -23,13 +23,13 @@ import com.mongodb.DBObject;
 import com.vividsolutions.jts.geom.Geometry;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.geotools.data.mongodb.complex.MongoComplexUtilities;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.util.logging.Logging;
@@ -85,7 +85,8 @@ public class MongoInferredMapper extends AbstractCollectionMapper {
         
         Set<String> indexedGeometries = MongoUtil.findIndexedGeometries(collection);
         Set<String> indexedFields = MongoUtil.findIndexedFields(collection);
-        Map<String, Class<?>> mappedFields = MongoUtil.findMappableFields(collection);
+        //Map<String, Class<?>> mappedFields = MongoUtil.findMappableFields(collection);
+        Map<String, Class> mappedFields = MongoComplexUtilities.findMappings(collection.findOne());
         
         // don't need to worry about indexed properties we've found in our scan...
         indexedFields.removeAll(mappedFields.keySet());
@@ -128,7 +129,7 @@ public class MongoInferredMapper extends AbstractCollectionMapper {
         LOG.log(Level.INFO, "building type {0}: mapping geometry field {1} from collection {2}",
                     new Object[] {name, geometryField, collection.getFullName() });
         
-        for (Map.Entry<String, Class<?>> mappedField : mappedFields.entrySet()) {
+        for (Map.Entry<String, Class> mappedField : mappedFields.entrySet()) {
             String field = mappedField.getKey();
             Class<?> binding = mappedField.getValue();
             ftBuilder.userData(MongoDataStore.KEY_mapping, field);

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/CollectionIdFunction.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/CollectionIdFunction.java
@@ -1,0 +1,42 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+
+import java.util.UUID;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+/**
+ * Function that returns a random ID for a collection.
+ */
+public final class CollectionIdFunction extends FunctionExpressionImpl {
+
+    private static final FunctionName DEFINITION = new FunctionNameImpl(
+            "collectionId", parameter("value", Object.class), parameter("path", String.class));
+
+    public CollectionIdFunction() {
+        super(DEFINITION);
+    }
+
+    public Object evaluate(Object object) {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/CollectionLinkFunction.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/CollectionLinkFunction.java
@@ -1,0 +1,57 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+/**
+ * Function used to chain an entity with a sub collection.
+ */
+public final class CollectionLinkFunction extends FunctionExpressionImpl {
+
+    private static final FunctionName DEFINITION = new FunctionNameImpl(
+            "collectionLink", parameter("value", String.class), parameter("path", String.class));
+
+    public CollectionLinkFunction() {
+        super(DEFINITION);
+    }
+
+    public Object evaluate(Object object) {
+        String path = (String) this.params.get(0).evaluate(object);
+        return new LinkCollection(path);
+    }
+
+    /**
+     * Contains information about a linked collection.
+     */
+    static final class LinkCollection {
+
+        private final String collectionPath;
+
+        LinkCollection(String collectionPath) {
+            this.collectionPath = collectionPath;
+        }
+
+        String getCollectionPath() {
+            return collectionPath;
+        }
+    }
+}

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/JsonSelectAllFunction.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/JsonSelectAllFunction.java
@@ -1,0 +1,50 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import org.geotools.feature.NameImpl;
+import org.geotools.filter.AttributeExpressionImpl;
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+/**
+ * Extracts all the values of a given JSON path.
+ */
+public class JsonSelectAllFunction extends FunctionExpressionImpl {
+
+    public static FunctionName DEFINITION = new FunctionNameImpl(
+            "jsonSelectAll", parameter("path", String.class));
+
+    public JsonSelectAllFunction() {
+        super(DEFINITION);
+    }
+
+    public Object evaluate(Object object) {
+        String path = (String) this.params.get(0).evaluate(object);
+        if (object == null) {
+            return new AttributeExpressionImpl(new NameImpl(path));
+        }
+        return MongoComplexUtilities.getValues(object, path);
+    }
+
+    public String getJsonPath() {
+        return (String) this.params.get(0).evaluate(null);
+    }
+}

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/JsonSelectFunction.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/JsonSelectFunction.java
@@ -1,0 +1,50 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import org.geotools.feature.NameImpl;
+import org.geotools.filter.AttributeExpressionImpl;
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+/**
+ * Function that selects a JSON object using a JSON path.
+ */
+public final class JsonSelectFunction extends FunctionExpressionImpl {
+
+    private static final FunctionName DEFINITION = new FunctionNameImpl(
+            "jsonSelect", parameter("path", String.class));
+
+    public JsonSelectFunction() {
+        super(DEFINITION);
+    }
+
+    public Object evaluate(Object object) {
+        String path = (String) this.params.get(0).evaluate(object);
+        if (object == null) {
+            return new AttributeExpressionImpl(new NameImpl(path));
+        }
+        return MongoComplexUtilities.getValue(object, path);
+    }
+
+    public String getJsonPath() {
+        return (String) this.params.get(0).evaluate(null);
+    }
+}

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoCollectionFeature.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoCollectionFeature.java
@@ -1,0 +1,64 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import org.geotools.data.mongodb.MongoFeature;
+import org.geotools.feature.simple.SimpleFeatureImpl;
+import org.geotools.filter.identity.FeatureIdImpl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Contains information about a chained collection.
+ */
+final class MongoCollectionFeature extends SimpleFeatureImpl {
+
+    private final MongoFeature mongoFeature;
+
+    private final Map<String, Integer> collectionsIndexes = new HashMap<>();
+
+    static MongoCollectionFeature build(Object feature, String collectionPath, int collectionIndex) {
+        feature = MongoComplexUtilities.extractFeature(feature, collectionPath);
+        if (feature instanceof MongoFeature) {
+            return new MongoCollectionFeature((MongoFeature) feature, collectionPath, collectionIndex);
+        } else if (feature instanceof MongoCollectionFeature) {
+            return new MongoCollectionFeature((MongoCollectionFeature) feature, collectionPath, collectionIndex);
+        }
+        throw new RuntimeException("The feature must be a mongo feature.");
+    }
+
+    private MongoCollectionFeature(MongoCollectionFeature collectionFeature, String collectionPath, int collectionIndex) {
+        this(collectionFeature.getMongoFeature(), collectionPath, collectionIndex);
+        this.collectionsIndexes.putAll(collectionFeature.getCollectionsIndexes());
+    }
+
+    private MongoCollectionFeature(MongoFeature feature, String collectionPath, int collectionIndex) {
+        super(feature.getValues(), feature.getFeatureType(), new FeatureIdImpl(UUID.randomUUID().toString()), false);
+        this.mongoFeature = feature;
+        this.collectionsIndexes.put(collectionPath, collectionIndex);
+    }
+
+    MongoFeature getMongoFeature() {
+        return mongoFeature;
+    }
+
+    Map<String, Integer> getCollectionsIndexes() {
+        return collectionsIndexes;
+    }
+}

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexUtilities.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexUtilities.java
@@ -1,0 +1,330 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.DBObject;
+import org.geotools.data.mongodb.AbstractCollectionMapper;
+import org.geotools.data.mongodb.MongoFeature;
+import org.geotools.data.mongodb.MongoGeometryBuilder;
+import org.opengis.feature.Feature;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class contains utilities methods for dealing with MongoDB complex features.
+ */
+public final class MongoComplexUtilities {
+
+    private MongoComplexUtilities() {
+    }
+
+    /**
+     * Will try to extract from the provided object the value that correspond to the given json path.
+     */
+    public static Object getValue(Object object, String jsonPath) {
+        // let's make sure we have a feature
+        Feature feature = extractFeature(object, jsonPath);
+        if (feature instanceof MongoFeature) {
+            // no a nested element mongo feature
+            MongoFeature mongoFeature = (MongoFeature) feature;
+            return getValue(mongoFeature.getMongoObject(), jsonPath);
+        }
+        if (feature instanceof MongoCollectionFeature) {
+            // a mongo feature in the context of a nested element
+            MongoCollectionFeature collectionFeature = (MongoCollectionFeature) object;
+            return getValue(collectionFeature.getMongoFeature().getMongoObject(), collectionFeature.getCollectionsIndexes(), jsonPath);
+        }
+        // could not find a mongo feature, we can do nothing
+        throw invalidFeature(feature, jsonPath);
+    }
+
+    /**
+     * Method for extracting or casting a feature from the provided object.
+     */
+    public static Feature extractFeature(Object feature, String jsonPath) {
+        // we should have a feature
+        if (!(feature instanceof Feature)) {
+            // not a feature so nothing to do
+            throw invalidFeature(feature, jsonPath);
+        }
+        // let's see if we have the a mongo feature in the user data
+        Object mongoFeature = ((Feature) feature).getUserData().get(AbstractCollectionMapper.MONGO_OBJECT_FEATURE_KEY);
+        // if we could not find a mongo feature in the user data we stick we the original feature
+        return mongoFeature == null ? (Feature) feature : (Feature) mongoFeature;
+    }
+
+    /**
+     * Helper method that creates an exception for when the provided object is not of the correct type.
+     */
+    private static RuntimeException invalidFeature(Object feature, String jsonPath) {
+        return new RuntimeException(String.format(
+                "No possible to obtain a mongo object from '%s' to extract '%s'.",
+                feature.getClass(), jsonPath));
+    }
+
+    /**
+     * Will extract from the mongo db object the value that correspond to the given json path.
+     * If the path contain a nested list of values an exception will be throw.
+     */
+    public static Object getValue(DBObject mongoObject, String jsonPath) {
+        return getValue(mongoObject, Collections.emptyMap(), jsonPath);
+    }
+
+    /**
+     * Will extract from the mongo db object the value that correspond to the given json path.
+     * The provided collections indexes will be used to select the proper element for the
+     * collections present in the path.
+     */
+    public static Object getValue(DBObject mongoObject, Map<String, Integer> collectionsIndexes, String jsonPath) {
+        MongoObjectWalker walker = new MongoObjectWalker(mongoObject, collectionsIndexes, jsonPath);
+        // try to convert the founded value to a geometry
+        return convertGeometry(walker.getValue());
+    }
+
+    /**
+     * Helper method that checks if a mongodb value is a geometry and perform the proper conversion.
+     */
+    private static Object convertGeometry(Object value) {
+        if (!(value instanceof DBObject) || value instanceof List) {
+            // not a mongodb object or a list of values so nothing to do
+            return value;
+        }
+        DBObject object = (DBObject) value;
+        Set keys = object.keySet();
+        if (keys.size() != 2 || !keys.contains("coordinates") || !keys.contains("type")) {
+            // is mongo db object but not a geometry
+            return value;
+        }
+        // we have a geometry so let's try to convert it
+        MongoGeometryBuilder builder = new MongoGeometryBuilder();
+        try {
+            // return the converted geometry
+            return builder.toGeometry(object);
+        } catch (Exception exception) {
+            // well could not convert the mongo db object to a geometry
+        }
+        return value;
+    }
+
+    /**
+     * Utility class class to extract information from a MongoDB object giving a certain path.
+     */
+    private static final class MongoObjectWalker {
+
+        private final Map<String, Integer> collectionsIndexes;
+        private final String[] jsonPathParts;
+
+        private String currentJsonPath;
+        private int currentJsonPathPartIndex;
+        private Object currentObject;
+
+        MongoObjectWalker(DBObject mongoObject, Map<String, Integer> collectionsIndexes, String jsonPath) {
+            this.collectionsIndexes = collectionsIndexes;
+            this.jsonPathParts = jsonPath.split("\\.");
+            this.currentJsonPath = "";
+            this.currentJsonPathPartIndex = 0;
+            this.currentObject = mongoObject;
+        }
+
+        Object getValue() {
+            while (hasNext() && currentObject != null) {
+                next();
+            }
+            // end of the walked path or NULL value found
+            return currentObject;
+        }
+
+        private boolean hasNext() {
+            // we have a next element if we still have paths parts or we are currently
+            // walking a collection and there is a index defined for this collection
+            return currentJsonPathPartIndex < jsonPathParts.length
+                    || (currentObject instanceof BasicDBList && collectionsIndexes.get(currentJsonPath) != null);
+        }
+
+        private void next() {
+            // let's walk to the next path part using the current object
+            if (currentObject instanceof List) {
+                // the current object is a list, we need to select the current index
+                currentObject = next((List) currentObject);
+            } else if (currentObject instanceof DBObject) {
+                currentObject = next((DBObject) currentObject);
+            } else {
+                throw new RuntimeException(String.format(
+                        "Trying to get data from a non MongoDB object, current json path is '%s'.", currentJsonPath));
+            }
+        }
+
+        private Object next(DBObject dbObject) {
+            // we have a mongo db object, let's update the current json path
+            currentJsonPath = concatPath(currentJsonPath, jsonPathParts[currentJsonPathPartIndex]);
+            // get the value from the mongo db object that correspond to the current json path part
+            Object result = dbObject.get(jsonPathParts[currentJsonPathPartIndex]);
+            currentJsonPathPartIndex++;
+            return result;
+        }
+
+        private Object next(List basicDBList) {
+            // let's find current index for this collection
+            Integer rawCollectionIndex = collectionsIndexes.get(currentJsonPath);
+            if (rawCollectionIndex == null && basicDBList.size() == 1) {
+                // this collection only has a single element and there is not index information for this collection
+                return basicDBList.get(0);
+            }
+            if (rawCollectionIndex == null) {
+                throw new RuntimeException(String.format(
+                        "There is no index available for collection '%s'.", currentJsonPath));
+            }
+            // just return the list element that matches the current index
+            return basicDBList.get(rawCollectionIndex);
+        }
+    }
+
+    /**
+     * Will try to extract from the provided object all the values that correspond to the given json path.
+     */
+    public static Object getValues(Object object, String jsonPath) {
+        // let's make sure we have a feature
+        Feature feature = extractFeature(object, jsonPath);
+        if (feature instanceof MongoFeature) {
+            // no a nested element mongo feature
+            MongoFeature mongoFeature = (MongoFeature) feature;
+            return getValues(mongoFeature.getMongoObject(), jsonPath);
+        }
+        if (feature instanceof MongoCollectionFeature) {
+            // a mongo feature in the context of a nested element
+            MongoCollectionFeature collectionFeature = (MongoCollectionFeature) object;
+            return getValues(collectionFeature.getMongoFeature().getMongoObject(), jsonPath);
+        }
+        // could not find a mongo feature, we can do nothing
+        throw invalidFeature(feature, jsonPath);
+    }
+
+    /**
+     * Will extract from the mongo db object all the values that correspond to the given json path.
+     * If the path contains nested collections the values from all the branches will be merged.
+     */
+    public static Object getValues(DBObject dbObject, String jsonPath) {
+        if (jsonPath == null || jsonPath.isEmpty() || dbObject == null) {
+            // nothing to do here
+            return Collections.emptyList();
+        }
+        // let's split the json path in parts which will give us the necessary keys
+        String[] jsonPathParts = jsonPath.split("\\.");
+        // recursively get the values using an helper function
+        List<Object> values = getValuesHelper(dbObject, jsonPathParts, new ArrayList<>(), 0);
+        if (values.size() == 1) {
+            // we only have a single value, let's extract it
+            return values.get(0);
+        }
+        return values;
+    }
+
+    /**
+     * Helper function that will walk a mongo db object and retrieve all the values for a certain path.
+     */
+    private static List<Object> getValuesHelper(DBObject dbObject, String[] jsonPathParts, List<Object> values, int index) {
+        // get the object corresponding to the current index
+        Object object = dbObject.get(jsonPathParts[index]);
+        if (object == null) {
+            // we are done
+            return values;
+        }
+        // check if we reach the end of the json path
+        boolean finalPath = index == jsonPathParts.length - 1;
+        index++;
+        if (object instanceof List) {
+            if (finalPath) {
+                // we reached the end of the json path and we have a list, so let's add all the elements of the list
+                for (Object value : (List) object) {
+                    values.add(convertGeometry(value));
+                }
+            } else {
+                // well we have a list so we need to interact over each element of the list
+                for (Object element : (List) object) {
+                    getValuesHelper((DBObject) element, jsonPathParts, values, index);
+                }
+            }
+        } else {
+            if (finalPath) {
+                // we reached the end of the json path so let's add this object
+                values.add(convertGeometry(object));
+            } else {
+                // we need to go deeper in this object
+                getValuesHelper((DBObject) object, jsonPathParts, values, index);
+            }
+        }
+        // we return the list of founded values for commodity
+        return values;
+    }
+
+    /**
+     * Simple method that adds an element ot a json path.
+     */
+    private static String concatPath(String parentPath, String path) {
+        if (parentPath == null || parentPath.isEmpty()) {
+            // first element of the path
+            return path;
+        }
+        return parentPath + "." + path;
+    }
+
+    /**
+     * Compute the mappings for a mongo db object, this can be used to create a feature mapping.
+     */
+    public static Map<String, Class> findMappings(DBObject dbObject) {
+        Map<String, Class> mappings = new HashMap<>();
+        findMappingsHelper(dbObject, "", mappings);
+        return mappings;
+    }
+
+    /**
+     * Helper method that will recursively walk a mongo db object and compute is mappings.
+     */
+    private static void findMappingsHelper(Object object, String parentPath, Map<String, Class> mappings) {
+        if (object == null) {
+            return;
+        }
+        if (object instanceof DBObject) {
+            DBObject dbObject = (DBObject) object;
+            for (String key : dbObject.keySet()) {
+                Object value = dbObject.get(key);
+                if (value == null) {
+                    continue;
+                }
+                String path = concatPath(parentPath, key);
+                if (value instanceof List) {
+                    List list = (List) value;
+                    if (!list.isEmpty()) {
+                        findMappingsHelper(list.get(0), path, mappings);
+                    }
+                } else if (value instanceof DBObject) {
+                    findMappingsHelper(value, path, mappings);
+                } else {
+                    mappings.put(path, value.getClass());
+                }
+            }
+        } else {
+            mappings.put(parentPath, object.getClass());
+        }
+    }
+}

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoNestedAttributeExpressionFactory.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoNestedAttributeExpressionFactory.java
@@ -1,0 +1,114 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import org.geotools.data.complex.AttributeMapping;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.NestedAttributeMapping;
+import org.geotools.data.complex.filter.XPathUtil;
+import org.geotools.data.complex.spi.CustomAttributeExpressionFactory;
+import org.opengis.filter.expression.Expression;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Custom nested attribute expressions builder for MongoDB.
+ */
+public class MongoNestedAttributeExpressionFactory implements CustomAttributeExpressionFactory {
+
+
+    @Override
+    public Expression createNestedAttributeExpression(FeatureTypeMapping mappings, XPathUtil.StepList xpath,
+                                                      NestedAttributeMapping nestedMapping) {
+        return getSourceExpression(mappings, xpath, nestedMapping);
+    }
+
+    private Expression getSourceExpression(FeatureTypeMapping mappings, XPathUtil.StepList xpath,
+                                           NestedAttributeMapping nestedMapping) {
+        if (!nestedMapping.getTargetXPath().equalsIgnoreIndex(xpath.subList(0, nestedMapping.getTargetXPath().size()))) {
+            return Expression.NIL;
+        }
+        int steps = xpath.size();
+        XPathUtil.StepList finalXpath = xpath.subList(nestedMapping.getTargetXPath().size(), steps);
+        AttributeMapping attributeMapping = nestedMapping;
+        int end = finalXpath.size();
+        int start = 0;
+        while (end > start) {
+            try {
+                SearchResult result = search(finalXpath.subList(start, end), attributeMapping);
+                if (!result.found) {
+                    break;
+                }
+                attributeMapping = result.attributeMapping;
+                start += result.index;
+            } catch (Exception exception) {
+                throw new RuntimeException("Error getting feature type mapping.");
+            }
+        }
+        if (attributeMapping == null) {
+            return Expression.NIL;
+        }
+        Expression sourceExpression = attributeMapping.getSourceExpression();
+        if (sourceExpression instanceof JsonSelectFunction) {
+            List<Expression> parameters = new ArrayList<>();
+            JsonSelectAllFunction jsonSelect = new JsonSelectAllFunction();
+            jsonSelect.setParameters(((JsonSelectFunction) sourceExpression).getParameters());
+            return jsonSelect;
+        }
+        return sourceExpression;
+    }
+
+    private static final class SearchResult {
+
+        static final SearchResult NOT_FOUND = new SearchResult(false, -1, null);
+
+        final boolean found;
+        final int index;
+        final AttributeMapping attributeMapping;
+
+        SearchResult(boolean found, int index, AttributeMapping attributeMapping) {
+            this.found = found;
+            this.index = index;
+            this.attributeMapping = attributeMapping;
+        }
+    }
+
+    private SearchResult search(XPathUtil.StepList xpath, AttributeMapping attributeMapping) throws Exception {
+        for (int i = xpath.size(); i > 0; i--) {
+            AttributeMapping foundAttributeMapping = match(attributeMapping, xpath.subList(0, i));
+            if (foundAttributeMapping != null) {
+                return new SearchResult(true, i, foundAttributeMapping);
+            }
+        }
+        return SearchResult.NOT_FOUND;
+    }
+
+    private AttributeMapping match(AttributeMapping attributeMapping, XPathUtil.StepList xpath) throws IOException {
+        if (attributeMapping instanceof NestedAttributeMapping) {
+            FeatureTypeMapping mappings = ((NestedAttributeMapping) attributeMapping).getFeatureTypeMapping(null);
+            List<AttributeMapping> attributesMappings = mappings.getAttributeMappings();
+            for (AttributeMapping candidateAttributeMapping : attributesMappings) {
+                if (xpath.equalsIgnoreIndex(candidateAttributeMapping.getTargetXPath())) {
+                    return candidateAttributeMapping;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoNestedMapping.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoNestedMapping.java
@@ -1,0 +1,211 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import com.mongodb.DBObject;
+import org.geotools.data.DataAccess;
+import org.geotools.data.FeatureListener;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.Query;
+import org.geotools.data.QueryCapabilities;
+import org.geotools.data.ResourceInfo;
+import org.geotools.data.complex.AppSchemaDataAccess;
+import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.MappingFeatureCollection;
+import org.geotools.data.complex.MappingFeatureSource;
+import org.geotools.data.complex.NestedAttributeMapping;
+import org.geotools.data.complex.filter.XPathUtil;
+import org.geotools.data.memory.MemoryFeatureCollection;
+import org.geotools.data.mongodb.MongoFeature;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.feature.Feature;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.Filter;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.PropertyName;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.xml.sax.helpers.NamespaceSupport;
+
+import java.awt.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * MongoDB custom nested attribute mapping for app-schema.
+ */
+public class MongoNestedMapping extends NestedAttributeMapping {
+
+    public MongoNestedMapping(Expression idExpression, Expression parentExpression,
+                              XPathUtil.StepList targetXPath, boolean isMultiValued,
+                              Map<Name, Expression> clientProperties, Expression sourceElement,
+                              XPathUtil.StepList sourcePath, NamespaceSupport namespaces) throws IOException {
+        super(idExpression, parentExpression, targetXPath, isMultiValued, clientProperties, sourceElement, sourcePath, namespaces);
+    }
+
+    @Override
+    public List<Feature> getFeatures(Object source, Object foreignKeyValue, List<Object> idValues, CoordinateReferenceSystem reprojection,
+                                     Object feature, List<PropertyName> selectedProperties, boolean includeMandatory, int resolveDepth,
+                                     Integer resolveTimeOut) throws IOException {
+        if (!(foreignKeyValue instanceof CollectionLinkFunction.LinkCollection)) {
+            throw new RuntimeException("MongoDB nesting only supports foreign keys of 'CollectionLink' type.");
+        }
+        CollectionLinkFunction.LinkCollection linkCollection = (CollectionLinkFunction.LinkCollection) foreignKeyValue;
+        List collection = getSubCollection(feature, linkCollection.getCollectionPath());
+        if (collection == null) {
+            return Collections.emptyList();
+        }
+        List<SimpleFeature> features = new ArrayList<>();
+        for (int i = 0; i < collection.size(); i++) {
+            features.add(MongoCollectionFeature.build(feature, linkCollection.getCollectionPath(), i));
+        }
+        FeatureSource fSource = buildMappingFeatureSource(feature, features);
+        ArrayList<Feature> matchingFeatures = new ArrayList<Feature>();
+        // get all the mapped nested features based on the link values
+        FeatureCollection<FeatureType, Feature> fCollection = fSource.getFeatures(Query.ALL);
+        if (fCollection instanceof MappingFeatureCollection) {
+            FeatureIterator<Feature> iterator = fCollection.features();
+            while (iterator.hasNext()) {
+                matchingFeatures.add(iterator.next());
+            }
+            iterator.close();
+        }
+        return matchingFeatures;
+    }
+
+    private MappingFeatureSource buildMappingFeatureSource(Object feature, List<SimpleFeature> features) throws IOException {
+        MappingFeatureSource originalFeatureSource = (MappingFeatureSource) getMappingSource(feature);
+        FeatureTypeMapping mapping = originalFeatureSource.getMapping();
+        AppSchemaDataAccess dataAccess = (AppSchemaDataAccess) originalFeatureSource.getDataStore();
+        MemoryFeatureCollection collection = new MemoryFeatureCollection(null);
+        collection.addAll(features);
+        MongoStaticFeatureSource staticSource = new MongoStaticFeatureSource(collection, mapping.getSource());
+        FeatureTypeMapping staticMapping = new FeatureTypeMapping(staticSource, mapping.getTargetFeature(),
+                mapping.getAttributeMappings(), mapping.getNamespaces(), mapping.isDenormalised());
+        return new MappingFeatureSource(dataAccess, staticMapping);
+    }
+
+    private List getSubCollection(Object feature, String collectionPath) {
+        feature = MongoComplexUtilities.extractFeature(feature, collectionPath);
+        if (feature instanceof MongoFeature) {
+            DBObject mongoObject = ((MongoFeature) feature).getMongoObject();
+            return getSubCollection(mongoObject, collectionPath, Collections.emptyMap());
+        } else if (feature instanceof MongoCollectionFeature) {
+            MongoCollectionFeature collectionFeature = (MongoCollectionFeature) feature;
+            return getSubCollection(collectionFeature.getMongoFeature().getMongoObject(),
+                    collectionPath, collectionFeature.getCollectionsIndexes());
+        }
+        throw new RuntimeException("MongoDB nesting only works with MongoDB features.");
+    }
+
+    private List getSubCollection(DBObject mongoObject, String collectionPath, Map<String, Integer> collectionsIndexes) {
+        Object value = MongoComplexUtilities.getValue(mongoObject, collectionsIndexes, collectionPath);
+        if (value == null) {
+            return Collections.emptyList();
+        }
+        if (value instanceof List) {
+            return (List) value;
+        }
+        throw new RuntimeException("Could not extract collection from path.");
+    }
+
+    private static final class MongoStaticFeatureSource implements FeatureSource {
+
+        private final FeatureCollection features;
+        private final FeatureSource originalFeatureSource;
+
+        public MongoStaticFeatureSource(FeatureCollection features, FeatureSource originalFeatureSource) {
+            this.features = features;
+            this.originalFeatureSource = originalFeatureSource;
+        }
+
+        @Override
+        public Name getName() {
+            return originalFeatureSource.getName();
+        }
+
+        @Override
+        public ResourceInfo getInfo() {
+            return originalFeatureSource.getInfo();
+        }
+
+        @Override
+        public DataAccess getDataStore() {
+            return originalFeatureSource.getDataStore();
+        }
+
+        @Override
+        public QueryCapabilities getQueryCapabilities() {
+            return originalFeatureSource.getQueryCapabilities();
+        }
+
+        @Override
+        public void addFeatureListener(FeatureListener listener) {
+        }
+
+        @Override
+        public void removeFeatureListener(FeatureListener listener) {
+        }
+
+        @Override
+        public FeatureCollection getFeatures(Filter filter) throws IOException {
+            return features;
+        }
+
+        @Override
+        public FeatureCollection getFeatures(Query query) throws IOException {
+            return features;
+        }
+
+        @Override
+        public FeatureCollection getFeatures() throws IOException {
+            return features;
+        }
+
+        @Override
+        public FeatureType getSchema() {
+            return originalFeatureSource.getSchema();
+        }
+
+        @Override
+        public ReferencedEnvelope getBounds() throws IOException {
+            return features.getBounds();
+        }
+
+        @Override
+        public ReferencedEnvelope getBounds(Query query) throws IOException {
+            return features.getBounds();
+        }
+
+        @Override
+        public int getCount(Query query) throws IOException {
+            return features.size();
+        }
+
+        @Override
+        public Set<RenderingHints.Key> getSupportedHints() {
+            return originalFeatureSource.getSupportedHints();
+        }
+    }
+}

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoNestedMappingFactory.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoNestedMappingFactory.java
@@ -1,0 +1,50 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb.complex;
+
+import org.geotools.data.complex.NestedAttributeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
+import org.geotools.data.complex.filter.XPathUtil;
+import org.geotools.data.complex.spi.CustomMappingFactory;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.expression.Expression;
+import org.xml.sax.helpers.NamespaceSupport;
+
+import java.util.Map;
+
+/**
+ * Custom nested attributes mappings builder for MongoDB.
+ */
+public class MongoNestedMappingFactory implements CustomMappingFactory {
+
+    @Override
+    public NestedAttributeMapping createNestedAttributeMapping(AppSchemaDataAccessConfigurator configuration, Expression idExpression,
+                                                               Expression parentExpression, XPathUtil.StepList targetXPath, boolean isMultiValued,
+                                                               Map<Name, Expression> clientProperties, Expression sourceElement,
+                                                               XPathUtil.StepList sourcePath, NamespaceSupport namespaces) {
+        try {
+            if (parentExpression instanceof CollectionLinkFunction) {
+                return new MongoNestedMapping(idExpression, parentExpression, targetXPath,
+                        isMultiValued, clientProperties, sourceElement, sourcePath, namespaces);
+            }
+            // not a MongoDB mapping
+            return null;
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.geotools.data.complex.spi.CustomAttributeExpressionFactory
+++ b/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.geotools.data.complex.spi.CustomAttributeExpressionFactory
@@ -1,0 +1,1 @@
+org.geotools.data.mongodb.complex.MongoNestedAttributeExpressionFactory

--- a/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.geotools.data.complex.spi.CustomMappingFactory
+++ b/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.geotools.data.complex.spi.CustomMappingFactory
@@ -1,0 +1,1 @@
+org.geotools.data.mongodb.complex.MongoNestedMappingFactory

--- a/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.geotools.filter.FunctionExpression
+++ b/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.geotools.filter.FunctionExpression
@@ -1,0 +1,4 @@
+org.geotools.data.mongodb.complex.JsonSelectFunction
+org.geotools.data.mongodb.complex.CollectionIdFunction
+org.geotools.data.mongodb.complex.CollectionLinkFunction
+org.geotools.data.mongodb.complex.JsonSelectAllFunction

--- a/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -1,0 +1,4 @@
+org.geotools.data.mongodb.complex.JsonSelectFunction
+org.geotools.data.mongodb.complex.CollectionIdFunction
+org.geotools.data.mongodb.complex.CollectionLinkFunction
+org.geotools.data.mongodb.complex.JsonSelectAllFunction


### PR DESCRIPTION
This pull requests makes MongoDB usable with App-Schema. 

Two extensions points were created in App-Schema to allow extensions to contribute custom mappings for nested attributes. MongoDB data store was extended to be able to work in a complex mode.

Detailed documentation and online tests (integrations tests) are added by this pull request:
https://github.com/geoserver/geoserver/pull/2205

Associated issue: https://osgeo-org.atlassian.net/browse/GEOT-5690