### PR TITLE
Docs antrun to use ant 1.8.1

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -217,14 +217,21 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <dependencies>
           <dependency>
-            <groupId>ant</groupId>
+            <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.6.5</version>
+            <version>1.8.1</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>
             <artifactId>ant-contrib</artifactId>
             <version>1.0b3</version>
+            <exclusions>
+              <exclusion>
+                <groupId>ant</groupId>
+                <artifactId>ant</artifactId>
+              </exclusion>
+            </exclusions>
+
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
The root pom has a dependency on ant 1.8.1 while the docs module depends on 1.6.5.  This can lead to build failures.