### PR TITLE
GEOT-5588 according to gdal spec iw the integers width is 0 …

### DIFF
--- a/modules/plugin/ogr/ogr-core/src/main/java/org/geotools/data/ogr/FeatureTypeMapper.java
+++ b/modules/plugin/ogr/ogr-core/src/main/java/org/geotools/data/ogr/FeatureTypeMapper.java
@@ -124,7 +124,9 @@ class FeatureTypeMapper {
         int width = ogr.FieldGetWidth(field);
         
         if (ogr.FieldIsIntegerType(type)) {
-            if (width <= 3) {
+            if (width == 0) {
+		return BigDecimal.class;
+	     } else if (width <= 3) {
                 return Byte.class;
             } else if (width <= 5) {
                 return Short.class;


### PR DESCRIPTION
according to gdal spec iw the integers width is 0 it means the width is not specified.

https://osgeo-org.atlassian.net/browse/GEOT-5588