### PR TITLE
[GEOT-5666] Avoid parsing the LookAt as the placemark geometry.

### DIFF
--- a/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/bindings/LookAtTypeBinding.java
+++ b/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/bindings/LookAtTypeBinding.java
@@ -97,13 +97,13 @@ public class LookAtTypeBinding extends AbstractComplexBinding {
         Coordinate c = new Coordinate();
 
         //&lt;element default="0" minOccurs="0" name="longitude" type="kml:angle180"/&gt;
-        c.y = ((Double) node.getChildValue("longitude", Double.valueOf(0d))).doubleValue();
+        c.x = (Double) node.getChildValue("longitude", 0d);
 
         //&lt;element default="0" minOccurs="0" name="latitude" type="kml:angle90"/&gt;
-        c.x = ((Double) node.getChildValue("latitude", Double.valueOf(0d))).doubleValue();
+        c.y = (Double) node.getChildValue("latitude", 0d);
 
         //&lt;element default="0" minOccurs="0" name="altitude" type="double"/&gt;
-        c.z = ((Double) node.getChildValue("altitude", Double.valueOf(0d))).doubleValue();
+        c.z = (Double) node.getChildValue("altitude", 0d);
 
         Point p = geometryFactory.createPoint(c);
 

--- a/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/bindings/PlacemarkTypeBinding.java
+++ b/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/bindings/PlacemarkTypeBinding.java
@@ -29,6 +29,8 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 import com.vividsolutions.jts.geom.Geometry;
+import java.util.Arrays;
+import java.util.List;
 
 
 /**
@@ -58,6 +60,12 @@ import com.vividsolutions.jts.geom.Geometry;
  * @source $URL$
  */
 public class PlacemarkTypeBinding extends AbstractComplexBinding {
+
+    private final List<String> SUPPORTED_GEOMETRY_TYPES;
+
+    public PlacemarkTypeBinding() {
+        SUPPORTED_GEOMETRY_TYPES = Arrays.asList("Point", "LineString", "Polygon", "MultiGeometry");
+    }
 
     /**
      * @generated
@@ -105,7 +113,13 @@ public class PlacemarkTypeBinding extends AbstractComplexBinding {
         b.init(feature);
 
         //&lt;element minOccurs="0" ref="kml:Geometry"/&gt;
-        b.set("Geometry", node.getChildValue(Geometry.class));
+        for(Object childObj : node.getChildren(Geometry.class)) {
+            Node childNode = (Node)childObj;
+            String componentName = childNode.getComponent().getName();
+            if (SUPPORTED_GEOMETRY_TYPES.contains(componentName)) {
+                b.set("Geometry", childNode.getValue());
+            }
+        }
 
         return b.buildFeature(feature.getID());
     }

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/bindings/LookAtTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/bindings/LookAtTypeBindingTest.java
@@ -46,16 +46,16 @@ public class LookAtTypeBindingTest extends KMLTestSupport {
 
         Point p = (Point) parse();
         Coordinate c = p.getCoordinate();
-        assertEquals(1d, c.y, 0.1);
-        assertEquals(2d, c.x, 0.1);
+        assertEquals(1d, c.x, 0.1);
+        assertEquals(2d, c.y, 0.1);
         assertEquals(3d, c.z, 0.1);
 
         xml = "<LookAt/>";
         buildDocument(xml);
         p = (Point) parse();
         c = p.getCoordinate();
-        assertEquals(0d, c.y, 0.1);
         assertEquals(0d, c.x, 0.1);
+        assertEquals(0d, c.y, 0.1);
         assertEquals(0d, c.z, 0.1);
     }
 }

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLPlacemarkLookAtTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLPlacemarkLookAtTest.java
@@ -1,0 +1,50 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2017, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.kml.v22;
+
+import java.util.List;
+
+import org.geotools.xml.Parser;
+import org.opengis.feature.simple.SimpleFeature;
+
+import com.vividsolutions.jts.geom.Point;
+
+public class KMLPlacemarkLookAtTest extends KMLTestSupport {
+
+    public void testParseDocument() throws Exception {
+        Parser parser = new Parser(createConfiguration());
+        SimpleFeature doc = (SimpleFeature) parser.parse(getClass().getResourceAsStream("geot5666.kml"));
+        assertNotNull(doc);
+        assertEquals("document", doc.getType().getTypeName());
+        assertEquals("GEOT-5666", doc.getAttribute("name"));
+        List features = (List)doc.getAttribute("Feature");
+        assertEquals(1, features.size());
+        SimpleFeature placemark = (SimpleFeature) features.get(0);
+        
+        assertEquals("Placemark with LookAt", placemark.getAttribute("name"));
+        
+        Point lookat = (Point) placemark.getAttribute("LookAt");
+        assertEquals(149.1717, lookat.getX(), 0.0001);
+        assertEquals(-35.3446, lookat.getY(), 0.0001);
+
+        Point geometry = (Point) placemark.getDefaultGeometry();
+        assertEquals(149.2884, geometry.getX(), 0.0001);
+        assertEquals(-35.1779, geometry.getY(), 0.0001);
+
+    }
+
+}

--- a/modules/extension/xsd/xsd-kml/src/test/resources/org/geotools/kml/v22/geot5666.kml
+++ b/modules/extension/xsd/xsd-kml/src/test/resources/org/geotools/kml/v22/geot5666.kml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>GEOT-5666</name>
+	<Style id="s_ylw-pushpin_hl">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<StyleMap id="m_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Placemark>
+		<name>Placemark with LookAt</name>
+		<LookAt>
+			<longitude>149.1717555555555</longitude>
+			<latitude>-35.3446388888889</latitude>
+			<altitude>0</altitude>
+			<heading>-8.181960514640499</heading>
+			<tilt>6</tilt>
+			<range>6873.771954086397</range>
+		</LookAt>
+		<styleUrl>#m_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>149.2884222313531,-35.1779724991807,0</coordinates>
+		</Point>
+	</Placemark>
+</Document>
+</kml>


### PR DESCRIPTION
From https://osgeo-org.atlassian.net/browse/GEOT-5666  - fix LookAt coordinate order and avoid parsing LookAt as the placemark geometry.