### PR TITLE
[GEOT-5748] Improvements to App-Schema's connection usage

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/MappingAttributeIterator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/MappingAttributeIterator.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import org.geotools.data.Query;
+import org.geotools.data.Transaction;
 import org.geotools.data.complex.filter.XPath;
 import org.geotools.data.complex.filter.XPathUtil.StepList;
 import org.opengis.feature.type.Name;
@@ -49,7 +50,12 @@ public class MappingAttributeIterator extends DataAccessMappingFeatureIterator {
 
     public MappingAttributeIterator(AppSchemaDataAccess store, FeatureTypeMapping mapping,
             Query query, Query unrolledQuery) throws IOException {
-        super(store, mapping, query, unrolledQuery, false);
+        this(store, mapping, query, unrolledQuery, null);
+    }
+
+    public MappingAttributeIterator(AppSchemaDataAccess store, FeatureTypeMapping mapping,
+            Query query, Query unrolledQuery, Transaction transaction) throws IOException {
+        super(store, mapping, query, unrolledQuery, false, transaction);
         elementName = mapping.getTargetFeature().getName();
         checkAttributeMappings();
     }

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/MappingFeatureCollection.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/MappingFeatureCollection.java
@@ -22,7 +22,9 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import org.geotools.data.DataUtilities;
+import org.geotools.data.DefaultTransaction;
 import org.geotools.data.Query;
+import org.geotools.data.Transaction;
 import org.geotools.data.crs.ReprojectFeatureResults;
 import org.geotools.feature.CollectionListener;
 import org.geotools.feature.FeatureCollection;
@@ -175,7 +177,31 @@ public class MappingFeatureCollection implements FeatureCollection<FeatureType, 
             throw new RuntimeException(e);
         }
     }
-    
+
+    /**
+     * <p>
+     * This overload allows client code to explicitly specify the transaction that the created iterator will be working against.
+     * </p>
+     * 
+     * <p>
+     * Passing <code>null</code> is equivalent to calling {@link #features()} and lets the iterator decide whether a new transaction should be created
+     * (and closed when the iterator is closed) or not. Currently, a new transaction is created by {@link DataAccessMappingFeatureIterator} only if a
+     * database backend is available and joining is enabled, to reduce the number of concurrent connections opened due to feature chaining.
+     * </p>
+     * 
+     * @see org.geotools.feature.FeatureCollection#features()
+     * 
+     * @param transaction the transaction the created iterator will be working against
+     */
+    public FeatureIterator<Feature> features(Transaction transaction) {
+        try {
+            return MappingFeatureIteratorFactory.getInstance(store, mapping, query, unrolledFilter,
+                    transaction);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public XmlMappingFeatureIterator features(String xpath, String value) throws IOException {
         return new XmlMappingFeatureIterator(store, mapping, query, xpath, value);
     }

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/MappingFeatureIteratorFactory.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/MappingFeatureIteratorFactory.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
+import org.geotools.data.Transaction;
 import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
 import org.geotools.data.complex.config.Types;
 import org.geotools.data.complex.filter.ComplexFilterSplitter;
@@ -105,6 +106,11 @@ public class MappingFeatureIteratorFactory {
 
     public static IMappingFeatureIterator getInstance(AppSchemaDataAccess store,
             FeatureTypeMapping mapping, Query query, Filter unrolledFilter) throws IOException {
+        return MappingFeatureIteratorFactory.getInstance(store, mapping, query, unrolledFilter, null);
+    }
+
+    public static IMappingFeatureIterator getInstance(AppSchemaDataAccess store,
+            FeatureTypeMapping mapping, Query query, Filter unrolledFilter, Transaction transaction) throws IOException {
 
         if (mapping instanceof XmlFeatureTypeMapping) {
             return new XmlMappingFeatureIterator(store, mapping, query);
@@ -155,10 +161,11 @@ public class MappingFeatureIteratorFactory {
                         .getRootMapping());
             }
             if (isSimpleType(mapping)) {
-                iterator = new MappingAttributeIterator(store, mapping, query, unrolledQuery);
+                iterator = new MappingAttributeIterator(store, mapping, query, unrolledQuery,
+                        transaction);
             } else {
                 iterator = new DataAccessMappingFeatureIterator(store, mapping, query,
-                        unrolledQuery, false);
+                        unrolledQuery, false, transaction);
             }
         } else {
             // HACK HACK HACK
@@ -224,7 +231,7 @@ public class MappingFeatureIteratorFactory {
                     removeQueryLimitIfDenormalised = true;
                 } 
                 iterator = new DataAccessMappingFeatureIterator(store, mapping, query, isFiltered,
-                        removeQueryLimitIfDenormalised, hasPostFilter);
+                        removeQueryLimitIfDenormalised, hasPostFilter, transaction);
                 if (isListFilter != null) {
                     ((DataAccessMappingFeatureIterator) iterator).setListFilter(isListFilter);
                 }

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/XmlMappingFeatureIterator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/XmlMappingFeatureIterator.java
@@ -91,7 +91,7 @@ public class XmlMappingFeatureIterator extends DataAccessMappingFeatureIterator 
      */
     public XmlMappingFeatureIterator(AppSchemaDataAccess store, FeatureTypeMapping mapping,
             Query query) throws IOException {
-        super(store, mapping, query);
+        super(store, mapping, query, null, false);
 
         setIdXPath();
         
@@ -105,7 +105,7 @@ public class XmlMappingFeatureIterator extends DataAccessMappingFeatureIterator 
 
     public XmlMappingFeatureIterator(AppSchemaDataAccess store, FeatureTypeMapping mapping,
             Query query, String xpath, String value) throws IOException {
-        super(store, mapping, query);
+        super(store, mapping, query, null, false);
 
         setIdXPath();
 

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
@@ -109,7 +109,9 @@ public class AppSchemaDataAccessConfigurator {
     private AppSchemaDataAccessDTO config;
 
     private AppSchemaFeatureTypeRegistry typeRegistry;
-    
+
+    private DataAccessMap dataStoreMap;
+
     private FilterFactory ff = new FilterFactoryImplReportInvalidProperty();
 
     /**
@@ -150,8 +152,9 @@ public class AppSchemaDataAccessConfigurator {
      * @param config
      *            DOCUMENT ME!
      */
-    private AppSchemaDataAccessConfigurator(AppSchemaDataAccessDTO config) {
+    private AppSchemaDataAccessConfigurator(AppSchemaDataAccessDTO config, DataAccessMap dataStoreMap) {
         this.config = config;
+        this.dataStoreMap = dataStoreMap;
         namespaces = new NamespaceSupport();
         Map nsMap = config.getNamespaces();
         for (Iterator it = nsMap.entrySet().iterator(); it.hasNext();) {
@@ -181,9 +184,23 @@ public class AppSchemaDataAccessConfigurator {
      *             if any error occurs while creating the mappings
      */
     public static Set<FeatureTypeMapping> buildMappings(AppSchemaDataAccessDTO config) throws IOException {
+        return buildMappings(config, new DataAccessMap());
+    }
+
+    /**
+     * This method will not create a source data store if an equivalent one (i.e. same configuration parameters) is found in the provided
+     * <code>sourceDataStoreMap</code>.
+     * 
+     * @see AppSchemaDataAccessConfigurator#buildMappings(AppSchemaDataAccessDTO)
+     * 
+     * @param sourceDataStoreMap map holding the source data stores created so far, e.g. while parsing App-Schema configuration files included by the one
+     *        currently being processed
+     */
+    public static Set<FeatureTypeMapping> buildMappings(AppSchemaDataAccessDTO config,
+            DataAccessMap sourceDataStoreMap) throws IOException {
         AppSchemaDataAccessConfigurator mappingsBuilder;
 
-        mappingsBuilder = new AppSchemaDataAccessConfigurator(config);
+        mappingsBuilder = new AppSchemaDataAccessConfigurator(config, sourceDataStoreMap);
         Set<FeatureTypeMapping> mappingObjects = mappingsBuilder.buildMappings();
 
         return mappingObjects;
@@ -682,7 +699,13 @@ public class AppSchemaDataAccessConfigurator {
 
             AppSchemaDataAccessConfigurator.LOGGER.fine("looking for datastore " + id);
 
-            DataAccess<FeatureType, Feature> dataStore = DataAccessFinder.getDataStore(datastoreParams);
+            DataAccess<FeatureType, Feature> dataStore = null;
+            if (dataStoreMap != null && dataStoreMap.containsKey(datastoreParams)) {
+                dataStore = dataStoreMap.get(datastoreParams);
+            } else {
+                dataStore = DataAccessFinder.getDataStore(datastoreParams);
+                dataStoreMap.put(datastoreParams, dataStore);
+            }
 
             if (dataStore == null) {
                 AppSchemaDataAccessConfigurator.LOGGER.log(Level.SEVERE,

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/DataAccessMap.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/DataAccessMap.java
@@ -1,0 +1,32 @@
+/* (c) 2017 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geotools.data.complex.config;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.geotools.data.DataAccess;
+import org.opengis.feature.Feature;
+import org.opengis.feature.type.FeatureType;
+
+/**
+ * Utility class to help keep track of the DataAccess instances created while parsing App-Schema
+ * configuration and thus avoid creating the same (i.e. with identical configuration parameters)
+ * DataAccess twice.
+ * 
+ * <p>
+ * DataAccess instances are indexed by the parameters map used to create them.
+ * </p>
+ * 
+ * @author Stefano Costa, GeoSolutions
+ *
+ */
+public class DataAccessMap extends HashMap<Map<String, Serializable>, DataAccess<FeatureType, Feature>> {
+
+    /** serialVersionUID */
+    private static final long serialVersionUID = 133019722648852790L;
+
+}


### PR DESCRIPTION
Implements what was suggested in this geoserver-user thread: [PostGIS Connections hanging under App Schema Plugin](http://osgeo-org.1560.x6.nabble.com/PostGIS-Connections-hanging-under-App-Schema-Plugin-td5319085.html#a5319171)

Connection re-use is limited to feature types belonging to the same App-Schema data store.

Further online unit tests will be added in a separate GeoServer PR.