### PR TITLE
NullPointerException clearing coverages in NetCDFReader.dispose

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFReader.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFReader.java
@@ -692,8 +692,8 @@ public class NetCDFReader extends AbstractGridCoverage2DReader implements Struct
                     CoverageSource sourceCov = coverages.get(key);
                     sourceCov.dispose();
                 }
+                coverages.clear();
             }
-            coverages.clear();
             coverages = null;
         }
         if (access != null) {


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-5923

NetCDFReader references a coverage list without checking for null, causing the access cleanup portion of dispose() to be skipped (line 696).
Move "coverages.clear()" into the conditional check that coverages is not null.
```sh
java.lang.NullPointerException
at org.geotools.coverage.io.netcdf.NetCDFReader.dispose(NetCDFReader.java:696)
...
```
  