### PR TITLE
Css units related improvements

### DIFF
--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssParser.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssParser.java
@@ -251,7 +251,7 @@ public class CssParser extends BaseParser<Object> {
     }
 
     Rule MaxScaleSelector() {
-        return Sequence("[", OptionalWhiteSpace(), "@scale", OptionalWhiteSpace(),
+        return Sequence("[", OptionalWhiteSpace(), FirstOf("@scale", "@sd"), OptionalWhiteSpace(),
                 FirstOf("<=", "<"), OptionalWhiteSpace(), ScaleValue(), push(new ScaleRange(0, true,
                         parseScaleValue(match()), false)), //
                 OptionalWhiteSpace(), "]");
@@ -261,7 +261,7 @@ public class CssParser extends BaseParser<Object> {
         return Sequence(
                 "[",
                 OptionalWhiteSpace(),
-                "@scale",
+                FirstOf("@scale", "@sd"),
                 OptionalWhiteSpace(),
                 FirstOf(">=", ">"),
                 OptionalWhiteSpace(),

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
@@ -1087,7 +1087,34 @@ public class TranslatorSyntheticTest extends CssBaseTest {
         Function saturate = (Function) color;
         assertThat(saturate.getParameters().get(0), instanceOf(DarkenFunction.class));
     }
+    
+    @Test
+    public void testScaleDependencyUnits() throws Exception {
+        // k
+        assertScaleMinMax("[@scale < 1k] {stroke: black}", null, 1e3);
+        assertScaleMinMax("[@scale > 1k] {stroke: black}", 1e3, null);
+        // m
+        assertScaleMinMax("[@scale < 1M] {stroke: black}", null, 1e6);
+        assertScaleMinMax("[@scale > 1M] {stroke: black}", 1e6, null);
+        // g
+        assertScaleMinMax("[@scale < 1G] {stroke: black}", null, 1e9);
+        assertScaleMinMax("[@scale > 1G] {stroke: black}", 1e9, null);
+    }
 
+    private void assertScaleMinMax(String css, Double min, Double max) {
+        Style style = translate(css);
+        Rule rule = assertSingleRule(style);
+        if(min == null) {
+            assertEquals(0, rule.getMinScaleDenominator(), 0d);
+        } else {
+            assertEquals(min, rule.getMinScaleDenominator(), 0d);
+        }
+        if(max == null) {
+            assertEquals(Double.POSITIVE_INFINITY, rule.getMaxScaleDenominator(), 0d);
+        } else {
+            assertEquals(max, rule.getMaxScaleDenominator(), 0d);
+        }
+    }
 
     private Function assertTransformation(FeatureTypeStyle fts) {
         Expression ex = fts.getTransformation();

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
@@ -1100,6 +1100,12 @@ public class TranslatorSyntheticTest extends CssBaseTest {
         assertScaleMinMax("[@scale < 1G] {stroke: black}", null, 1e9);
         assertScaleMinMax("[@scale > 1G] {stroke: black}", 1e9, null);
     }
+    
+    @Test
+    public void testScaleDenominatorPseudoVariable() throws Exception {
+        assertScaleMinMax("[@sd < 1k] {stroke: black}", null, 1e3);
+        assertScaleMinMax("[@sd > 1k] {stroke: black}", 1e3, null);
+    }
 
     private void assertScaleMinMax(String css, Double min, Double max) {
         Style style = translate(css);


### PR DESCRIPTION
- Usage of metrix prefixes (that's how SI calls them, because they normally come before the unit, while in CSS case they are suffix to the value because a scale is just a ratio, it's unitless)
- Allow using "@sd" instead of "@scale" in scale denominator rules