### PR TITLE
Update NetCDFReader.java

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFReader.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFReader.java
@@ -691,9 +691,10 @@ public class NetCDFReader extends AbstractGridCoverage2DReader implements Struct
                     String key = keysIt.next();
                     CoverageSource sourceCov = coverages.get(key);
                     sourceCov.dispose();
-                }
+                } 
+                coverages.clear();
             }
-            coverages.clear();
+  
             coverages = null;
         }
         if (access != null) {

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFReader.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFReader.java
@@ -691,10 +691,9 @@ public class NetCDFReader extends AbstractGridCoverage2DReader implements Struct
                     String key = keysIt.next();
                     CoverageSource sourceCov = coverages.get(key);
                     sourceCov.dispose();
-                } 
+                }
                 coverages.clear();
             }
-  
             coverages = null;
         }
         if (access != null) {


### PR DESCRIPTION
NetCDFReader references a coverage list without checking for null, causing the access cleanup portion of dispose() to be skipped (line 696).

Move "coverages.clear()" into the conditional check that coverages is not null.

```sh
java.lang.NullPointerException
	at org.geotools.coverage.io.netcdf.NetCDFReader.dispose(NetCDFReader.java:696)
	...
```