### PR TITLE
GEOT-5730 (backport) check if sources are supplied by 'Sources' parameter

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Multiply.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Multiply.java
@@ -22,6 +22,7 @@ import it.geosolutions.jaiext.algebra.AlgebraDescriptor.Operator;
 
 import java.awt.image.RenderedImage;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 
 import javax.media.jai.ParameterBlockJAI;
@@ -30,6 +31,8 @@ import javax.media.jai.operator.MultiplyDescriptor;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.processing.BaseMathOperationJAI;
 import org.geotools.util.NumberRange;
+import org.opengis.parameter.InvalidParameterValueException;
+import org.opengis.parameter.ParameterNotFoundException;
 import org.opengis.parameter.ParameterValueGroup;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
@@ -133,9 +136,23 @@ public class Multiply extends BaseMathOperationJAI {
         }
     }
 
+    @Override
+    protected void extractSources(ParameterValueGroup parameters, Collection<GridCoverage2D> sources, String[] sourceNames) throws ParameterNotFoundException, InvalidParameterValueException {
+        try {
+            Collection<GridCoverage2D> paramSources = (Collection<GridCoverage2D>) parameters.parameter("Sources").getValue();
+            if (paramSources.size() >= 2) {
+                sources.addAll(paramSources);
+                return;
+            }
+        } catch (ParameterNotFoundException e) {
+            //sources parameter from jai ext not set, try to continue?
+        }
+        super.extractSources(parameters, sources, sourceNames);
+    }
+
     protected Map<String, ?> getProperties(RenderedImage data, CoordinateReferenceSystem crs,
-            InternationalString name, MathTransform gridToCRS, GridCoverage2D[] sources,
-            Parameters parameters) {
+                                           InternationalString name, MathTransform gridToCRS, GridCoverage2D[] sources,
+                                           Parameters parameters) {
         return handleROINoDataProperties(null, parameters.parameters, sources[0], "algebric", 1, 2, 3);
     }
 }

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/MultiplyProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/MultiplyProcessTest.java
@@ -1,0 +1,102 @@
+package org.geotools.process.raster;
+
+import it.geosolutions.jaiext.JAIExt;
+import it.geosolutions.jaiext.range.NoDataContainer;
+import org.geotools.coverage.CoverageFactoryFinder;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridCoverageFactory;
+import org.geotools.factory.GeoTools;
+import org.geotools.factory.Hints;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.awt.image.Raster;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test for the 'Multiply' process
+ */
+public class MultiplyProcessTest {
+
+    GridCoverageFactory covFactory;
+
+    @BeforeClass
+    public static void setupJaiExt() {
+        JAIExt.initJAIEXT(true,true);
+    }
+
+    @AfterClass
+    public static void teardownJaiExt() {
+        JAIExt.initJAIEXT(false,false);
+    }
+
+
+
+    @Before
+    public void setUp() {
+        covFactory = CoverageFactoryFinder.getGridCoverageFactory(GeoTools.getDefaultHints());
+    }
+
+
+
+    private void doTestMultiply() {
+
+        float[][] grid = new float[][] {
+                {1,2,3,4},
+                {5,6,8,9},
+                {10,11,12,13},
+                {14,15,16,17},
+        };
+
+
+        HashMap properties = new HashMap<>();
+        org.geotools.resources.coverage.CoverageUtilities.setNoDataProperty(properties,new NoDataContainer(2));
+        GridCoverage2D cov = covFactory.create("test", grid, new ReferencedEnvelope(0, 10, 0, 10, DefaultGeographicCRS.WGS84));
+        GridCoverage2D coverageNoData = covFactory.create("nodata", cov.getRenderedImage(), cov.getEnvelope(), cov.getSampleDimensions(), null, properties);
+
+        MultiplyCoveragesProcess p = new MultiplyCoveragesProcess();
+        GridCoverage2D norm = p.execute(cov,cov,null);
+
+        float[] data = data(norm);
+        for (int i = 0; i < data.length; i++) {
+            assertEquals(Math.pow(grid[i/grid.length][i%grid.length],2.), data[i], 1E-9);
+        }
+
+        GridCoverage2D nodataResult= p.execute(cov,coverageNoData,null);
+        if (JAIExt.isJAIExtOperation("algebric")) {
+            //Only jai EXT takes nodata into account
+            assertEquals(0., data(nodataResult)[1], 1E-9);
+        }else {
+            assertEquals(4., data(nodataResult)[1], 1E-9);
+        }
+
+    }
+
+    /**
+     *
+     * @throws Exception
+     */
+
+    @Test
+    public void testMultiplyJAIExt() throws Exception {
+        doTestMultiply();
+    }
+
+
+    float[] data(GridCoverage2D cov) {
+        Raster data = cov.getRenderedImage().getData();
+        int w = data.getWidth();
+        int h = data.getHeight();
+
+        float[] grid = new float[w*h];
+        data.getDataElements(0, 0, w, h, grid);
+
+        return grid;
+    }
+}


### PR DESCRIPTION

* GEOT-5730 check if sources are supplied by 'Sources' parameter, which is what the WPS process, and possbily also other JAI-EXT code does. This makes switching between jai and jai-ext more transparant (for the multiply operation).

* GEOT-5730 unit test now uses and tests jai-ext behaviour, which should makes it work when running it on travis

* GEOT-5730 removed redundand jai-ext setup calls

* GEOT-5730 force jai reinit, to avoid unwanted changes from other unit tests