### PR TITLE
Maven Javadoc module: Activate JDK8 profiles only with Java 8

### DIFF
--- a/build/maven/javadoc/pom.xml
+++ b/build/maven/javadoc/pom.xml
@@ -92,34 +92,12 @@
 
     <profiles>
         <!-- =========================================================== -->
-        <!--     Sun's tools dependency (pre JDK 1.7)                    -->
+        <!--     Oracle tools dependency (JDK 8)                        -->
         <!-- =========================================================== -->
         <profile>
-            <id>default-tools.jar</id>
+            <id>jdk-8-default-tools.jar</id>
             <activation>
-                <property>
-                    <name>java.vendor</name>
-                    <value>Sun Microsystems Inc.</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                    <version>1.5</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
-          <!-- Note: a ${tools.jar} variable exists - we should try to use it. -->
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <!-- =========================================================== -->
-        <!--     Oracle tools dependency (JDK 7+)                        -->
-        <!-- =========================================================== -->
-        <profile>
-            <id>jdk-7-default-tools.jar</id>
-            <activation>
+                <jdk>1.8</jdk>
                 <property>
                     <name>java.vendor</name>
                     <value>Oracle Corporation</value>
@@ -144,6 +122,7 @@
         <profile>
             <id>ibm-default-tools.jar</id>
             <activation>
+                <jdk>1.8</jdk>
                 <property>
                     <name>java.vendor</name>
                     <value>IBM Corporation</value>
@@ -167,6 +146,7 @@
         <profile>
             <id>google-jdk-default-tools.jar</id>
             <activation>
+                <jdk>1.8</jdk>
                 <property>
                     <name>java.vendor</name>
                     <value>Google Inc.</value>


### PR DESCRIPTION
I try to build GeoTools with Java 9. The first build failure is in Maven Javadoc module, as it relies on the existence of `tools.jar` in JDK directory. This is no longer true starting from JDK9, so the current profiles must be restricted to JDK8. The obsolete pre-JDK7 profile has been dropped.