### PR TITLE
[GEOT-5823] Mapping java.sql.Timestamp to TIMESTAMP database type

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -163,6 +163,7 @@ public class OracleDialect extends PreparedStatementSQLDialect {
     		put("NVARCHAR", String.class);
     		put("NVARCHAR2", String.class);
             put("DATE", java.sql.Date.class);
+            put("TIMESTAMP", java.sql.Timestamp.class);
     	}
     };
     
@@ -1436,6 +1437,8 @@ public class OracleDialect extends PreparedStatementSQLDialect {
         // starting with Oracle 11 + recent JDBC drivers the DATE type does not have a mapping
         // anymore in the JDBC driver, manually register it instead
         overrides.put(Types.DATE, "DATE");
+        // overriding default java.sql.Timestamp to Oracle DATE mapping
+        overrides.put(Types.TIMESTAMP, "TIMESTAMP");
     }
     
     @Override

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDateOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDateOnlineTest.java
@@ -2,10 +2,20 @@ package org.geotools.data.oracle;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.TimeZone;
 
+import org.geotools.data.DataUtilities;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.Query;
+import org.geotools.data.Transaction;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.jdbc.JDBCDateOnlineTest;
 import org.geotools.jdbc.JDBCDateTestSetup;
+import org.geotools.jdbc.JDBCFeatureStore;
+import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
 
 /**
  * 
@@ -35,5 +45,41 @@ public class OracleDateOnlineTest extends JDBCDateOnlineTest {
     public void testFilterByTime() throws Exception {
         // Oracle makes you go through various stages of pain to work simply against Time,
         // not worth supporting it until someone has real time to deal with it
+    }
+
+    public void testInsertTemporal() throws Exception {
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        TimeZone gmtTimeZone = TimeZone.getTimeZone("GMT");
+        try {
+            TimeZone.setDefault(gmtTimeZone);
+
+            final String timestampsTable = tname("timestamps");
+            SimpleFeatureType ft = dataStore.getSchema(timestampsTable);
+            SimpleFeatureBuilder builder = new SimpleFeatureBuilder(ft);
+            long theTimestamp = 1503926476000L; // August 28, 2017 13:21:16 GMT
+            builder.add(new Timestamp(theTimestamp));
+            SimpleFeature feature = builder.buildFeature(null);
+
+            Transaction t = new DefaultTransaction("add");
+            JDBCFeatureStore fs = (JDBCFeatureStore) dataStore.getFeatureSource(timestampsTable, t);
+            try {
+                fs.addFeatures(DataUtilities.collection(feature));
+                t.commit();
+            } catch (Exception ex) {
+                t.rollback();
+                throw ex;
+            } finally {
+                t.close();
+            }
+
+            FilterFactory ff = dataStore.getFilterFactory();
+            Filter f = ff.equals(ff.property(aname("t")), ff.literal("2017-08-28 13:21:16"));
+
+            JDBCFeatureStore fs2 = (JDBCFeatureStore) dataStore.getFeatureSource(timestampsTable);
+
+            assertEquals(1, fs2.getCount(new Query(timestampsTable, f)));
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
     }
 }

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDateTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDateTestSetup.java
@@ -35,11 +35,17 @@ public class OracleDateTestSetup extends JDBCDateTestSetup {
                 "TO_DATE('2009-09-29', 'yyyy-MM-dd'), " +
                 "TO_DATE('2009-09-29 17:54:23', 'yyyy-MM-dd HH24:mi:ss')," +
                 "TO_DATE('17:54:23', 'HH24:mi:ss')  )");
+        
+        run( "CREATE TABLE TIMESTAMPS (" +
+                "ID NUMERIC(10) NOT NULL, " + 
+                "T TIMESTAMP, " +
+                "CONSTRAINT temporals_pk PRIMARY KEY (id))");
     }
 
     @Override
     protected void dropDateTable() throws Exception {
         runSafe("DROP TABLE DATES");
+        runSafe("DROP TABLE TIMESTAMPS");
     }
 
 }


### PR DESCRIPTION
We need to register a new type mapping to force java.sql.Timestamp to
be mapped to Oracle TIMESTAMP type (not DATE type) so time information
won't be lost when inserting features with java.sql.Timestamp attributes
(GeoTools maps DATE to java.sql.Date and strips time information before
inserting to database).