### PR TITLE
[GEOT-5697] fix encoding the filter Not( is null ) as XML

### DIFF
--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCNotBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCNotBinding.java
@@ -24,6 +24,7 @@ import org.opengis.filter.BinaryLogicOperator;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.Not;
+import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.identity.Identifier;
 import org.opengis.filter.spatial.BinarySpatialOperator;
 import org.geotools.filter.v1_1.OGC;
@@ -94,6 +95,7 @@ public class OGCNotBinding extends AbstractComplexBinding {
         return filterfactory.not(filter);
     }
 
+    @Override
     public Object getProperty(Object object, QName name)
         throws Exception {
         Not not = (Not) object;
@@ -110,6 +112,9 @@ public class OGCNotBinding extends AbstractComplexBinding {
             return not.getFilter();
         }
 
+        if (OGC.comparisonOps.equals(name) && not.getFilter() instanceof PropertyIsNull) {
+            return not.getFilter();
+        }
         return null;
     }
 }

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
@@ -254,6 +254,10 @@ public class FilterMockData {
         return not;
     }
 
+    static Not notIsNull() {
+        return f.not(propertyIsNull());
+    }
+
     static Beyond beyond() {
         return f.beyond(f.property("the_geom"), f.literal(geometry()), 1.0d, "m");
     }

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/NotBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/NotBindingTest.java
@@ -49,4 +49,19 @@ public class NotBindingTest extends FilterTestSupport {
             dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyIsEqualTo.getLocalPart())
                .getLength());
     }
+
+    public void testNotNullEncode() throws Exception {
+        Document dom = encode(FilterMockData.notIsNull(), OGC.Not);
+        /*
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ogc:Not xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc">
+          <ogc:PropertyIsNull>
+            <ogc:PropertyName>foo</ogc:PropertyName>
+          </ogc:PropertyIsNull>
+        </ogc:Not>
+         */
+        assertEquals(1,
+                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyIsNull.getLocalPart())
+                        .getLength());
+    }
 }


### PR DESCRIPTION
  - [x] Add a failing testcase to illustrate [GEOT-5697](https://osgeo-org.atlassian.net/browse/GEOT-5697)
  - [x] Add a fix