### PR TITLE
[GEOT-5885] GML 3.2 encoding misses mandatory gml:id on geometry elements - fast path

### DIFF
--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/FeatureCollectionEncoderDelegate.java
@@ -79,6 +79,8 @@ public abstract class FeatureCollectionEncoderDelegate implements EncoderDelegat
     QName boundedBy;
 
     QName name;
+    
+    protected boolean encodeGeometryIds = false;
 
     protected FeatureCollectionEncoderDelegate(SimpleFeatureCollection features, Encoder encoder,
             GMLDelegate gml) {
@@ -173,7 +175,8 @@ public abstract class FeatureCollectionEncoderDelegate implements EncoderDelegat
                 continue;
             }
 
-            encodeValue(output, ee, value, attribute);
+            String gmlId = encodeGeometryIds ? f.getID() + "." + name.getLocalPart() : null;
+            encodeValue(output, ee, value, attribute, gmlId);
         }
 
         output.endElement(ftContext.featureQualifiedName);
@@ -182,7 +185,7 @@ public abstract class FeatureCollectionEncoderDelegate implements EncoderDelegat
     }
 
     private void encodeValue(GMLWriter output, ObjectEncoder ee, Object value,
-            AttributeContext attribute) throws SAXException, Exception {
+            AttributeContext attribute, String featureId) throws SAXException, Exception {
         output.startElement(attribute.name, null);
 
         if (value instanceof Geometry) {
@@ -193,7 +196,7 @@ public abstract class FeatureCollectionEncoderDelegate implements EncoderDelegat
                     ((GeometryDescriptor) attribute.descriptor).getCoordinateReferenceSystem(),
                     dimension);
             GeometryEncoder geometryEncoder = getGeometryEncoder(value, attribute);
-            geometryEncoder.encode(g, atts, output);
+            geometryEncoder.encode(g, atts, output, featureId);
         } else if (value instanceof Envelope) {
             ReferencedEnvelope e = (ReferencedEnvelope) value;
             Integer dimension = GML2EncodingUtils.getEnvelopeDimension(e,

--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GMLWriter.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GMLWriter.java
@@ -193,7 +193,7 @@ public class GMLWriter {
             qualifiedName = qualify(qn.getNamespaceURI(), qn.getLocalPart(), null);
         }
         if (atts == null) {
-            atts =new AttributesImpl();
+            atts = new AttributesImpl();
         }
         if (qualifiedName != null) {
             String localName = null;

--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GeometryEncoder.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GeometryEncoder.java
@@ -16,13 +16,17 @@
  */
 package org.geotools.gml2.simple;
 
+import org.geotools.gml2.GML;
 import org.geotools.xml.Encoder;
 import org.xml.sax.helpers.AttributesImpl;
 
 import com.vividsolutions.jts.geom.Geometry;
 
 /**
- * Base class for all encoders writing a Geometry
+ * Base class for all encoders writing a Geometry. Implementations should provide one of the two "encode" methods,
+ * {@link #encode(Geometry, AttributesImpl, GMLWriter)} or {@link #encode(Geometry, AttributesImpl, GMLWriter, String)},
+ * failing to do so will result in a infinite recursion and eventually in a {@link StackOverflowError}
+ * 
  * 
  * @author Justin Deoliveira, OpenGeo
  * @author Andrea Aime - GeoSolutions
@@ -35,6 +39,61 @@ public abstract class GeometryEncoder<T extends Geometry> extends ObjectEncoder<
         super(encoder);
     }
 
-    public abstract void encode(T geometry, AttributesImpl atts, GMLWriter handler)
-            throws Exception;
+    /**
+     * Encodes a geometry value with a given gmlId (implementations might choose to use it
+     * to generate gml:id attributes, depending on the GML version. The default implementation
+     * does not use gmlId and simply delegates to {@link #encode(Geometry, AttributesImpl, GMLWriter)}
+     * 
+     * @param geometry The Geometry to be encoded
+     * @param atts Its attributes
+     * @param handler The handler used to write XML
+     * @param gmlId If not null, some implementation will use to as the gml:id 
+     *                 (and to build ids for the nested features)
+     * @throws Exception
+     */
+    public void encode(T geometry, AttributesImpl atts, GMLWriter handler, String gmlId) throws Exception {
+        encode(geometry, atts, handler);
+    }
+
+    /**
+     * Returns a new AttributesImpl based on the provided on, with the addition of a gml:id
+     * attribute
+     * @param atts The base attributes (can be null)
+     * @param gmlId The desired gml:id value
+     * @return The provided atts object if gmlId is null, a clone of the provided one plus the gml:id attribute otherwise
+     */
+    protected AttributesImpl cloneWithGmlId(AttributesImpl atts, String gmlId) {
+        if(gmlId == null) {
+            return atts;
+        }
+        AttributesImpl result;
+        if ( atts == null) {
+            result = new AttributesImpl();
+        } else {
+            result = new AttributesImpl(atts);
+        }
+        addGmlId(result, gmlId);
+
+        return result;
+    }
+
+    /**
+     * Adds a gmlId to an existing and non null attribute set 
+     */
+    protected void addGmlId(AttributesImpl attributes, String gmlId) {
+        attributes.addAttribute(GML.NAMESPACE, "id", "gml:id", null, gmlId);
+    }
+
+    /**
+     * Encodes a geometry value
+     *
+     * @param geometry The Geometry to be encoded
+     * @param atts Its attributes
+     * @param handler The handler used to write XML
+     * @throws Exception
+     */
+    public void encode(T geometry, AttributesImpl atts, GMLWriter handler)
+            throws Exception {
+        encode(geometry, atts, handler, null);
+    }
 }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/CurveEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/CurveEncoder.java
@@ -60,8 +60,12 @@ class CurveEncoder extends GeometryEncoder<LineString> {
         this.arcString = ARC_STRING.derive(gmlPrefix, gmlUri);
     }
 
-    public void encode(LineString geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(LineString geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
+        if ( gmlId != null) {
+            atts = cloneWithGmlId(atts, gmlId);
+        }
+        
         handler.startElement(curve, atts);
         handler.startElement(segments, null);
 

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML32FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML32FeatureCollectionEncoderDelegate.java
@@ -60,6 +60,7 @@ public class GML32FeatureCollectionEncoderDelegate extends
 
     public GML32FeatureCollectionEncoderDelegate(SimpleFeatureCollection features, Encoder encoder) {
         super(features, encoder, new GML32Delegate(encoder));
+        this.encodeGeometryIds = true;
     }
 
     public static class GML32Delegate implements org.geotools.gml2.simple.GMLDelegate {

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
@@ -63,34 +63,34 @@ public class GenericGeometryEncoder extends GeometryEncoder<Geometry> {
     }
 
     @Override
-    public void encode(Geometry geometry, AttributesImpl atts, GMLWriter handler) throws Exception {
+    public void encode(Geometry geometry, AttributesImpl atts, GMLWriter handler, String parentId) throws Exception {
         
         if (geometry instanceof LineString) {
             LineStringEncoder lineString = new LineStringEncoder(encoder,
                 LineStringEncoder.LINE_STRING);
-            lineString.encode((LineString) geometry, atts, handler);
+            lineString.encode((LineString) geometry, atts, handler, parentId);
         } else if (geometry instanceof Point) {
             PointEncoder pt = new PointEncoder(encoder, gmlPrefix, gmlUri);
-            pt.encode((Point) geometry, atts, handler);
+            pt.encode((Point) geometry, atts, handler, parentId);
         } else if (geometry instanceof Polygon) {
             PolygonEncoder polygon = new PolygonEncoder(encoder, gmlPrefix, gmlUri);
-            polygon.encode((Polygon) geometry, atts, handler);
+            polygon.encode((Polygon) geometry, atts, handler, parentId);
         } else if (geometry instanceof MultiLineString) {
             MultiLineStringEncoder multiLineString = new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, true);
-            multiLineString.encode((MultiLineString) geometry, atts, handler);
+            multiLineString.encode((MultiLineString) geometry, atts, handler, parentId);
         } else if (geometry instanceof MultiPoint) {
             MultiPointEncoder multiPoint = new MultiPointEncoder(encoder, gmlPrefix, gmlUri);
-            multiPoint.encode((MultiPoint) geometry, atts, handler);
+            multiPoint.encode((MultiPoint) geometry, atts, handler, parentId);
         } else if (geometry instanceof MultiPolygon) {
             MultiPolygonEncoder multiPolygon = new MultiPolygonEncoder(encoder, gmlPrefix, gmlUri);
-            multiPolygon.encode((MultiPolygon) geometry, atts, handler);
+            multiPolygon.encode((MultiPolygon) geometry, atts, handler, parentId);
         } else if (geometry instanceof LinearRing) {
             LinearRingEncoder linearRing = new LinearRingEncoder(encoder, gmlPrefix, gmlUri);
-            linearRing.encode((LinearRing) geometry, atts, handler);
+            linearRing.encode((LinearRing) geometry, atts, handler, parentId);
         } else if (geometry instanceof CircularString || geometry instanceof CompoundCurve
                         || geometry instanceof CircularRing || geometry instanceof CompoundRing) {
             CurveEncoder curve = new CurveEncoder(encoder, gmlPrefix, gmlUri);
-            curve.encode((LineString) geometry, atts, handler);
+            curve.encode((LineString) geometry, atts, handler, parentId);
         } else {
             throw new Exception("Unsupported geometry " + geometry.toString());
         }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
@@ -52,12 +52,13 @@ class GeometryCollectionEncoder extends GeometryEncoder<GeometryCollection> {
     }
 
     @Override
-    public void encode(GeometryCollection geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(GeometryCollection geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
+        atts = cloneWithGmlId(atts, gmlId);
         handler.startElement(multiGeometry, atts);
         for (int i = 0; i < geometry.getNumGeometries(); i++) {
             handler.startElement(geometryMember, null);
-            gge.encode(geometry.getGeometryN(i), atts, handler);
+            gge.encode(geometry.getGeometryN(i), null, handler, gmlId + "." + (i + 1));
             handler.endElement(geometryMember);
         }
         handler.endElement(multiGeometry);

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LineStringEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LineStringEncoder.java
@@ -46,8 +46,9 @@ class LineStringEncoder extends GeometryEncoder<LineString> {
         this.element = element;
     }
 
-    public void encode(LineString geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(LineString geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
+        atts = cloneWithGmlId(atts, gmlId);
         handler.startElement(element, atts);
         handler.posList(geometry.getCoordinateSequence());
         handler.endElement(element);

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LinearRingEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LinearRingEncoder.java
@@ -16,9 +16,12 @@
  */
 package org.geotools.gml3.simple;
 
+import com.vividsolutions.jts.geom.LineString;
+import org.geotools.gml2.simple.GMLWriter;
 import org.geotools.gml2.simple.QualifiedName;
 import org.geotools.gml3.GML;
 import org.geotools.xml.Encoder;
+import org.xml.sax.helpers.AttributesImpl;
 
 /**
  * Encodes a GML3 linear ring
@@ -32,5 +35,11 @@ class LinearRingEncoder extends LineStringEncoder {
 
     protected LinearRingEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder, LINEAR_RING.derive(gmlPrefix, gmlUri));
+    }
+
+    @Override
+    public void encode(LineString geometry, AttributesImpl atts, GMLWriter handler, String gmlId) throws Exception {
+        // linearRing is not a geometry, just a component, has no id
+        super.encode(geometry, atts, handler, null);
     }
 }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiLineStringEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiLineStringEncoder.java
@@ -73,26 +73,28 @@ class MultiLineStringEncoder extends GeometryEncoder<Geometry> {
     }
 
     @Override
-    public void encode(Geometry geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(Geometry geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
+        atts = cloneWithGmlId(atts, gmlId);
         handler.startElement(multiContainer, atts);
 
-        encodeMembers(geometry, handler);
+        encodeMembers(geometry, handler, gmlId);
 
         handler.endElement(multiContainer);
     }
 
-    protected void encodeMembers(Geometry geometry, GMLWriter handler) throws SAXException,
+    protected void encodeMembers(Geometry geometry, GMLWriter handler, String gmlId) throws SAXException,
             Exception {
         for (int i = 0; i < geometry.getNumGeometries(); i++) {
             handler.startElement(member, null);
             LineString line = (LineString) geometry.getGeometryN(i);
+            String childId = gmlId + "." + (i + 1);
             if (curveEncoding && line instanceof CurvedGeometry) {
-                ce.encode(line, null, handler);
+                ce.encode(line, null, handler, childId);
             } else if (line instanceof LinearRing) {
-                lre.encode(line, null, handler);
+                lre.encode(line, null, handler, childId);
             } else {
-                lse.encode(line, null, handler);
+                lse.encode(line, null, handler, childId);
             }
             handler.endElement(member);
         }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPointEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPointEncoder.java
@@ -51,13 +51,14 @@ class MultiPointEncoder extends GeometryEncoder<MultiPoint> {
     }
 
     @Override
-    public void encode(MultiPoint geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(MultiPoint geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
+        atts = cloneWithGmlId(atts, gmlId);
         handler.startElement(multiPoint, atts);
 
         for (int i = 0; i < geometry.getNumGeometries(); i++) {
             handler.startElement(pointMember, null);
-            pe.encode((Point) geometry.getGeometryN(i), null, handler);
+            pe.encode((Point) geometry.getGeometryN(i), null, handler, gmlId + "." + (i + 1));
             handler.endElement(pointMember);
         }
 

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPolygonEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPolygonEncoder.java
@@ -54,13 +54,14 @@ class MultiPolygonEncoder extends GeometryEncoder<MultiPolygon> {
     }
 
     @Override
-    public void encode(MultiPolygon geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(MultiPolygon geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
+        atts = cloneWithGmlId(atts, gmlId);
         handler.startElement(multiSurface, atts);
 
         for (int i = 0; i < geometry.getNumGeometries(); i++) {
             handler.startElement(surfaceMember, null);
-            pe.encode((Polygon) geometry.getGeometryN(i), null, handler);
+            pe.encode((Polygon) geometry.getGeometryN(i), null, handler, gmlId + "." + (i + 1));
             handler.endElement(surfaceMember);
         }
 

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PointEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PointEncoder.java
@@ -48,8 +48,9 @@ class PointEncoder extends GeometryEncoder<Point> {
     }
 
     @Override
-    public void encode(Point geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(Point geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
+        atts = cloneWithGmlId(atts, gmlId);
         handler.startElement(point, atts);
         handler.startElement(pos, null);
         

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PolygonEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PolygonEncoder.java
@@ -60,28 +60,29 @@ class PolygonEncoder extends GeometryEncoder<Polygon> {
     }
     
     @Override
-    public void encode(Polygon geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(Polygon geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
+        atts = cloneWithGmlId(atts, gmlId);
         handler.startElement(polygon, atts);
         
         handler.startElement(exterior, null);
-        encodeRing(geometry.getExteriorRing(), handler);
+        encodeRing(geometry.getExteriorRing(), handler, gmlId + ".1");
         handler.endElement(exterior);
         
         for ( int i = 0; i < geometry.getNumInteriorRing(); i++ ) {
             handler.startElement(interior, null);
-            encodeRing(geometry.getInteriorRingN(i), handler);
+            encodeRing(geometry.getInteriorRingN(i), handler, gmlId + "." + (i + 2));
             handler.endElement(interior);
         }
         
         handler.endElement(polygon);
     }
 
-    private void encodeRing(LineString ring, GMLWriter handler) throws Exception {
+    private void encodeRing(LineString ring, GMLWriter handler, String gmlId) throws Exception {
         if (ring instanceof CurvedGeometry) {
-            re.encode(ring, null, handler);
+            re.encode(ring, null, handler, gmlId);
         } else {
-            lre.encode(ring, null, handler);
+            lre.encode(ring, null, handler, gmlId);
         }
     }
     

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/RingEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/RingEncoder.java
@@ -41,11 +41,11 @@ public class RingEncoder extends MultiLineStringEncoder {
     }
 
     @Override
-    public void encode(Geometry geometry, AttributesImpl atts, GMLWriter handler)
+    public void encode(Geometry geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {
         handler.startElement(ring, atts);
 
-        encodeMembers(geometry, handler);
+        encodeMembers(geometry, handler, gmlId);
 
         handler.endElement(ring);
     }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/CurveEncoderTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/CurveEncoderTest.java
@@ -19,6 +19,7 @@ package org.geotools.gml3.simple;
 
 import org.geotools.geometry.jts.WKTReader2;
 import org.geotools.gml3.GML;
+import org.geotools.xml.test.XMLTestSupport;
 import org.w3c.dom.Document;
 
 import com.vividsolutions.jts.geom.Geometry;
@@ -29,8 +30,8 @@ public class CurveEncoderTest extends GeometryEncoderTestSupport {
         CurveEncoder encoder = new CurveEncoder(gtEncoder, "gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2()
                 .read("CIRCULARSTRING(-10 0, -8 2, -6 0, -8 -2, -10 0)");
-        Document doc = encode(encoder, geometry);
-        // XMLTestSupport.print(doc);
+        Document doc = encode(encoder, geometry, "circle.abc");
+        // MLTestSupport.print(doc);
         assertEquals(1,
                 xpath.getMatchingNodes("//gml:Curve/gml:segments/gml:ArcString/gml:posList", doc)
                 .getLength());
@@ -38,13 +39,15 @@ public class CurveEncoderTest extends GeometryEncoderTestSupport {
                 xpath.evaluate("//gml:Curve/gml:segments/gml:ArcString/@interpolation", doc));
         assertEquals("-10 0 -8 2 -6 0 -8 -2 -10 0",
                 xpath.evaluate("//gml:Curve/gml:segments/gml:ArcString/gml:posList", doc));
+        // geometry ids
+        assertEquals("circle.abc", xpath.evaluate("//gml:Curve/@gml:id", doc));
     }
 
     public void testEncodeCompound() throws Exception {
         CurveEncoder encoder = new CurveEncoder(gtEncoder, "gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2()
                 .read("COMPOUNDCURVE(CIRCULARSTRING(0 0, 2 0, 2 1, 2 3, 4 3),(4 3, 4 5, 1 4, 0 0))");
-        Document doc = encode(encoder, geometry);
+        Document doc = encode(encoder, geometry, "compound.3");
         // XMLTestSupport.print(doc);
         assertEquals(2, xpath.getMatchingNodes("//gml:Curve//gml:segments/*", doc).getLength());
         assertEquals(1, xpath.getMatchingNodes("//gml:ArcString", doc).getLength());
@@ -55,6 +58,8 @@ public class CurveEncoderTest extends GeometryEncoderTestSupport {
         assertEquals("linear", xpath.evaluate("//gml:LineStringSegment/@interpolation", doc));
         assertEquals("4 3 4 5 1 4 0 0",
                 xpath.evaluate("//gml:LineStringSegment/gml:posList", doc));
+        // geometry ids
+        assertEquals("compound.3", xpath.evaluate("//gml:Curve/@gml:id", doc));
     }
 
 

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryCollectionEncoderTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryCollectionEncoderTest.java
@@ -21,6 +21,8 @@ import com.vividsolutions.jts.io.ParseException;
 
 import org.geotools.geometry.jts.WKTReader2;
 import org.geotools.gml3.GML;
+import org.geotools.xml.XMLUtils;
+import org.geotools.xml.test.XMLTestSupport;
 import org.w3c.dom.Document;
 /**
  * Unit test for GeometryCollectionEncoder
@@ -34,7 +36,8 @@ public class GeometryCollectionEncoderTest extends GeometryEncoderTestSupport {
         Geometry geometry = new WKTReader2().read(
             "GEOMETRYCOLLECTION (LINESTRING"
             + " (180 200, 160 180), POINT (19 19), POINT (20 10))");
-        Document doc = encode(gce, geometry);
+        Document doc = encode(gce, geometry, "feature.1");
+        // XMLTestSupport.print(doc);
         assertEquals(1,
             xpath.getMatchingNodes("//gml:LineString", doc).getLength());
         assertEquals(2, xpath.getMatchingNodes("//gml:Point", doc).getLength());
@@ -46,5 +49,9 @@ public class GeometryCollectionEncoderTest extends GeometryEncoderTestSupport {
         assertEquals("19 19",
             xpath.evaluate(
                 "//gml:MultiGeometry/gml:geometryMember/gml:Point/gml:pos", doc));
+        assertEquals("feature.1", xpath.evaluate("//gml:MultiGeometry/@gml:id", doc));
+        assertEquals("feature.1.1", xpath.evaluate("//gml:MultiGeometry/gml:geometryMember[1]/gml:LineString/@gml:id", doc));
+        assertEquals("feature.1.2", xpath.evaluate("//gml:MultiGeometry/gml:geometryMember[2]/gml:Point/@gml:id", doc));
+        assertEquals("feature.1.3", xpath.evaluate("//gml:MultiGeometry/gml:geometryMember[3]/gml:Point/@gml:id", doc));
     }
 }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryEncoderTestSupport.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryEncoderTestSupport.java
@@ -58,8 +58,12 @@ public abstract class GeometryEncoderTestSupport extends GML3TestSupport {
         this.gtEncoder = new Encoder(createConfiguration());
         this.xpath = XMLUnit.newXpathEngine();
     }
-
+    
     protected Document encode(GeometryEncoder encoder, Geometry geometry) throws Exception {
+        return encode(encoder, geometry, null);
+    }
+
+    protected Document encode(GeometryEncoder encoder, Geometry geometry, String gmlId) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         // create the document serializer
@@ -83,7 +87,7 @@ public abstract class GeometryEncoderTestSupport extends GML3TestSupport {
         handler.startPrefixMapping("gml", GML.NAMESPACE);
         handler.endPrefixMapping("gml");
 
-        encoder.encode(geometry, new AttributesImpl(), handler);
+        encoder.encode(geometry, new AttributesImpl(), handler, gmlId);
         handler.endDocument();
 
         ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/LineString3DTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/LineString3DTest.java
@@ -31,9 +31,10 @@ public class LineString3DTest extends GeometryEncoderTestSupport {
     public void testEncode3DLine() throws Exception {
         LineStringEncoder encoder = new LineStringEncoder(gtEncoder, "gml", GML.NAMESPACE);
         Geometry geometry = new WKTReader2().read("LINESTRING(0 0 50, 120 0 100)");
-        Document doc = encode(encoder, geometry);
+        Document doc = encode(encoder, geometry, "threed");
         // print(doc);
         assertEquals("0 0 50 120 0 100", xpath.evaluate("//gml:posList", doc));
+        assertEquals("threed", xpath.evaluate("//gml:LineString/@gml:id", doc));
     }
     
     public void testEncode3DLineFromLiteCS() throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiCurveEncoderTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiCurveEncoderTest.java
@@ -19,6 +19,7 @@ package org.geotools.gml3.simple;
 
 import org.geotools.geometry.jts.WKTReader2;
 import org.geotools.gml3.GML;
+import org.geotools.xml.test.XMLTestSupport;
 import org.w3c.dom.Document;
 
 import com.vividsolutions.jts.geom.Geometry;
@@ -96,12 +97,16 @@ public class MultiCurveEncoderTest extends GeometryEncoderTestSupport {
         MultiLineStringEncoder encoder = new MultiLineStringEncoder(gtEncoder, "gml", GML.NAMESPACE, false);
         Geometry geometry = new WKTReader2()
                 .read("MULTILINESTRING((105 105, 125 125))");
-        Document doc = encode(encoder, geometry);
+        Document doc = encode(encoder, geometry, "multi");
         // XMLTestSupport.print(doc);
         assertEquals(1, xpath.getMatchingNodes("//gml:MultiLineString", doc).getLength());
         assertEquals(1, xpath.getMatchingNodes("//gml:MultiLineString/gml:lineStringMember", doc).getLength());
         assertEquals("105 105 125 125", xpath.evaluate(
                 "//gml:MultiLineString/gml:lineStringMember[1]/gml:LineString/gml:posList", doc));
+
+        // geometry ids
+        assertEquals("multi", xpath.evaluate("/gml:MultiLineString/@gml:id", doc));
+        assertEquals("multi.1", xpath.evaluate("/gml:MultiLineString/gml:lineStringMember/gml:LineString/@gml:id", doc));
     }
 
 }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiPointTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiPointTest.java
@@ -1,0 +1,39 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gml3.simple;
+
+import com.vividsolutions.jts.geom.Geometry;
+import org.geotools.geometry.jts.WKTReader2;
+import org.geotools.gml3.GML;
+import org.w3c.dom.Document;
+
+public class MultiPointTest extends GeometryEncoderTestSupport {
+
+    public void testEncodeMultiPoint() throws Exception {
+        MultiPointEncoder encoder = new MultiPointEncoder(gtEncoder, "gml" , GML.NAMESPACE);
+        Geometry geometry = new WKTReader2().read("MULTIPOINT(0 0, 1 1)");
+        Document doc = encode(encoder, geometry, "points");
+        // print(doc);
+        assertEquals("0 0", xpath.evaluate("/gml:MultiPoint/gml:pointMember[1]/gml:Point/gml:pos", doc));
+        assertEquals("1 1", xpath.evaluate("/gml:MultiPoint/gml:pointMember[2]/gml:Point/gml:pos", doc));
+        // ids
+        assertEquals("points", xpath.evaluate("/gml:MultiPoint/@gml:id", doc));
+        assertEquals("points.1", xpath.evaluate("/gml:MultiPoint/gml:pointMember[1]/gml:Point/@gml:id", doc));
+        assertEquals("points.2", xpath.evaluate("/gml:MultiPoint/gml:pointMember[2]/gml:Point/@gml:id", doc));
+    }
+
+}

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiPolygonTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiPolygonTest.java
@@ -1,0 +1,40 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gml3.simple;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import org.geotools.geometry.jts.WKTReader2;
+import org.geotools.gml3.GML;
+import org.w3c.dom.Document;
+
+public class MultiPolygonTest extends GeometryEncoderTestSupport {
+
+    public void testEncodeMultiPolygon() throws Exception {
+        MultiPolygonEncoder encoder = new MultiPolygonEncoder(gtEncoder, "gml" , GML.NAMESPACE);
+        Geometry geometry = new WKTReader2().read("MULTIPOLYGON(((1 1,5 1,5 5,1 5,1 1),(2 2, 3 2, 3 3, 2 3,2 2)),((3 3,6 2,6 4,3 3)))");
+        Document doc = encode(encoder, geometry, "mpoly");
+        // print(doc);
+        // quick geom test
+        assertEquals("1 1 5 1 5 5 1 5 1 1", xpath.evaluate("/gml:MultiSurface/gml:surfaceMember[1]/gml:Polygon/gml:exterior/gml:LinearRing/gml:posList", doc));
+        // ids
+        assertEquals("mpoly", xpath.evaluate("/gml:MultiSurface/@gml:id", doc));
+        assertEquals("mpoly.1", xpath.evaluate("/gml:MultiSurface/gml:surfaceMember[1]/gml:Polygon/@gml:id", doc));
+        assertEquals("mpoly.2", xpath.evaluate("/gml:MultiSurface/gml:surfaceMember[2]/gml:Polygon/@gml:id", doc));
+    }
+
+}

--- a/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/v2_0/WFS20FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/v2_0/WFS20FeatureCollectionEncoderDelegate.java
@@ -34,6 +34,7 @@ class WFS20FeatureCollectionEncoderDelegate extends FeatureCollectionEncoderDele
 
     public WFS20FeatureCollectionEncoderDelegate(SimpleFeatureCollection features, Encoder encoder) {
         super(features, encoder, new WFS20EncoderDelegate(encoder));
+        this.encodeGeometryIds = true;
     }
 
     static class WFS20EncoderDelegate extends GML32FeatureCollectionEncoderDelegate.GML32Delegate {

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/WFSFeatureCollectionEncodingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/WFSFeatureCollectionEncodingTest.java
@@ -25,6 +25,7 @@ import net.opengis.wfs.FeatureCollectionType;
 import net.opengis.wfs.WfsFactory;
 import net.opengis.wfs20.Wfs20Factory;
 
+import org.custommonkey.xmlunit.XMLAssert;
 import org.geotools.data.memory.MemoryDataStore;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -32,6 +33,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.gml3.GMLConfiguration;
 import org.geotools.xml.Configuration;
 import org.geotools.xml.Encoder;
+import org.geotools.xml.test.XMLTestSupport;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -98,8 +100,7 @@ public class WFSFeatureCollectionEncodingTest extends TestCase {
         e.setIndenting(true);
         
         Document d = e.encodeAsDOM( fc, WFS.FeatureCollection );
-//        TransformerFactory.newInstance().newTransformer().transform(
-//            new DOMSource(d), new StreamResult(System.out));
+        // XMLTestSupport.print(d);
         
         NamedNodeMap attributes = d.getDocumentElement().getAttributes();
         assertEquals("unknown", attributes.getNamedItem("numberMatched" ).getTextContent());
@@ -109,6 +110,12 @@ public class WFSFeatureCollectionEncodingTest extends TestCase {
         assertEquals( 2, d.getElementsByTagName( "gml:Point" ).getLength() );
         assertEquals( 2, d.getElementsByTagName( "gml:pos" ).getLength() );
         assertEquals( 0, d.getElementsByTagName( "gml:coord" ).getLength() );
+        
+        // check ids
+        assertEquals("zero.geometry", d.getElementsByTagName("gml:Point").item(0).getAttributes().getNamedItem("gml:id").getNodeValue());
+        assertEquals("one.geometry", d.getElementsByTagName("gml:Point").item(1).getAttributes().getNamedItem("gml:id").getNodeValue());
+
+        XMLAssert.
         
         assertEquals( 2, d.getElementsByTagName( "geotools:feature" ).getLength() );
         assertNotNull( ((Element)d.getElementsByTagName( "geotools:feature").item( 0 )).getAttribute("gml:id") );
@@ -220,6 +227,8 @@ public class WFSFeatureCollectionEncodingTest extends TestCase {
     }
     
     Encoder encoder() {
-        return new Encoder(new org.geotools.wfs.v2_0.WFSConfiguration());
+        WFSConfiguration configuration = new WFSConfiguration();
+        configuration.getProperties().add(org.geotools.gml2.GMLConfiguration.OPTIMIZED_ENCODING);
+        return new Encoder(configuration);
     }
 }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5885