### PR TITLE
Fix OS X Compile failure in GeoPkgDataStoreAPIOnlineTest

### DIFF
--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDataStoreAPIOnlineTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDataStoreAPIOnlineTest.java
@@ -37,7 +37,6 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.filter.FilterFactory;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import sun.awt.X11.Screen;
 
 import java.awt.geom.AffineTransform;
 import java.io.IOException;


### PR DESCRIPTION
Some recent changes to geopackage added an unnecessary import which causes a compilation failure on OS X. 
Since the import does not appear to be being used, I have removed it.