### PR TITLE
GEOT-5730 check if sources are supplied by 'Sources' parameter

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Multiply.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Multiply.java
@@ -22,6 +22,7 @@ import it.geosolutions.jaiext.algebra.AlgebraDescriptor.Operator;
 
 import java.awt.image.RenderedImage;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 
 import javax.media.jai.ParameterBlockJAI;
@@ -30,6 +31,8 @@ import javax.media.jai.operator.MultiplyDescriptor;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.processing.BaseMathOperationJAI;
 import org.geotools.util.NumberRange;
+import org.opengis.parameter.InvalidParameterValueException;
+import org.opengis.parameter.ParameterNotFoundException;
 import org.opengis.parameter.ParameterValueGroup;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
@@ -133,9 +136,23 @@ public class Multiply extends BaseMathOperationJAI {
         }
     }
 
+    @Override
+    protected void extractSources(ParameterValueGroup parameters, Collection<GridCoverage2D> sources, String[] sourceNames) throws ParameterNotFoundException, InvalidParameterValueException {
+        try {
+            Collection<GridCoverage2D> paramSources = (Collection<GridCoverage2D>) parameters.parameter("Sources").getValue();
+            if (paramSources.size() >= 2) {
+                sources.addAll(paramSources);
+                return;
+            }
+        } catch (ParameterNotFoundException e) {
+            //sources parameter from jai ext not set, try to continue?
+        }
+        super.extractSources(parameters, sources, sourceNames);
+    }
+
     protected Map<String, ?> getProperties(RenderedImage data, CoordinateReferenceSystem crs,
-            InternationalString name, MathTransform gridToCRS, GridCoverage2D[] sources,
-            Parameters parameters) {
+                                           InternationalString name, MathTransform gridToCRS, GridCoverage2D[] sources,
+                                           Parameters parameters) {
         return handleROINoDataProperties(null, parameters.parameters, sources[0], "algebric", 1, 2, 3);
     }
 }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5730

check if sources are supplied by 'Sources' parameter, which is what the WPS process, and possibily also other JAI-EXT code does. This makes switching between jai and jai-ext more transparant (for the multiply operation). 
Also included unit test, only could not find a way to properly test both jai-ext and jai in one test.