### PR TITLE
[GEOT-5709] Support coverage property SourceUrl

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/GridCoverage2DReader.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/GridCoverage2DReader.java
@@ -21,6 +21,7 @@ import it.geosolutions.imageio.maskband.DatasetLayout;
 import java.awt.image.ColorModel;
 import java.awt.image.SampleModel;
 import java.io.IOException;
+import java.net.URL;
 import java.util.List;
 import java.util.Set;
 
@@ -113,7 +114,12 @@ public interface GridCoverage2DReader extends GridCoverageReader {
      */
     public static final String FILE_SOURCE_PROPERTY = "OriginalFileSource";
 
-    
+    /**
+     * Name of a {@link GridCoverage2D} property that is a {@link URL} for the original source of the coverage. This {@link URL} might be used to
+     * obtain further information on the coverage that is not otherwise available through the {@link GridCoverage2D} API.
+     */
+    public static String SOURCE_URL_PROPERTY = "SourceUrl";
+
     /**
      * This property is present, and evaluates to "true", if the reader can do reprojection
      * on its own (that is, it is not backed by actual data, but by a remote service that

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFResponse.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFResponse.java
@@ -45,6 +45,7 @@ import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.coverage.grid.io.DimensionDescriptor;
+import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.io.CoverageReadRequest;
 import org.geotools.coverage.io.CoverageResponse;
 import org.geotools.coverage.io.SpatialRequestHelper.CoverageProperties;
@@ -479,18 +480,16 @@ class NetCDFResponse extends CoverageResponse{
      * @throws IOException
      */
     private GridCoverage2D prepareCoverage(RenderedImage image, GridSampleDimension[] sampleDimensions, double[] noData) throws IOException {
-
-        Map<String, Object> properties = null;
+        Map<String, Object> properties = new HashMap<String, Object>();
         if (noData != null && noData.length > 0) {
-            properties = new HashMap<String, Object>();
             CoverageUtilities.setNoDataProperty(properties, noData[0]);
         }
+        properties.put(GridCoverage2DReader.SOURCE_URL_PROPERTY, datasetURL);
         return COVERAGE_FACTORY.create(request.name, image, new GridGeometry2D(new GridEnvelope2D(PlanarImage.wrapRenderedImage(image)
                         .getBounds()), PixelInCell.CELL_CORNER, finalGridToWorldCorner,
                         this.targetBBox.getCoordinateReferenceSystem(), hints), sampleDimensions, null,
                 properties);
     }
-    
 
     /**
      * Load a specified a raster as a portion of the granule describe by this {@link DefaultGranuleDescriptor}.

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFReaderTest.java
@@ -16,10 +16,6 @@
  */
 package org.geotools.coverage.io.netcdf;
 
-import it.geosolutions.jaiext.JAIExt;
-import it.geosolutions.jaiext.range.NoDataContainer;
-import ucar.nc2.dataset.NetcdfDataset;
-
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.io.File;
@@ -48,6 +44,7 @@ import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.coverage.grid.io.DimensionDescriptor;
+import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.grid.io.GridFormatFinder;
 import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
 import org.geotools.coverage.processing.CoverageProcessor;
@@ -90,6 +87,10 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.util.InternationalString;
+
+import it.geosolutions.jaiext.JAIExt;
+import it.geosolutions.jaiext.range.NoDataContainer;
+import ucar.nc2.dataset.NetcdfDataset;
 
 public class NetCDFReaderTest extends Assert {
 
@@ -1252,6 +1253,19 @@ public class NetCDFReaderTest extends Assert {
         GeneralEnvelope envelope = reader.getOriginalEnvelope();
         assertNotNull(envelope);
         assertFalse(envelope.isEmpty());
+    }
+
+    /**
+     * Test that {@link GridCoverage2DReader#SOURCE_URL_PROPERTY} is correctly set on a coverage read from a NetCDF file.
+     */
+    @Test
+    public void testSourceUrl() throws Exception {
+        NetCDFReader reader = new NetCDFReader(TestData.file(this, "O3-NO2.nc"), null);
+        GridCoverage2D coverage = reader.read("O3", new GeneralParameterValue[] {});
+        URL sourceUrl = (URL) coverage.getProperty(GridCoverage2DReader.SOURCE_URL_PROPERTY);
+        assertNotNull(sourceUrl);
+        assertEquals("file", sourceUrl.getProtocol());
+        assertTrue(sourceUrl.getPath().endsWith("O3-NO2.nc"));
     }
 
 }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5709

See also [GSIP 158 - NetCDF output support for variable attributes and extra variables](https://github.com/geoserver/geoserver/wiki/GSIP-158).

Depended on by https://github.com/geoserver/geoserver/pull/2281 ([GEOS-8099](https://osgeo-org.atlassian.net/browse/GEOS-8099)).