### PR TITLE
[GEOT-5780] OGR GeoJSON layer name changes with GDAL 2.2 or later, breaking BridjOGRDataStoreTest (master)

### DIFF
--- a/docs/user/library/data/ogr.rst
+++ b/docs/user/library/data/ogr.rst
@@ -70,14 +70,14 @@ Here is how you would read a shapefile::
        it.close();
     }
 
-Here is how you would count the features in a GeoJSON file::
+Here is how you would count the features in a GeoJSON file. See the `GDAL GeoJSON documentation <http://www.gdal.org/drv_geojson.html>`_ for layer naming details::
 
     File file = new File("states.geojson");
     Map<String, String> connectionParams = new HashMap<String, String>();
     connectionParams.put("DriverName", "GeoJSON");
     connectionParams.put("DatasourceName", file.getAbsolutePath());
     DataStore dataStore = DataStoreFinder.getDataStore(connectionParams);
-    System.out.println(dataStore.getFeatureSource("OGRGeoJSON").getCount(Query.ALL));
+    System.out.println(dataStore.getFeatureSource(dataStore.getTypeNames()[0]).getCount(Query.ALL));
 
 Here is how you would write a GeoJSON file::
 

--- a/modules/plugin/ogr/ogr-core/src/test/java/org/geotools/data/ogr/OGRDataStoreTest.java
+++ b/modules/plugin/ogr/ogr-core/src/test/java/org/geotools/data/ogr/OGRDataStoreTest.java
@@ -404,7 +404,9 @@ public abstract class OGRDataStoreTest extends TestCaseSupport {
         OGRDataStore s = new OGRDataStore(tmpFile.getAbsolutePath(), "GeoJSON", null, ogr);
         s.createSchema(features, true, null);
         assertEquals(1, s.getTypeNames().length);
-        SimpleFeatureCollection fc = s.getFeatureSource("OGRGeoJSON").getFeatures();
+        // OGR GeoJSON layer name is "OGRGeoJSON" in GDAL up to 2.1 and "junk" (set from feature
+        // collection name) in GDAL 2.2 or later. See: http://www.gdal.org/drv_geojson.html
+        SimpleFeatureCollection fc = s.getFeatureSource(s.getTypeNames()[0]).getFeatures();
         assertEquals(features.size(), fc.size());
         // Read
         int c = 0;


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5780