### PR TITLE
[GEOT-5866] MongoDB integration with App-Schema nested mappings are not evaluated relatively

### DIFF
--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/CollectionIdFunction.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/CollectionIdFunction.java
@@ -30,7 +30,7 @@ import static org.geotools.filter.capability.FunctionNameImpl.parameter;
 public final class CollectionIdFunction extends FunctionExpressionImpl {
 
     private static final FunctionName DEFINITION = new FunctionNameImpl(
-            "collectionId", parameter("value", Object.class), parameter("path", String.class));
+            "collectionId", parameter("value", Object.class));
 
     public CollectionIdFunction() {
         super(DEFINITION);

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/JsonSelectFunction.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/JsonSelectFunction.java
@@ -38,12 +38,21 @@ public final class JsonSelectFunction extends FunctionExpressionImpl {
 
     public Object evaluate(Object object) {
         String path = (String) this.params.get(0).evaluate(object);
+        if (object instanceof MongoCollectionFeature) {
+            if (!MongoComplexUtilities.useLegacyPaths()) {
+                String parentPath = ((MongoCollectionFeature) object).getCollectionPath();
+                path = parentPath + "." + path;
+            }
+        }
         if (object == null) {
             return new AttributeExpressionImpl(new NameImpl(path));
         }
         return MongoComplexUtilities.getValue(object, path);
     }
 
+    /**
+     * Return the JSON path to be selected.
+     */
     public String getJsonPath() {
         return (String) this.params.get(0).evaluate(null);
     }

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoCollectionFeature.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoCollectionFeature.java
@@ -31,6 +31,8 @@ final class MongoCollectionFeature extends SimpleFeatureImpl {
 
     private final MongoFeature mongoFeature;
 
+    private final String collectionPath;
+
     private final Map<String, Integer> collectionsIndexes = new HashMap<>();
 
     static MongoCollectionFeature build(Object feature, String collectionPath, int collectionIndex) {
@@ -52,6 +54,7 @@ final class MongoCollectionFeature extends SimpleFeatureImpl {
         super(feature.getValues(), feature.getFeatureType(), new FeatureIdImpl(UUID.randomUUID().toString()), false);
         this.mongoFeature = feature;
         this.collectionsIndexes.put(collectionPath, collectionIndex);
+        this.collectionPath = collectionPath;
     }
 
     MongoFeature getMongoFeature() {
@@ -60,5 +63,9 @@ final class MongoCollectionFeature extends SimpleFeatureImpl {
 
     Map<String, Integer> getCollectionsIndexes() {
         return collectionsIndexes;
+    }
+
+    public String getCollectionPath() {
+        return collectionPath;
     }
 }

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexUtilities.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexUtilities.java
@@ -35,7 +35,36 @@ import java.util.Set;
  */
 public final class MongoComplexUtilities {
 
+    // if this property is set to TRUE the system will expect nested collection full path to be provided
+    private final static boolean USE_LEGACY_PATHS = Boolean.parseBoolean(
+            System.getProperty("org.geotools.data.mongodb.complex.useLegacyPaths", "false"));
+
+    // key used to store the parent JSON path in a feature user data map
+    public static final String MONGO_PARENT_PATH = "MONGO_PARENT_PATH";
+
     private MongoComplexUtilities() {
+    }
+
+    /**
+     * Concat the parent path if it exists to the provided JSON path.
+     */
+    public static String resolvePath(Feature feature, String jsonPath) {
+        Object parentPath = feature.getUserData().get(MONGO_PARENT_PATH);
+        return parentPath == null ? jsonPath : parentPath + "." + jsonPath;
+    }
+
+    /**
+     * Store the parent path in a feature user data map.
+     */
+    public static void setParentPath(Feature feature, String parentPath) {
+        feature.getUserData().put(MONGO_PARENT_PATH, parentPath);
+    }
+
+    /**
+     * If TRUE no recursive paths will be used, this onyl exists for backwards compatibility.
+     */
+    public static boolean useLegacyPaths() {
+        return USE_LEGACY_PATHS;
     }
 
     /**

--- a/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/NestedCollectionLinkFunction.java
+++ b/modules/unsupported/mongodb/src/main/java/org/geotools/data/mongodb/complex/NestedCollectionLinkFunction.java
@@ -25,40 +25,16 @@ import static org.geotools.filter.capability.FunctionNameImpl.parameter;
 /**
  * Function used to chain an entity with a sub collection.
  */
-public final class CollectionLinkFunction extends FunctionExpressionImpl {
+public final class NestedCollectionLinkFunction extends FunctionExpressionImpl {
 
     private static final FunctionName DEFINITION = new FunctionNameImpl(
-            "collectionLink", parameter("value", String.class), parameter("path", String.class));
+            "nestedCollectionLink", parameter("value", String.class));
 
-    public CollectionLinkFunction() {
+    public NestedCollectionLinkFunction() {
         super(DEFINITION);
     }
 
     public Object evaluate(Object object) {
-        String path = (String) this.params.get(0).evaluate(object);
-        return new LinkCollection(path);
-    }
-
-    /**
-     * Return the collection path referenced by this function.
-     */
-    public String getPath() {
-        return (String) this.params.get(0).evaluate(null);
-    }
-
-    /**
-     * Contains information about a linked collection.
-     */
-    static final class LinkCollection {
-
-        private final String collectionPath;
-
-        LinkCollection(String collectionPath) {
-            this.collectionPath = collectionPath;
-        }
-
-        String getCollectionPath() {
-            return collectionPath;
-        }
+        return null;
     }
 }

--- a/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.geotools.filter.FunctionExpression
+++ b/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.geotools.filter.FunctionExpression
@@ -1,4 +1,5 @@
 org.geotools.data.mongodb.complex.JsonSelectFunction
 org.geotools.data.mongodb.complex.CollectionIdFunction
 org.geotools.data.mongodb.complex.CollectionLinkFunction
+org.geotools.data.mongodb.complex.NestedCollectionLinkFunction
 org.geotools.data.mongodb.complex.JsonSelectAllFunction

--- a/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/modules/unsupported/mongodb/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -1,4 +1,5 @@
 org.geotools.data.mongodb.complex.JsonSelectFunction
 org.geotools.data.mongodb.complex.CollectionIdFunction
 org.geotools.data.mongodb.complex.CollectionLinkFunction
+org.geotools.data.mongodb.complex.NestedCollectionLinkFunction
 org.geotools.data.mongodb.complex.JsonSelectAllFunction


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOT-5866

Integration tests where updated accordingly: https://github.com/geoserver/geoserver/pull/2632

Note that all the changes happen in ``org.geotools.data.mongodb.complex`` package.

Non recursive paths make MongoDB mappings very impossible to manage \ create mappings for a complex use case. But to avoid that someone who use the old full paths notation to be stuck on an upgrade a legacy compatibility mode was created.