### PR TITLE
[GEOT-5795] remove services file org.geotools.xml.schema.Schema from wfs-ng

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/data/wms/xml/ogcComplexTypes.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/wms/xml/ogcComplexTypes.java
@@ -246,13 +246,6 @@ public class ogcComplexTypes {
             
             if (canEncode(element, value, hints)) {
                 AttributesImpl attributes = new AttributesImpl();
-//                attributes.addAttribute(WFSSchema.NAMESPACE.toString(),
-//                    attrs[0].getName(), null, "string", attrs[0].getFixed());
-//                attributes.addAttribute(WFSSchema.NAMESPACE.toString(),
-//                    attrs[1].getName(), null, "string", attrs[1].getFixed());
-//                attributes.addAttribute(WFSSchema.NAMESPACE.toString(),
-//                    attrs[2].getName(), null, "string", attrs[2].getFixed());
-                
                 
                 try {
                     output.startElement(element.getNamespace(), element.getName(), attributes);

--- a/modules/unsupported/wfs-ng/src/main/resources/META-INF/services/org.geotools.xml.schema.Schema
+++ b/modules/unsupported/wfs-ng/src/main/resources/META-INF/services/org.geotools.xml.schema.Schema
@@ -1,1 +1,0 @@
-org.geotools.data.wfs.v1_0_0.xml.WFSSchema


### PR DESCRIPTION
because this lists a non-existent class, also remove commented code that used this class.

see: https://osgeo-org.atlassian.net/browse/GEOT-5795