### PR TITLE
[GEOT-5790] dbtype and filetype should be marked as 'program'-level parameters

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/AppSchemaDataAccessFactory.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/AppSchemaDataAccessFactory.java
@@ -26,11 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.geotools.data.DataAccess;
-import org.geotools.data.DataAccessFactory;
-import org.geotools.data.DataStore;
-import org.geotools.data.DataStoreFactorySpi;
-import org.geotools.data.DataUtilities;
+import org.geotools.data.*;
 import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
 import org.geotools.data.complex.config.AppSchemaDataAccessDTO;
 import org.geotools.data.complex.config.DataAccessMap;
@@ -58,8 +54,8 @@ public class AppSchemaDataAccessFactory implements DataAccessFactory {
 
     public static final String DBTYPE_STRING = "app-schema";
 
-    public static final DataAccessFactory.Param DBTYPE = new DataAccessFactory.Param("dbtype",
-            String.class, "Fixed value '" + DBTYPE_STRING + "'", true, DBTYPE_STRING);
+    public static final DataAccessFactory.Param DBTYPE = new DataAccessFactory.Param("dbtype", String.class,
+            "Fixed value '" + DBTYPE_STRING + "'", true, DBTYPE_STRING, Collections.singletonMap(Parameter.LEVEL, "program"));
 
     public static final DataAccessFactory.Param URL = new DataAccessFactory.Param("url", URL.class,
             "URL to an application schema datastore XML configuration file", true);

--- a/modules/extension/app-schema/sample-data-access/src/main/java/org/geotools/data/SampleDataAccessFactory.java
+++ b/modules/extension/app-schema/sample-data-access/src/main/java/org/geotools/data/SampleDataAccessFactory.java
@@ -49,8 +49,8 @@ public class SampleDataAccessFactory implements DataAccessFactory {
      */
     public static final String DBTYPE_STRING = "sample-data-access";
 
-    public static final DataAccessFactory.Param DBTYPE = new DataAccessFactory.Param("dbtype",
-            String.class, "Fixed value '" + DBTYPE_STRING + "'", true, DBTYPE_STRING);
+    public static final DataAccessFactory.Param DBTYPE = new DataAccessFactory.Param("dbtype",  String.class,
+            "Fixed value '" + DBTYPE_STRING + "'", true, DBTYPE_STRING, Collections.singletonMap(Parameter.LEVEL, "program"));
 
     /**
      * The connection parameters required to use this factory.

--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/datasource/DBCPDataSourceFactory.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/datasource/DBCPDataSourceFactory.java
@@ -19,6 +19,7 @@ package org.geotools.data.jdbc.datasource;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -26,6 +27,7 @@ import javax.sql.DataSource;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.geotools.data.DataSourceException;
 import org.geotools.data.DataAccessFactory.Param;
+import org.geotools.data.Parameter;
 
 /**
  * A datasource factory using DBCP connection pool
@@ -39,8 +41,8 @@ import org.geotools.data.DataAccessFactory.Param;
  */
 public class DBCPDataSourceFactory extends AbstractDataSourceFactorySpi {
 
-    public static final Param DSTYPE = new Param("dstype", String.class,
-            "Must be DBCP", false);
+    public static final Param DSTYPE = new Param("dstype", String.class, "Must be DBCP", false,
+            null, Collections.singletonMap(Parameter.LEVEL, "program"));
     
     public static final Param USERNAME = new Param("username", String.class,
             "User name to login as", false);

--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/datasource/JNDIDataSourceFactory.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/datasource/JNDIDataSourceFactory.java
@@ -17,12 +17,14 @@
 package org.geotools.data.jdbc.datasource;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.sql.DataSource;
 
 import org.geotools.data.DataSourceException;
 import org.geotools.data.DataAccessFactory.Param;
+import org.geotools.data.Parameter;
 import org.geotools.factory.GeoTools;
 
 /**
@@ -36,8 +38,8 @@ import org.geotools.factory.GeoTools;
  */
 public class JNDIDataSourceFactory extends AbstractDataSourceFactorySpi {
     
-    public static final Param DSTYPE = new Param("dstype", String.class,
-            "Must be JNDI", false);
+    public static final Param DSTYPE = new Param("dstype", String.class, "Must be JNDI", false,
+            null, Collections.singletonMap(Parameter.LEVEL, "program"));
 
     public static final Param JNDI_REFNAME = new Param("jdniReferenceName", String.class,
             "The path where the connection pool must be located", true);

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
@@ -57,7 +57,8 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 public abstract class JDBCDataStoreFactory implements DataStoreFactorySpi {
     
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true);
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, null,
+            Collections.singletonMap(Parameter.LEVEL, "program"));
 
     /** parameter for database host */
     public static final Param HOST = new Param("host", String.class, "Host", true, "localhost");

--- a/modules/plugin/arcsde/datastore/src/main/java/org/geotools/arcsde/ArcSDEDataStoreFactory.java
+++ b/modules/plugin/arcsde/datastore/src/main/java/org/geotools/arcsde/ArcSDEDataStoreFactory.java
@@ -96,8 +96,8 @@ public final class ArcSDEDataStoreFactory implements DataStoreFactorySpi {
     public static final Param NAMESPACE_PARAM = new Param(NAMESPACE_PARAM_NAME, String.class,
             "namespace associated to this data store", false);
 
-    public static final Param DBTYPE_PARAM = new Param(DBTYPE_PARAM_NAME, String.class,
-            "fixed value. Must be \"arcsde\"", true, "arcsde");
+    public static final Param DBTYPE_PARAM = new Param(DBTYPE_PARAM_NAME, String.class, "fixed value. Must be \"arcsde\"",
+            true, "arcsde", Collections.singletonMap(Parameter.LEVEL, "program"));
 
     public static final Param SERVER_PARAM = new Param(SERVER_NAME_PARAM_NAME, String.class,
             "sever name where the ArcSDE gateway is running", true);

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDataStoreFactory.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDataStoreFactory.java
@@ -18,9 +18,11 @@ package org.geotools.geopkg;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.commons.dbcp.BasicDataSource;
+import org.geotools.data.Parameter;
 import org.geotools.geopkg.geom.GeoPkgGeomWriter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
@@ -37,7 +39,8 @@ import org.sqlite.SQLiteConfig;
 public class GeoPkgDataStoreFactory extends JDBCDataStoreFactory {
 
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "geopkg");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "geopkg",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     
     /** optional user parameter */
     public static final Param USER = new Param(JDBCDataStoreFactory.USER.key, JDBCDataStoreFactory.USER.type, 

--- a/modules/plugin/jdbc/jdbc-db2/src/main/java/org/geotools/data/db2/DB2NGDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-db2/src/main/java/org/geotools/data/db2/DB2NGDataStoreFactory.java
@@ -24,9 +24,11 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Map;
 
 import org.geotools.data.DataAccessFactory.Param;
+import org.geotools.data.Parameter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
@@ -55,7 +57,8 @@ public class DB2NGDataStoreFactory extends JDBCDataStoreFactory {
     public static String SelectGeometryColumns="select * from db2gse.st_geometry_columns where 0 = 1";
     
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "db2");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "db2",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     
     /** enables using EnvelopesIntersect in bbox queries */
     public static final Param LOOSEBBOX = new Param("Loose bbox", Boolean.class, "Perform only primary filter on bbox", false, Boolean.TRUE);

--- a/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2DataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2DataStoreFactory.java
@@ -18,11 +18,13 @@ package org.geotools.data.h2;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.sql.DataSource;
 
 import org.apache.commons.dbcp.BasicDataSource;
+import org.geotools.data.Parameter;
 import org.geotools.data.jdbc.datasource.DBCPDataSource;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
@@ -41,7 +43,8 @@ import org.geotools.jdbc.SQLDialect;
  */
 public class H2DataStoreFactory extends JDBCDataStoreFactory {
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "h2");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "h2",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     
     /** parameter for how to handle associations */
     public static final Param ASSOCIATIONS = new Param("Associations", Boolean.class,

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDataStoreFactory.java
@@ -18,10 +18,12 @@ package org.geotools.data.mysql;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Map;
 
 import org.geotools.data.DataStore;
 import org.geotools.data.DataAccessFactory.Param;
+import org.geotools.data.Parameter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
@@ -39,7 +41,8 @@ import org.geotools.jdbc.SQLDialect;
  */
 public class MySQLDataStoreFactory extends JDBCDataStoreFactory {
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true,"mysql");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true,"mysql",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     /** Default port number for MYSQL */
     public static final Param PORT = new Param("port", Integer.class, "Port", true, 3306);
     /** Storage engine to use when creating tables */

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGDataStoreFactory.java
@@ -19,10 +19,12 @@ package org.geotools.data.oracle;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Map;
 
 import oracle.jdbc.OracleConnection;
 
+import org.geotools.data.Parameter;
 import org.geotools.data.Transaction;
 import org.geotools.data.DataAccessFactory.Param;
 import org.geotools.jdbc.JDBCDataStore;
@@ -43,7 +45,7 @@ public class OracleNGDataStoreFactory extends JDBCDataStoreFactory {
     private static final String JDBC_PATH = "jdbc:oracle:thin:@";
     
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "oracle");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "oracle", Collections.singletonMap(Parameter.LEVEL, "program"));
 
     /** parameter for database port */
     public static final Param PORT = new Param("port", Integer.class, "Port", false, 1521);

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisNGDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisNGDataStoreFactory.java
@@ -24,10 +24,12 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.sql.DataSource;
 
+import org.geotools.data.Parameter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
@@ -41,7 +43,8 @@ import org.geotools.util.KVP;
 public class PostgisNGDataStoreFactory extends JDBCDataStoreFactory {
     
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "postgis");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "postgis",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     
     /** enables using && in bbox queries */
     public static final Param LOOSEBBOX = new Param("Loose bbox", Boolean.class, "Perform only primary filter on bbox", false, Boolean.TRUE);

--- a/modules/plugin/jdbc/jdbc-spatialite/src/main/java/org/geotools/data/spatialite/SpatiaLiteDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-spatialite/src/main/java/org/geotools/data/spatialite/SpatiaLiteDataStoreFactory.java
@@ -20,9 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.commons.dbcp.BasicDataSource;
+import org.geotools.data.Parameter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
@@ -43,7 +45,8 @@ public class SpatiaLiteDataStoreFactory extends JDBCDataStoreFactory {
 
   
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "spatialite");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "spatialite",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     
     /** optional user parameter */
     public static final Param USER = new Param(JDBCDataStoreFactory.USER.key, JDBCDataStoreFactory.USER.type, 

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDataStoreFactory.java
@@ -17,8 +17,10 @@
 package org.geotools.data.sqlserver;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
+import org.geotools.data.Parameter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
@@ -35,7 +37,8 @@ import org.geotools.jdbc.SQLDialect;
  */
 public class SQLServerDataStoreFactory extends JDBCDataStoreFactory {
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "sqlserver");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "sqlserver",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
 
     /** parameter for using integrated security, only works on windows, ignores the user and password parameters, the current windows user account is used for login*/
     public static final Param INTSEC = new Param("Integrated Security", Boolean.class, "Login as current windows user account. Works only in windows. Ignores user and password settings.", false, new Boolean(false));

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/jtds/JTDSSqlServerDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/jtds/JTDSSqlServerDataStoreFactory.java
@@ -19,8 +19,10 @@
 package org.geotools.data.sqlserver.jtds;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
+import org.geotools.data.Parameter;
 import org.geotools.data.sqlserver.SQLServerDataStoreFactory;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.SQLDialect;
@@ -28,7 +30,8 @@ import org.geotools.jdbc.SQLDialect;
 
 public class JTDSSqlServerDataStoreFactory extends SQLServerDataStoreFactory {
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "jtds-sqlserver");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "jtds-sqlserver",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     /* (non-Javadoc)
      * @see org.geotools.data.sqlserver.SQLServerDataStoreFactory#getDescription()
      */

--- a/modules/plugin/jdbc/jdbc-teradata/src/main/java/org/geotools/data/teradata/TeradataDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-teradata/src/main/java/org/geotools/data/teradata/TeradataDataStoreFactory.java
@@ -18,12 +18,14 @@ package org.geotools.data.teradata;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
 import org.apache.commons.dbcp.BasicDataSource;
+import org.geotools.data.Parameter;
 import org.geotools.data.jdbc.datasource.DBCPDataSource;
 import org.geotools.feature.type.BasicFeatureTypes;
 import org.geotools.jdbc.CompositePrimaryKeyFinder;
@@ -48,7 +50,8 @@ public class TeradataDataStoreFactory extends JDBCDataStoreFactory {
     /**
      * parameter for database type
      */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "teradata");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "teradata",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     
     public static final Param LOBWORKAROUND = new Param("Disable LOB Workaround",Boolean.class,
             "Disable LOB workaround", false, Boolean.FALSE);

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStoreFactory.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStoreFactory.java
@@ -82,7 +82,7 @@ public class ShapefileDataStoreFactory implements FileDataStoreFactorySpi {
      */
     public static final Param FILE_TYPE = new Param("filetype", String.class,
             "Discriminator for directory stores", false, "shapefile", new KVP(Param.LEVEL,
-                    "advanced"));
+                    "program"));
 
     /**
      * Optional - Enable/disable the automatic creation of spatial index

--- a/modules/unsupported/jdbc-ng/jdbc-ingres/src/main/java/org/geotools/data/ingres/IngresDataStoreFactory.java
+++ b/modules/unsupported/jdbc-ng/jdbc-ingres/src/main/java/org/geotools/data/ingres/IngresDataStoreFactory.java
@@ -19,7 +19,8 @@ import org.geotools.jdbc.SQLDialect;
 public class IngresDataStoreFactory extends JDBCDataStoreFactory {
 
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "ingres");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "ingres",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     
     /** parameter for namespace of the datastore */
     public static final Param LOOSEBBOX = new Param("Loose bbox", Boolean.class, "Perform only primary filter on bbox", false, Boolean.TRUE);

--- a/modules/unsupported/mbtiles/src/main/java/org/geotools/mbtiles/MBTilesDataStoreFactory.java
+++ b/modules/unsupported/mbtiles/src/main/java/org/geotools/mbtiles/MBTilesDataStoreFactory.java
@@ -1,8 +1,10 @@
 package org.geotools.mbtiles;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.dbcp.BasicDataSource;
+import org.geotools.data.Parameter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
@@ -11,7 +13,8 @@ import org.sqlite.SQLiteConfig;
 public class MBTilesDataStoreFactory extends JDBCDataStoreFactory {
 
     /** parameter for database type */
-    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "mbtiles");
+    public static final Param DBTYPE = new Param("dbtype", String.class, "Type", true, "mbtiles",
+            Collections.singletonMap(Parameter.LEVEL, "program"));
     
     /** optional user parameter */
     public static final Param USER = new Param(JDBCDataStoreFactory.USER.key, JDBCDataStoreFactory.USER.type, 


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOT-5790

Adds LEVEL="program" to DBTYPE / DSTYPE / FILETYPE parameters for all the various datastore implementations.

Ultimately intended to fix https://osgeo-org.atlassian.net/browse/GEOS-8010