### PR TITLE
[GEOT-5712] Add a vendor option to enable kerning in text symbolizer (and have it on by default)

### DIFF
--- a/docs/user/extension/ysld.rst
+++ b/docs/user/extension/ysld.rst
@@ -570,6 +570,9 @@ The majority of hints focus on controlling text:
       
       # The minimum distance between two labels, in pixels
       x-spaceAround: 50
+      
+      # When true enables text kerning (adjustment of space between characters to get a more compact and readable layout)
+      x-kerning: true
 
 Additional hints for working with graphic fills:
 

--- a/docs/user/library/render/style.rst
+++ b/docs/user/library/render/style.rst
@@ -550,6 +550,8 @@ Considerable vendor options are provided for working with TextSymbolizers:
 
 * underlineText(true): When true instructs the renderer to underline labels
 
+* kerning(true): When true enables text kerning (adjustment of space between characters to get a more compact and readable layout) 
+
 Raster Symbolizer
 '''''''''''''''''
 

--- a/modules/library/api/src/main/java/org/geotools/styling/TextSymbolizer.java
+++ b/modules/library/api/src/main/java/org/geotools/styling/TextSymbolizer.java
@@ -310,6 +310,16 @@ public interface TextSymbolizer extends org.opengis.style.TextSymbolizer,Symboli
     boolean DEFAULT_PARTIALS = false;
     
     /**
+     * Option to enable automatic adjustment of the space between characters
+     */
+    String KERNING = "kerning";
+
+    /**
+     * Default behaviour is to perform kerning
+     */
+    boolean DEFAULT_KERNING = true;
+    
+    /**
      * Returns the expression that will be evaluated to determine what text is
      * displayed.
      *

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelSplitter.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelSplitter.java
@@ -251,7 +251,7 @@ class LabelSplitter {
                         Font.LAYOUT_RIGHT_TO_LEFT);
             }
         }
-        return font.createGlyphVector(graphics.getFontRenderContext(), chars);
+        return font.layoutGlyphVector(graphics.getFontRenderContext(), chars, 0, chars.length, 0);
     }
 
     List<FontRange> buildFontRanges(String text, Font[] fonts) {

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/PartialsTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/PartialsTest.java
@@ -199,8 +199,7 @@ public class PartialsTest extends TestCase {
 
         final BufferedImage image = RendererBaseTest.renderImage(renderer, bounds, null);
         // RenderedImageBrowser.showChain(image);
-        RendererBaseTest.assertPixel(image, 150, 2, Color.BLACK, 30);
-
+        RendererBaseTest.assertPixel(image, 150, 1, Color.BLACK, 30);
     }
 
     public void testPartialAreaLabelNo() throws Exception {

--- a/modules/library/render/src/test/java/org/geotools/renderer/style/SLDStyleFactoryTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/style/SLDStyleFactoryTest.java
@@ -17,11 +17,13 @@
 package org.geotools.renderer.style;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
 
 import java.awt.Color;
 import java.awt.Shape;
 import java.awt.Stroke;
 import java.awt.TexturePaint;
+import java.awt.font.TextAttribute;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.PathIterator;
@@ -413,6 +415,33 @@ public class SLDStyleFactoryTest extends TestCase {
         options.put(FeatureTypeStyle.SORT_BY, sortBySpec);
         SortBy[] sortBy = SLDStyleFactory.getSortBy(options);
         assertArrayEquals(expected, sortBy);
+    }
+    
+    public void testKerningOnByDefault() throws Exception {
+        TextSymbolizer ts = sf.createTextSymbolizer();
+        ts.setFill(sf.createFill(null));
+        Font font = sf.createFont(ff.literal("Serif"), ff.literal("italic"), ff.literal("bold"), ff.literal(20));
+        ts.setFont(font);
+        
+        TextStyle2D tsd = (TextStyle2D) sld.createTextStyle(feature, ts, range);
+        assertEquals(20, tsd.getFont().getSize());
+        Map<TextAttribute, ?> attributes = tsd.getFont().getAttributes();
+        Object kerningValue = attributes.get(TextAttribute.KERNING);
+        assertEquals(TextAttribute.KERNING_ON, kerningValue);
+    }
+    
+    public void testKerningOffByDefault() throws Exception {
+        TextSymbolizer ts = sf.createTextSymbolizer();
+        ts.setFill(sf.createFill(null));
+        Font font = sf.createFont(ff.literal("Serif"), ff.literal("italic"), ff.literal("bold"), ff.literal(20));
+        ts.setFont(font);
+        ts.getOptions().put(TextSymbolizer.KERNING, "false");
+        
+        TextStyle2D tsd = (TextStyle2D) sld.createTextStyle(feature, ts, range);
+        assertEquals(20, tsd.getFont().getSize());
+        Map<TextAttribute, ?> attributes = tsd.getFont().getAttributes();
+        Object kerningValue = attributes.get(TextAttribute.KERNING);
+        assertNull(kerningValue);
     }
 
 }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
@@ -217,6 +217,7 @@ public class CssTranslator {
             put("-gt-label-force-ltr", "forceLeftToRight");
             put("-gt-label-conflict-resolution", "conflictResolution");
             put("-gt-label-fit-goodness", "goodnessOfFit");
+            put("-gt-label-kerning", "kerning");
             put("-gt-shield-resize", "graphic-resize");
             put("-gt-shield-margin", "graphic-margin");
         }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5712

Mailing list discussion: http://osgeo-org.1560.x6.nabble.com/Adding-a-kerning-vendor-option-and-enable-it-by-default-td5314295.html