### PR TITLE
[GEOT-5751] MySQLdialect postCreate enhancements

### DIFF
--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialect.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialect.java
@@ -319,7 +319,9 @@ public class MySQLDialect extends SQLDialect {
     public void encodePostColumnCreateTable(AttributeDescriptor att, StringBuffer sql) {
         //make geometry columns non null in order to be able to index them
         if (att instanceof GeometryDescriptor && !att.isNillable()) {
-            sql.append( " NOT NULL");
+        	if (!sql.toString().trim().endsWith(" NOT NULL")) {
+        		sql.append( " NOT NULL");
+        	}
         }
     }
     
@@ -398,6 +400,14 @@ public class MySQLDialect extends SQLDialect {
             
             StringBuffer sql = new StringBuffer("INSERT INTO ");
             encodeTableName("geometry_columns", sql);
+            sql.append(" (");
+            encodeColumnName(null, "f_table_schema", sql); sql.append(", ");
+            encodeColumnName(null, "f_table_name", sql); sql.append(", ");
+            encodeColumnName(null, "f_geometry_column", sql); sql.append(", ");
+            encodeColumnName(null, "coord_dimension", sql); sql.append(", ");
+            encodeColumnName(null, "srid", sql); sql.append(", ");
+            encodeColumnName(null, "type", sql);
+            sql.append(") ");
             sql.append(" VALUES (");
             sql.append(schemaName != null ? "'"+schemaName+"'" : "NULL").append(", ");
             sql.append("'").append(featureType.getTypeName()).append("', ");


### PR DESCRIPTION
The pull request affects the behavior of some postCreate actions of MySQLDialect class. More specifically

- in encodePostColumnCreateTable() method it checks whether for the GeometryDescriptor column, NOT NULL is already specified
- in postCreateTable(...) the SQL statement used for inserting entries in the geometry_columns tables (which maintains meta data information about spatial columns in other tables) now includes the column names. This is pretty useful in the case the geometry_columns has been manually created and includes an extra PK autogenerated or any other extra columns.

The enhancement can be applied at least to all geotools versions for 14.x and onwards 

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>