### PR TITLE
Improved Barnes bounds performance by controlling requested bounds [GEOT-5532]

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -126,6 +126,7 @@ import org.opengis.coverage.processing.OperationNotFoundException;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.feature.type.Name;
@@ -1655,20 +1656,23 @@ public class StreamingRenderer implements GTRenderer {
             List<ReferencedEnvelope> bboxes) throws IllegalFilterException {
         Filter filter = Filter.INCLUDE;
         final int length = attributes.size();
-        Object attType;
+        AttributeDescriptor attType;
 
         for (int j = 0; j < length; j++) {
             //NC - support nested attributes -> use evaluation for getting descriptor
             //result is not necessary a descriptor, is Name in case of @attribute
-            attType =  attributes.get(j).evaluate(schema);
+            attType =  (AttributeDescriptor) attributes.get(j).evaluate(schema);
 
-            // the attribute type might be missing because of rendering transformations, skip it
             if (attType == null) {
-                continue;
+                // the attribute type might be missing because of rendering transformations
+                // use the default since that is what BarnesSurfaceProcess works with
+                attType = schema.getGeometryDescriptor();
             }
 
             if (attType instanceof GeometryDescriptor) {
-                Filter gfilter = new FastBBOX(attributes.get(j), bboxes.get(0), filterFactory);
+                PropertyName propertyName = filterFactory.property(attType.getName());
+                
+                Filter gfilter = new FastBBOX(propertyName, bboxes.get(0), filterFactory);
 
                 if (filter == Filter.INCLUDE) {
                     filter = gfilter;
@@ -1678,8 +1682,7 @@ public class StreamingRenderer implements GTRenderer {
 
                 if(bboxes.size() > 0) {
                     for (int k = 1; k < bboxes.size(); k++) {
-                        //filter = filterFactory.or( filter, new FastBBOX(localName, bboxes.get(k), filterFactory) );
-                        filter = filterFactory.or( filter, new FastBBOX(attributes.get(j), bboxes.get(k), filterFactory) );
+                        filter = filterFactory.or( filter, new FastBBOX( propertyName, bboxes.get(k), filterFactory) );
                     }
                 }
             }

--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/BarnesSurfaceProcess.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/BarnesSurfaceProcess.java
@@ -40,6 +40,7 @@ import org.geotools.process.factory.DescribeParameter;
 import org.geotools.process.factory.DescribeProcess;
 import org.geotools.process.factory.DescribeResult;
 import org.geotools.referencing.CRS;
+import org.opengis.coverage.grid.GridCoordinates;
 import org.opengis.coverage.grid.GridCoverage;
 import org.opengis.coverage.grid.GridGeometry;
 import org.opengis.feature.simple.SimpleFeature;
@@ -360,6 +361,9 @@ public class BarnesSurfaceProcess implements VectorProcess {
         double queryBuffer = 0;
         if (argQueryBuffer != null) {
             queryBuffer = argQueryBuffer;
+            if( targetQuery.getFilter() == Filter.INCLUDE ){
+                return null;
+            }
         }
 
         targetQuery.setFilter(expandBBox(targetQuery.getFilter(), queryBuffer));


### PR DESCRIPTION
For more details see: https://osgeo-org.atlassian.net/browse/GEOT-5532

The pull request provides two fixes:

* Using default geometry, to account for a rendering transformation changing schema
* Detecting when all content is requested

This hot-fix was provided for a customer, it has been sitting without a test case on my harddrive.