### PR TITLE
[GEOT-5737] DataUtilities.fileToUrl does not percent-encode non-ASCII characters (master)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -281,23 +281,18 @@ public class DataUtilities {
     }
 
     /**
-     * A replacement for File.toURI().toURL().
+     * A replacement for {@link File#toURL()} and <code>File.toURI().toURL()</code>.
      * <p>
-     * The handling of file.toURL() is broken; the handling of file.toURI().toURL() is known to be
-     * broken on a few platforms like mac. We have the urlToFile( URL ) method that is able to
-     * untangle both these problems and we use it in the geotools library.
-     * <p>
-     * However occasionally we need to pick up a file and hand it to a third party library like EMF;
-     * this method performs a couple of sanity checks which we can use to prepare a good URL
-     * reference to a file in these situtations.
+     * {@link File#toURL()} does not percent-escape characters and <code>File.toURI().toURL()</code> does not percent-escape non-ASCII characters.
+     * This method ensures that URL characters are correctly percent-escaped, and works around the reported misbehaviour of some Java implementations
+     * on Mac.
      * 
      * @param file
      * @return URL
      */
     public static URL fileToURL(File file) {
         try {
-            URL url = file.toURI().toURL();
-            String string = url.toExternalForm();
+            String string = file.toURI().toASCIIString();
             if (string.contains("+")) {
                 // this represents an invalid URL created using either
                 // file.toURL(); or

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -251,6 +251,13 @@ public class DataUtilitiesTest extends DataTestCase {
         assertNotNull(windowsShareFile);
     }
 
+    public void testFileToUrl() {
+        String url = DataUtilities.fileToURL(new File("file café")).toString();
+        assertTrue("Expected '" + url + "' to start with 'file:'", url.startsWith("file:"));
+        assertTrue("Expected '" + url + "' to end with 'file%20caf%C3%A9'",
+                url.endsWith("file%20caf%C3%A9"));
+    }
+
     private String replaceSlashes(String string) {
         return string.replaceAll("\\\\", "/");
     }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5737

This PR also ports updates to the cut-down version of `DataUtilities` in gt-referencing. Further changes to that class will be the subject of another PR. See: https://osgeo-org.atlassian.net/browse/GEOT-5739.