### PR TITLE
fixed icon padding test

### DIFF
--- a/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/SymbolMBLayerTest.java
+++ b/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/SymbolMBLayerTest.java
@@ -155,7 +155,7 @@ public class SymbolMBLayerTest {
     	assertEquals(2.0, testLayerDefault.getIconPadding());
     	assertEquals("20.0", featureTypePoint.get(0).rules().get(0).getSymbolizers()[1].getOptions().get("spaceAround"));
     	assertEquals(30.0, testLineLayer.getIconPadding());
-    	assertEquals("30.0", featureTypeLine.get(0).rules().get(0).getSymbolizers()[0].getOptions().get("spaceAround"));
+    	assertEquals("15.0", featureTypeLine.get(0).rules().get(0).getSymbolizers()[0].getOptions().get("spaceAround"));
     }
     @Test
     public void testTextFont(){


### PR DESCRIPTION
The test result changed due to the removal of the icon field in the .json test file.  15 would be the desired result now.