### PR TITLE
Mbspec fixup

### DIFF
--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -11,7 +11,7 @@ The intended audience of this quick reference includes:
 - Feature support is provided for the `Mapbox GL JS <https://www.mapbox.com/mapbox-gl-js/api/>`__, `Open Layers <http://openlayers.org>`__ and the GeoTools mbstyle module.
 - Where appropriate examples have been changed to reference `GeoWebCache <http://geowebcache.org/>`__.
 
-:info:
+.. info::
       The `Mapbox Style Specification <https://www.mapbox.com/mapbox-gl-style-spec>`__ is generated from the BSD `Mapbox GL JS <https://github.com/mapbox/mapbox-gl-js>`__ github repository, reproduced here with details on this GeoTools implementation.
 
 
@@ -60,7 +60,7 @@ A human-readable name for the style.
 
 Arbitrary properties useful to track with the stylesheet, but do not influence rendering. Properties should be prefixed to avoid collisions.
 
-:note: *unsupported.*
+.. note:: *unsupported.*
 
 `center <#root-center>`__
 
@@ -76,7 +76,7 @@ Default map center in longitude and latitude. The style center will be used only
       -73.9749, 40.7736
     ]
 
-:note: *unsupported*
+.. note:: *unsupported*
 
 `zoom <#root-zoom>`__
 
@@ -102,7 +102,7 @@ will be used only if the map has not been positioned by other means
 
     "bearing": 29
 
-:note: *unsupported*
+.. note:: *unsupported*
 
 `pitch <#root-pitch>`__
 

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -5815,59 +5815,49 @@ hcl
 
 
 .. list-table::
-   :widths: 30, 30, 30, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
+     - >= 17.1
+     - 
    * - ``property``
      - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+     - >= 17.1
+     - 
    * - ``type``
      - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+     - >= 17.1
+     - 
    * - ``exponential`` type
      - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+     - >= 17.1
+     - 
    * - ``interval`` type
      - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+     - >= 17.1
+     - 
    * - ``categorical`` type
      - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+     - >= 17.1
+     - 
    * - ``identity`` type
      - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+     - >= 17.1
+     - 
    * - ``default`` type
      - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+     - >= 17.1
+     - 
    * - ``colorSpace`` type
      - >= 0.26.0
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 
 
 
 **Zoom functions** allow the appearance of a map feature to change with
@@ -6082,24 +6072,19 @@ are Polygons, but have a different ``class`` value, and so on.
       ["!in", "$type", "Polygon"]
     ]
 
-
 .. list-table::
-   :widths: 30, 30, 30, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
+     - >= 17.1
+     - 
    * - ``has``/``!has``
      - >= 0.19.0
-     - >= 4.1.0
-     - >= 3.3.0
-     - >= 0.1.0
-
+     - >= 17.1
+     - 

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -5591,24 +5591,16 @@ than or equal to ``fill-extrusion-height``.
      - Not yet supported
 
 
-`Types <#types>`__
-------------------
+Types
+-----
 
 A Mapbox style contains values of various types, most commonly as values
 for the style properties of a layer.
 
-.. raw:: html
-
-   <div class="keyline-all fill-white">
-
-.. raw:: html
-
-   <div class="pad2 keyline-bottom">
-
 .. _types-color:
 
 Color
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~
 
 Colors are written as JSON strings in a variety of permitted formats:
 HTML-style hex values, rgb, rgba, hsl, and hsla. Predefined HTML colors
@@ -5629,11 +5621,6 @@ names, like ``yellow`` and ``blue``, are also permitted.
 Especially of note is the support for hsl, which can be `easier to
 reason about than rgb() <http://mothereffinghsl.com/>`__.
 
-
-.. raw:: html
-
-   <div class="pad2 keyline-bottom">
-
 .. _types-enum:
 
 Enum
@@ -5646,11 +5633,6 @@ One of a fixed list of string values. Use quotes around values.
     {
       "text-transform": "uppercase"
     }
-
-
-.. raw:: html
-
-   <div class="pad2 keyline-bottom">
 
 .. _types-string:
 
@@ -5669,10 +5651,6 @@ to by putting them in curly braces, as seen in the example below.
     }
 
 
-.. raw:: html
-
-   <div class="pad2 keyline-bottom">
-
 .. _types-boolean:
 
 Boolean
@@ -5685,11 +5663,6 @@ Boolean means yes or no, so it accepts the values ``true`` or ``false``.
     {
       "fill-enabled": true
     }
-
-
-.. raw:: html
-
-   <div class="pad2 keyline-bottom">
 
 .. _types-number:
 
@@ -5704,11 +5677,6 @@ Written without quotes.
     {
       "text-size": 24
     }
-
-
-.. raw:: html
-
-   <div class="pad2 keyline-bottom">
 
 .. _types-array:
 
@@ -5725,11 +5693,6 @@ numbers specify intervals of line, break, and line again.
       "line-dasharray": [2, 4]
     }
 
-
-.. raw:: html
-
-   <div class="pad2 keyline-bottom">
-
 .. _types-function:
 
 Function
@@ -5739,21 +5702,13 @@ The value for any layout or paint property may be specified as a
 *function*. Functions allow you to make the appearance of a map feature
 change with the current zoom level and/or the feature's properties.
 
-.. raw:: html
-
-   <div class="col12 pad1x">
-
-.. raw:: html
-
-   <div class="col12 clearfix pad0y pad2x space-bottom2">
-
-
 
 .. _stops:
 
 stops
+^^^^^
 
-*Required (except for identity functions) `array <#types-array>`__.*
+*Required (except for identity functions) :ref:`types-array`.*
 
 
 
@@ -5761,15 +5716,10 @@ stops
 Functions are defined in terms of input and output values. A set of one
 input value and one output value is known as a "stop."
 
-
-
-.. raw:: html
-
-   <div class="col12 clearfix pad0y pad2x space-bottom2">
-
 .. _property:
 
 property
+^^^^^^^^
 
 *Optional* :ref:`types-string`.
 
@@ -5782,20 +5732,12 @@ an input. See `Zoom Functions and Property
 Functions <#types-function-zoom-property>`__ for more information.
 
 
-
-.. raw:: html
-
-   <div class="col12 clearfix pad0y pad2x space-bottom2">
-
 .. _base:
 
 base
-.. raw:: html
+^^^^
 
-   <i>Optional <a href="#number">number</a>. Default is</i> 1.
-
-
-
+*Optional* :ref:`types-number`. *Default is* 1.
 
 
 The exponential base of the interpolation curve. It controls the rate at
@@ -5803,21 +5745,12 @@ which the function output increases. Higher values make the output
 increase more towards the high end of the range. With values close to 1
 the output increases linearly.
 
-
-
-.. raw:: html
-
-   <div class="col12 clearfix pad0y pad2x space-bottom2">
-
 .. _type:
 
 type
+^^^^
 
-.. raw:: html
-
-   <i>Optional <a href="#enum">enum</a>. One of</i> identity, exponential, interval, categorical.
-
-
+*Optional* :ref:`types-enum`. *One of* identity, exponential, interval, categorical.
 
 identity
     functions return their input as their output.
@@ -5834,17 +5767,10 @@ categorical
     functions return the output value of the stop equal to the function
     input.
 
-
-.. raw:: html
-
-   <div class="col12 clearfix pad0y pad2x space-bottom2">
-
 .. _function-default:
 
 default
-
-
-
+^^^^^^^
 
 A value to serve as a fallback function result when a value isn't
 otherwise available. It is used in the following circumstances:
@@ -5862,25 +5788,16 @@ otherwise available. It is used in the following circumstances:
    when the feature value is not numeric.
 
 
-
 If no default is provided, the style property's default is used in these
 circumstances.
 
 
-
-.. raw:: html
-
-   <div class="col12 clearfix pad0y pad2x space-bottom2">
-
 .. _function-colorspace:
 
 colorSpace
+^^^^^^^^^^
 
-.. raw:: html
-
-   <i>Optional <a href="#enum">enum</a>. One of</i> rgb, lab, hcl.
-
-
+*Optional* :ref:`types-enum`. *One of* rgb, lab, hcl.
 
 The color space in which colors interpolated. Interpolating colors in
 perceptual color spaces like LAB and HCL tend to produce color ramps
@@ -5958,10 +5875,6 @@ map’s zoom level. Zoom functions can be used to create the illusion of
 depth and control data density. Each stop is an array with two elements:
 the first is a zoom level and the second is a function output value.
 
-.. raw:: html
-
-   <div class="col12 space-bottom">
-
 ::
 
     {
@@ -5978,12 +5891,10 @@ the first is a zoom level and the second is a function output value.
       }
     }
 
-
-
-The rendered values of `color <#types-color>`__,
-`number <#types-number>`__, and `array <#types-array>`__ properties are
-intepolated between stops. `Enum <#types-enum>`__,
-`boolean <#types-boolean>`__, and `string <#types-string>`__ property
+The rendered values of :ref:`types-color`,
+:ref:`types-number`, and :ref:`types-array` properties are
+intepolated between stops. :ref:`types-enum`,
+:ref:`types-boolean`, and :ref:`types-string` property
 values cannot be intepolated, so their rendered values only change at
 the specified stops.
 
@@ -6010,10 +5921,6 @@ property input value and the second is a function output value. Note
 that support for property functions is not available across all
 properties and platforms at this time.
 
-.. raw:: html
-
-   <div class="col12 space-bottom">
-
 ::
 
     {
@@ -6033,15 +5940,11 @@ properties and platforms at this time.
 
 
 
-\ **Zoom-and-property functions** allow the appearance of a map feature
+**Zoom-and-property functions** allow the appearance of a map feature
 to change with both its properties *and* zoom. Each stop is an array
 with two elements, the first is an object with a property input value
 and a zoom, and the second is a function output value. Note that support
 for property functions is not yet complete.
-
-.. raw:: html
-
-   <div class="col12 space-bottom">
 
 ::
 
@@ -6066,13 +5969,6 @@ for property functions is not yet complete.
       }
     }
 
-
-
-
-.. raw:: html
-
-   <div class="pad2">
-
 .. _types-filter:
 
 Filter
@@ -6081,12 +5977,8 @@ Filter
 A filter selects specific features from a layer. A filter is an array of
 one of the following forms:
 
-.. raw:: html
-
-   <div class="col12 clearfix space-bottom2">
-
 Existential Filters
-~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^
 
 ``["has", key]`` feature[key] exists
 
@@ -6095,7 +5987,7 @@ Existential Filters
 
 
 Comparison Filters
-~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
 ``["==", key, value]`` equality: feature[key] = value
 
@@ -6116,7 +6008,7 @@ Comparison Filters
 
 
 Set Membership Filters
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 ``["in", key, v0, ..., vn]`` set inclusion: feature[key] ∈ {v0, ..., vn}
 
@@ -6126,7 +6018,7 @@ vn}
 
 
 Combining Filters
-~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^
 
 ``["all", f0, ..., fn]`` logical ``AND``: f0 ∧ ... ∧ fn
 
@@ -6149,7 +6041,7 @@ following special keys:
    operators.
 
 A value (and v0, ..., vn for set operators) must be a
-`string <#string>`__, `number <#number>`__, or `boolean <#boolean>`__ to
+:ref:`types-string`, :ref:`types-number`, or :ref:`types-boolean` to
 compare the property value against.
 
 Set membership filters are a compact and efficient way to test whether a

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -5251,31 +5251,17 @@ none
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
    * - basic functionality
      - >= 0.27.0
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
+     - >= 17.1
+     - 
 
 
 Paint Properties
@@ -5293,38 +5279,22 @@ available.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
    * - basic functionality
      - >= 0.27.0
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
+     - >= 17.1
+     - 
 
 fill-extrusion-color
 """"""""""""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000. *Disabled by* fill-extrusion-pattern.
-
 
 
 The base color of the extruded fill. The extrusion's surfaces will be
@@ -5335,37 +5305,17 @@ component, the alpha component will be ignored; use
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
    * - basic functionality
      - >= 0.27.0
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-   * - data-driven styling
-     - >= 0.27.0
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
+     - >= 17.1
+     - 
 
 fill-extrusion-translate
 """"""""""""""""""""""""
@@ -5379,37 +5329,21 @@ and up (on the flat plane), respectively.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
    * - basic functionality
      - >= 0.27.0
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 
    * - data-driven styling
      - Not yet supported
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
+     - 
 
 fill-extrusion-translate-anchor
 """""""""""""""""""""""""""""""
@@ -5429,36 +5363,21 @@ viewport
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
    * - basic functionality
      - >= 0.27.0
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 
    * - data-driven styling
      - Not yet supported
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
+     - 
 
 
 fill-extrusion-pattern
@@ -5472,39 +5391,22 @@ Name of image in sprite to use for drawing images on extruded fills. For
 seamless patterns, image width and height must be a factor of two (2, 4,
 8, ..., 512).
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
    * - basic functionality
      - >= 0.27.0
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 
    * - data-driven styling
      - Not yet supported
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
+     - 
 
 fill-extrusion-height
 """""""""""""""""""""
@@ -5516,36 +5418,21 @@ The height with which to extrude this layer.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
    * - basic functionality
      - >= 0.27.0
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 
    * - data-driven styling
      - >= 0.27.0
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
+     - 
 
 
 fill-extrusion-base
@@ -5558,37 +5445,22 @@ fill-extrusion-base
 The height with which to extrude the base of this layer. Must be less
 than or equal to ``fill-extrusion-height``.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
    * - basic functionality
      - >= 0.27.0
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 
    * - data-driven styling
      - >= 0.27.0
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 
 
 
 Types

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -391,9 +391,6 @@ done in several ways:
 
 -  By providing a ``"url"`` to a TileJSON resource:
 
-   .. raw:: html
-
-      <div class="space-bottom1 clearfix">
 
    ::
 
@@ -481,9 +478,9 @@ higher zoom levels.
      - GeoTools
      - OpenLayers
    * - basic functionality
-     - >= 0.10.0
+     - 0.10.0
      - not yet supported
-     - 
+     -
 
 raster
 ~~~~~~
@@ -556,7 +553,7 @@ configurable for raster layers.
    * - basic functionality
      - >= 0.10.0
      - not yet supported
-     - 
+     -
 
 geojson
 ~~~~~~~
@@ -666,13 +663,13 @@ clustered).
      - GeoTools
      - OpenLayers
    * - basic functionality
-     - >= 0.10.0
+     - 0.10.0
      - not yet supported
-     - 
+     -
    * - clustering
-     - >= 0.14.0
+     - 0.14.0
      - not yet supported
-     - 
+     -
 
 image
 ~~~~~
@@ -698,7 +695,7 @@ right, bottom left.
 url
 ^^^
 
-*Required* :ref:`types-string`. 
+*Required* :ref:`types-string`.
 
 URL that points to an image.
 
@@ -718,9 +715,9 @@ Corners of image specified in longitude, latitude pairs.
      - GeoTools
      - OpenLayers
    * - basic functionality
-     - >= 0.10.0
+     - 0.10.0
      - not yet supported
-     - 
+     -
 
 video
 ~~~~~
@@ -776,9 +773,9 @@ Corners of video specified in longitude, latitude pairs.
      - GeoTools
      - OpenLayers
    * - basic functionality
-     - >= 0.10.0
+     - 0.10.0
      - not yet supported
-     - 
+     -
 
 canvas
 ~~~~~~
@@ -829,7 +826,7 @@ Whether the canvas source is animated. If the canvas is static,
 canvas
 ^^^^^^
 
-*Required* :ref:`types-string`. 
+*Required* :ref:`types-string`.
 
 HTML ID of the canvas from which to read pixels.
 
@@ -843,9 +840,9 @@ HTML ID of the canvas from which to read pixels.
      - GeoTools
      - OpenLayers
    * - basic functionality
-     - >= 0.32.0
+     - 0.32.0
      - not yet supported
-     - 
+     -
 
 .. _sprite:
 
@@ -954,7 +951,7 @@ for that style.
 duration
 ~~~~~~~~
 
-*Optional* :ref:`types-number`. *Units in milliseconds. Defaults to* 300. 
+*Optional* :ref:`types-number`. *Units in milliseconds. Defaults to* 300.
 
 
 Time allotted for transitions to complete.
@@ -962,7 +959,7 @@ Time allotted for transitions to complete.
 delay
 ~~~~~
 
-*Optional* :ref:`types-number`. *Units in milliseconds. Defaults to* 0. 
+*Optional* :ref:`types-number`. *Units in milliseconds. Defaults to* 0.
 
 Length of time before a transition begins.
 
@@ -1000,7 +997,7 @@ Layer Properties
 id
 ^^
 
-*Required* :ref:`types-string`. 
+*Required* :ref:`types-string`.
 
 
 Unique layer name.
@@ -1292,7 +1289,7 @@ Whether or not the fill should be antialiased.
      - not yet supported
    * - Data
      - not yet supported
-     - 18.0
+     - 17.1
      - not yet supported
 
 fill-opacity
@@ -1315,11 +1312,11 @@ stroke is used.
      - OpenLayers
    * - Basic
      - 0.10.0
-     - 18.0
+     - 17.1
      - 4.1.1
    * - Data
      - 0.21.0
-     - 18.0
+     - 17.1
      - 4.1.1
 
 fill-color
@@ -1343,11 +1340,11 @@ affect the opacity of the 1px stroke, if it is used.
      - OpenLayers
    * - Basic
      - 0.10.0
-     - 18.0
+     - 17.1
      - 4.1.1
    * - Data
      - 0.19.0
-     - 18.0
+     - 17.1
      - 4.1.1
 
 fill-outline-color
@@ -1369,11 +1366,11 @@ unspecified.
      - OpenLayers
    * - Basic
      - 0.10.0
-     - 18.0
+     - 17.1
      - 4.1.1
    * - Data
      - 0.19.0
-     - 18.0
+     - 17.1
      - 4.1.1
 
 fill-translate
@@ -1395,11 +1392,11 @@ and up, respectively.
      - OpenLayers
    * - Basic
      - 0.10.0
-     - 18.0
+     - 17.1
      - 4.1.1
    * - Data
      - not yet supported
-     - 18.0
+     - 17.1
      - not yet supported
 
 fill-translate-anchor
@@ -1425,7 +1422,7 @@ viewport
      - OpenLayers
    * - Basic
      - 0.10.0
-     - 18.0
+     - 17.1
      - 4.1.1
    * - Data
      - not yet supported
@@ -1452,16 +1449,12 @@ patterns, image width and height must be a factor of two (2, 4, 8, ...,
      - OpenLayers
    * - Basic
      - 0.10.0
-     - 18.0
+     - 17.1
      - 4.1.1
    * - Data
      - not yet supported
-     - 18.0
+     - 17.1
      - not yet supported
-
-.. raw:: html
-
-   <div id="layers-line" class="pad2 keyline-bottom">
 
 line
 ~~~~
@@ -1501,35 +1494,12 @@ square
      - OpenLayers
    * - Basic
      - 0.10.0
-     - 18.0
+     - 17.1
      - 4.1.1
    * - Data
      - not yet supported
-     - 18.0
+     - 17.1
      - not yet supported
-
-
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 line-join
 """""""""
@@ -1554,36 +1524,21 @@ miter
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 line-miter-limit
 """"""""""""""""
@@ -1595,36 +1550,21 @@ angles.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 line-round-limit
 """"""""""""""""
@@ -1637,34 +1577,20 @@ angles.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -1684,34 +1610,20 @@ none
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -1728,35 +1640,21 @@ The opacity at which the line will be drawn.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+   * - Data
+     - 0.29.0
+     - 17.1
+     - Not yet supported
 
 
 line-color
@@ -1768,35 +1666,21 @@ The color with which the line will be drawn.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.23.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+   * - Data
+     - 0.23.0
+     - 17.1
+     - Not yet supported
 
 
 line-translate
@@ -1810,37 +1694,21 @@ and up, respectively.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 line-translate-anchor
 """""""""""""""""""""
@@ -1858,34 +1726,20 @@ viewport
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -1898,36 +1752,21 @@ Stroke thickness.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 line-gap-width
 """"""""""""""
@@ -1941,35 +1780,21 @@ width of the inner gap.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+   * - Data
+     - 0.29.0
+     - 17.1
+     - Not yet supported
 
 line-offset
 """""""""""
@@ -1982,38 +1807,22 @@ line to the right, relative to the direction of the line, and a negative
 value to the left. For polygon features, a positive value results in an
 inset, and a negative value results in an outset.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.12.1
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.12.1
-     - >= 3.0.0
-     - >= 3.1.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
+   * - Data
+     - 0.29.0
+     - 17.1
+     - Not yet supported
 
 line-blur
 """""""""
@@ -2023,37 +1832,22 @@ line-blur
 
 Blur applied to the line, in pixels.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+   * - Data
+     - 0.29.0
+     - 17.1
+     - Not yet supported
 
 
 line-dasharray
@@ -2065,36 +1859,21 @@ Specifies the lengths of the alternating dashes and gaps that form the
 dash pattern. The lengths are later scaled by the line width. To convert
 a dash length to pixels, multiply the length by the current line width.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 line-pattern
@@ -2107,42 +1886,22 @@ line-pattern
 Name of image in sprite to use for drawing image lines. For seamless
 patterns, image width must be a factor of two (2, 4, 8, ..., 512).
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-.. raw:: html
-
-   <div id="layers-symbol" class="pad2 keyline-bottom">
 
 symbol
 ~~~~~~
@@ -2166,36 +1925,21 @@ line
     The label is placed along the line of the geometry. Can only be used
     on ``LineString`` and ``Polygon`` geometries.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -2206,36 +1950,21 @@ symbol-spacing
 
 Distance between two symbol anchors.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -2250,36 +1979,21 @@ collisions. Recommended in layers that don't have enough padding in the
 vector tile to prevent collisions, or if it is a point symbol layer
 placed after a line symbol layer.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -2292,38 +2006,22 @@ icon-allow-overlap
 If true, the icon will be visible even if it collides with other
 previously drawn symbols.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 icon-ignore-placement
 """""""""""""""""""""
@@ -2334,36 +2032,21 @@ icon-ignore-placement
 If true, other symbols can be visible even if they collide with the
 icon.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -2377,38 +2060,22 @@ icon-optional
 If true, text will display without their corresponding icons when the
 icon collides with other symbols and the text does not.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 icon-rotation-alignment
 """""""""""""""""""""""
@@ -2433,43 +2100,26 @@ auto
     ``viewport``. When ``symbol-placement`` is set to ``line``, this is
     equivalent to ``map``.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
    * - ``auto`` value
-     - >= 0.25.0
-     - >= 4.2.0
-     - >= 3.4.0
-     - >= 0.3.0
-   * - data-driven styling
+     - 0.25.0
+     - 17.1
+     -
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
+     - 17.1
+     -
 
 icon-size
 """""""""
@@ -2479,37 +2129,21 @@ Scale factor for icon. 1 is original size, 3 triples the size.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.35.0
+   * - Data
+     - 0.35.0
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 icon-text-fit
 """""""""""""
@@ -2534,36 +2168,21 @@ both
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.21.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.21.0
-     - >= 4.2.0
-     - >= 3.4.0
-     - >= 0.2.1
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 icon-text-fit-padding
 """""""""""""""""""""
@@ -2575,34 +2194,20 @@ Size of the additional area added to dimensions determined by
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.21.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.21.0
-     - >= 4.2.0
-     - >= 3.4.0
-     - >= 0.2.1
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -2617,37 +2222,23 @@ Name of image in sprite to use for drawing an image background. A string
 with {tokens} replaced, referencing the data property to pull from.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.35.0
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-
 
 icon-rotate
 """""""""""
@@ -2657,37 +2248,23 @@ icon-rotate
 Rotates the icon clockwise.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.21.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
+   * - Data
+     - 0.21.0
+     - 17.1
+     - Not yet supported
 
 icon-padding
 """"""""""""
@@ -2700,37 +2277,21 @@ detecting symbol collisions.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 icon-keep-upright
 """""""""""""""""
@@ -2743,36 +2304,21 @@ upside-down.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 icon-offset
 """""""""""
@@ -2785,35 +2331,21 @@ and down, while negative values indicate left and up. When combined with
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+   * - Data
+     - 0.29.0
+     - 17.1
+     - Not yet supported
 
 
 text-pitch-alignment
@@ -2833,43 +2365,26 @@ viewport
 auto
     Automatically matches the value of ``text-rotation-alignment``.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
    * - ``auto`` value
-     - >= 0.25.0
-     - >= 4.2.0
-     - >= 3.4.0
-     - >= 0.3.0
-   * - data-driven styling
+     - 0.25.0
+     - 17.1
+     -
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 
 text-rotation-alignment
@@ -2895,44 +2410,26 @@ auto
     ``viewport``. When ``symbol-placement`` is set to ``line``, this is
     equivalent to ``map``.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
    * - ``auto`` value
-     - >= 0.25.0
-     - >= 4.2.0
-     - >= 3.4.0
-     - >= 0.3.0
-   * - data-driven styling
+     - 0.25.0
+     - 17.1
+     -
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-field
 """"""""""
@@ -2947,36 +2444,21 @@ literal ``text-field`` values--not for property functions.)
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 text-font
 """""""""
@@ -2985,39 +2467,22 @@ text-font
 
 Font stack to use for displaying text.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-size
 """""""""
@@ -3029,38 +2494,23 @@ text-size
 Font size.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.35.0
+   * - Data
+     - 0.35.0
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-max-width
 """"""""""""""
@@ -3073,36 +2523,21 @@ The maximum line width for text wrapping.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 text-line-height
 """"""""""""""""
@@ -3115,34 +2550,20 @@ Text leading value for multi-line text.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -3157,37 +2578,21 @@ Text tracking amount.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-justify
 """"""""""""
@@ -3209,36 +2614,21 @@ right
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 text-anchor
 """""""""""
@@ -3280,34 +2670,20 @@ bottom-right
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -3321,36 +2697,21 @@ Maximum angle change between adjacent characters.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 text-rotate
 """""""""""
@@ -3363,37 +2724,21 @@ Rotates the text clockwise.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.35.0
+   * - Data
+     - 0.35.0
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-padding
 """"""""""""
@@ -3407,36 +2752,21 @@ detecting symbol collisions.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 
 text-keep-upright
@@ -3451,37 +2781,21 @@ rendered upside-down.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-transform
 """"""""""""""
@@ -3503,37 +2817,21 @@ lowercase
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 text-offset
 """""""""""
@@ -3545,37 +2843,21 @@ and down, while negative values indicate left and up.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.35.0
+   * - Data
+     - 0.35.0
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-allow-overlap
 """"""""""""""""""
@@ -3589,37 +2871,21 @@ previously drawn symbols.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-ignore-placement
 """""""""""""""""""""
@@ -3633,37 +2899,21 @@ text.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-optional
 """""""""""""
@@ -3677,36 +2927,21 @@ text collides with other symbols and the icon does not.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
 
 
 visibility
@@ -3727,37 +2962,21 @@ none
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 Paint Properties
 ^^^^^^^^^^^^^^^^
@@ -3772,35 +2991,21 @@ The opacity at which the icon will be drawn.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 
 icon-color
@@ -3814,37 +3019,21 @@ The color of the icon. This can only be used with sdf icons.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 icon-halo-color
 """""""""""""""
@@ -3858,36 +3047,21 @@ icons.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 icon-halo-width
 """""""""""""""
@@ -3900,37 +3074,21 @@ Distance of halo to the icon outline.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 icon-halo-blur
 """"""""""""""
@@ -3943,37 +3101,21 @@ Fade out the halo towards the outside.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 icon-translate
 """"""""""""""
@@ -3987,38 +3129,23 @@ Positive values indicate right and down, while negative values indicate
 left and up.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 icon-translate-anchor
 """""""""""""""""""""
@@ -4036,36 +3163,21 @@ map
 viewport
     Icons are translated relative to the viewport.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
@@ -4078,37 +3190,23 @@ text-opacity
 The opacity at which the text will be drawn.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 
 text-color
@@ -4121,37 +3219,23 @@ text-color
 The color with which the text will be drawn.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 
 text-halo-color
@@ -4164,38 +3248,23 @@ text-halo-color
 The color of the text's halo, which helps it stand out from backgrounds.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 text-halo-width
 """""""""""""""
@@ -4208,38 +3277,23 @@ Distance of halo to the font outline. Max text halo width is 1/4 of the
 font-size.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 text-halo-blur
 """"""""""""""
@@ -4252,37 +3306,21 @@ The halo's fadeout distance towards the outside.
 
 
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.33.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
+   * - Data
+     - 0.33.0
+     - 17.1
+     - Not yet supported
 
 text-translate
 """"""""""""""
@@ -4296,38 +3334,23 @@ Positive values indicate right and down, while negative values indicate
 left and up.
 
 
+
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
+     - 17.1
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
 
 text-translate-anchor
 """""""""""""""""""""
@@ -4345,890 +3368,26 @@ map
 viewport
     The text is translated relative to the viewport.
 
-
 .. list-table::
-   :widths: 10, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - Mapbox
+   * - Support
+     - Mapbox
      - GeoTools
      - OpenLayers
-   * - 0.27.0
-     - 18.0
+   * - Basic
+     - 0.10.0
+     - 17.1
      - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
+   * - Data
      - Not yet supported
-     - Not yet supported
-     - Not yet supported
+     - 17.1
      - Not yet supported
 
 
 raster
 ~~~~~~
-
-Layout Properties
-^^^^^^^^^^^^^^^^^
-
-visibility
-""""""""""
-
-*Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
-
-
-
-Whether this layer is displayed.
-
-
-visible
-    The layer is shown.
-
-none
-    The layer is not shown.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-Paint Properties
-^^^^^^^^^^^^^^^^
-
-raster-opacity
-""""""""""""""
-
-*Optional* :ref:`types-number`. *Defaults to* 1.
-
-
-The opacity at which the image will be drawn.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-`raster-hue-rotate <#paint-raster-hue-rotate>`__
-
-*Optional* :ref:`types-number`. *Units in* degrees. *Defaults to* 0.
-
-
-
-Rotates hues around the color wheel.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-raster-brightness-min
-"""""""""""""""""""""
-
-*Optional* :ref:`types-number`. *Defaults to* 0.
-
-
-Increase or reduce the brightness of the image. The value is the minimum
-brightness.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-raster-brightness-max
-"""""""""""""""""""""
-
-*Optional* :ref:`types-number`. *Defaults to* 1.
-
-
-Increase or reduce the brightness of the image. The value is the maximum
-brightness.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-raster-saturation
-"""""""""""""""""
-
-*Optional* :ref:`types-number`. *Defaults to* 0.
-
-
-Increase or reduce the saturation of the image.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-raster-contrast
-"""""""""""""""
-
-*Optional* :ref:`types-number`. *Defaults to* 0.
-
-
-Increase or reduce the contrast of the image.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-raster-fade-duration
-""""""""""""""""""""
-
-*Optional* :ref:`types-number` *Units in* milliseconds. *Defaults to* 300.
-
-
-
-Fade duration when a new tile is added.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-circle
-~~~~~~
-
-Layout Properties
-^^^^^^^^^^^^^^^^^
-
-visibility
-""""""""""
-
-*Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
-
-
-
-Whether this layer is displayed.
-
-
-visible
-    The layer is shown.
-
-none
-    The layer is not shown.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-
-
-Paint Properties
-^^^^^^^^^^^^^^^^
-
-circle-radius
-"""""""""""""
-
-*Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 5.
-
-
-
-Circle radius.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
-
-circle-color
-""""""""""""
-
-*Optional* :ref:`types-color`. *Defaults to* #000000.
-
-
-
-The fill color of the circle.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.18.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
-
-circle-blur
-"""""""""""
-
-*Optional* :ref:`types-number`. *Defaults to* 0.
-
-
-Amount to blur the circle. 1 blurs the circle such that only the
-centerpoint is full opacity.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.20.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
-
-circle-opacity
-""""""""""""""
-
-*Optional* :ref:`types-number`. *Defaults to* 1.
-
-
-The opacity at which the circle will be drawn.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - >= 0.20.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
-circle-translate
-""""""""""""""""
-
-*Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0,0.
-
-
-
-The geometry's offset. Values are [x, y] where negatives indicate left
-and up, respectively.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-circle-translate-anchor
-"""""""""""""""""""""""
-
-*Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map. *Requires* circle-translate.
-
-
-
-Controls the translation reference point.
-
-
-map
-    The circle is translated relative to the map.
-
-viewport
-    The circle is translated relative to the viewport.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-circle-pitch-scale
-""""""""""""""""""
-
-*Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map.
-
-
-
-Controls the scaling behavior of the circle when the map is pitched.
-
-
-map
-    Circles are scaled according to their apparent distance to the
-    camera.
-
-viewport
-    Circles are not scaled.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.21.0
-     - >= 4.2.0
-     - >= 3.4.0
-     - >= 0.2.1
-   * - data-driven styling
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-     - Not yet supported
-
-
-
-circle-stroke-width
-"""""""""""""""""""
-
-*Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 5.
-
-
-
-The width of the circle's stroke. Strokes are placed outside of the
-``circle-radius``.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-   * - data-driven styling
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
-circle-stroke-color
-"""""""""""""""""""
-
-*Optional* :ref:`types-color`. *Defaults to* #000000.
-
-
-
-The stroke color of the circle.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-   * - data-driven styling
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-circle-stroke-opacity
-"""""""""""""""""""""
-
-*Optional* :ref:`types-number`. *Defaults to* 1.
-
-
-The opacity of the circle's stroke.
-
-
-.. list-table::
-   :widths: 10, 30, 30
-   :header-rows: 1
-
-   * - Mapbox
-     - GeoTools
-     - OpenLayers
-   * - 0.27.0
-     - 18.0
-     - 4.1.1
-
-.. list-table::
-   :widths: 30, 30, 30, 30, 30
-   :header-rows: 1
-
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
-   * - basic functionality
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-   * - data-driven styling
-     - >= 0.29.0
-     - >= 5.0.0
-     - >= 3.5.0
-     - >= 0.4.0
-
-
-
-fill-extrusion
-~~~~~~~~~~~~~~
 
 Layout Properties
 ^^^^^^^^^^^^^^^^^
@@ -5258,6 +3417,562 @@ none
      - Mapbox
      - GeoTools
      - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+Paint Properties
+^^^^^^^^^^^^^^^^
+
+raster-opacity
+""""""""""""""
+
+*Optional* :ref:`types-number`. *Defaults to* 1.
+
+
+The opacity at which the image will be drawn.
+
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+`raster-hue-rotate <#paint-raster-hue-rotate>`__
+
+*Optional* :ref:`types-number`. *Units in* degrees. *Defaults to* 0.
+
+
+
+Rotates hues around the color wheel.
+
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+
+raster-brightness-min
+"""""""""""""""""""""
+
+*Optional* :ref:`types-number`. *Defaults to* 0.
+
+
+Increase or reduce the brightness of the image. The value is the minimum
+brightness.
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+
+raster-brightness-max
+"""""""""""""""""""""
+
+*Optional* :ref:`types-number`. *Defaults to* 1.
+
+
+Increase or reduce the brightness of the image. The value is the maximum
+brightness.
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+raster-saturation
+"""""""""""""""""
+
+*Optional* :ref:`types-number`. *Defaults to* 0.
+
+
+Increase or reduce the saturation of the image.
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+raster-contrast
+"""""""""""""""
+
+*Optional* :ref:`types-number`. *Defaults to* 0.
+
+
+Increase or reduce the contrast of the image.
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+
+raster-fade-duration
+""""""""""""""""""""
+
+*Optional* :ref:`types-number` *Units in* milliseconds. *Defaults to* 300.
+
+
+
+Fade duration when a new tile is added.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+
+circle
+~~~~~~
+
+Layout Properties
+^^^^^^^^^^^^^^^^^
+
+visibility
+""""""""""
+
+*Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
+
+
+
+Whether this layer is displayed.
+
+
+visible
+    The layer is shown.
+
+none
+    The layer is not shown.
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+
+
+Paint Properties
+^^^^^^^^^^^^^^^^
+
+circle-radius
+"""""""""""""
+
+*Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 5.
+
+
+
+Circle radius.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - 0.18.0
+     - 17.1
+     - Not yet supported
+
+circle-color
+""""""""""""
+
+*Optional* :ref:`types-color`. *Defaults to* #000000.
+
+
+
+The fill color of the circle.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - 0.18.0
+     - 17.1
+     - Not yet supported
+
+
+circle-blur
+"""""""""""
+
+*Optional* :ref:`types-number`. *Defaults to* 0.
+
+
+Amount to blur the circle. 1 blurs the circle such that only the
+centerpoint is full opacity.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - 0.20.0
+     - 17.1
+     - Not yet supported
+
+
+circle-opacity
+""""""""""""""
+
+*Optional* :ref:`types-number`. *Defaults to* 1.
+
+
+The opacity at which the circle will be drawn.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - 0.20.0
+     - 17.1
+     - Not yet supported
+
+circle-translate
+""""""""""""""""
+
+*Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0,0.
+
+
+
+The geometry's offset. Values are [x, y] where negatives indicate left
+and up, respectively.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+
+circle-translate-anchor
+"""""""""""""""""""""""
+
+*Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map. *Requires* circle-translate.
+
+
+
+Controls the translation reference point.
+
+
+map
+    The circle is translated relative to the map.
+
+viewport
+    The circle is translated relative to the viewport.
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.10.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+
+circle-pitch-scale
+""""""""""""""""""
+
+*Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map.
+
+
+
+Controls the scaling behavior of the circle when the map is pitched.
+
+
+map
+    Circles are scaled according to their apparent distance to the
+    camera.
+
+viewport
+    Circles are not scaled.
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.21.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - Not yet supported
+     - 17.1
+     - Not yet supported
+
+
+circle-stroke-width
+"""""""""""""""""""
+
+*Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 5.
+
+
+
+The width of the circle's stroke. Strokes are placed outside of the
+``circle-radius``.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.29.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - 0.29.0
+     - 17.1
+     - Not yet supported
+
+circle-stroke-color
+"""""""""""""""""""
+
+*Optional* :ref:`types-color`. *Defaults to* #000000.
+
+
+
+The stroke color of the circle.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.29.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - 0.29.0
+     - 17.1
+     - Not yet supported
+
+circle-stroke-opacity
+"""""""""""""""""""""
+
+*Optional* :ref:`types-number`. *Defaults to* 1.
+
+
+The opacity of the circle's stroke.
+
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - Basic
+     - 0.29.0
+     - 17.1
+     - 4.1.1
+   * - Data
+     - 0.29.0
+     - 17.1
+     - Not yet supported
+
+fill-extrusion
+~~~~~~~~~~~~~~
+
+Layout Properties
+^^^^^^^^^^^^^^^^^
+
+visibility
+""""""""""
+
+*Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
+
+
+
+Whether this layer is displayed.
+
+
+visible
+    The layer is shown.
+
+none
+    The layer is not shown.
+
+.. list-table::
+   :widths: 10, 30, 30, 30
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.27.0
      - >= 17.1
@@ -5276,6 +3991,7 @@ fill-extrusion-opacity
 The opacity of the entire fill extrusion layer. This is rendered on a
 per-layer, not per-feature, basis, and data-driven styling is not
 available.
+
 
 
 .. list-table::
@@ -5345,8 +4061,6 @@ and up (on the flat plane), respectively.
      - Not yet supported
      - 
 
-fill-extrusion-translate-anchor
-"""""""""""""""""""""""""""""""
 
 *Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map. *Requires* fill-extrusion-translate.
 
@@ -5360,7 +4074,6 @@ map
 
 viewport
     The fill extrusion is translated relative to the viewport.
-
 
 .. list-table::
    :widths: 10, 30, 30, 30
@@ -5603,7 +4316,6 @@ If specified, the function will take the specified feature property as
 an input. See `Zoom Functions and Property
 Functions <#types-function-zoom-property>`__ for more information.
 
-
 .. _base:
 
 base
@@ -5662,7 +4374,6 @@ otherwise available. It is used in the following circumstances:
 
 If no default is provided, the style property's default is used in these
 circumstances.
-
 
 .. _function-colorspace:
 

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -240,11 +240,8 @@ style.
     }
 
 
-.. raw:: html
-
-   <div class="pad2 keyline-all fill-white">
-
-`anchor <#light-anchor>`__
+anchor
+~~~~~~
 
 *Optional* :ref:`types-enum`. *One of* map, viewport. *Defaults to* viewport.
 
@@ -277,7 +274,8 @@ viewport
      - not yet supported
      - not yet supported
 
-`position <#light-position>`__
+position
+~~~~~~~~
 
 *Optional* :ref:`types-array`. *Defaults to* 1.15,210,30.
 
@@ -313,7 +311,8 @@ the light (from 0°, directly above, to 180°, directly below).
      - not yet supported
      - not yet supported
 
-`color <#light-color>`__
+color
+~~~~~
 
 *Optional* :ref:`types-color`. *Defaults to* #ffffff.
 
@@ -334,7 +333,8 @@ Color tint for lighting extruded geometries.
      - not yet supported
      - not yet supported
 
-`intensity <#light-intensity>`__
+intensity
+~~~~~~~~~
 
 *Optional* :ref:`types-number`. *Defaults to* 0.5.
 
@@ -359,7 +359,7 @@ present as more extreme contrast.
 .. _sources:
 
 Sources
---------
+-------
 
 Sources supply data to be shown on the map. The type of source is
 specified by the ``"type"`` property, and must be one of vector, raster,
@@ -378,10 +378,6 @@ done in several ways:
 -  By supplying TileJSON properties such as ``"tiles"``, ``"minzoom"``,
    and ``"maxzoom"`` directly in the source:
 
-   .. raw:: html
-
-      <div class="space-bottom1 clearfix">
-
    ::
 
        "mapbox-streets": {
@@ -392,10 +388,6 @@ done in several ways:
          ],
          "maxzoom": 14
        }
-
-   .. raw:: html
-
-      </div>
 
 -  By providing a ``"url"`` to a TileJSON resource:
 
@@ -409,10 +401,6 @@ done in several ways:
          "type": "vector",
          "url": "http://api.example.com/tilejson.json"
        }
-
-   .. raw:: html
-
-      </div>
 
 -  By providing a url to a WMS server that supports EPSG:3857 (or
    EPSG:900913) as a source of tiled data. The server url should contain
@@ -428,8 +416,6 @@ done in several ways:
          ],
          "tileSize": 256
        }
-
-.. _sources-vector:
 
 vector
 ~~~~~~
@@ -447,7 +433,8 @@ Mapbox, the ``"url"`` value should be of the form ``mapbox://mapid``.
       "url": "mapbox://mapbox.mapbox-streets-v6"
     }
 
-`url <#sources-vector-url>`__
+url
+^^^
 
 *Optional* :ref:`types-string`.
 
@@ -456,7 +443,8 @@ Mapbox, the ``"url"`` value should be of the form ``mapbox://mapid``.
 A URL to a TileJSON resource. Supported protocols are ``http:``,
 ``https:``, and ``mapbox://<mapid>``.
 
-`tiles <#sources-vector-tiles>`__
+tiles
+^^^^^
 
 *Optional* :ref:`types-array`.
 
@@ -464,7 +452,8 @@ A URL to a TileJSON resource. Supported protocols are ``http:``,
 
 An array of one or more tile source URLs, as in the TileJSON spec.
 
-`minzoom <#sources-vector-minzoom>`__
+minzoom
+^^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 0.
 
@@ -472,7 +461,8 @@ An array of one or more tile source URLs, as in the TileJSON spec.
 Minimum zoom level for which tiles are available, as in the TileJSON
 spec.
 
-`maxzoom <#sources-vector-maxzoom>`__
+maxzoom
+^^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 22.
 
@@ -497,12 +487,6 @@ higher zoom levels.
      - >= 2.0.0
      - >= 0.1.0
 
-.. raw:: html
-
-   <div id="sources-raster" class="pad2 keyline-bottom">
-
-.. _sources-raster:
-
 raster
 ~~~~~~
 
@@ -517,7 +501,8 @@ value should be of the form ``mapbox://mapid``.
       "tileSize": 256
     }
 
-`url <#sources-raster-url>`__
+url
+^^^
 
 *Optional* :ref:`types-string`.
 
@@ -525,7 +510,8 @@ value should be of the form ``mapbox://mapid``.
 A URL to a TileJSON resource. Supported protocols are ``http:``,
 ``https:``, and ``mapbox://<mapid>``.
 
-`tiles <#sources-raster-tiles>`__
+tiles
+^^^^^
 
 *Optional* :ref:`types-array`.
 
@@ -533,7 +519,8 @@ A URL to a TileJSON resource. Supported protocols are ``http:``,
 
 An array of one or more tile source URLs, as in the TileJSON spec.
 
-`minzoom <#sources-raster-minzoom>`__
+minzoom
+^^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 0.
 
@@ -541,7 +528,8 @@ An array of one or more tile source URLs, as in the TileJSON spec.
 Minimum zoom level for which tiles are available, as in the TileJSON
 spec.
 
-`maxzoom <#sources-raster-maxzoom>`__
+maxzoom
+^^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 22.
 
@@ -550,7 +538,8 @@ Maximum zoom level for which tiles are available, as in the TileJSON
 spec. Data from tiles at the maxzoom are used when displaying the map at
 higher zoom levels.
 
-`tileSize <#sources-raster-tileSize>`__
+tileSize
+^^^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 512.
 
@@ -573,15 +562,8 @@ configurable for raster layers.
      - >= 2.0.0
      - >= 0.1.0
 
-
-.. raw:: html
-
-   <div id="sources-geojson" class="pad2 keyline-bottom">
-
-.. _sources-geojson:
-
 geojson
-~~~~~~~~
+~~~~~~~
 
 A `GeoJSON <http://geojson.org/>`__ source. Data must be provided via a
 ``"data"`` property, whose value can be a URL or inline GeoJSON.
@@ -613,14 +595,16 @@ accessible using `CORS <http://enable-cors.org/>`__.
       "data": "./lines.geojson"
     }
 
-`data <#sources-geojson-data>`__
+data
+^^^^
 
 *Optional*
 
 
 A URL to a GeoJSON file, or inline GeoJSON.
 
-`maxzoom <#sources-geojson-maxzoom>`__
+maxzoom
+^^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 18.
 
@@ -628,7 +612,8 @@ A URL to a GeoJSON file, or inline GeoJSON.
 Maximum zoom level at which to create vector tiles (higher means greater
 detail at high zoom levels).
 
-`buffer <#sources-geojson-buffer>`__
+buffer
+^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 128.
 
@@ -638,7 +623,8 @@ value of 512 produces a buffer as wide as the tile itself. Larger values
 produce fewer rendering artifacts near tile edges and slower
 performance.
 
-`tolerance <#sources-geojson-tolerance>`__
+tolerance
+^^^^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 0.375.
 
@@ -646,7 +632,8 @@ performance.
 Douglas-Peucker simplification tolerance (higher means simpler
 geometries and faster performance).
 
-`cluster <#sources-geojson-cluster>`__
+cluster
+^^^^^^^
 
 *Optional* :ref:`types-boolean`. *Defaults to* false.
 
@@ -654,7 +641,8 @@ geometries and faster performance).
 If the data is a collection of point features, setting this to true
 clusters the points by radius into groups.
 
-`clusterRadius <#sources-geojson-clusterRadius>`__
+clusterRadius
+^^^^^^^^^^^^^
 
 *Optional* :ref:`types-number`. *Defaults to* 50.
 
@@ -663,10 +651,10 @@ clusters the points by radius into groups.
 Radius of each cluster if clustering is enabled. A value of 512
 indicates a radius equal to the width of a tile.
 
-`clusterMaxZoom <#sources-geojson-clusterMaxZoom>`__
+clusterMaxZoom
+^^^^^^^^^^^^^^
 
 *Optional* :ref:`types-number`.
-
 
 
 Max zoom on which to cluster points if clustering is enabled. Defaults
@@ -709,13 +697,6 @@ clustered).
    >= 3.4.0
    >= 0.3.0
 
-
-.. raw:: html
-
-   <div id="sources-image" class="pad2 keyline-bottom">
-
-.. _sources-image:
-
 image
 ~~~~~
 
@@ -737,19 +718,17 @@ right, bottom left.
       ]
     }
 
-
-`url <#sources-image-url>`__
+url
+^^^
 
 *Required* :ref:`types-string`. 
 
-
-
 URL that points to an image.
 
-`coordinates <#sources-image-coordinates>`__
+coordinates
+^^^^^^^^^^^
 
 *Required* :ref:`types-array`.
-
 
 Corners of image specified in longitude, latitude pairs.
 
@@ -767,13 +746,6 @@ Corners of image specified in longitude, latitude pairs.
      - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
      - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
      - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
-
-
-.. raw:: html
-
-   <div id="sources-video" class="pad2 keyline-bottom">
-
-.. _sources-video:
 
 video
 ~~~~~
@@ -803,8 +775,8 @@ right, bottom left.
       ]
     }
 
-`urls <#sources-video-urls>`__
-
+urls
+^^^^
 
 *Required* :ref:`types-array`.
 
@@ -812,10 +784,10 @@ right, bottom left.
 
 URLs to video content in order of preferred format.
 
-`coordinates <#sources-video-coordinates>`__
+coordinates
+^^^^^^^^^^^
 
 *Required* :ref:`types-array`.
-
 
 
 Corners of video specified in longitude, latitude pairs.
@@ -850,15 +822,8 @@ Corners of video specified in longitude, latitude pairs.
    `Not yet
    supported <https://github.com/mapbox/mapbox-gl-native/issues/601>`__
 
-
-.. raw:: html
-
-   <div id="sources-canvas" class="pad2 keyline-bottom">
-
-.. _sources-canvas:
-
 canvas
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~
 
 A canvas source. The ``"canvas"`` value is the ID of the canvas element
 in the document.
@@ -875,8 +840,6 @@ If an HTML document contains a canvas such as this:
 
 the corresponding canvas source would be specified as follows:
 
-
-
 ::
 
     "canvas": {
@@ -890,8 +853,8 @@ the corresponding canvas source would be specified as follows:
       ]
     }
 
-`coordinates <#sources-canvas-coordinates>`__
-
+coordinates
+^^^^^^^^^^^
 
 *Required* :ref:`types-array`.
 
@@ -899,22 +862,16 @@ the corresponding canvas source would be specified as follows:
 
 Corners of canvas specified in longitude, latitude pairs.
 
-`animate <#sources-canvas-animate>`__
-
-.. raw:: html
-
-   <i>Optional <a href="#boolean">boolean</a>. </i><i>Defaults to </i>true.
-
-
+animate
+^^^^^^^
 
 Whether the canvas source is animated. If the canvas is static,
 ``animate`` should be set to ``false`` to improve performance.
 
-`canvas <#sources-canvas-canvas>`__
+canvas
+^^^^^^
 
 *Required* :ref:`types-string`. 
-
-
 
 HTML ID of the canvas from which to read pixels.
 
@@ -934,14 +891,10 @@ HTML ID of the canvas from which to read pixels.
      - Not supported
      - Not supported
 
-.. raw:: html
-
-   <div class="pad2 prose">
-
 .. _sprite:
 
 Sprite
---------------------
+------
 
 A style's ``sprite`` property supplies a URL template for loading small
 images to use in rendering ``background-pattern``, ``fill-pattern``,

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -856,10 +856,6 @@ A style's ``sprite`` property supplies a URL template for loading small
 images to use in rendering ``background-pattern``, ``fill-pattern``,
 ``line-pattern``, and ``icon-image`` style properties.
 
-.. raw:: html
-
-   <div class="space-bottom1 pad2x clearfix">
-
 ::
 
     "sprite" : "/geoserver/styles/mark"
@@ -876,10 +872,6 @@ A valid sprite source must supply two types of files:
    (``x`` and ``y``). For example, a sprite containing a single image
    might have the following index file contents:
 
-   .. raw:: html
-
-      <div class="space-bottom1 clearfix">
-
    ::
 
        {
@@ -891,10 +883,6 @@ A valid sprite source must supply two types of files:
            "pixelRatio": 1
          }
        }
-
-   .. raw:: html
-
-      </div>
 
    Then the style could refer to this sprite image by creating a symbol
    layer with the layout property ``"icon-image": "poi"``, or with the
@@ -922,22 +910,13 @@ files, you can use
 line utility that builds Mapbox GL compatible sprite PNGs and index
 files from a directory of SVGs.
 
-
-.. raw:: html
-
-   <div class="pad2 prose">
-
 .. _glyphs:
 
 Glyphs
---------------------
+------
 
 A style's ``glyphs`` property provides a URL template for loading
 signed-distance-field glyph sets in PBF format.
-
-.. raw:: html
-
-   <div class="space-bottom1 pad2x clearfix">
 
 ::
 
@@ -957,22 +936,13 @@ This URL template should include two tokens:
    would be ``0-255``. The actual ranges that are loaded are determined
    at runtime based on what text needs to be displayed.
 
-
-.. raw:: html
-
-   <div class="pad2 prose">
-
 .. _transition:
 
 Transition
-----------------------------
+----------
 
 A style's ``transition`` property provides global transition defaults
 for that style.
-
-.. raw:: html
-
-   <div class="space-bottom1 pad2x clearfix">
 
 ::
 
@@ -981,38 +951,25 @@ for that style.
       "delay": 0
     }
 
-
-.. raw:: html
-
-   <div class="pad2 keyline-all fill-white">
-
-`duration <#transition-duration>`__
+duration
+~~~~~~~~
 
 *Optional* :ref:`types-number`. *Units in milliseconds. Defaults to* 300. 
 
 
 Time allotted for transitions to complete.
 
-`delay <#transition-delay>`__
+delay
+~~~~~
 
 *Optional* :ref:`types-number`. *Units in milliseconds. Defaults to* 0. 
 
-
-
 Length of time before a transition begins.
-
-
-
-
-
-.. raw:: html
-
-   <div class="pad2 prose">
 
 .. _layers:
 
 Layers
---------------------
+------
 
 A style's ``layers`` property lists all of the layers available in that
 style. The type of layer is specified by the ``"type"`` property, and
@@ -1022,10 +979,6 @@ fill-extrusion.
 Except for layers of the background type, each layer needs to refer to a
 source. Layers take the data that they get from a source, optionally
 filter features, and then define how those features are styled.
-
-.. raw:: html
-
-   <div class="space-bottom1 pad2x clearfix">
 
 ::
 
@@ -1041,24 +994,19 @@ filter features, and then define how those features are styled.
       }
     ]
 
+Layer Properties
+~~~~~~~~~~~~~~~~
 
-.. raw:: html
-
-   <div class="pad2 keyline-all fill-white">
-
-.. _layer_id:
-
-``id``
+id
+^^
 
 *Required* :ref:`types-string`. 
 
 
 Unique layer name.
 
-.. _layer-type:
-
-``type``
-
+type
+^^^^
 
 *Optional* :ref:`types-enum`. *One of fill, line, symbol, circle, fill-extrusion, raster, background.*
 
@@ -1087,7 +1035,8 @@ Rendering type of this layer.
 *background*
     The background color or pattern of the map.
 
-``metadata``
+metadata
+^^^^^^^^
 
 *Optional*
 
@@ -1096,7 +1045,8 @@ Arbitrary properties useful to track with the layer, but do not
 influence rendering. Properties should be prefixed to avoid collisions,
 like 'mapbox:'.
 
-``ref``
+ref
+^^^
 
 *Optional* :ref:`types-string`.
 
@@ -1106,7 +1056,8 @@ References another layer to copy ``type``, ``source``, ``source-layer``,
 ``minzoom``, ``maxzoom``, ``filter``, and ``layout`` properties from.
 This allows the layers to share processing and be more efficient.
 
-``source``
+source
+^^^^^^
 
 *Optional* :ref:`types-string`.
 
@@ -1114,7 +1065,8 @@ This allows the layers to share processing and be more efficient.
 
 Name of a source description to be used for this layer.
 
-``source-layer``
+source-layer
+^^^^^^^^^^^^
 
 *Optional* :ref:`types-string`.
 
@@ -1123,7 +1075,8 @@ Name of a source description to be used for this layer.
 Layer to use from a vector tile source. Required if the source supports
 multiple layers.
 
-``minzoom``
+minzoom
+^^^^^^^
 
 *Optional* :ref:`types-number`.
 
@@ -1131,7 +1084,8 @@ multiple layers.
 
 The minimum zoom level on which the layer gets parsed and appears on.
 
-``maxzoom``
+maxzoom
+^^^^^^^
 
 *Optional* :ref:`types-number`.
 
@@ -1139,7 +1093,8 @@ The minimum zoom level on which the layer gets parsed and appears on.
 
 The maximum zoom level on which the layer gets parsed and appears on.
 
-``filter``
+filter
+^^^^^^
 
 *Optional* :ref:`types-filter`.
 
@@ -1148,18 +1103,15 @@ The maximum zoom level on which the layer gets parsed and appears on.
 A expression specifying conditions on source features. Only features
 that match the filter are displayed.
 
-``layout``
+layout
+^^^^^^
 
 layout properties for the layer
 
-``paint``
+paint
+^^^^^
 
 *Optional* paint properties for the layer
-
-
-.. raw:: html
-
-   <div class="pad2 prose">
 
 Layers have two sub-properties that determine how data from that layer
 is rendered: ``layout`` and ``paint`` properties.
@@ -1177,27 +1129,14 @@ that shares layout properties with another layer can have independent
 paint properties. Paint properties appear in the layer's ``"paint"``
 object.
 
-Key: `supports interpolated functions <#function>`__ `supports piecewise
-constant functions <#function>`__ transitionable
+background
+~~~~~~~~~~
 
-.. raw:: html
+Layout Properties
+^^^^^^^^^^^^^^^^^
 
-   <div class="space-bottom4 fill-white keyline-all">
-
-.. raw:: html
-
-   <div id="layers-background" class="pad2 keyline-bottom">
-
-
-`background <#layers-background>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-
-`Layout Properties <#layout_background>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`visibility <#layout-background-visibility>`__
+visibility
+""""""""""
 
 *Optional* :ref:`types-enum`. *One of* visible, none, *Defaults to* visible.
 
@@ -1224,11 +1163,11 @@ none
      - not yet supported
      - not yet supported
 
-`Paint Properties <#paint_background>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Paint Properties
+^^^^^^^^^^^^^^^^
 
-`background-color <#paint-background-color>`__
-
+background-color
+""""""""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000. *Disabled by* background-pattern.
 
@@ -1249,7 +1188,8 @@ The color with which the background will be drawn.
      - not yet supported
      - not yet supported
 
-`background-pattern <#paint-background-pattern>`__
+background-pattern
+""""""""""""""""""
 
 *Optional* :ref:`types-string`.
 
@@ -1273,7 +1213,8 @@ seamless patterns, image width and height must be a factor of two (2, 4,
      - not yet supported
      - not yet supported
 
-`background-opacity <#paint-background-opacity>`__
+background-opacity
+""""""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.
 
@@ -1292,17 +1233,14 @@ The opacity at which the background will be drawn.
      - not yet supported
      - not yet supported
 
-.. raw:: html
+fill
+~~~~
 
-   <div id="layers-fill" class="pad2 keyline-bottom">
+Layout Properties
+^^^^^^^^^^^^^^^^^
 
-`fill <#layers-fill>`__
-~~~~~~~~~~~~~~~~~~~~~~~
-
-`Layout Properties <#layout_fill>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`visibility <#layout-fill-visibility>`__
+visibility
+""""""""""
 
 
 *Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
@@ -1328,14 +1266,13 @@ none
      - not yet supported
      - not yet supported
 
-`Paint Properties <#paint_fill>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Paint Properties
+^^^^^^^^^^^^^^^^
 
-`fill-antialias <#paint-fill-antialias>`__
+fill-antialias
+""""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* true.
-
-
 
 
 Whether or not the fill should be antialiased.
@@ -1358,7 +1295,8 @@ Whether or not the fill should be antialiased.
      - 18.0
      - not yet supported
 
-`fill-opacity <#paint-fill-opacity>`__
+fill-opacity
+""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.
 
@@ -1384,8 +1322,8 @@ stroke is used.
      - 18.0
      - 4.1.1
 
-`fill-color <#paint-fill-color>`__
-
+fill-color
+""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000. *Disabled by* fill-pattern.
 
@@ -1412,8 +1350,8 @@ affect the opacity of the 1px stroke, if it is used.
      - 18.0
      - 4.1.1
 
-`fill-outline-color <#paint-fill-outline-color>`__
-
+fill-outline-color
+""""""""""""""""""
 
 *Optional* :ref:`types-color`. *Disabled by* fill-pattern. *Requires* fill-antialias = true.
 
@@ -1438,7 +1376,8 @@ unspecified.
      - 18.0
      - 4.1.1
 
-`fill-translate <#paint-fill-translate>`__
+fill-translate
+""""""""""""""
 
 *Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0.0.
 
@@ -1463,8 +1402,8 @@ and up, respectively.
      - 18.0
      - not yet supported
 
-`fill-translate-anchor <#paint-fill-translate-anchor>`__
-
+fill-translate-anchor
+"""""""""""""""""""""
 
 *Optional* :ref:`types-enum`. *One of* map, viewport. *Defaults to* map. *Requires* fill-translate.
 
@@ -1493,7 +1432,8 @@ viewport
      - not yet supported
      - not yet supported
 
-`fill-pattern <#paint-fill-pattern>`__
+fill-pattern
+""""""""""""
 
 *Optional* :ref:`types-string`.
 
@@ -1523,14 +1463,14 @@ patterns, image width and height must be a factor of two (2, 4, 8, ...,
 
    <div id="layers-line" class="pad2 keyline-bottom">
 
-`line <#layers-line>`__
-~~~~~~~~~~~~~~~~~~~~~~~
+line
+~~~~
 
-`Layout Properties <#layout_line>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Layout Properties
+^^^^^^^^^^^^^^^^^
 
-`line-cap <#layout-line-line-cap>`__
-
+line-cap
+""""""""
 
 *Optional* :ref:`types-enum`. *One of* butt, round, square. *Defaults to* butt.
 
@@ -1591,8 +1531,8 @@ square
      - Not yet supported
 
 
-`line-join <#layout-line-line-join>`__
-
+line-join
+"""""""""
 
 *Optional* :ref:`types-enum`. *One of* bevel, round, miter. *Defaults to* miter.
 
@@ -1645,8 +1585,8 @@ miter
      - Not yet supported
 
 
-`line-miter-limit <#layout-line-line-miter-limit>`__
-
+line-miter-limit
+""""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 2. *Requires* line-join = miter.
 
@@ -1686,7 +1626,8 @@ angles.
      - Not yet supported
 
 
-`line-round-limit <#layout-line-line-round-limit>`__
+line-round-limit
+""""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.05. *Requires* line-join = round.
 
@@ -1727,8 +1668,8 @@ angles.
      - Not yet supported
 
 
-`visibility <#layout-line-visibility>`__
-
+visibility
+""""""""""
 
 *Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
 
@@ -1774,10 +1715,11 @@ none
      - Not yet supported
 
 
-`Paint Properties <#paint_line>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Paint Properties
+^^^^^^^^^^^^^^^^
 
-`line-opacity <#paint-line-opacity>`__
+line-opacity
+""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.
 
@@ -1817,8 +1759,8 @@ The opacity at which the line will be drawn.
      - >= 0.4.0
 
 
-`line-color <#paint-line-color>`__
-
+line-color
+""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000. *Disabled by* line-pattern.
 
@@ -1857,7 +1799,8 @@ The color with which the line will be drawn.
      - >= 0.4.0
 
 
-`line-translate <#paint-line-translate>`__
+line-translate
+""""""""""""""
 
 *Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0.0.
 
@@ -1899,9 +1842,8 @@ and up, respectively.
 
 
 
-`line-translate-anchor <#paint-line-translate-anchor>`__
-
-
+line-translate-anchor
+"""""""""""""""""""""
 
 *Optional* :ref:`types-enum`. *One of* map, viewport. *Defaults to* map. *Requires* line-translate.
 
@@ -1947,7 +1889,8 @@ viewport
      - Not yet supported
 
 
-`line-width <#paint-line-width>`__
+line-width
+""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 1.
 
@@ -1986,7 +1929,8 @@ Stroke thickness.
      - Not yet supported
 
 
-`line-gap-width <#paint-line-gap-width>`__
+line-gap-width
+""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 0.
 
@@ -2027,7 +1971,8 @@ width of the inner gap.
      - >= 3.5.0
      - >= 0.4.0
 
-`line-offset <#paint-line-offset>`__
+line-offset
+"""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 0.
 
@@ -2070,7 +2015,8 @@ inset, and a negative value results in an outset.
      - >= 0.4.0
 
 
-`line-blur <#paint-line-blur>`__
+line-blur
+"""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 0.
 
@@ -2110,8 +2056,8 @@ Blur applied to the line, in pixels.
      - >= 0.4.0
 
 
-`line-dasharray <#paint-line-dasharray>`__
-
+line-dasharray
+""""""""""""""
 
 *Optional* :ref:`types-array`. *Units in* line widths. *Disabled by* line-pattern.
 
@@ -2151,7 +2097,8 @@ a dash length to pixels, multiply the length by the current line width.
      - Not yet supported
      - Not yet supported
 
-`line-pattern <#paint-line-pattern>`__
+line-pattern
+""""""""""""
 
 *Optional* :ref:`types-string`.
 
@@ -2197,15 +2144,14 @@ patterns, image width must be a factor of two (2, 4, 8, ..., 512).
 
    <div id="layers-symbol" class="pad2 keyline-bottom">
 
-`symbol <#layers-symbol>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+symbol
+~~~~~~
 
+Layout Properties
+^^^^^^^^^^^^^^^^^
 
-
-`Layout Properties <#layout_symbol>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`symbol-placement <#layout-symbol-symbol-placement>`__
+symbol-placement
+""""""""""""""""
 
 
 *Optional* :ref:`types-enum`. *One of* point, line. *Defaults to* point.
@@ -2253,9 +2199,8 @@ line
      - Not yet supported
 
 
-`symbol-spacing <#layout-symbol-symbol-spacing>`__
-
-
+symbol-spacing
+""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 250. *Requires* symbol-placement = line.
 
@@ -2294,7 +2239,8 @@ Distance between two symbol anchors.
      - Not yet supported
 
 
-`symbol-avoid-edges <#layout-symbol-symbol-avoid-edges>`__
+symbol-avoid-edges
+""""""""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* false.
 
@@ -2337,7 +2283,8 @@ placed after a line symbol layer.
      - Not yet supported
 
 
-`icon-allow-overlap <#layout-symbol-icon-allow-overlap>`__
+icon-allow-overlap
+""""""""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* false. *Requires* icon-image.
 
@@ -2378,7 +2325,8 @@ previously drawn symbols.
      - Not yet supported
 
 
-`icon-ignore-placement <#layout-symbol-icon-ignore-placement>`__
+icon-ignore-placement
+"""""""""""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* false. *Requires* icon-image.
 
@@ -2419,7 +2367,8 @@ icon.
      - Not yet supported
 
 
-`icon-optional <#layout-symbol-icon-optional>`__
+icon-optional
+"""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* false. *<Requires* icon-image, text-field.
 
@@ -2461,8 +2410,8 @@ icon collides with other symbols and the text does not.
      - Not yet supported
 
 
-`icon-rotation-alignment <#layout-symbol-icon-rotation-alignment>`__
-
+icon-rotation-alignment
+"""""""""""""""""""""""
 
 *Optional* :ref:`types-enum`. *One of* map, viewport, auto. *Defaults to* auto. *Requires* icon-image.
 
@@ -2522,8 +2471,8 @@ auto
      - Not yet supported
 
 
-`icon-size <#layout-symbol-icon-size>`__
-
+icon-size
+"""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1. *Requires* icon-image.
 Scale factor for icon. 1 is original size, 3 triples the size.
@@ -2562,8 +2511,8 @@ Scale factor for icon. 1 is original size, 3 triples the size.
 
 
 
-`icon-text-fit <#layout-symbol-icon-text-fit>`__
-
+icon-text-fit
+"""""""""""""
 
 *Optional* :ref:`types-enum`. *One of* none, width, height, both. *Defaults to* none. *Requires* icon-image, text-field.
 
@@ -2616,8 +2565,8 @@ both
      - Not yet supported
 
 
-`icon-text-fit-padding <#layout-symbol-icon-text-fit-padding>`__
-
+icon-text-fit-padding
+"""""""""""""""""""""
 
 *Optional :ref:`types-array`. *Units in* pixels. *Defaults to* 0,0,0,0. *Requires* icon-image, text-field, icon-text-fit = one of both, width, height.
 
@@ -2657,7 +2606,8 @@ Size of the additional area added to dimensions determined by
      - Not yet supported
 
 
-`icon-image <#layout-symbol-icon-image>`__
+icon-image
+""""""""""
 
 *Optional* :ref:`types-string`.
 
@@ -2699,8 +2649,8 @@ with {tokens} replaced, referencing the data property to pull from.
      - Not yet supported
 
 
-`icon-rotate <#layout-symbol-icon-rotate>`__
-
+icon-rotate
+"""""""""""
 
 *Optional* :ref:`types-number`. *Units in* degrees. *Defaults to* 0. *Requires* icon-image.
 
@@ -2739,8 +2689,8 @@ Rotates the icon clockwise.
      - >= 0.4.0
 
 
-`icon-padding <#layout-symbol-icon-padding>`__
-
+icon-padding
+""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 2. *Requires* icon-image.
 
@@ -2782,7 +2732,8 @@ detecting symbol collisions.
 
 
 
-`icon-keep-upright <#layout-symbol-icon-keep-upright>`__
+icon-keep-upright
+"""""""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* false. *Requires* icon-image, icon-rotation-alignment = map, symbol-placement = line.
 
@@ -2823,8 +2774,8 @@ upside-down.
      - Not yet supported
 
 
-`icon-offset <#layout-symbol-icon-offset>`__
-
+icon-offset
+"""""""""""
 
 *Optional* :ref:`types-array`. *Defaults to* 0,0. *Requires* icon-image.
 
@@ -2865,8 +2816,8 @@ and down, while negative values indicate left and up. When combined with
      - >= 0.4.0
 
 
-`text-pitch-alignment <#layout-symbol-text-pitch-alignment>`__
-
+text-pitch-alignment
+""""""""""""""""""""
 
 *Optional* :ref:`types-enum` *One of* map, viewport, auto. *Defaults to* auto. *Requires* text-field.
 
@@ -2921,7 +2872,8 @@ auto
 
 
 
-`text-rotation-alignment <#layout-symbol-text-rotation-alignment>`__
+text-rotation-alignment
+"""""""""""""""""""""""
 
 *Optional* :ref:`types-enum`. *One of* map, viewport, auto. *Defaults to* auto. *Requires* text-field.
 
@@ -2982,7 +2934,8 @@ auto
 
 
 
-`text-field <#layout-symbol-text-field>`__
+text-field
+""""""""""
 
 *Optional* :ref:`types-string`.
 
@@ -3025,8 +2978,8 @@ literal ``text-field`` values--not for property functions.)
      - >= 0.4.0
 
 
-`text-font <#layout-symbol-text-font>`__
-
+text-font
+"""""""""
 
 *Optional* :ref:`types-array`. *Defaults to* Open Sans Regular,Arial Unicode MS Regular. *Requires* text-field.
 
@@ -3066,7 +3019,8 @@ Font stack to use for displaying text.
 
 
 
-`text-size <#layout-symbol-text-size>`__
+text-size
+"""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 16. *Requires* text-field.
 
@@ -3108,7 +3062,8 @@ Font size.
 
 
 
-`text-max-width <#layout-symbol-text-max-width>`__
+text-max-width
+""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 10. *Requires* text-field.
 
@@ -3149,7 +3104,8 @@ The maximum line width for text wrapping.
      - Not yet supported
 
 
-`text-line-height <#layout-symbol-text-line-height>`__
+text-line-height
+""""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* ems. *Defaults to* 1.2. *Requires* text-field.
 
@@ -3190,7 +3146,8 @@ Text leading value for multi-line text.
      - Not yet supported
 
 
-`text-letter-spacing <#layout-symbol-text-letter-spacing>`__
+text-letter-spacing
+"""""""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* ems. *Defaults to* 0. *Requires* text-field.
 
@@ -3232,7 +3189,8 @@ Text tracking amount.
 
 
 
-`text-justify <#layout-symbol-text-justify>`__
+text-justify
+""""""""""""
 
 *Optional* :ref:`types-enum`. *One of* left, center, right. *Defaults to* center. *Requires* text-field.
 
@@ -3282,7 +3240,8 @@ right
      - Not yet supported
 
 
-`text-anchor <#layout-symbol-text-anchor>`__
+text-anchor
+"""""""""""
 
 *Optional* :ref:`types-enum`. *One of* center, left, right, top, bottom, top-left, top-right, bottom-left, bottom-right.
 *Defaults to* center. *Requires* text-field.
@@ -3352,7 +3311,8 @@ bottom-right
      - Not yet supported
 
 
-`text-max-angle <#layout-symbol-text-max-angle>`__
+text-max-angle
+""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* degrees. *Defaults to* 45. *Requires* text-field, symbol-placement = line.
 
@@ -3392,7 +3352,8 @@ Maximum angle change between adjacent characters.
      - Not yet supported
 
 
-`text-rotate <#layout-symbol-text-rotate>`__
+text-rotate
+"""""""""""
 
 *Optional* :ref:`types-number`. *Units in* degrees. *Defaults to* 0. *Requires* text-field.
 
@@ -3434,7 +3395,8 @@ Rotates the text clockwise.
 
 
 
-`text-padding <#layout-symbol-text-padding>`__
+text-padding
+""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 2. *Requires* text-field.
 
@@ -3477,7 +3439,8 @@ detecting symbol collisions.
 
 
 
-`text-keep-upright <#layout-symbol-text-keep-upright>`__
+text-keep-upright
+"""""""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* true. *Requires* text-field, text-rotation-alignment = true, symbol-placement = true.
 
@@ -3520,8 +3483,8 @@ rendered upside-down.
 
 
 
-`text-transform <#layout-symbol-text-transform>`__
-
+text-transform
+""""""""""""""
 
 *Optional* :ref:`types-enum`. *One of* none, uppercase, lowercase. *Defaults to* none. *Requires* text-field.
 
@@ -3572,7 +3535,8 @@ lowercase
 
 
 
-`text-offset <#layout-symbol-text-offset>`__
+text-offset
+"""""""""""
 
 *Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0,0. *Requires* icon-image.
 
@@ -3613,7 +3577,8 @@ and down, while negative values indicate left and up.
 
 
 
-`text-allow-overlap <#layout-symbol-text-allow-overlap>`__
+text-allow-overlap
+""""""""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* false. *Requires* text-field.
 
@@ -3656,7 +3621,8 @@ previously drawn symbols.
 
 
 
-`text-ignore-placement <#layout-symbol-text-ignore-placement>`__
+text-ignore-placement
+"""""""""""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* false. *Requires* text-field
 
@@ -3699,7 +3665,8 @@ text.
 
 
 
-`text-optional <#layout-symbol-text-optional>`__
+text-optional
+"""""""""""""
 
 *Optional* :ref:`types-boolean`. *Defaults to* false. *Requires* text-field, icon-image.
 
@@ -3742,7 +3709,8 @@ text collides with other symbols and the icon does not.
 
 
 
-`visibility <#layout-symbol-visibility>`__
+visibility
+""""""""""
 
 *Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
 
@@ -3791,10 +3759,11 @@ none
 
 
 
-`Paint Properties <#paint_symbol>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Paint Properties
+^^^^^^^^^^^^^^^^
 
-`icon-opacity <#paint-icon-opacity>`__
+icon-opacity
+""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1. <i>Requires </i>icon-image.
 
@@ -3834,7 +3803,8 @@ The opacity at which the icon will be drawn.
      - >= 0.4.0
 
 
-`icon-color <#paint-icon-color>`__
+icon-color
+""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000. *Requires* icon-image.
 
@@ -3876,7 +3846,8 @@ The color of the icon. This can only be used with sdf icons.
 
 
 
-`icon-halo-color <#paint-icon-halo-color>`__
+icon-halo-color
+"""""""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* rgba(0, 0, 0, 0). *Requires* icon-image.
 
@@ -3918,7 +3889,8 @@ icons.
      - >= 0.4.0
 
 
-`icon-halo-width <#paint-icon-halo-width>`__
+icon-halo-width
+"""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 0. *Requires* icon-image.
 
@@ -3960,7 +3932,8 @@ Distance of halo to the icon outline.
 
 
 
-`icon-halo-blur <#paint-icon-halo-blur>`__
+icon-halo-blur
+""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 0. *Requires* icon-image.
 
@@ -4002,7 +3975,8 @@ Fade out the halo towards the outside.
 
 
 
-`icon-translate <#paint-icon-translate>`__
+icon-translate
+""""""""""""""
 
 *Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0,0. *Requires* icon-image.
 
@@ -4046,7 +4020,8 @@ left and up.
 
 
 
-`icon-translate-anchor <#paint-icon-translate-anchor>`__
+icon-translate-anchor
+"""""""""""""""""""""
 
 *Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map. *Requires* icon-image, icon-translate.
 
@@ -4094,7 +4069,8 @@ viewport
      - Not yet supported
 
 
-`text-opacity <#paint-text-opacity>`__
+text-opacity
+""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1. <i>Requires </i>text-field.
 
@@ -4135,7 +4111,8 @@ The opacity at which the text will be drawn.
 
 
 
-`text-color <#paint-text-color>`__
+text-color
+""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000. *Requires* text-field.
 
@@ -4177,7 +4154,8 @@ The color with which the text will be drawn.
 
 
 
-`text-halo-color <#paint-text-halo-color>`__
+text-halo-color
+"""""""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* rgba(0, 0, 0, 0). *Requires* text-field.
 
@@ -4219,7 +4197,8 @@ The color of the text's halo, which helps it stand out from backgrounds.
 
 
 
-`text-halo-width <#paint-text-halo-width>`__
+text-halo-width
+"""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 0. *Requires* text-field.
 
@@ -4262,7 +4241,8 @@ font-size.
 
 
 
-`text-halo-blur <#paint-text-halo-blur>`__
+text-halo-blur
+""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 0. *Requires* text-field.
 
@@ -4304,7 +4284,8 @@ The halo's fadeout distance towards the outside.
 
 
 
-`text-translate <#paint-text-translate>`__
+text-translate
+""""""""""""""
 
 *Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0,0. *Requires* text-field.
 
@@ -4348,7 +4329,8 @@ left and up.
 
 
 
-`text-translate-anchor <#paint-text-translate-anchor>`__
+text-translate-anchor
+"""""""""""""""""""""
 
 *Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map. *Requires* text-field, text-translate.
 
@@ -4396,20 +4378,14 @@ viewport
      - Not yet supported
 
 
+raster
+~~~~~~
 
-.. raw:: html
+Layout Properties
+^^^^^^^^^^^^^^^^^
 
-   <div id="layers-raster" class="pad2 keyline-bottom">
-
-`raster <#layers-raster>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-
-`Layout Properties <#layout_raster>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`visibility <#layout-raster-visibility>`__
+visibility
+""""""""""
 
 *Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
 
@@ -4458,10 +4434,11 @@ none
 
 
 
-`Paint Properties <#paint_raster>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Paint Properties
+^^^^^^^^^^^^^^^^
 
-`raster-opacity <#paint-raster-opacity>`__
+raster-opacity
+""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.
 
@@ -4544,7 +4521,8 @@ Rotates hues around the color wheel.
 
 
 
-`raster-brightness-min <#paint-raster-brightness-min>`__
+raster-brightness-min
+"""""""""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 0.
 
@@ -4586,7 +4564,8 @@ brightness.
 
 
 
-`raster-brightness-max <#paint-raster-brightness-max>`__
+raster-brightness-max
+"""""""""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.
 
@@ -4628,7 +4607,8 @@ brightness.
 
 
 
-`raster-saturation <#paint-raster-saturation>`__
+raster-saturation
+"""""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 0.
 
@@ -4669,7 +4649,8 @@ Increase or reduce the saturation of the image.
 
 
 
-`raster-contrast <#paint-raster-contrast>`__
+raster-contrast
+"""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 0.
 
@@ -4710,7 +4691,8 @@ Increase or reduce the contrast of the image.
 
 
 
-`raster-fade-duration <#paint-raster-fade-duration>`__
+raster-fade-duration
+""""""""""""""""""""
 
 *Optional* :ref:`types-number` *Units in* milliseconds. *Defaults to* 300.
 
@@ -4751,20 +4733,14 @@ Fade duration when a new tile is added.
      - Not yet supported
 
 
+circle
+~~~~~~
 
-.. raw:: html
+Layout Properties
+^^^^^^^^^^^^^^^^^
 
-   <div id="layers-circle" class="pad2 keyline-bottom">
-
-`circle <#layers-circle>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-
-`Layout Properties <#layout_circle>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`visibility <#layout-circle-visibility>`__
+visibility
+""""""""""
 
 *Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
 
@@ -4807,10 +4783,11 @@ none
      - >= 0.1.0
 
 
-`Paint Properties <#paint_circle>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Paint Properties
+^^^^^^^^^^^^^^^^
 
-`circle-radius <#paint-circle-radius>`__
+circle-radius
+"""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 5.
 
@@ -4852,7 +4829,8 @@ Circle radius.
 
 
 
-`circle-color <#paint-circle-color>`__
+circle-color
+""""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000.
 
@@ -4894,7 +4872,8 @@ The fill color of the circle.
 
 
 
-`circle-blur <#paint-circle-blur>`__
+circle-blur
+"""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 0.
 
@@ -4936,7 +4915,8 @@ centerpoint is full opacity.
 
 
 
-`circle-opacity <#paint-circle-opacity>`__
+circle-opacity
+""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.
 
@@ -4976,7 +4956,8 @@ The opacity at which the circle will be drawn.
      - >= 0.4.0
 
 
-`circle-translate <#paint-circle-translate>`__
+circle-translate
+""""""""""""""""
 
 *Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0,0.
 
@@ -5019,7 +5000,8 @@ and up, respectively.
 
 
 
-`circle-translate-anchor <#paint-circle-translate-anchor>`__
+circle-translate-anchor
+"""""""""""""""""""""""
 
 *Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map. *Requires* circle-translate.
 
@@ -5068,7 +5050,8 @@ viewport
 
 
 
-`circle-pitch-scale <#paint-circle-pitch-scale>`__
+circle-pitch-scale
+""""""""""""""""""
 
 *Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map.
 
@@ -5118,7 +5101,8 @@ viewport
 
 
 
-`circle-stroke-width <#paint-circle-stroke-width>`__
+circle-stroke-width
+"""""""""""""""""""
 
 *Optional* :ref:`types-number`. *Units in* pixels. *Defaults to* 5.
 
@@ -5160,7 +5144,8 @@ The width of the circle's stroke. Strokes are placed outside of the
      - >= 0.4.0
 
 
-`circle-stroke-color <#paint-circle-stroke-color>`__
+circle-stroke-color
+"""""""""""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000.
 
@@ -5200,7 +5185,8 @@ The stroke color of the circle.
      - >= 3.5.0
      - >= 0.4.0
 
-`circle-stroke-opacity <#paint-circle-stroke-opacity>`__
+circle-stroke-opacity
+"""""""""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.
 
@@ -5241,19 +5227,14 @@ The opacity of the circle's stroke.
 
 
 
-.. raw:: html
+fill-extrusion
+~~~~~~~~~~~~~~
 
-   <div id="layers-fill-extrusion" class="pad2 keyline-bottom">
+Layout Properties
+^^^^^^^^^^^^^^^^^
 
-`fill-extrusion <#layers-fill-extrusion>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-
-`Layout Properties <#layout_fill-extrusion>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`visibility <#layout-fill-extrusion-visibility>`__
+visibility
+""""""""""
 
 *Optional* :ref:`types-enum`. *One of* visible, none. *Defaults to* visible.
 
@@ -5297,10 +5278,11 @@ none
 
 
 
-`Paint Properties <#paint_fill-extrusion>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Paint Properties
+^^^^^^^^^^^^^^^^
 
-`fill-extrusion-opacity <#paint-fill-extrusion-opacity>`__
+fill-extrusion-opacity
+""""""""""""""""""""""
 
 *Optional* :ref:`types-number`. *Defaults to* 1.
 
@@ -5338,7 +5320,8 @@ available.
 
 
 
-`fill-extrusion-color <#paint-fill-extrusion-color>`__
+fill-extrusion-color
+""""""""""""""""""""
 
 *Optional* :ref:`types-color`. *Defaults to* #000000. *Disabled by* fill-extrusion-pattern.
 
@@ -5384,7 +5367,8 @@ component, the alpha component will be ignored; use
 
 
 
-`fill-extrusion-translate <#paint-fill-extrusion-translate>`__
+fill-extrusion-translate
+""""""""""""""""""""""""
 
 *Optional* :ref:`types-array`. *Units in* pixels. *Defaults to* 0,0.
 
@@ -5427,7 +5411,8 @@ and up (on the flat plane), respectively.
 
 
 
-`fill-extrusion-translate-anchor <#paint-fill-extrusion-translate-anchor>`__
+fill-extrusion-translate-anchor
+"""""""""""""""""""""""""""""""
 
 *Optional* :ref:`types-enum` *One of* map, viewport. *Defaults to* map. *Requires* fill-extrusion-translate.
 
@@ -5476,7 +5461,8 @@ viewport
 
 
 
-`fill-extrusion-pattern <#paint-fill-extrusion-pattern>`__
+fill-extrusion-pattern
+""""""""""""""""""""""
 
 *Optional* :ref:`types-string`.
 
@@ -5520,7 +5506,8 @@ seamless patterns, image width and height must be a factor of two (2, 4,
 
 
 
-`fill-extrusion-height <#paint-fill-extrusion-height>`__
+fill-extrusion-height
+"""""""""""""""""""""
 
 *Optional* :ref:`types-number` *Units in* meters. *Defaults to* 0.
 
@@ -5561,7 +5548,8 @@ The height with which to extrude this layer.
 
 
 
-`fill-extrusion-base <#paint-fill-extrusion-base>`__
+fill-extrusion-base
+"""""""""""""""""""
 
 *Optional* :ref:`types-number` *Units in* meters. *Defaults to* 0. *Requires* fill-extrusion-height.
 
@@ -5602,11 +5590,6 @@ than or equal to ``fill-extrusion-height``.
      - Not yet supported
      - Not yet supported
 
-
-
-.. raw:: html
-
-   <div class="pad2 prose">
 
 `Types <#types>`__
 ------------------

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -11,7 +11,7 @@ The intended audience of this quick reference includes:
 - Feature support is provided for the `Mapbox GL JS <https://www.mapbox.com/mapbox-gl-js/api/>`__, `Open Layers <http://openlayers.org>`__ and the GeoTools mbstyle module.
 - Where appropriate examples have been changed to reference `GeoWebCache <http://geowebcache.org/>`__.
 
-.. info::
+.. note::
       The `Mapbox Style Specification <https://www.mapbox.com/mapbox-gl-style-spec>`__ is generated from the BSD `Mapbox GL JS <https://github.com/mapbox/mapbox-gl-js>`__ github repository, reproduced here with details on this GeoTools implementation.
 
 
@@ -33,7 +33,7 @@ Root level properties of a Mapbox style specify the map's layers, tile sources a
 
 
 version
-^^^^^^^
+~~~~~~~
 
 *Required* :ref:`types-enum`.
 
@@ -45,7 +45,7 @@ Style specification version number. Must be 8.
 
 
 name
-^^^^
+~~~~
 
 *Optional* :ref:`types-string`.
 
@@ -56,7 +56,7 @@ A human-readable name for the style.
     "name": "Bright"
 
 metadata
-^^^^^^^^
+~~~~~~~~
 
 *Optional*
 
@@ -65,7 +65,7 @@ Arbitrary properties useful to track with the stylesheet, but do not influence r
 .. note:: *unsupported.*
 
 center
-^^^^^^
+~~~~~~
 
 *Optional* :ref:`types-array`.
 
@@ -81,7 +81,7 @@ Default map center in longitude and latitude. The style center will be used only
 .. note:: *unsupported*
 
 zoom
-^^^^
+~~~~
 
 *Optional* :ref:`types-number`.
 
@@ -94,7 +94,7 @@ been positioned by other means (e.g. map options or user interaction).
     "zoom": 12.5
 
 bearing
-^^^^^^^
+~~~~~~~
 
 *Optional* :ref:`types-number`. *Units in degrees. Defaults to* 0.
 
@@ -109,7 +109,7 @@ will be used only if the map has not been positioned by other means
 .. note:: *unsupported*
 
 pitch
-^^^^^
+~~~~~
 
 *Optional* :ref:`types-number`. *Units in degrees. Defaults to* 0.
 
@@ -124,7 +124,7 @@ interaction).
     "pitch": 50
 
 light
-^^^^^
+~~~~~
 
 The global light source.
 
@@ -137,7 +137,7 @@ The global light source.
     }
 
 sources
-^^^^^^^
+~~~~~~~
 
 *Required* :ref:`sources`.
 
@@ -154,7 +154,7 @@ Data source specifications.
     }
 
 sprite
-^^^^^^
+~~~~~~
 
 *Optional* :ref:`types-string`.
 
@@ -171,7 +171,7 @@ appended. This property is required if any layer uses the
     "sprite" : "/geoserver/styles/mark"
 
 glyphs
-^^^^^^
+~~~~~~
 
 *Optional* :ref:`types-string`.
 
@@ -187,7 +187,7 @@ property.
     "glyphs": "{fontstack}/{range}.pbf"
 
 transition
-^^^^^^^^^^
+~~~~~~~~~~
 
 *Required* :ref:`transition`.
 
@@ -203,7 +203,7 @@ A global transition definition to use as a default across properties.
     }
 
 layers
-^^^^^^
+~~~~~~
 
 *Required* :ref:`types-array`.
 
@@ -1286,7 +1286,7 @@ constant functions <#function>`__ transitionable
 
 
 `Layout Properties <#layout_background>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `visibility <#layout-background-visibility>`__
 
@@ -1316,7 +1316,7 @@ none
      - not yet supported
 
 `Paint Properties <#paint_background>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `background-color <#paint-background-color>`__
 
@@ -1391,7 +1391,7 @@ The opacity at which the background will be drawn.
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 `Layout Properties <#layout_fill>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `visibility <#layout-fill-visibility>`__
 
@@ -1420,7 +1420,7 @@ none
      - not yet supported
 
 `Paint Properties <#paint_fill>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `fill-antialias <#paint-fill-antialias>`__
 
@@ -1618,7 +1618,7 @@ patterns, image width and height must be a factor of two (2, 4, 8, ...,
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 `Layout Properties <#layout_line>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `line-cap <#layout-line-line-cap>`__
 
@@ -1866,7 +1866,7 @@ none
 
 
 `Paint Properties <#paint_line>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `line-opacity <#paint-line-opacity>`__
 
@@ -2294,7 +2294,7 @@ patterns, image width must be a factor of two (2, 4, 8, ..., 512).
 
 
 `Layout Properties <#layout_symbol>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `symbol-placement <#layout-symbol-symbol-placement>`__
 
@@ -3883,7 +3883,7 @@ none
 
 
 `Paint Properties <#paint_symbol>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `icon-opacity <#paint-icon-opacity>`__
 
@@ -4498,7 +4498,7 @@ viewport
 
 
 `Layout Properties <#layout_raster>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `visibility <#layout-raster-visibility>`__
 
@@ -4550,7 +4550,7 @@ none
 
 
 `Paint Properties <#paint_raster>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `raster-opacity <#paint-raster-opacity>`__
 
@@ -4853,7 +4853,7 @@ Fade duration when a new tile is added.
 
 
 `Layout Properties <#layout_circle>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `visibility <#layout-circle-visibility>`__
 
@@ -4899,7 +4899,7 @@ none
 
 
 `Paint Properties <#paint_circle>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `circle-radius <#paint-circle-radius>`__
 
@@ -5342,7 +5342,7 @@ The opacity of the circle's stroke.
 
 
 `Layout Properties <#layout_fill-extrusion>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `visibility <#layout-fill-extrusion-visibility>`__
 
@@ -5389,7 +5389,7 @@ none
 
 
 `Paint Properties <#paint_fill-extrusion>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `fill-extrusion-opacity <#paint-fill-extrusion-opacity>`__
 
@@ -6194,7 +6194,7 @@ one of the following forms:
    <div class="col12 clearfix space-bottom2">
 
 Existential Filters
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 ``["has", key]`` feature[key] exists
 
@@ -6203,7 +6203,7 @@ Existential Filters
 
 
 Comparison Filters
-^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
 ``["==", key, value]`` equality: feature[key] = value
 
@@ -6224,7 +6224,7 @@ Comparison Filters
 
 
 Set Membership Filters
-^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~
 
 ``["in", key, v0, ..., vn]`` set inclusion: feature[key] ∈ {v0, ..., vn}
 
@@ -6234,7 +6234,7 @@ vn}
 
 
 Combining Filters
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 ``["all", f0, ..., fn]`` logical ``AND``: f0 ∧ ... ∧ fn
 

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -32,8 +32,8 @@ Root level properties of a Mapbox style specify the map's layers, tile sources a
     }
 
 
-`version <#root-version>`__
-
+version
+^^^^^^^
 
 *Required* :ref:`types-enum`.
 
@@ -44,7 +44,8 @@ Style specification version number. Must be 8.
     "version": 8
 
 
-`name <#root-name>`__
+name
+^^^^
 
 *Optional* :ref:`types-string`.
 
@@ -54,7 +55,8 @@ A human-readable name for the style.
 
     "name": "Bright"
 
-`metadata <#root-metadata>`__
+metadata
+^^^^^^^^
 
 *Optional*
 
@@ -62,8 +64,8 @@ Arbitrary properties useful to track with the stylesheet, but do not influence r
 
 .. note:: *unsupported.*
 
-`center <#root-center>`__
-
+center
+^^^^^^
 
 *Optional* :ref:`types-array`.
 
@@ -78,7 +80,8 @@ Default map center in longitude and latitude. The style center will be used only
 
 .. note:: *unsupported*
 
-`zoom <#root-zoom>`__
+zoom
+^^^^
 
 *Optional* :ref:`types-number`.
 
@@ -90,7 +93,8 @@ been positioned by other means (e.g. map options or user interaction).
 
     "zoom": 12.5
 
-`bearing <#root-bearing>`__
+bearing
+^^^^^^^
 
 *Optional* :ref:`types-number`. *Units in degrees. Defaults to* 0.
 
@@ -104,7 +108,8 @@ will be used only if the map has not been positioned by other means
 
 .. note:: *unsupported*
 
-`pitch <#root-pitch>`__
+pitch
+^^^^^
 
 *Optional* :ref:`types-number`. *Units in degrees. Defaults to* 0.
 
@@ -118,14 +123,8 @@ interaction).
 
     "pitch": 50
 
-.. _root-light:
-
-Light
-
-.. raw:: html
-
-   <i>Optional <a href="#light">light</a>.</i>
-
+light
+^^^^^
 
 The global light source.
 
@@ -137,7 +136,8 @@ The global light source.
       "intensity": 0.4
     }
 
-`sources <#root-sources>`__
+sources
+^^^^^^^
 
 *Required* :ref:`sources`.
 
@@ -153,7 +153,8 @@ Data source specifications.
       }
     }
 
-`sprite <#root-sprite>`__
+sprite
+^^^^^^
 
 *Optional* :ref:`types-string`.
 
@@ -169,7 +170,8 @@ appended. This property is required if any layer uses the
 
     "sprite" : "/geoserver/styles/mark"
 
-`glyphs <#root-glyphs>`__
+glyphs
+^^^^^^
 
 *Optional* :ref:`types-string`.
 
@@ -184,7 +186,8 @@ property.
 
     "glyphs": "{fontstack}/{range}.pbf"
 
-`transition <#root-transition>`__
+transition
+^^^^^^^^^^
 
 *Required* :ref:`transition`.
 
@@ -199,7 +202,8 @@ A global transition definition to use as a default across properties.
       "delay": 0
     }
 
-`layers <#root-layers>`__
+layers
+^^^^^^
 
 *Required* :ref:`types-array`.
 
@@ -221,23 +225,11 @@ Layers will be drawn in the order of this array.
       }
     ]
 
-
-
-
-
-.. raw:: html
-
-   <div class="pad2 prose">
-
-`Light <#light>`__
-------------------
+Light
+-----
 
 A style's ``light`` property provides global light source for that
 style.
-
-.. raw:: html
-
-   <div class="space-bottom1 pad2x clearfix">
 
 ::
 

--- a/docs/user/unsupported/mbstyle/spec.rst
+++ b/docs/user/unsupported/mbstyle/spec.rst
@@ -473,19 +473,17 @@ higher zoom levels.
 
 
 .. list-table::
-   :widths: 20, 30, 30, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
+     - not yet supported
+     - 
 
 raster
 ~~~~~~
@@ -548,19 +546,17 @@ The minimum visual size to display tiles for this layer. Only
 configurable for raster layers.
 
 .. list-table::
-   :widths: 20, 30, 30, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
+     - not yet supported
+     - 
 
 geojson
 ~~~~~~~
@@ -662,40 +658,21 @@ to one zoom less than maxzoom (so that last zoom features are not
 clustered).
 
 .. list-table::
-   :widths: 20, 30, 30, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.10.0
-     - >= 2.0.1
-     - >= 2.0.0
-     - >= 0.1.0
+     - not yet supported
+     - 
    * - clustering
      - >= 0.14.0
-     - >= 4.2.0
-     - >= 3.4.0
-     - >= 0.3.0
-..
-   SDK Requirements
-   Mapbox GL JS
-   Android SDK
-   iOS SDK
-   macOS SDK
-   basic functionality
-   >= 0.10.0
-   >= 2.0.1
-   >= 2.0.0
-   >= 0.1.0
-   clustering
-   >= 0.14.0
-   >= 4.2.0
-   >= 3.4.0
-   >= 0.3.0
+     - not yet supported
+     - 
 
 image
 ~~~~~
@@ -733,19 +710,17 @@ coordinates
 Corners of image specified in longitude, latitude pairs.
 
 .. list-table::
-   :widths: 20, 30, 30, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.10.0
-     - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
-     - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
-     - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
+     - not yet supported
+     - 
 
 video
 ~~~~~
@@ -793,34 +768,17 @@ coordinates
 Corners of video specified in longitude, latitude pairs.
 
 .. list-table::
-   :widths: 20, 30, 30, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.10.0
-     - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
-     - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
-     - `Not yet supported <https://github.com/mapbox/mapbox-gl-native/issues/1350>`__
-
-..
-   SDK Support
-   Mapbox GL JS
-   Android SDK
-   iOS SDK
-   macOS SDK
-   basic functionality
-   >= 0.10.0
-   `Not yet
-   supported <https://github.com/mapbox/mapbox-gl-native/issues/601>`__
-   `Not yet
-   supported <https://github.com/mapbox/mapbox-gl-native/issues/601>`__
-   `Not yet
-   supported <https://github.com/mapbox/mapbox-gl-native/issues/601>`__
+     - not yet supported
+     - 
 
 canvas
 ~~~~~~
@@ -877,19 +835,17 @@ HTML ID of the canvas from which to read pixels.
 
 
 .. list-table::
-   :widths: 20, 30, 30, 30, 30
+   :widths: 10, 30, 30, 30
    :header-rows: 1
 
-   * - SDK Support
-     - Mapbox GL JS
-     - Android SDK
-     - iOS SDK
-     - macOS SDK
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
    * - basic functionality
      - >= 0.32.0
-     - Not supported
-     - Not supported
-     - Not supported
+     - not yet supported
+     - 
 
 .. _sprite:
 


### PR DESCRIPTION
Fixed up `info` and `note` admonitions.

Fixed up headings in the root section.

Still todo:

- [x] Headings (with reference) all sections after the **Sources** section
- [x] Supported versions in all sections after the **Sources** section