### PR TITLE
GEOT-5773 avoid NPE in GridCoverageRenderer when colormodel is null

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/TypeMap.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/TypeMap.java
@@ -510,6 +510,9 @@ public final class TypeMap {
 	public static ColorInterpretation getColorInterpretation(final ColorModel model, final int band)
             throws IllegalArgumentException
     {
+        if (model == null) {
+            return ColorInterpretation.UNDEFINED;
+        }
         if (band<0 || band>=ColorUtilities.getNumBands(model)) {
             throw new IllegalArgumentException(Errors.format(ErrorKeys.BAD_BAND_NUMBER_$1, band));
         }

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRenderer.java
@@ -665,7 +665,7 @@ public final class GridCoverageRenderer {
         for(int i=0;i<numBands;i++) {
             sd[i]= new GridSampleDimension(TypeMap.getColorInterpretation(im.getColorModel(), i).name());
         }
-        
+
         Map properties = input.getProperties();
         if(properties == null){
             properties = new HashMap<>();


### PR DESCRIPTION
@dromagnoli 
This can occur with non-byte images. (Remote sensing images commonly use shorts as data type, both in netcdf and geotiff files.)
