### PR TITLE
GEOT-5730 check if sources are supplied by 'Sources' parameter, which…

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Multiply.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Multiply.java
@@ -22,6 +22,7 @@ import it.geosolutions.jaiext.algebra.AlgebraDescriptor.Operator;
 
 import java.awt.image.RenderedImage;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 
 import javax.media.jai.ParameterBlockJAI;
@@ -30,6 +31,8 @@ import javax.media.jai.operator.MultiplyDescriptor;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.processing.BaseMathOperationJAI;
 import org.geotools.util.NumberRange;
+import org.opengis.parameter.InvalidParameterValueException;
+import org.opengis.parameter.ParameterNotFoundException;
 import org.opengis.parameter.ParameterValueGroup;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
@@ -133,9 +136,23 @@ public class Multiply extends BaseMathOperationJAI {
         }
     }
 
+    @Override
+    protected void extractSources(ParameterValueGroup parameters, Collection<GridCoverage2D> sources, String[] sourceNames) throws ParameterNotFoundException, InvalidParameterValueException {
+        try {
+            Collection<GridCoverage2D> paramSources = (Collection<GridCoverage2D>) parameters.parameter("Sources").getValue();
+            if (paramSources.size() >= 2) {
+                sources.addAll(paramSources);
+                return;
+            }
+        } catch (ParameterNotFoundException e) {
+            //sources parameter from jai ext not set, try to continue?
+        }
+        super.extractSources(parameters, sources, sourceNames);
+    }
+
     protected Map<String, ?> getProperties(RenderedImage data, CoordinateReferenceSystem crs,
-            InternationalString name, MathTransform gridToCRS, GridCoverage2D[] sources,
-            Parameters parameters) {
+                                           InternationalString name, MathTransform gridToCRS, GridCoverage2D[] sources,
+                                           Parameters parameters) {
         return handleROINoDataProperties(null, parameters.parameters, sources[0], "algebric", 1, 2, 3);
     }
 }

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/MultiplyProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/MultiplyProcessTest.java
@@ -6,6 +6,7 @@ import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.factory.GeoTools;
+import org.geotools.factory.Hints;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.AfterClass;
@@ -27,12 +28,12 @@ public class MultiplyProcessTest {
 
     @BeforeClass
     public static void setupJaiExt() {
-        JAIExt.initJAIEXT(true);
+        JAIExt.initJAIEXT(true,true);
     }
 
     @AfterClass
     public static void teardownJaiExt() {
-        JAIExt.initJAIEXT(false);
+        JAIExt.initJAIEXT(false,false);
     }
 
 

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/MultiplyProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/MultiplyProcessTest.java
@@ -8,7 +8,9 @@ import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.factory.GeoTools;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.awt.image.Raster;
@@ -23,16 +25,24 @@ public class MultiplyProcessTest {
 
     GridCoverageFactory covFactory;
 
+    @BeforeClass
+    public static void setupJaiExt() {
+        JAIExt.initJAIEXT(true);
+    }
+
+    @AfterClass
+    public static void teardownJaiExt() {
+        JAIExt.initJAIEXT(false);
+    }
+
+
 
     @Before
     public void setUp() {
         covFactory = CoverageFactoryFinder.getGridCoverageFactory(GeoTools.getDefaultHints());
     }
 
-    @Test
-    public void testMultiply() throws Exception {
-        doTestMultiply();
-    }
+
 
     private void doTestMultiply() {
 
@@ -68,17 +78,18 @@ public class MultiplyProcessTest {
     }
 
     /**
-     * We would like to test with jai ext enabled, but this seems to break the test without jai ext....
+     *
      * @throws Exception
      */
-    /*
+
     @Test
     public void testMultiplyJAIExt() throws Exception {
         JAIExt.initJAIEXT(true, true);
         doTestMultiply();
         JAIExt.initJAIEXT(false, true);
     }
-    */
+
+
     float[] data(GridCoverage2D cov) {
         Raster data = cov.getRenderedImage().getData();
         int w = data.getWidth();

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/MultiplyProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/MultiplyProcessTest.java
@@ -84,9 +84,7 @@ public class MultiplyProcessTest {
 
     @Test
     public void testMultiplyJAIExt() throws Exception {
-        JAIExt.initJAIEXT(true, true);
         doTestMultiply();
-        JAIExt.initJAIEXT(false, true);
     }
 
 


### PR DESCRIPTION
… is what the WPS process, and possbily also other JAI-EXT code does. This makes switching between jai and jai-ext more transparant (for the multiply operation).
Also added unit test, only was not able to test both deprecated jai and jai-ext in same test.