### PR TITLE
Encode in functions

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
@@ -45,6 +45,7 @@ import org.geotools.feature.visitor.SumAreaVisitor;
 import org.geotools.feature.visitor.SumVisitor;
 import org.geotools.feature.visitor.UniqueVisitor;
 import org.geotools.filter.FilterCapabilities;
+import org.geotools.filter.function.InFunction;
 import org.geotools.filter.visitor.PostPreProcessFilterSplittingVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
@@ -136,6 +137,7 @@ public abstract class SQLDialect {
         {
             addAll(FilterCapabilities.LOGICAL_OPENGIS);
             addAll(FilterCapabilities.SIMPLE_COMPARISONS_OPENGIS);
+            addAll(InFunction.getInCapabilities());
             
             //simple arithmetic
             addType(Add.class);

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCInEncodingOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCInEncodingOnlineTest.java
@@ -1,0 +1,111 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.jdbc;
+
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.expression.Function;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static java.util.Arrays.asList;
+
+public abstract class JDBCInEncodingOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected abstract JDBCTestSetup createTestSetup();
+    
+    public void testSimpleIn() throws IOException {
+        FilterFactory ff = dataStore.getFilterFactory();
+        Function function = ff.function("in", ff.property(aname("intProperty")), ff.literal("1"), ff.literal("2"));
+        Filter filter = ff.equal(function, ff.literal("true"), false);
+        
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("ft1"));
+        SimpleFeatureCollection fc = fs.getFeatures(filter);
+        assertEquals(getCaseInsensitiveSet("ft1.1", "ft1.2"), collectFeatureIds(fc));
+    }
+
+    /**
+     * Tests "in3" with 3 values that are the same 
+     * @throws IOException
+     */
+    public void testSimpleIn3() throws IOException {
+        FilterFactory ff = dataStore.getFilterFactory();
+        Function function = ff.function("in3", ff.property(aname("intProperty")), ff.literal("1"), ff.literal("1"), ff.literal("1"));
+        Filter filter = ff.equal(function, ff.literal("true"), false);
+
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("ft1"));
+        SimpleFeatureCollection fc = fs.getFeatures(filter);
+        assertEquals(getCaseInsensitiveSet("ft1.1"), collectFeatureIds(fc));
+    }
+
+    public void testNotEqual() throws IOException {
+        FilterFactory ff = dataStore.getFilterFactory();
+        Function function = ff.function("in", ff.property(aname("intProperty")), ff.literal("1"), ff.literal("2"));
+        Filter filter = ff.notEqual(function, ff.literal("true"), false);
+
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("ft1"));
+        SimpleFeatureCollection fc = fs.getFeatures(filter);
+        assertEquals(getCaseInsensitiveSet("ft1.0"), collectFeatureIds(fc));
+    }
+
+    public void testNegated() throws IOException {
+        FilterFactory ff = dataStore.getFilterFactory();
+        Function function = ff.function("in", ff.property(aname("intProperty")), ff.literal("1"), ff.literal("2"));
+        Filter filter = ff.not(ff.equal(function, ff.literal("true"), false));
+
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("ft1"));
+        SimpleFeatureCollection fc = fs.getFeatures(filter);
+        assertEquals(getCaseInsensitiveSet("ft1.0"), collectFeatureIds(fc));
+    }
+
+    public void testGreater() throws IOException {
+        FilterFactory ff = dataStore.getFilterFactory();
+        Function function = ff.function("in", ff.property(aname("intProperty")), ff.literal("1"), ff.literal("2"));
+        Filter filter = ff.greater(function, ff.literal("false"), false);
+
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("ft1"));
+        SimpleFeatureCollection fc = fs.getFeatures(filter);
+        assertEquals(getCaseInsensitiveSet("ft1.1", "ft1.2"), collectFeatureIds(fc));
+    }
+
+    public Set<String> getCaseInsensitiveSet(String... values) {
+        Set<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        result.addAll(asList(values));
+        
+        return result;
+    }
+
+    protected Set<String> collectFeatureIds(SimpleFeatureCollection fc) {
+        Set<String> identifiers = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        try(SimpleFeatureIterator fi = fc.features()) {
+            while(fi.hasNext()) {
+                SimpleFeature sf = fi.next();
+                identifiers.add(sf.getID());
+            }
+        }
+        return identifiers;
+    }
+
+
+}

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in10.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in10.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in10 extends FunctionExpressionImpl {
     
     public static FunctionName NAME = new FunctionNameImpl("in10", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class),
             parameter("in3", Object.class),

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in2.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in2.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in2 extends FunctionExpressionImpl {
 
     public static FunctionName NAME = new FunctionNameImpl("in2", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class));
 

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in3.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in3.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in3 extends FunctionExpressionImpl {
     
     public static FunctionName NAME = new FunctionNameImpl("in3", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class),
             parameter("in3", Object.class));

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in4.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in4.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in4 extends FunctionExpressionImpl {
     
     public static FunctionName NAME = new FunctionNameImpl("in4", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class),
             parameter("in3", Object.class),

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in5.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in5.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in5 extends FunctionExpressionImpl {
     
     public static FunctionName NAME = new FunctionNameImpl("in5", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class),
             parameter("in3", Object.class),

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in6.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in6.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in6 extends FunctionExpressionImpl {
     
     public static FunctionName NAME = new FunctionNameImpl("in6", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class),
             parameter("in3", Object.class),

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in7.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in7.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in7 extends FunctionExpressionImpl {
     
     public static FunctionName NAME = new FunctionNameImpl("in7", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class),
             parameter("in3", Object.class),

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in8.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in8.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in8 extends FunctionExpressionImpl {
 
     public static FunctionName NAME = new FunctionNameImpl("in8", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class),
             parameter("in3", Object.class),

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in9.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_in9.java
@@ -32,7 +32,7 @@ import org.opengis.filter.capability.FunctionName;
 public class FilterFunction_in9 extends FunctionExpressionImpl {
     
     public static FunctionName NAME = new FunctionNameImpl("in9", Boolean.class,
-            parameter("value", Boolean.class),
+            parameter("value", Object.class),
             parameter("in1", Object.class),
             parameter("in2", Object.class),
             parameter("in3", Object.class),

--- a/modules/library/main/src/main/java/org/geotools/filter/function/InFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/InFunction.java
@@ -17,11 +17,12 @@
 
 package org.geotools.filter.function;
 
-import java.util.List;
-
+import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.FunctionExpressionImpl;
 import org.opengis.filter.capability.FunctionName;
 import org.opengis.filter.expression.Expression;
+
+import java.util.List;
 
 /**
  * The function checks whether a candidate value is contained in an arbitrary long list
@@ -40,6 +41,44 @@ import org.opengis.filter.expression.Expression;
  *
  */
 public class InFunction extends FunctionExpressionImpl {
+
+    /**
+     * Returns true if the expression is a function in the "in" family, that is, "in", "in2", "in3", ...
+     *
+     * @param expression The expression to be tested 
+     */
+    public static boolean isInFunction(Expression expression) {
+        return expression instanceof InFunction
+                || expression instanceof FilterFunction_in2
+                || expression instanceof FilterFunction_in3
+                || expression instanceof FilterFunction_in4
+                || expression instanceof FilterFunction_in5
+                || expression instanceof FilterFunction_in6
+                || expression instanceof FilterFunction_in7
+                || expression instanceof FilterFunction_in8
+                || expression instanceof FilterFunction_in9
+                || expression instanceof FilterFunction_in10;
+    }
+
+    /**
+     * Returns filter capabilities for all the "in" functions
+     * @return a {@link FilterCapabilities} with all the functions in the "in" family 
+     */
+    public static FilterCapabilities getInCapabilities() {
+        FilterCapabilities caps = new FilterCapabilities();
+        caps.addType(InFunction.class);
+        caps.addType(FilterFunction_in2.class);
+        caps.addType(FilterFunction_in3.class);
+        caps.addType(FilterFunction_in4.class);
+        caps.addType(FilterFunction_in5.class);
+        caps.addType(FilterFunction_in6.class);
+        caps.addType(FilterFunction_in7.class);
+        caps.addType(FilterFunction_in8.class);
+        caps.addType(FilterFunction_in9.class);
+        caps.addType(FilterFunction_in10.class);
+        
+        return caps;
+    }
 
     public static FunctionName NAME = functionName("in", "result:Boolean", "candidate:Object:1,1",
             "v:Object:1,");

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgInEncodingOnlineTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgInEncodingOnlineTest.java
@@ -1,0 +1,27 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.geopkg;
+
+import org.geotools.jdbc.JDBCInEncodingOnlineTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class GeoPkgInEncodingOnlineTest extends JDBCInEncodingOnlineTest {
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new GeoPkgTestSetup();
+    }
+}

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2InEncodingOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2InEncodingOnlineTest.java
@@ -1,0 +1,27 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.h2;
+
+import org.geotools.jdbc.JDBCInEncodingOnlineTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class H2InEncodingOnlineTest extends JDBCInEncodingOnlineTest {
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new H2TestSetup();
+    }
+}

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLInEncodingOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLInEncodingOnlineTest.java
@@ -1,0 +1,28 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mysql;
+
+import org.geotools.jdbc.JDBCInEncodingOnlineTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class MySQLInEncodingOnlineTest extends JDBCInEncodingOnlineTest {
+    
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new MySQLTestSetup();
+    }
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleInEncodingOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleInEncodingOnlineTest.java
@@ -1,0 +1,35 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.oracle;
+
+import org.geotools.jdbc.JDBCInEncodingOnlineTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+import java.io.IOException;
+
+public class OracleInEncodingOnlineTest extends JDBCInEncodingOnlineTest {
+    
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new OracleTestSetup();
+    }
+
+    @Override
+    public void testGreater() throws IOException {
+        // Oracle cannot handle this "odd" case
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisInEncodingOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisInEncodingOnlineTest.java
@@ -1,0 +1,27 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCInEncodingOnlineTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class PostgisInEncodingOnlineTest extends JDBCInEncodingOnlineTest {
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new PostGISTestSetup();
+    }
+}

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerInEncodingOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerInEncodingOnlineTest.java
@@ -1,0 +1,35 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.sqlserver;
+
+import org.geotools.jdbc.JDBCInEncodingOnlineTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+import java.io.IOException;
+
+public class SQLServerInEncodingOnlineTest extends JDBCInEncodingOnlineTest {
+    
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new SQLServerTestSetup();
+    }
+
+    @Override
+    public void testGreater() throws IOException {
+        // SQLServer cannot handle this "odd" case
+    }
+}


### PR DESCRIPTION
I had the doubt of whether to allow encoding of "in" functions in sqlserver and oracle since they don't accept them as expressions like other databases but... I don't think it's worth throwing away the good use case (in(att, v1, v2, v3)=true) because those database don't support the one that does not make sense (in(att, v1, v2, v3) > false),  even if evaluated in memory it actually works.