### PR TITLE
[GEOT-5840] Fix handling WellKnownScaleSet in WMTS getCapabilities

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/model/TileMatrixSet.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/model/TileMatrixSet.java
@@ -55,6 +55,8 @@ public class TileMatrixSet {
 
     private String crs;
 
+    private String wellKnownScaleSet;
+
     CoordinateReferenceSystem coordinateReferenceSystem;
 
     private CRSEnvelope bbox;
@@ -134,6 +136,14 @@ public class TileMatrixSet {
 
     public void setBbox(CRSEnvelope bbox) {
         this.bbox = bbox;
+    }
+
+    public String getWellKnownScaleSet() {
+        return wellKnownScaleSet;
+    }
+
+    public void setWellKnownScaleSet(String wellKnownScaleSet) {
+        this.wellKnownScaleSet = wellKnownScaleSet;
     }
 
     public String toString() {

--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/model/WMTSCapabilities.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/model/WMTSCapabilities.java
@@ -305,6 +305,7 @@ public class WMTSCapabilities extends Capabilities {
             throws RuntimeException, IllegalArgumentException, ServiceException {
         TileMatrixSet matrixSet = new TileMatrixSet();
         matrixSet.setCRS(tm.getSupportedCRS());
+        matrixSet.setWellKnownScaleSet(tm.getWellKnownScaleSet());
         matrixSet.setIdentifier(tm.getIdentifier().getValue());
         if (tm.getBoundingBox() != null) {
             matrixSet.setBbox(bbox2bbox(tm.getBoundingBox()));

--- a/modules/extension/wmts/src/test/java/org/geotools/data/wmts/model/WMTSCapabilitiesTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/data/wmts/model/WMTSCapabilitiesTest.java
@@ -231,6 +231,30 @@ public class WMTSCapabilitiesTest extends TestCase {
         }
     }
 
+    public void testParserOLSample() throws Exception {
+        WMTSCapabilities capabilities = createCapabilities("ol.getcapa.xml");
+        try {
+            assertEquals("1.0.0", capabilities.getVersion());
+
+            WMTSService service = (WMTSService) capabilities.getService();
+            assertEquals("Koordinates Labs", service.getTitle());
+
+            List<TileMatrixSet> matrixSets = capabilities.getMatrixSets();
+            assertNotNull(matrixSets);
+            assertFalse(matrixSets.isEmpty());
+
+            assertEquals("urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible", matrixSets.get(0).getWellKnownScaleSet());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            if ((e.getMessage() != null) && e.getMessage().indexOf("timed out") > 0) {
+                System.err.println("Unable to test - timed out: " + e);
+            } else {
+                throw (e);
+            }
+        }
+    }
+
     protected WebMapTileServer getCustomWMS(URL featureURL)
             throws SAXException, URISyntaxException, IOException {
         return new WebMapTileServer(featureURL);

--- a/modules/extension/wmts/src/test/java/org/geotools/data/wmts/model/WMTSCapabilitiesTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/data/wmts/model/WMTSCapabilitiesTest.java
@@ -243,10 +243,11 @@ public class WMTSCapabilitiesTest extends TestCase {
             assertNotNull(matrixSets);
             assertFalse(matrixSets.isEmpty());
 
-            assertEquals("urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible", matrixSets.get(0).getWellKnownScaleSet());
+            assertEquals("urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
+                    matrixSets.get(0).getWellKnownScaleSet());
 
         } catch (Exception e) {
-            e.printStackTrace();
+            // a standard catch block shared with the other tests
             if ((e.getMessage() != null) && e.getMessage().indexOf("timed out") > 0) {
                 System.err.println("Unable to test - timed out: " + e);
             } else {

--- a/modules/extension/wmts/src/test/resources/test-data/ol.getcapa.xml
+++ b/modules/extension/wmts/src/test/resources/test-data/ol.getcapa.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities version="1.0.0" xmlns="http://www.opengis.net/wmts/1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
+    <ows:ServiceIdentification>
+        <ows:Title>Koordinates Labs</ows:Title>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+    </ows:ServiceIdentification>
+    <ows:ServiceProvider>
+        <ows:ProviderName>Koordinates</ows:ProviderName>
+        <ows:ProviderSite xlink:href="http://labs.koordinates.com"/>
+        <ows:ServiceContact/>
+    </ows:ServiceProvider>
+    <ows:OperationsMetadata>
+        <ows:Operation name="GetCapabilities">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="https://labs.koordinates.com/services;key=d740ea02e0c44cafb70dce31a774ca10/wmts/1.0.0/layer/7328/WMTSCapabilities.xml?">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>KVP</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="GetFeatureInfo">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="https://labs.koordinates.com/services;key=d740ea02e0c44cafb70dce31a774ca10/wmts/?">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>KVP</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+    </ows:OperationsMetadata>
+    <Contents>
+        <Layer>
+            <ows:Title>New Zealand Earthquakes</ows:Title>
+            <ows:Abstract>Historical earthquake data, accessed via the [GeoNet WFS feed](http://info.geonet.org.nz/display/appdata/Advanced+Queries). The data has been filtered to only include quakes in proximity to New Zealand with an `eventtype` of &quot;Earthquake&quot; or &quot;none&quot; per the [GeoNet catalogue](http://info.geonet.org.nz/display/appdata/Catalogue+Output). Most fields have been removed. Please also note the excluded data per this [GeoNet page](http://info.geonet.org.nz/display/appdata/The+Gap). We acknowledge the New Zealand GeoNet project and its sponsors EQC, GNS Science and LINZ, for providing data used in this layer.</ows:Abstract>
+            <ows:Identifier>layer-7328</ows:Identifier>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::3857">
+                <ows:LowerCorner>-20037508.342789 -6406581.708337</ows:LowerCorner>
+                <ows:UpperCorner>20037508.342789 -3653545.667928</ows:UpperCorner>
+            </ows:BoundingBox>
+            <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+                <ows:LowerCorner>-180.000000 -49.454297</ows:LowerCorner>
+                <ows:UpperCorner>180.000000 -31.160000</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <Style isDefault="true">
+                <ows:Title>Weighted point styles</ows:Title>
+                <ows:Identifier>style=39</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <InfoFormat>application/json</InfoFormat>
+            <InfoFormat>text/html</InfoFormat>
+            <TileMatrixSetLink>
+                <TileMatrixSet>EPSG:3857</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://koordinates-tiles-a.global.ssl.fastly.net/services;key=d740ea02e0c44cafb70dce31a774ca10/tiles/v4/layer=7328,{style}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"/>
+            <ResourceURL format="application/json" resourceType="FeatureInfo" template="https://labs.koordinates.com/services;key=d740ea02e0c44cafb70dce31a774ca10/wmts/1.0.0/layer/7328/featureinfo/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}/{I}/{J}.json"/>
+            <ResourceURL format="text/html" resourceType="FeatureInfo" template="https://labs.koordinates.com/services;key=d740ea02e0c44cafb70dce31a774ca10/wmts/1.0.0/layer/7328/featureinfo/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}/{I}/{J}.html"/>
+        </Layer>
+        <TileMatrixSet>
+            <ows:Title>GoogleMapsCompatible</ows:Title>
+            <ows:Abstract>The well-known 'GoogleMapsCompatible' tile matrix set defined by the OGC WMTS specification</ows:Abstract>
+            <ows:Identifier>EPSG:3857</ows:Identifier>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::3857">
+                <ows:LowerCorner>-20037508.342789 -20037508.342789</ows:LowerCorner>
+                <ows:UpperCorner>20037508.342789 20037508.342789</ows:UpperCorner>
+            </ows:BoundingBox>
+            <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+            <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
+            <TileMatrix>
+                <ows:Identifier>0</ows:Identifier>
+                <ScaleDenominator>559082264.029</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>1</MatrixWidth>
+                <MatrixHeight>1</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>1</ows:Identifier>
+                <ScaleDenominator>279541132.014</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2</MatrixWidth>
+                <MatrixHeight>2</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>2</ows:Identifier>
+                <ScaleDenominator>139770566.007</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>4</MatrixWidth>
+                <MatrixHeight>4</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>3</ows:Identifier>
+                <ScaleDenominator>69885283.0036</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8</MatrixWidth>
+                <MatrixHeight>8</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>4</ows:Identifier>
+                <ScaleDenominator>34942641.5018</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>16</MatrixWidth>
+                <MatrixHeight>16</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>5</ows:Identifier>
+                <ScaleDenominator>17471320.7509</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>32</MatrixWidth>
+                <MatrixHeight>32</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>6</ows:Identifier>
+                <ScaleDenominator>8735660.37545</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>64</MatrixWidth>
+                <MatrixHeight>64</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>7</ows:Identifier>
+                <ScaleDenominator>4367830.18772</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>128</MatrixWidth>
+                <MatrixHeight>128</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>8</ows:Identifier>
+                <ScaleDenominator>2183915.09386</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>256</MatrixWidth>
+                <MatrixHeight>256</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>9</ows:Identifier>
+                <ScaleDenominator>1091957.54693</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>512</MatrixWidth>
+                <MatrixHeight>512</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>10</ows:Identifier>
+                <ScaleDenominator>545978.773466</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>1024</MatrixWidth>
+                <MatrixHeight>1024</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>11</ows:Identifier>
+                <ScaleDenominator>272989.386733</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2048</MatrixWidth>
+                <MatrixHeight>2048</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>12</ows:Identifier>
+                <ScaleDenominator>136494.693366</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>4096</MatrixWidth>
+                <MatrixHeight>4096</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>13</ows:Identifier>
+                <ScaleDenominator>68247.3466832</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8192</MatrixWidth>
+                <MatrixHeight>8192</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>14</ows:Identifier>
+                <ScaleDenominator>34123.6733416</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>16384</MatrixWidth>
+                <MatrixHeight>16384</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>15</ows:Identifier>
+                <ScaleDenominator>17061.8366708</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>32768</MatrixWidth>
+                <MatrixHeight>32768</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>16</ows:Identifier>
+                <ScaleDenominator>8530.9183354</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>65536</MatrixWidth>
+                <MatrixHeight>65536</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>17</ows:Identifier>
+                <ScaleDenominator>4265.4591677</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>131072</MatrixWidth>
+                <MatrixHeight>131072</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>18</ows:Identifier>
+                <ScaleDenominator>2132.72958385</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>262144</MatrixWidth>
+                <MatrixHeight>262144</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>19</ows:Identifier>
+                <ScaleDenominator>1066.36479192</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>524288</MatrixWidth>
+                <MatrixHeight>524288</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>20</ows:Identifier>
+                <ScaleDenominator>533.182395962</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>1048576</MatrixWidth>
+                <MatrixHeight>1048576</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>21</ows:Identifier>
+                <ScaleDenominator>266.591197981</ScaleDenominator>
+                <TopLeftCorner>-20037508.3428 20037508.3428</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2097152</MatrixWidth>
+                <MatrixHeight>2097152</MatrixHeight>
+            </TileMatrix>
+        </TileMatrixSet>
+    </Contents>
+    <ServiceMetadataURL xlink:href="https://labs.koordinates.com/services;key=d740ea02e0c44cafb70dce31a774ca10/wmts/1.0.0/layer/7328/WMTSCapabilities.xml"/>
+</Capabilities>

--- a/modules/extension/xsd/xsd-wmts/src/main/java/org/geotools/wmts/bindings/ContentsTypeBinding.java
+++ b/modules/extension/xsd/xsd-wmts/src/main/java/org/geotools/wmts/bindings/ContentsTypeBinding.java
@@ -3,9 +3,7 @@ package org.geotools.wmts.bindings;
 import org.geotools.wmts.WMTS;
 import org.geotools.xml.*;
 import org.geotools.xml.AbstractComplexBinding;
-import org.opengis.metadata.MetaData;
 
-import net.opengis.ows20.DatasetDescriptionSummaryBaseType;
 import net.opengis.ows20.MetadataType;
 import net.opengis.wmts.v_1.ContentsType;
 import net.opengis.wmts.v_1.TileMatrixSetType;

--- a/modules/extension/xsd/xsd-wmts/src/main/java/org/geotools/wmts/bindings/TileMatrixSetBinding.java
+++ b/modules/extension/xsd/xsd-wmts/src/main/java/org/geotools/wmts/bindings/TileMatrixSetBinding.java
@@ -110,9 +110,9 @@ public class TileMatrixSetBinding extends AbstractComplexBinding {
      */
     public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
 
-        if(node.getChildren().isEmpty()) {
+        if (node.getChildren().isEmpty()) {
             // we are in a Contents/Layer/TileMatrixSetLink/TileMatrixSet (simple) element
-            return (String)value;
+            return (String) value;
         }
 
         // we are in a Contents/TileMatrixSet (complex) element
@@ -121,13 +121,13 @@ public class TileMatrixSetBinding extends AbstractComplexBinding {
         matrixSet.setIdentifier((CodeType) node.getChildValue("Identifier"));
         matrixSet.setSupportedCRS(((URI) node.getChildValue("SupportedCRS")).toString());
 
-        URI wkss = (URI)node.getChildValue("WellKnownScaleSet");
-        if(wkss != null) {
+        URI wkss = (URI) node.getChildValue("WellKnownScaleSet");
+        if (wkss != null) {
             matrixSet.setWellKnownScaleSet(wkss.toString());
         }
         matrixSet.getAbstract().addAll(node.getChildren("abstract"));
         List<Node> children = node.getChildren("TileMatrix");
-        for(Node c:children) {
+        for (Node c : children) {
             matrixSet.getTileMatrix().add((TileMatrixType) c.getValue());
         }
 

--- a/modules/extension/xsd/xsd-wmts/src/main/java/org/geotools/wmts/bindings/TileMatrixSetBinding.java
+++ b/modules/extension/xsd/xsd-wmts/src/main/java/org/geotools/wmts/bindings/TileMatrixSetBinding.java
@@ -120,7 +120,11 @@ public class TileMatrixSetBinding extends AbstractComplexBinding {
         matrixSet.setBoundingBox((BoundingBoxType) node.getChildValue("BoundingBox"));
         matrixSet.setIdentifier((CodeType) node.getChildValue("Identifier"));
         matrixSet.setSupportedCRS(((URI) node.getChildValue("SupportedCRS")).toString());
-        matrixSet.setWellKnownScaleSet((String) node.getChildValue("WellKnownScaleSet"));
+
+        URI wkss = (URI)node.getChildValue("WellKnownScaleSet");
+        if(wkss != null) {
+            matrixSet.setWellKnownScaleSet(wkss.toString());
+        }
         matrixSet.getAbstract().addAll(node.getChildren("abstract"));
         List<Node> children = node.getChildren("TileMatrix");
         for(Node c:children) {


### PR DESCRIPTION
Using the capabilitites document at
https://openlayers.org/en/v4.3.4/examples/data/WMTSCapabilities.xml
an exception is thrown:
```
java.lang.RuntimeException: Parsing failed for TileMatrixSet: java.lang.ClassCastException: java.net.URI cannot be cast to java.lang.String
at org.geotools.wmts.bindings.TileMatrixSetBinding.parse(TileMatrixSetBinding.java:123)
...