### PR TITLE
[GEOT-5722] Updated temporal component "T" for case sensitive

### DIFF
--- a/modules/library/cql/src/main/jjtree/ECQLGrammar.jjt
+++ b/modules/library/cql/src/main/jjtree/ECQLGrammar.jjt
@@ -182,9 +182,14 @@ TOKEN [IGNORE_CASE]: /* temporal expression*/
 	<TEQUALS: "tequals">  | 
 	<BEFORE: "before"> 	| 
 	<DURING: "during"> 	|
-	<AFTER:  "after">  	|
+	<AFTER:  "after">
+}
+
+TOKEN: /* time temporal expression*/
+{
 	<UTC: "T">
 }
+
 TOKEN [IGNORE_CASE]: /* existence predicate*/
 {
 	<EXISTS: "exists"> |


### PR DESCRIPTION
IGNORING_CASE for "T" temporal component not allowing to query with attribute name "t" throwing exception :org.geotools.filter.text.cql2.CQLException: 