### PR TITLE
Use multiple 'NamedLayer's for seperate MBStyle 'source-layer's

### DIFF
--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/source/GeoJsonMBSource.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/source/GeoJsonMBSource.java
@@ -27,7 +27,7 @@ import org.json.simple.JSONObject;
  * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-geojson">https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-geojson</a>
  *
  */
-public class GeoJsonMBSource extends TileMBSource {
+public class GeoJsonMBSource extends MBSource {
 
     public GeoJsonMBSource(JSONObject json) {
         this(json, null);

--- a/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/MapBoxStyleTest.java
+++ b/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/MapBoxStyleTest.java
@@ -22,6 +22,10 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
 
+import org.geotools.styling.NamedLayer;
+import org.geotools.styling.StyledLayerDescriptor;
+import org.geotools.styling.UserLayer;
+import org.geotools.styling.UserLayerImpl;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -43,5 +47,22 @@ public class MapBoxStyleTest {
         problems = MapBoxStyle.validate(reader);
         
         assertEquals("styleInvalidLayers 2 failure", 2, problems.size() );
+    }
+
+    @Test
+    public void testNamedLayers() throws IOException, ParseException {
+        Reader reader = MapboxTestUtils.readerTestStyle("groupStyleTest.json");
+        StyledLayerDescriptor sld = MapBoxStyle.parse(reader);
+
+        assertEquals(4, sld.getStyledLayers().length);
+        assertEquals("background", sld.getStyledLayers()[0].getName());
+        assertTrue(sld.getStyledLayers()[0] instanceof UserLayer);
+
+
+        assertEquals("Lakes", sld.getStyledLayers()[1].getName());
+        assertTrue(sld.getStyledLayers()[1] instanceof NamedLayer);
+
+        assertEquals("BasicPolygons", sld.getStyledLayers()[2].getName());
+        assertEquals("NamedPlaces", sld.getStyledLayers()[3].getName());
     }
 }

--- a/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/parse/MBStopsTest.java
+++ b/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/parse/MBStopsTest.java
@@ -148,7 +148,7 @@ public class MBStopsTest {
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor transformed = mbStyle.transform();
         List<StyledLayer> styledLayers = transformed.layers();
-        List<FeatureTypeStyle> fts = ((UserLayer)styledLayers.get(0)).userStyles().get(0).featureTypeStyles();
+        List<FeatureTypeStyle> fts = ((UserLayer)styledLayers.get(0)).getUserStyles()[0].featureTypeStyles();
 
         int i = 0;
         for (FeatureTypeStyle layer : fts) {

--- a/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/parse/StyleParseTests.java
+++ b/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/parse/StyleParseTests.java
@@ -273,8 +273,6 @@ public class StyleParseTests {
         assertEquals(4, l.getLineOffset().intValue());
         assertEquals(4.0, l.getLineOffset().doubleValue(), .00001);
         // line-gap-width can be either an integer or double.
-        assertEquals(8, l.getLineGapWidth().intValue());
-        assertEquals(8.0, l.getLineGapWidth().doubleValue(), .00001);
         assertNotNull(l.lineTranslateDisplacement());
         Number dispX = l.lineTranslateDisplacement().getDisplacementX().evaluate(null, Number.class);
         Number dispY = l.lineTranslateDisplacement().getDisplacementY().evaluate(null, Number.class);

--- a/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/transform/VisualTransformerTest.java
+++ b/modules/unsupported/mbstyle/src/test/java/org/geotools/mbstyle/transform/VisualTransformerTest.java
@@ -188,8 +188,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(polygonFS, style));
@@ -215,8 +215,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(polygonFS, style));
@@ -243,8 +243,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(polygonsBigFS, style));
@@ -270,8 +270,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(polygonsBigFS, style));
@@ -297,8 +297,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(polygonsBigFS, style));
@@ -324,8 +324,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(pointFS, style));
@@ -351,8 +351,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(pointFS, style));
@@ -489,8 +489,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(pointsWithMarksFS, style));
@@ -517,8 +517,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(pointsWithMarksFS, style));
@@ -552,8 +552,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
         
         MapContent mc = new MapContent();
 
@@ -578,8 +578,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonObject);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
         
         MapContent mc = new MapContent();
 
@@ -630,8 +630,8 @@ public class VisualTransformerTest {
 //        JSONObject jsonObject = MapboxTestUtils.parseTestStyle("rasterStyleTestAllProperties.json");
 //        MBStyle mbStyle = new MBStyle(jsonObject);
 //        StyledLayerDescriptor sld = mbStyle.transform();
-//        UserLayer l = (UserLayer) sld.layers().get(0);
-//        Style style = l.getUserStyles()[0];
+//        NamedLayer l = (NamedLayer) sld.layers().get(0);
+//        Style style = l.getStyles()[0];
 //        RasterSymbolizer s = (RasterSymbolizer)style.featureTypeStyles().get(0).getRules()[0].getSymbolizers()[0];      
 //
 //        RenderedImage image = renderer.renderImage(worldPaletteReader, null, s,
@@ -647,8 +647,8 @@ public class VisualTransformerTest {
 //        // Get the style
 //        MBStyle mbStyle = new MBStyle(jsonObject);
 //        StyledLayerDescriptor sld = mbStyle.transform();
-//        UserLayer l = (UserLayer) sld.layers().get(0);
-//        Style style = l.getUserStyles()[0];
+//        NamedLayer l = (NamedLayer) sld.layers().get(0);
+//        Style style = l.getStyles()[0];
 //
 //        MapContent mc = new MapContent();
 //
@@ -670,14 +670,15 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonStyle);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
 
         MapContent mc = new MapContent();        
         if (includeGrid) {
             mc.addLayer(new FeatureLayer(gridFS, defaultLineStyle()));    
-        }        
-        mc.addLayer(new FeatureLayer(pointFS, style));
+        }
+        for (StyledLayer l : sld.layers()) {
+            NamedLayer nl = (NamedLayer) l;
+            mc.addLayer(new FeatureLayer(pointFS, nl.getStyles()[0]));
+        }
 
         StreamingRenderer renderer = new StreamingRenderer();
         renderer.setMapContent(mc);
@@ -695,8 +696,8 @@ public class VisualTransformerTest {
         // Get the style
         MBStyle mbStyle = new MBStyle(jsonStyle);
         StyledLayerDescriptor sld = mbStyle.transform();
-        UserLayer l = (UserLayer) sld.layers().get(0);
-        Style style = l.getUserStyles()[0];
+        NamedLayer l = (NamedLayer) sld.layers().get(0);
+        Style style = l.getStyles()[0];
 
         MapContent mc = new MapContent();
 

--- a/modules/unsupported/mbstyle/src/test/resources/org/geotools/mbstyle/groupStyleTest.json
+++ b/modules/unsupported/mbstyle/src/test/resources/org/geotools/mbstyle/groupStyleTest.json
@@ -1,0 +1,61 @@
+{
+  "version": 8,
+  "name": "citeGroup",
+  "center": [0,0],
+  "zoom": 7,
+  "sources": {
+    "cite": {
+      "type": "vector",
+      "tiles": [
+        "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=citeGroup&STYLE=&TILEMATRIX=EPSG:900913:{z}&TILEMATRIXSET=EPSG:900913&FORMAT=application/x-protobuf;type=mapbox-vector&TILECOL={x}&TILEROW={y}"
+      ],
+      "minZoom": 0,
+      "maxZoom": 14
+    }
+  },
+  "layers": [
+    {
+      "type": "background",
+      "id": "background",
+      "paint": {
+        "background-color": "#E3E3E9"
+      }
+    },
+    {
+      "type": "fill",
+      "id": "fill",
+      "source": "cite",
+      "source-layer": "Lakes",
+      "paint": {
+        "fill-color": "#C3C3C3",
+        "fill-opacity": 0.9
+      }
+    },
+    {
+      "type": "line",
+      "id": "line",
+      "source": "cite",
+      "source-layer": "BasicPolygons",
+      "paint": {
+        "line-color": "#777777",
+        "line-width": 1,
+        "line-dasharray": [4, 4]
+      }
+    },
+    {
+      "type": "symbol",
+      "id": "names",
+      "source": "cite",
+      "source-layer": "NamedPlaces",
+      "layout": {
+        "text-field": "{Name}",
+        "text-size": 14,
+        "text-font": ["Open Sans"],
+        "text-max-width": 100
+      },
+      "paint": {
+        "text-color": "#333333"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
* Adds support for the new "Style Group" functionality to MBStyle
* Uses world-spanning inline features for layers which have no geometry, i.e. background layers.
* GeoJSON layers now correctly extend MBSource rather than TileMBSource, in accordance with the MBStyle spec.