### PR TITLE
FactoryRegistry placeholder lookupProviders methods, and finalizer

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/factory/FactoryRegistry.java
+++ b/modules/library/metadata/src/main/java/org/geotools/factory/FactoryRegistry.java
@@ -169,6 +169,29 @@ public class FactoryRegistry {
         this(Arrays.asList(categories));
     }
 
+    @Override
+    protected void finalize() throws Throwable {
+        deregisterAll();
+        super.finalize();
+    }
+
+    /**
+     * @deprecated Replace with {@link ServiceLoader#load(Class)}
+     */
+    @Deprecated
+    public static <T> Iterator<T> lookupProviders(Class<T> service) {
+        return ServiceLoader.load(service).iterator();
+    }
+
+    /**
+     * @param classLoader 
+     * @deprecated Replace with {@link ServiceLoader#load(Class,ClassLoader)}
+     */
+    @Deprecated
+    public static <T> Iterator<T> lookupProviders(Class<T> service, ClassLoader classLoader) {
+        return ServiceLoader.load(service,classLoader).iterator();
+    }
+    
     /**
      * Constructs a new registry for the specified categories.
      *


### PR DESCRIPTION
Follow up to review and downstream integration experience.

Placeholder deprecated lookupProviders methods added to FactoryRegistry in case any code had a static dependency on a method formally available from superclass ServiceRegistry.

Added a finalize method to deregister all factortories on object cleanup.

Signed-off-by: Jody Garnett <jody.garnett@gmail.com>