### PR TITLE
GEOT-5889: Fix NPE in destroy method

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/SchemaIndexImpl.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/SchemaIndexImpl.java
@@ -102,6 +102,9 @@ public class SchemaIndexImpl implements SchemaIndex {
     
     public void destroy() {
         //remove the adapter from the schemas
+        if(schemas==null) {
+            return;
+        }
         for (int i = 0; i < schemas.length; i++) {
             synchronized(this.schemas[i].eAdapters()) {
                 this.schemas[i].eAdapters().remove(adapter);


### PR DESCRIPTION
Destroy method could throw a NPE if there were no schemas,