### PR TITLE
RangeLookupProcess: assigned no data property to same as coverage input

### DIFF
--- a/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/RangeLookupProcess.java
+++ b/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/RangeLookupProcess.java
@@ -154,13 +154,17 @@ public class RangeLookupProcess implements RasterProcess {
         // build the output coverage
         //
         
+        double outputNd = DEFAULT_NODATA;
+        if (noDataProperty != null) {
+            outputNd = noDataProperty.getAsSingleValue();
+        }
         
         // build the output sample dimensions, use the default value ( 0 ) as the no data
         final GridSampleDimension outSampleDimension = new GridSampleDimension("classification",
                 new Category[] { Category.NODATA }, null);
         final GridCoverageFactory factory = CoverageFactoryFinder.getGridCoverageFactory(GeoTools.getDefaultHints());
         HashMap<String,Object> properties = new HashMap<String,Object>(){{
-        	put(NoDataContainer.GC_NODATA,new NoDataContainer(0d));
+        	put(NoDataContainer.GC_NODATA,new NoDataContainer(outputNd));
         }};
         org.geotools.resources.coverage.CoverageUtilities.setROIProperty(properties, worker.getROI());
         final GridCoverage2D output = factory.create("reclassified", indexedClassification, coverage


### PR DESCRIPTION
RangeLookupProcess assign 0 by default to no data property at coverage.
This patch assign no data property value same as the original coverage if exists, otherwise 0.