### PR TITLE
[GEOT-5737] URLs.fileToUrl does not percent-encode non-ASCII characters (master)

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/URLs.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/URLs.java
@@ -85,21 +85,20 @@ public class URLs {
     }
 
     /**
-     * A replacement for File.toURI().toURL().
+     * A replacement for {@link File#toURL()} and <code>File.toURI().toURL()</code>.
      * <p>
-     * The handling of file.toURL() is broken; the handling of file.toURI().toURL() is known to be broken on a few platforms like mac. We have the
-     * urlToFile( URL ) method that is able to untangle both these problems and we use it in the geotools library.
-     * <p>
-     * However occasionally we need to pick up a file and hand it to a third party library like EMF; this method performs a couple of sanity checks
-     * which we can use to prepare a good URL reference to a file in these situtations.
+     * {@link File#toURL()} does not percent-encode characters and <code>File.toURI().toURL()</code> does not percent-encode non-ASCII characters.
+     * This method ensures that URL characters are correctly percent-encoded, and works around the reported misbehaviour of some Java implementations
+     * on Mac.
      * 
      * @param file
      * @return URL
      */
     public static URL fileToUrl(File file) {
         try {
-            URL url = file.toURI().toURL();
-            String string = url.toString();
+            // URI.toString() and thus URI.toURL() do not
+            // percent-encode non-ASCII characters [GEOT-5737]
+            String string = file.toURI().toASCIIString();
             if (string.contains("+")) {
                 // this represents an invalid URL created using either
                 // file.toURL(); or

--- a/modules/library/metadata/src/test/java/org/geotools/util/URLsTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/URLsTest.java
@@ -19,6 +19,7 @@ package org.geotools.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -59,6 +60,14 @@ public class URLsTest {
 
     private String replaceSlashes(String string) {
         return string.replaceAll("\\\\", "/");
+    }
+
+    @Test
+    public void testFileToUrl() {
+        String url = URLs.fileToUrl(new File("file café")).toString();
+        assertTrue("Expected '" + url + "' to start with 'file:'", url.startsWith("file:"));
+        assertTrue("Expected '" + url + "' to end with 'file%20caf%C3%A9'",
+                url.endsWith("file%20caf%C3%A9"));
     }
 
     @Test


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5737

Replaces https://github.com/geotools/geotools/pull/1602: the duplication was addressed by [GEOT-5740](https://osgeo-org.atlassian.net/browse/GEOT-5740), and this PR adds the requested explanatory comment.