### PR TITLE
[GEOT-5878] Very long symbols can cause an integer overflow when rendered

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/style/SLDStyleFactory.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/SLDStyleFactory.java
@@ -1273,32 +1273,39 @@ public class SLDStyleFactory {
    
         double size = evalToDouble(gr.getSize(), feature, 16);
         final double sizeX = size * shapeAspectRatio; // apply the aspect
-        												// ratio to fix the
-        												// sample's width.
+      	 					      // ratio to fix the
+        					      // sample's width.
         final double sizeY = size;
         
         // we need to paint the mark in a 3x3 grid to account for border effects
         // due to antialiasing (e.g., even if the mark is 10 pixels wide, due to the 
         // antialiasing graphically it occupies 12 or so pixels)
-        image = new BufferedImage((int) Math.ceil(sizeX * 3), (int) Math
-        		.ceil(sizeY * 3), BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2d = image.createGraphics();
-        g2d.setRenderingHints(renderingHints);
-        double rotation = Math.toRadians(evalToDouble(gr.getRotation(), feature, 0.0)); // fix for GEOS-6217
-        for (int i = -1; i < 2; i++) {
-        	for (int j = -1; j < 2; j++) {
-        		double tx = sizeX * 1.5 + sizeX * i;
-        		double ty = sizeY * 1.5 + sizeY * j;
-        		fillDrawMark(g2d, tx, ty, mark, size, rotation, feature);
-        	}
+        
+        //check if this will cause an overflow in the image creation
+        if ((sizeX * 3) * (sizeY * 3) > Integer.MAX_VALUE) {
+            LOGGER.warning("Size of mark (" + sizeX + " * " + sizeY + ") is too large");
+        } else {
+            image = new BufferedImage((int) Math.ceil(sizeX * 3), (int) Math.ceil(sizeY * 3),
+                    BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2d = image.createGraphics();
+            g2d.setRenderingHints(renderingHints);
+            double rotation = Math.toRadians(evalToDouble(gr.getRotation(), feature, 0.0)); // fix for GEOS-6217
+            for (int i = -1; i < 2; i++) {
+                for (int j = -1; j < 2; j++) {
+                    double tx = sizeX * 1.5 + sizeX * i;
+                    double ty = sizeY * 1.5 + sizeY * j;
+                    fillDrawMark(g2d, tx, ty, mark, size, rotation, feature);
+                }
+            }
+            g2d.dispose();
+
+            int iSizeX = (int) Math.floor(sizeX);
+            int iSizeY = (int) Math.floor(sizeY);
+            // updated to use the new sizes
+            image = image.getSubimage(iSizeX, iSizeY, Math.max(iSizeX, 1), Math.max(iSizeY, 1));
+            return image;
         }
-        g2d.dispose();
-   
-        int iSizeX = (int) Math.floor(sizeX);
-        int iSizeY = (int) Math.floor(sizeY);
-        // updated to use the new sizes
-        image = image.getSubimage(iSizeX, iSizeY, Math.max(iSizeX, 1), Math.max(iSizeY, 1));
-        return image;
+         return new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
     }
 
     /**

--- a/modules/library/render/src/main/java/org/geotools/renderer/style/SLDStyleFactory.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/SLDStyleFactory.java
@@ -1255,11 +1255,11 @@ public class SLDStyleFactory {
 
 	
 
-    private BufferedImage markToTilableImage(org.geotools.styling.Graphic gr, Object feature, Mark mark,
-            Shape shape) {
+    private BufferedImage markToTilableImage(org.geotools.styling.Graphic gr, Object feature,
+            Mark mark, Shape shape) {
         BufferedImage image;
         Rectangle2D shapeBounds = shape.getBounds2D();
-   
+
         // The aspect ratio is the relation between the width and height of
         // this mark (x width units per y height units or width/height). The
         // aspect ratio is used to render non isometric sized marks (where
@@ -1267,45 +1267,54 @@ public class SLDStyleFactory {
         // isometric
         // mark, simply calculate <code>height * aspectRatio</code>, where
         // height is given by getSize().
-        double shapeAspectRatio = (shapeBounds.getHeight() > 0 && shapeBounds
-        		.getWidth() > 0) ? shapeBounds.getWidth()
-        		/ shapeBounds.getHeight() : 1.0;
-   
+        double shapeAspectRatio = (shapeBounds.getHeight() > 0 && shapeBounds.getWidth() > 0)
+                ? shapeBounds.getWidth() / shapeBounds.getHeight() : 1.0;
+
         double size = evalToDouble(gr.getSize(), feature, 16);
         final double sizeX = size * shapeAspectRatio; // apply the aspect
-      	 					      // ratio to fix the
-        					      // sample's width.
+                                                      // ratio to fix the
+                                                      // sample's width.
         final double sizeY = size;
-        
-        // we need to paint the mark in a 3x3 grid to account for border effects
-        // due to antialiasing (e.g., even if the mark is 10 pixels wide, due to the 
-        // antialiasing graphically it occupies 12 or so pixels)
-        
-        //check if this will cause an overflow in the image creation
-        if ((sizeX * 3) * (sizeY * 3) > Integer.MAX_VALUE) {
-            LOGGER.warning("Size of mark (" + sizeX + " * " + sizeY + ") is too large");
-        } else {
-            image = new BufferedImage((int) Math.ceil(sizeX * 3), (int) Math.ceil(sizeY * 3),
-                    BufferedImage.TYPE_INT_ARGB);
-            Graphics2D g2d = image.createGraphics();
-            g2d.setRenderingHints(renderingHints);
-            double rotation = Math.toRadians(evalToDouble(gr.getRotation(), feature, 0.0)); // fix for GEOS-6217
-            for (int i = -1; i < 2; i++) {
-                for (int j = -1; j < 2; j++) {
-                    double tx = sizeX * 1.5 + sizeX * i;
-                    double ty = sizeY * 1.5 + sizeY * j;
-                    fillDrawMark(g2d, tx, ty, mark, size, rotation, feature);
-                }
-            }
-            g2d.dispose();
 
-            int iSizeX = (int) Math.floor(sizeX);
-            int iSizeY = (int) Math.floor(sizeY);
-            // updated to use the new sizes
-            image = image.getSubimage(iSizeX, iSizeY, Math.max(iSizeX, 1), Math.max(iSizeY, 1));
-            return image;
+        // we need to paint the mark in a 3x3 grid to account for border effects
+        // due to antialiasing (e.g., even if the mark is 10 pixels wide, due to the
+        // antialiasing graphically it occupies 12 or so pixels)
+
+        // check if this will cause an overflow in the image creation GEOT-5878
+        int repeat = 3;
+        if ((sizeX * repeat) * (sizeY * repeat) > Integer.MAX_VALUE) {
+            LOGGER.warning("Size of graphic (" + sizeX + " * " + sizeY + ") is too large");
+            if (sizeX * sizeY > Integer.MAX_VALUE) {
+                LOGGER.severe("Size of graphic (" + sizeX + " * " + sizeY
+                        + ") is too large will not draw");
+                return new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+            } else {
+                LOGGER.fine("Size of metatiled graphic (" + (3 * sizeX) + " * " + (3 * sizeY)
+                        + ") is too large, not metatiling it");
+                // try without meta-tiling
+                repeat = 1;
+            }
         }
-         return new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+        image = new BufferedImage((int) Math.ceil(sizeX * repeat), (int) Math.ceil(sizeY * repeat),
+                BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setRenderingHints(renderingHints);
+        double rotation = Math.toRadians(evalToDouble(gr.getRotation(), feature, 0.0)); // fix for GEOS-6217
+        for (int i = -1; i < 2; i++) {
+            for (int j = -1; j < 2; j++) {
+                double tx = sizeX * (repeat / 2.0) + sizeX * i;
+                double ty = sizeY * (repeat / 2.0) + sizeY * j;
+                fillDrawMark(g2d, tx, ty, mark, size, rotation, feature);
+            }
+        }
+        g2d.dispose();
+
+        int iSizeX = (int) Math.floor(sizeX);
+        int iSizeY = (int) Math.floor(sizeY);
+        // updated to use the new sizes
+        image = image.getSubimage(iSizeX, iSizeY, Math.max(iSizeX, 1), Math.max(iSizeY, 1));
+        return image;
+
     }
 
     /**

--- a/modules/library/render/src/main/java/org/geotools/renderer/style/SLDStyleFactory.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/SLDStyleFactory.java
@@ -1289,7 +1289,7 @@ public class SLDStyleFactory {
                         + ") is too large will not draw");
                 return new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
             } else {
-                LOGGER.fine("Size of metatiled graphic (" + (3 * sizeX) + " * " + (3 * sizeY)
+                LOGGER.fine("Size of metatiled graphic (" + (repeat * sizeX) + " * " + (repeat * sizeY)
                         + ") is too large, not metatiling it");
                 // try without meta-tiling
                 repeat = 1;

--- a/modules/library/render/src/test/java/org/geotools/renderer/style/SLDStyleFactoryTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/style/SLDStyleFactoryTest.java
@@ -464,8 +464,12 @@ public class SLDStyleFactoryTest extends TestCase {
         Object kerningValue = attributes.get(TextAttribute.KERNING);
         assertNull(kerningValue);
     }
-
-    public void testGEOT5878()  {
+    
+    /**
+     * A very large symbol can cause an Integer overflow in the renderer.
+     * The SLDFactory should give a warning instead and try again with out meta tiling.
+     */
+    public void testGEOT5878() {
         String wkt[] = {
                 "Polygon ((6438348.98000000044703484 4962869.70000000018626451, 6438348.88999999966472387 4962867.28000000026077032, 6438343.53000000026077032 4962867.28000000026077032, 6438343.53000000026077032 4962869.76999999955296516, 6438343.61000000033527613 4962870.17999999970197678, 6438348.90000000037252903 4962870.0400000000372529, 6438348.98000000044703484 4962869.70000000018626451))",
                 "Polygon ((6438339.7099999999627471 4962870.38999999966472387, 6438339.94000000040978193 4962873.86000000033527613, 6438346.65000000037252903 4962873.61000000033527613, 6438346.62999999988824129 4962870.38999999966472387, 6438339.7099999999627471 4962870.38999999966472387))" };
@@ -477,7 +481,7 @@ public class SLDStyleFactoryTest extends TestCase {
         try {
             crs = CRS.decode("EPSG:31276");
         } catch (FactoryException e1) {
-           fail(e1.getMessage());
+            fail(e1.getMessage());
         }
         ftb.add("the_geom", Polygon.class, crs);
         ftb.add("Nagib", Double.class);
@@ -495,7 +499,7 @@ public class SLDStyleFactoryTest extends TestCase {
             fb.set("the_geom", geom);
             fb.set("Nagib", naglib);
             features.add(fb.buildFeature(null));
-        }             
+        }
         StyleBuilder sb = new StyleBuilder();
         Mark mark = sb.createMark(
                 "wkt://LINESTRING(0 0, ${sin(Nagib) * 20000} ${cos(Nagib) * 20000} )", Color.red);
@@ -512,25 +516,25 @@ public class SLDStyleFactoryTest extends TestCase {
         content.addLayer(layer);
         StreamingRenderer renderer = new StreamingRenderer();
         renderer.addRenderListener(new RenderListener() {
-            
+
             @Override
             public void featureRenderer(SimpleFeature feature) {
                 // TODO Auto-generated method stub
-                
+
             }
-            
+
             @Override
             public void errorOccurred(Exception e) {
                 fail("an error occured");
-                
+
             }
         });
         renderer.setMapContent(content);
         BufferedImage img = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
         Rectangle paintArea = new Rectangle(0, 0, 100, 100);
-        
+
         renderer.paint(img.createGraphics(), paintArea, layer.getBounds(),
                 RendererUtilities.worldToScreenTransform(layer.getBounds(), paintArea));
-        
+
     }
 }


### PR DESCRIPTION
Adds a check to see if the size of the graphic * 3 will overflow MAX_INTEGER, prints a warning instead of a NegativeArraySizeException and Stacktrace. 