### PR TITLE
[GEOT-5232] Added a toString method for temporal filters.

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/temporal/BinaryTemporalOperatorImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/temporal/BinaryTemporalOperatorImpl.java
@@ -9,6 +9,7 @@
  */
 package org.geotools.filter.temporal;
 
+import org.geotools.filter.visitor.OperatorNameFilterVisitor;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.temporal.BinaryTemporalOperator;
 import org.opengis.temporal.Instant;
@@ -22,6 +23,8 @@ import org.opengis.temporal.TemporalPrimitive;
  * @source $URL$
  */
 public abstract class BinaryTemporalOperatorImpl implements BinaryTemporalOperator {
+
+    private static final OperatorNameFilterVisitor operationNameVisitor = new OperatorNameFilterVisitor();
 
     protected Expression e1,e2;
     protected MatchAction matchAction;
@@ -118,5 +121,13 @@ public abstract class BinaryTemporalOperatorImpl implements BinaryTemporalOperat
         return true;
     }
 
-    
+    /**
+     * Return this filter as a string.
+     * @return String representation of this temporal filter.
+     */
+    @Override
+    public String toString() {
+        Object operator = accept(operationNameVisitor, null);
+        return "[ " + getExpression1() + " " + operator + " " + getExpression2() + " ]";
+    }
 }

--- a/modules/library/main/src/main/java/org/geotools/temporal/object/DefaultInstant.java
+++ b/modules/library/main/src/main/java/org/geotools/temporal/object/DefaultInstant.java
@@ -140,16 +140,22 @@ public class DefaultInstant extends DefaultTemporalGeometricPrimitive implements
 
     @Override
     public String toString() {
-        StringBuilder s = new StringBuilder("Instant:").append('\n');
+        StringBuilder s = new StringBuilder();
         if (position != null) {
-            s.append("position:").append(position).append('\n');
+            s.append("position:").append(position);
         }
         if (begunBy != null) {
-            s.append("begunBy:").append(begunBy).append('\n');
+            if (s.length() > 0) {
+                s.append(", ");
+            }
+            s.append("begunBy:").append(begunBy);
         }
         if (endBy != null) {
-            s.append("endBy:").append(endBy).append('\n');
+            if (s.length() > 0) {
+                s.append(", ");
+            }
+            s.append("endBy:").append(endBy);
         }
-        return s.toString();
+        return s.insert(0, "Instant{").append('}').toString();
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/temporal/object/DefaultPeriod.java
+++ b/modules/library/main/src/main/java/org/geotools/temporal/object/DefaultPeriod.java
@@ -133,14 +133,16 @@ public class DefaultPeriod extends DefaultTemporalGeometricPrimitive implements 
 
     @Override
     public String toString() {
-        StringBuilder s = new StringBuilder("Period:").append('\n');
+        StringBuilder s = new StringBuilder();
         if (begining != null) {
-            s.append("begin:").append(begining).append('\n');
+            s.append("begin:").append(begining);
         }
         if (ending != null) {
-            s.append("end:").append(ending).append('\n');
+            if (s.length() > 0) {
+                s.append(", ");
+            }
+            s.append("end:").append(ending);
         }
-
-        return s.toString();
+        return s.insert(0, "Period{").append('}').toString();
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/temporal/object/DefaultPosition.java
+++ b/modules/library/main/src/main/java/org/geotools/temporal/object/DefaultPosition.java
@@ -160,11 +160,7 @@ public class DefaultPosition implements Position {
 
     @Override
     public String toString() {
-        StringBuilder s = new StringBuilder("Position:").append('\n');
-        if (position != null) {
-            s.append("position:").append(position).append('\n');
-        }
-        return s.toString();
+        return "Position{" + this.position + '}';
     }
 }
 

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/AfterImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/AfterImplTest.java
@@ -50,5 +50,7 @@ public class AfterImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         AfterImpl a = new AfterImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(AfterImpl.class.getName()));
+        assertTrue(a.toString().contains(AfterImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/BeforeImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/BeforeImplTest.java
@@ -51,5 +51,7 @@ public class BeforeImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         BeforeImpl a = new BeforeImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(BeforeImpl.class.getName()));
+        assertTrue(a.toString().contains(BeforeImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/BeginsImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/BeginsImplTest.java
@@ -43,5 +43,7 @@ public class BeginsImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         BeginsImpl a = new BeginsImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(BeginsImpl.class.getName()));
+        assertTrue(a.toString().contains(BeginsImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/BegunByImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/BegunByImplTest.java
@@ -44,5 +44,7 @@ public class BegunByImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         BegunByImpl a = new BegunByImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(BegunByImpl.class.getName()));
+        assertTrue(a.toString().contains(BegunByImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/DuringImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/DuringImplTest.java
@@ -44,5 +44,7 @@ public class DuringImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         DuringImpl a = new DuringImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(DuringImpl.class.getName()));
+        assertTrue(a.toString().contains(DuringImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/EndedByImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/EndedByImplTest.java
@@ -44,5 +44,7 @@ public class EndedByImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         EndedByImpl a = new EndedByImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(EndedByImpl.class.getName()));
+        assertTrue(a.toString().contains(EndedByImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/EndsImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/EndsImplTest.java
@@ -43,5 +43,7 @@ public class EndsImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         EndsImpl a = new EndsImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(EndsImpl.class.getName()));
+        assertTrue(a.toString().contains(EndsImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/MeetsImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/MeetsImplTest.java
@@ -41,5 +41,7 @@ public class MeetsImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         MeetsImpl a = new MeetsImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(MeetsImpl.class.getName()));
+        assertTrue(a.toString().contains(MeetsImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/MetByImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/MetByImplTest.java
@@ -44,5 +44,7 @@ public class MetByImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         MetByImpl a = new MetByImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(MetByImpl.class.getName()));
+        assertTrue(a.toString().contains(MetByImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/OverlappedByTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/OverlappedByTest.java
@@ -45,5 +45,7 @@ public class OverlappedByTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         OverlappedByImpl a = new OverlappedByImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(OverlappedByImpl.class.getName()));
+        assertTrue(a.toString().contains(OverlappedByImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/TContainsImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/TContainsImplTest.java
@@ -47,5 +47,7 @@ public class TContainsImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         TContainsImpl a = new TContainsImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(TContainsImpl.class.getName()));
+        assertTrue(a.toString().contains(TContainsImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/TEqualsImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/TEqualsImplTest.java
@@ -44,5 +44,7 @@ public class TEqualsImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         TEqualsImpl a = new TEqualsImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(TEqualsImpl.class.getName()));
+        assertTrue(a.toString().contains(TEqualsImpl.NAME));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/temporal/TOverlapsImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/temporal/TOverlapsImplTest.java
@@ -45,5 +45,7 @@ public class TOverlapsImplTest extends TemporalFilterTestSupport {
     void doAssert(TemporalPrimitive tp1, TemporalPrimitive tp2, boolean b) {
         TOverlapsImpl a = new TOverlapsImpl(ff.literal(tp1), ff.literal(tp2));
         assertEquals(b, a.evaluate(null));
+        assertFalse(a.toString().contains(TOverlapsImpl.class.getName()));
+        assertTrue(a.toString().contains(TOverlapsImpl.NAME));
     }
 }


### PR DESCRIPTION
This pull request adds a toString method for temporal filters that is similar to what is currently used for other types of filters.  It also modifies the toString method for temporal objects that are used in the temporal filters to remove their newlines.  The newlines make the logs difficult to read, especially in some GeoServer requests where the filter string may be displayed multiple times per request.

Unit tests were added that simply checks that the default Object toString method is not being used.

The following CQL filter in a GeoServer request:
> issuetime DURING 2017-06-15T11:55:00.000Z/2017-06-15T15:15:00.000Z

instead of displaying a useless string like:
> org.geotools.filter.temporal.DuringImpl@e998726e

now displays the following in the logs:
> [ issuetime During Period{begin:Instant{position:Position{Thu Jun 15 11:55:00 UTC 2017}}, end:Instant{position:Position{Thu Jun 15 15:15:00 UTC 2017}}} ]

This pull request can be backported to 17.x and 16.x.