### PR TITLE
Factoring out some centroid code from label cache to RendererUtiliites.

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
@@ -1270,7 +1270,7 @@ public final class LabelCacheImpl implements LabelCache {
         if(!pg.contains(centroid)) {
             // resort to sampling, computing the intersection is slow and
             // due invalid geometries can easily break with an exception
-            Point central = RendererUtilities.sampleForCentralPoint(geom, centroid, pg, gf, 5d, -1);
+            Point central = RendererUtilities.sampleForInternalPoint(geom, centroid, pg, gf, 5d, -1);
             if (central != null) {
                 centroid = central;
             }

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
@@ -1261,6 +1261,9 @@ public final class LabelCacheImpl implements LabelCache {
         }
         
         Point centroid = RendererUtilities.getPolygonCentroid(geom);
+        if (centroid == null) {
+            return false;
+        }
         
         // check we're inside, if not, use a different approach
         PreparedGeometry pg = PreparedGeometryFactory.prepare(geom);

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
@@ -44,6 +44,7 @@ import org.geotools.geometry.jts.LiteShape2;
 import org.geotools.renderer.VendorOptionParser;
 import org.geotools.renderer.label.LabelCacheItem.GraphicResize;
 import org.geotools.renderer.lite.LabelCache;
+import org.geotools.renderer.lite.RendererUtilities;
 import org.geotools.renderer.style.SLDStyleFactory;
 import org.geotools.renderer.style.TextStyle2D;
 import org.geotools.styling.TextSymbolizer;
@@ -1259,59 +1260,18 @@ public final class LabelCacheImpl implements LabelCache {
             return false;
         }
         
-        Point centroid;
-        try {
-            centroid = geom.getCentroid();
-        } catch (Exception e) {
-            // generalized polygons causes problems - this
-            // tries to hide them.
-            try {
-                centroid = geom.getExteriorRing().getCentroid();
-            } catch (Exception ee) {
-                try {
-                    centroid = geom.getFactory().createPoint(geom.getCoordinate());
-                } catch (Exception eee) {
-                    return false; // we're hooped
-                }
-            }
-        }
+        Point centroid = RendererUtilities.getPolygonCentroid(geom);
         
         // check we're inside, if not, use a different approach
         PreparedGeometry pg = PreparedGeometryFactory.prepare(geom);
         if(!pg.contains(centroid)) {
             // resort to sampling, computing the intersection is slow and
             // due invalid geometries can easily break with an exception
-            Envelope env = geom.getEnvelopeInternal();
-            double step = 5;
-            int steps = (int) Math.round((env.getMaxX() - env.getMinX()) / step);
-            Coordinate c = new Coordinate();
-            Point pp = gf.createPoint(c);
-            c.y = centroid.getY();
-            int max = -1;
-            int maxIdx = -1;
-            int containCounter = -1;
-            for (int i = 0; i < steps; i++) {
-                c.x = env.getMinX() + step * i;
-                pp.geometryChanged();
-                if(!pg.contains(pp)) {
-                    containCounter = 0;
-                } else if(i == 0) {
-                    containCounter = 1;
-                } else {
-                    containCounter++;
-                    if(containCounter > max) {
-                        max = containCounter;
-                        maxIdx = i;
-                    }
-                }
+            Point central = RendererUtilities.sampleForCentralPoint(geom, centroid, pg, gf, 5d, -1);
+            if (central != null) {
+                centroid = central;
             }
-                    
-            if(maxIdx != -1) {
-                int midIdx = max > 1 ? maxIdx - max / 2 : maxIdx;
-                c.x = env.getMinX() + step * midIdx;
-                pp.geometryChanged();
-                centroid = pp;
-            } else {
+            else {
                 return false;
             }
         }

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
@@ -29,6 +29,8 @@ import javax.measure.unit.SI;
 import javax.measure.unit.Unit;
 import javax.swing.Icon;
 
+import com.vividsolutions.jts.geom.prep.PreparedGeometry;
+import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory;
 import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.data.crs.ForceCoordinateSystemFeatureResults;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -873,5 +875,106 @@ public final class RendererUtilities {
             }
         }
         return features;
+    }
+
+    /**
+     * Finds a centroid for a polygon catching any exceptions resulting from generalization or 
+     * other polygon irregularities.
+     * 
+     * @param geom The polygon.
+     * @return The polygon centroid, or null if it can't be found.
+     */
+    public static Point getPolygonCentroid(Polygon geom) {
+        Point centroid;
+        try {
+            centroid = geom.getCentroid();
+        } catch (Exception e) {
+            // generalized polygons causes problems - this
+            // tries to hide them.
+            try {
+                centroid = geom.getExteriorRing().getCentroid();
+            } catch (Exception ee) {
+                try {
+                    centroid = geom.getFactory().createPoint(geom.getCoordinate());
+                } catch (Exception eee) {
+                    return null; // we're hooped
+                }
+            }
+        }
+        return centroid;
+    }
+
+    /**
+     * Uses a sampling technique to obtain a central point that lies inside the specified polygon.
+     * <p>
+     * Sampling occurs horizontally along the middle of the polygon obtained from the y coordinate of the polygon 
+     * centroid.
+     * </p>
+     * 
+     * @param geom The polygon.
+     * @param centroid The centroid of the polygon, can be null in which case it will be computed from {@link #getPolygonCentroid(Polygon)}.
+     * @param pg The prepared version of geom, can be null in which case it will be computed on demand.
+     * @param gf The geometry factory, can be null in which case the polygons factory will be used.
+     * 
+     * @return A central point that lies inside of the polygon, or null if one could not be found.
+     */
+    public static Point sampleForCentralPoint(Polygon geom, Point centroid, PreparedGeometry pg, GeometryFactory gf, 
+        double stepSize, int numSamples) {
+
+        if (centroid == null) {
+            centroid = getPolygonCentroid(geom);
+        }
+        if (pg == null) {
+            pg = PreparedGeometryFactory.prepare(geom);
+        }
+        if (gf == null) {
+            gf = geom.getFactory();
+        }
+
+        if (pg.contains(centroid)) {
+            return centroid;
+        }
+
+        Envelope env = geom.getEnvelopeInternal();
+        if (stepSize > 0) {
+            numSamples = (int) Math.round(env.getWidth() / stepSize);
+        }
+        else if (numSamples > 0) {
+            stepSize = env.getWidth() / numSamples;
+        }
+        else {
+            throw new IllegalArgumentException("One of stepSize or numSamples must be greater than zero");
+        }
+
+        Coordinate c = new Coordinate();
+        Point pp = gf.createPoint(c);
+        c.y = centroid.getY();
+        int max = -1;
+        int maxIdx = -1;
+        int containCounter = -1;
+        for (int i = 0; i < numSamples; i++) {
+            c.x = env.getMinX() + stepSize * i;
+            pp.geometryChanged();
+            if(!pg.contains(pp)) {
+                containCounter = 0;
+            } else if(i == 0) {
+                containCounter = 1;
+            } else {
+                containCounter++;
+                if(containCounter > max) {
+                    max = containCounter;
+                    maxIdx = i;
+                }
+            }
+        }
+
+        if(maxIdx != -1) {
+            int midIdx = max > 1 ? maxIdx - max / 2 : maxIdx;
+            c.x = env.getMinX() + stepSize * midIdx;
+            pp.geometryChanged();
+            return pp;
+        } else {
+            return null;
+        }
     }
 }

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
@@ -918,7 +918,7 @@ public final class RendererUtilities {
      * 
      * @return A central point that lies inside of the polygon, or null if one could not be found.
      */
-    public static Point sampleForCentralPoint(Polygon geom, Point centroid, PreparedGeometry pg, GeometryFactory gf, 
+    public static Point sampleForInternalPoint(Polygon geom, Point centroid, PreparedGeometry pg, GeometryFactory gf, 
         double stepSize, int numSamples) {
 
         if (centroid == null) {

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderUtilitiesTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderUtilitiesTest.java
@@ -20,6 +20,9 @@ import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.util.HashMap;
 
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.io.WKTReader;
 import junit.framework.TestCase;
 
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -280,5 +283,25 @@ public class RenderUtilitiesTest extends TestCase {
         scale = RendererUtilities.calculateScale(re, 1000, 500, 75);
         assertTrue(scale > 1.0d);
         
+    }
+
+    public void testSampleForCentralPoint() throws Exception {
+        // create a "C" shape polygon that won't contain it's centroid
+        Polygon g = (Polygon) new WKTReader().read("POLYGON ((-112.534433451864 43.8706532611928,-112.499157652296 44.7878240499628,-99.6587666095152 44.7878240499628,-99.7242788087131 43.2155312692142,-111.085391877449 43.099601544023,-110.744593363875 36.1862602686501,-98.6760836215473 35.9436771582516,-98.7415958207452 33.5197257879307,-111.77852346112 33.9783111823157,-111.758573671673 34.6566040234952,-113.088767445077 34.7644575726901,-113.023255245879 43.8706532611928,-112.534433451864 43.8706532611928))");
+        Point p = g.getCentroid();
+
+        assertFalse(g.contains(p));
+
+        // test with few samples, we shouldn't hit the inside
+        assertNull(RendererUtilities.sampleForCentralPoint(g, p, null, null, -1, 2));
+
+        // up the  samples, we should hit the inside now
+        assertNotNull(RendererUtilities.sampleForCentralPoint(g, p, null, null, -1, 10));
+    }
+
+    public void testFindCentralPoint() throws Exception {
+        // self crossing polygon
+        Polygon g = (Polygon) new WKTReader().read("POLYGON ((0 0, 0 10, 10 0, 10 10, 0 0))");
+        assertNotNull(RendererUtilities.getPolygonCentroid(g));
     }
 }

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderUtilitiesTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderUtilitiesTest.java
@@ -293,10 +293,10 @@ public class RenderUtilitiesTest extends TestCase {
         assertFalse(g.contains(p));
 
         // test with few samples, we shouldn't hit the inside
-        assertNull(RendererUtilities.sampleForCentralPoint(g, p, null, null, -1, 2));
+        assertNull(RendererUtilities.sampleForInternalPoint(g, p, null, null, -1, 2));
 
         // up the  samples, we should hit the inside now
-        assertNotNull(RendererUtilities.sampleForCentralPoint(g, p, null, null, -1, 10));
+        assertNotNull(RendererUtilities.sampleForInternalPoint(g, p, null, null, -1, 10));
     }
 
     public void testFindCentralPoint() throws Exception {


### PR DESCRIPTION
- Adds getGeometryCentroid method for “safe” centroid calculation for polygon
- Adds sampleForCentralPoint for finding “centroid” that lies within
the polygon

This change is in support of [GEOS-8033](https://osgeo-org.atlassian.net/browse/GEOS-8033) where the goal is to add some better placemark placement for polygons. The idea is to factor out some of the rendering code so it can be reused. 