### PR TITLE
MBstyle - Supported named (ttf) fonts

### DIFF
--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/layer/SymbolMBLayer.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/layer/SymbolMBLayer.java
@@ -1663,13 +1663,13 @@ public class SymbolMBLayer extends MBLayer {
         Fill fill = sf.fill(null, textColor(), textOpacity());
 
 
-        //Font not supported until glyphs are working
-        Font font = sb.createFont(ff.literal("" /* transformer.getDefaultFonts() */), ff.literal("normal"),
-                ff.literal("normal"), textSize());
-        /* else {
-            font = sb.createFont(ff.literal(getTextFont()), ff.literal("normal"),
-                    ff.literal("normal"), textSize());
-        } */
+        Font font = sb.createFont(ff.literal(""), ff.literal("normal"), ff.literal("normal"), textSize());
+        if (getTextFont() != null) {
+            font.getFamily().clear();
+            for (String textFont : getTextFont()) {
+                font.getFamily().add(ff.literal(textFont));
+            }
+        }
 
 
         // If the textField is a literal string (not a function), then

--- a/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/transform/StyleTransformTest.java
+++ b/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/transform/StyleTransformTest.java
@@ -433,6 +433,30 @@ public class StyleTransformTest {
 
         assertNull(psym.getStroke());
     }
+
+    @Test
+    public void testSymbolFont() throws IOException, ParseException {
+        JSONObject jsonObject = parseTestStyle("symbolTextTest.json");
+        MBStyle mbStyle = new MBStyle(jsonObject);
+        List<MBLayer> layers = mbStyle.layers("test-source");
+        assertEquals(1, layers.size());
+        assertTrue(layers.get(0) instanceof SymbolMBLayer);
+        FeatureTypeStyle fts = layers.get(0).transform(mbStyle);
+
+        assertEquals(1, fts.rules().size());
+        Rule r = fts.rules().get(0);
+
+        assertEquals(1, r.symbolizers().size());
+        Symbolizer symbolizer = r.symbolizers().get(0);
+        assertTrue(symbolizer instanceof TextSymbolizer);
+        TextSymbolizer tsym = (TextSymbolizer) symbolizer;
+
+        assertEquals(1, tsym.fonts().size());
+        assertEquals(2, tsym.fonts().get(0).getFamily().size());
+
+        assertEquals("Some Test Font", tsym.fonts().get(0).getFamily().get(0).toString());
+        assertEquals("Other Test Font", tsym.fonts().get(0).getFamily().get(1).toString());
+    }
     
     /**
      * 


### PR DESCRIPTION
Adds support for named system fonts to MBStyle (not using glyphs).

