### PR TITLE
stop newlines being eaten in XML parsing of CDATA

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ParseExecutor.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ParseExecutor.java
@@ -187,9 +187,6 @@ public class ParseExecutor implements Visitor {
             type = (XSDSimpleTypeDefinition) typeDefinition;
         } else {
             XSDComplexTypeDefinition complexType = (XSDComplexTypeDefinition) typeDefinition;
-            if (complexType.getContentType() instanceof XSDParticle) {
-                
-            }
             if (complexType.getContentType() instanceof XSDSimpleTypeDefinition) {
                 type = (XSDSimpleTypeDefinition) complexType.getContentType();
             }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ParseExecutor.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ParseExecutor.java
@@ -33,6 +33,7 @@ import org.eclipse.xsd.XSDLengthFacet;
 import org.eclipse.xsd.XSDMaxLengthFacet;
 import org.eclipse.xsd.XSDMinLengthFacet;
 import org.eclipse.xsd.XSDNamedComponent;
+import org.eclipse.xsd.XSDParticle;
 import org.eclipse.xsd.XSDSimpleTypeDefinition;
 import org.eclipse.xsd.XSDTypeDefinition;
 import org.eclipse.xsd.XSDVariety;
@@ -171,7 +172,7 @@ public class ParseExecutor implements Visitor {
     }
 
     /**
-     * Pre-parses the instance compontent checking the following:
+     * Pre-parses the instance component checking the following:
      * <p>
      *
      * </p>
@@ -181,12 +182,14 @@ public class ParseExecutor implements Visitor {
         // we only preparse text, so simple types
         XSDSimpleTypeDefinition type = null;
 
-        if (instance.getTypeDefinition() instanceof XSDSimpleTypeDefinition) {
-            type = (XSDSimpleTypeDefinition) instance.getTypeDefinition();
+        XSDTypeDefinition typeDefinition = instance.getTypeDefinition();
+        if (typeDefinition instanceof XSDSimpleTypeDefinition) {
+            type = (XSDSimpleTypeDefinition) typeDefinition;
         } else {
-            XSDComplexTypeDefinition complexType = (XSDComplexTypeDefinition) instance
-                .getTypeDefinition();
-
+            XSDComplexTypeDefinition complexType = (XSDComplexTypeDefinition) typeDefinition;
+            if (complexType.getContentType() instanceof XSDParticle) {
+                
+            }
             if (complexType.getContentType() instanceof XSDSimpleTypeDefinition) {
                 type = (XSDSimpleTypeDefinition) complexType.getContentType();
             }
@@ -197,7 +200,8 @@ public class ParseExecutor implements Visitor {
         if (type != null) {
             //alright, lets preparse some text
             //first base on variety
-            if (type.getVariety() == XSDVariety.LIST_LITERAL) {
+            XSDVariety variety = type.getVariety();
+            if (variety == XSDVariety.LIST_LITERAL) {
                 //list, whiteSpace is fixed to "COLLAPSE 
                 text = Whitespace.COLLAPSE.preparse(text);
 
@@ -292,7 +296,7 @@ public class ParseExecutor implements Visitor {
                 }
 
                 return parsed;
-            } else if (type.getVariety() == XSDVariety.UNION_LITERAL) {
+            } else if (variety == XSDVariety.UNION_LITERAL) {
                 //union, "valueSpace" and "lexicalSpace" facets are the union of the contained
                 // datatypes
                 return text;
@@ -326,10 +330,13 @@ public class ParseExecutor implements Visitor {
         } else {
             //type is not simple, or complex with simple content, do a check 
             // for mixed
-            if (instance.getTypeDefinition() instanceof XSDComplexTypeDefinition
-                    && ((XSDComplexTypeDefinition) instance.getTypeDefinition()).isMixed()) {
-                //collape the text
-                text = Whitespace.COLLAPSE.preparse(text);
+            //TODO: If this came from a CDATA block we should not collapse it,
+            // I just need to work out how to tell!
+            XSDComplexTypeDefinition complexTypeDefinition = (XSDComplexTypeDefinition) typeDefinition;
+            if (typeDefinition instanceof XSDComplexTypeDefinition
+                    && complexTypeDefinition.isMixed()) {
+                //Collapse the text
+                //text = Whitespace.COLLAPSE.preparse(text);
             }
         }
 

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xml/impl/ParseExecutorTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xml/impl/ParseExecutorTest.java
@@ -1,0 +1,84 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.xml.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map.Entry;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.geotools.ml.MLConfiguration;
+import org.geotools.xml.Configuration;
+import org.geotools.xml.Parser;
+import org.geotools.xml.SchemaLocator;
+import org.geotools.xml.XSD;
+import org.junit.Test;
+import org.picocontainer.MutablePicoContainer;
+import org.xml.sax.SAXException;
+
+/**
+ * @author ian
+ *
+ */
+public class ParseExecutorTest {
+    String data = "<ComplexData mimeType=\"text/csv\"><![CDATA[State,inc1980,inc1990,inc1995,inc2000,inc2003,inc2006,inc2009,inc2012\n"
+            + "Alabama,7465,14899,19683,23521,26338,30894,33096,35625\n"
+            + "Alaska,13007,20887,25798,29642,33568,38138,42603,46778\n"
+            + "Arizona,8854,16262,20634,24988,26838,31936,32935,35979\n"
+            + "Arkansas,7113,13779,18546,21995,24289,28473,31946,34723\n"
+            + "California,11021,20656,24496,32149,33749,39626,42325,44980\n"
+            + "Colorado,10143,18818,24865,32434,34283,39491,41344,45135\n"
+            + "Connecticut,11532,25426,31947,40702,43173,50762,54397,58908\n"
+            + "Delaware,10059,19719,25391,31012,32810,39131,39817,41940\n"
+            + "District of Columbia,12251,24643,33045,38838,48342,57746,66000,74710\n"
+            + "Florida,9246,18785,23512,27764,30446,36720,37780,40344\n]]></ComplexData>";
+
+    /**
+     * Test method for {@link org.geotools.xml.impl.ParseExecutor#preParse(org.geotools.xml.InstanceComponent)}.
+     * @throws ParserConfigurationException 
+     * @throws SAXException 
+     * @throws IOException 
+     */
+    @Test
+    public void testPreParse() throws IOException, SAXException, ParserConfigurationException {
+
+        Configuration configuration = new MLConfiguration();
+        Parser parser = new Parser(configuration);
+        parser.setValidating(true);
+
+        HashMap<String,String> parsed;
+
+        InputStream reader = new ByteArrayInputStream(data.getBytes());
+        parsed = (HashMap<String, String>) parser.parse(reader );
+        for(Entry<String, String> e:parsed.entrySet()) {
+            System.out.println(e);
+            if(e.getKey()!=null && e.getKey().equals("mimeType")) {
+                assertEquals("text/csv", e.getValue());
+            }else {
+                assertTrue(e.getValue().contains("\n"));
+            }
+        }
+    }
+
+}

--- a/modules/extension/xsd/xsd-csw/src/test/resources/org/geotools/csw/Record.xml
+++ b/modules/extension/xsd/xsd-csw/src/test/resources/org/geotools/csw/Record.xml
@@ -10,7 +10,7 @@
    <dc:identifier>00180e67-b7cf-40a3-861d-b3a09337b195</dc:identifier>
    <dc:title>Image2000 Product 1 (at1) Multispectral</dc:title>
    <dct:modified>2004-10-04 00:00:00</dct:modified>
-   <dct:abstract>IMAGE2000 product 1 individual orthorectified scenes. IMAGE2000 was  produced from ETM+ Landsat 7 satellite data and provides a consistent European coverage of individual orthorectified scenes in national map projection systems.</dct:abstract>
+   <dct:abstract>IMAGE2000 product 1 individual orthorectified scenes. IMAGE2000 was produced from ETM+ Landsat 7 satellite data and provides a consistent European coverage of individual orthorectified scenes in national map projection systems.</dct:abstract>
    <dc:type>dataset</dc:type>
    <dc:subject scheme="http://www.digest.org/2.1">Vegetation</dc:subject>
    <dc:subject>baseMaps</dc:subject>

--- a/modules/extension/xsd/xsd-csw/src/test/resources/org/geotools/csw/SummaryRecord.xml
+++ b/modules/extension/xsd/xsd-csw/src/test/resources/org/geotools/csw/SummaryRecord.xml
@@ -14,5 +14,5 @@
    <dc:subject>earthCover</dc:subject>
    <dc:format>BIL</dc:format>
    <dct:modified>2004-10-04 00:00:00</dct:modified>
-   <dct:abstract>IMAGE2000 product 1 individual orthorectified scenes. IMAGE2000 was  produced from ETM+ Landsat 7 satellite data and provides a consistent European coverage of individual orthorectified scenes in national map projection systems.</dct:abstract>
+   <dct:abstract>IMAGE2000 product 1 individual orthorectified scenes. IMAGE2000 was produced from ETM+ Landsat 7 satellite data and provides a consistent European coverage of individual orthorectified scenes in national map projection systems.</dct:abstract>
 </SummaryRecord>


### PR DESCRIPTION
Initial fix to prevent GeoTools eating the newlines in CDATA blocks of WPS requests. Needs two minor fixes to existing tests as I can't limit the behaviour to just CDATA blocks as that information seems to be lost by the time GT currently collapses the white space.