### PR TITLE
GEOT-5931: Temporal operators in opengis FilterCapabilities implementation and wrapper

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/Capabilities.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/Capabilities.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2018, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -27,6 +27,7 @@ import org.geotools.filter.capability.FunctionsImpl;
 import org.geotools.filter.capability.OperatorImpl;
 import org.geotools.filter.capability.SpatialOperatorImpl;
 import org.geotools.filter.capability.SpatialOperatorsImpl;
+import org.geotools.filter.capability.TemporalOperatorImpl;
 import org.geotools.filter.visitor.IsFullySupportedFilterVisitor;
 import org.geotools.filter.visitor.IsSupportedFilterVisitor;
 import org.geotools.filter.visitor.OperatorNameFilterVisitor;
@@ -46,6 +47,7 @@ import org.opengis.filter.PropertyIsNotEqualTo;
 import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.capability.FilterCapabilities;
 import org.opengis.filter.capability.GeometryOperand;
+import org.opengis.filter.capability.TemporalOperators;
 import org.opengis.filter.expression.Add;
 import org.opengis.filter.expression.Divide;
 import org.opengis.filter.expression.Expression;
@@ -63,6 +65,20 @@ import org.opengis.filter.spatial.Intersects;
 import org.opengis.filter.spatial.Overlaps;
 import org.opengis.filter.spatial.Touches;
 import org.opengis.filter.spatial.Within;
+import org.opengis.filter.temporal.After;
+import org.opengis.filter.temporal.AnyInteracts;
+import org.opengis.filter.temporal.Before;
+import org.opengis.filter.temporal.Begins;
+import org.opengis.filter.temporal.BegunBy;
+import org.opengis.filter.temporal.During;
+import org.opengis.filter.temporal.EndedBy;
+import org.opengis.filter.temporal.Ends;
+import org.opengis.filter.temporal.Meets;
+import org.opengis.filter.temporal.MetBy;
+import org.opengis.filter.temporal.OverlappedBy;
+import org.opengis.filter.temporal.TContains;
+import org.opengis.filter.temporal.TEquals;
+import org.opengis.filter.temporal.TOverlaps;
 
 /**
  * Allows for easier interaction with FilterCapabilities.
@@ -123,6 +139,24 @@ public class Capabilities {
         spatialNames.put(Beyond.class,Beyond.NAME);
         spatialNames.put(DWithin.class,DWithin.NAME);
     }
+    private static Map<Class<?>,String> temporalNames;
+    static {
+        temporalNames = new HashMap<>();
+        temporalNames.put(After.class, After.NAME );
+        temporalNames.put(AnyInteracts.class, AnyInteracts.NAME );
+        temporalNames.put(Before.class, Before.NAME );
+        temporalNames.put(Begins.class, Begins.NAME );
+        temporalNames.put(BegunBy.class, BegunBy.NAME );
+        temporalNames.put(During.class, During.NAME );
+        temporalNames.put(EndedBy.class, EndedBy.NAME );
+        temporalNames.put(Ends.class, Ends.NAME );
+        temporalNames.put(Meets.class, Meets.NAME );
+        temporalNames.put(MetBy.class, MetBy.NAME );
+        temporalNames.put(OverlappedBy.class, OverlappedBy.NAME );
+        temporalNames.put(TContains.class, TContains.NAME );
+        temporalNames.put(TEquals.class, TEquals.NAME );
+        temporalNames.put(TOverlaps.class, TOverlaps.NAME );
+    }
     private static Map<Class<?>,String> logicalNames;
     static {
         logicalNames = new HashMap<Class<?>,String>();
@@ -135,6 +169,7 @@ public class Capabilities {
         filterNames = new HashMap<Class<?>,String>();
         filterNames.putAll( scalarNames );
         filterNames.putAll( spatialNames );
+        filterNames.putAll( temporalNames );
         filterNames.putAll( logicalNames );
         
         filterNames.put(Id.class, "Id"); // not an operator name, see idCapabilities.hasFID() or idCapabilities.hasEID()
@@ -275,6 +310,13 @@ public class Capabilities {
                 operator.getGeometryOperands().add( GeometryOperand.Point );
                 operator.getGeometryOperands().add( GeometryOperand.Polygon );
                 
+                operators.getOperators().add( operator );
+            }
+        }
+        else if( temporalNames.containsValue( name )){
+            TemporalOperators operators = contents.getTemporalCapabilities().getTemporalOperators();
+            if( operators.getOperator( name ) == null ){
+                TemporalOperatorImpl operator = new TemporalOperatorImpl(name);
                 operators.getOperators().add( operator );
             }
         }

--- a/modules/library/main/src/main/java/org/geotools/filter/capability/FilterCapabilitiesImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/capability/FilterCapabilitiesImpl.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2018, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -164,8 +164,10 @@ public class FilterCapabilitiesImpl implements FilterCapabilities {
     }
 
     public TemporalCapabilities getTemporalCapabilities() {
-        // TODO Auto-generated method stub
-        return null;
+        if( temporal == null ){
+            temporal = new TemporalCapabilitiesImpl();
+        }
+        return temporal;
     }
     
     public void addAll( FilterCapabilities copy ){

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/IsFullySupportedFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/IsFullySupportedFilterVisitor.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2018, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -501,7 +501,7 @@ public class IsFullySupportedFilterVisitor implements FilterVisitor, ExpressionV
     }
 
     public Object visit(BegunBy begunBy, Object extraData) {
-        return visit((BinaryTemporalOperator)begunBy, extraData);
+        return visit((BinaryTemporalOperator)begunBy, BegunBy.NAME);
     }
 
     public Object visit(During during, Object extraData) {

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/IsSupportedFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/IsSupportedFilterVisitor.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2018, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -42,7 +42,6 @@ import org.opengis.filter.capability.ScalarCapabilities;
 import org.opengis.filter.capability.SpatialCapabilities;
 import org.opengis.filter.capability.SpatialOperators;
 import org.opengis.filter.capability.TemporalCapabilities;
-import org.opengis.filter.capability.TemporalOperator;
 import org.opengis.filter.capability.TemporalOperators;
 import org.opengis.filter.expression.Add;
 import org.opengis.filter.expression.Divide;
@@ -446,7 +445,7 @@ public class IsSupportedFilterVisitor implements FilterVisitor, ExpressionVisito
     }
 
     public Object visit(BegunBy begunBy, Object extraData) {
-        return visit((BinaryTemporalOperator)begunBy, extraData);
+        return visit((BinaryTemporalOperator)begunBy, BegunBy.NAME);
     }
 
     public Object visit(During during, Object extraData) {

--- a/modules/library/main/src/test/java/org/geotools/filter/CapabilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/CapabilitiesTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  * 
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2018, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -18,12 +18,24 @@ package org.geotools.filter;
 
 import junit.framework.TestCase;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.temporal.object.DefaultInstant;
+import org.geotools.temporal.object.DefaultPeriod;
+import org.geotools.temporal.object.DefaultPosition;
 import org.opengis.filter.And;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.spatial.Beyond;
+import org.opengis.filter.temporal.After;
+import org.opengis.filter.temporal.BegunBy;
+import org.opengis.temporal.Instant;
+import org.opengis.temporal.Period;
 /**
  * Unit test for FilterCapabilities.
  *
@@ -36,6 +48,7 @@ public class CapabilitiesTest extends TestCase {
     public void testCapablities(){
         Capabilities capabilities = new Capabilities();
         capabilities.addType( Beyond.class ); // add to SpatialCapabilities
+        capabilities.addType( After.class ); // add to TemporalCapabilities
         capabilities.addType( PropertyIsEqualTo.class ); // add to ScalarCapabilities
         capabilities.addName( "NullCheck" ); // will enable PropertyIsNull use
         capabilities.addName( "Mul" ); // will enable hasSimpleArithmatic
@@ -51,6 +64,9 @@ public class CapabilitiesTest extends TestCase {
         filter = ff.equals(ff.property("x"), ff.literal( 2 ) );        
         assertTrue("supports", capabilities.supports( filter ) );
         
+        filter = ff.after(ff.property("x"), ff.literal("1970-01-01 00:00:00"));
+        assertTrue("supports", capabilities.supports( filter ) );
+
         assertTrue("fullySupports", capabilities.fullySupports( filter ) );
 
         Capabilities capabilities2 = new Capabilities();
@@ -70,5 +86,24 @@ public class CapabilitiesTest extends TestCase {
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
         Filter filter = ff.lessOrEqual(ff.property("x"), ff.literal( 2 ) );
         assertTrue("supports", capabilities.supports( filter ) );
+    }
+
+    public void testCapabilities_BegunBy() throws ParseException{
+        Capabilities capabilities = new Capabilities();
+        capabilities.addType( BegunBy.class );
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        Date date1 = dateFormat.parse("1970-07-19T01:02:03.456Z");
+        Instant temporalInstant = new DefaultInstant(new DefaultPosition(date1));
+        Date date2 = dateFormat.parse("1970-07-19T07:08:09.101Z");
+        Instant temporalInstant2 = new DefaultInstant(new DefaultPosition(date2));
+        Period period = new DefaultPeriod(temporalInstant, temporalInstant2);
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        BegunBy filter = ff.begunBy(ff.literal(period), ff.property("dateAttr"));
+        assertTrue("supports", capabilities.supports( filter ) );
+
+        assertTrue("fullySupports", capabilities.fullySupports( filter ) );
+
     }
 }


### PR DESCRIPTION
Update opengis FilterCapabilities implementation and wrapper to support temporal operators. Also fix a bug with `BegunBy` in the IsSupportedFilterVisitors which would cause the operator to never be supported.

*CLA has been sent to OSGeo* 