### PR TITLE
GEOT-5938 OSMTileFactory can throw an exception when looking for the TopLeft tile

### DIFF
--- a/modules/extension/tile-client/pom.xml
+++ b/modules/extension/tile-client/pom.xml
@@ -112,11 +112,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-        	<groupId>org.geotools</groupId>
-        	<artifactId>gt-wms</artifactId>
-        	<version>${project.version}</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/modules/extension/tile-client/pom.xml
+++ b/modules/extension/tile-client/pom.xml
@@ -112,6 +112,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+        	<groupId>org.geotools</groupId>
+        	<artifactId>gt-wms</artifactId>
+        	<version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/modules/extension/tile-client/src/main/java/org/geotools/tile/impl/osm/OSMTileFactory.java
+++ b/modules/extension/tile-client/src/main/java/org/geotools/tile/impl/osm/OSMTileFactory.java
@@ -49,7 +49,8 @@ public class OSMTileFactory extends WebMercatorTileFactory {
         int yTile = (int) Math.floor(
                 (1 - Math.log(Math.tan(lat * Math.PI / 180) + 1 / Math.cos(lat * Math.PI / 180))
                         / Math.PI) / 2 * (1 << zoomLevel.getZoomLevel()));
-
+        if(yTile<0)
+          yTile=0;
         return new OSMTile(xTile, yTile, zoomLevel, service);
     }
 

--- a/modules/extension/tile-client/src/test/java/org/geotools/tile/impl/osm/OSMTileFactoryTest.java
+++ b/modules/extension/tile-client/src/test/java/org/geotools/tile/impl/osm/OSMTileFactoryTest.java
@@ -23,6 +23,7 @@ import org.geotools.tile.TileFactory;
 import org.geotools.tile.TileFactoryTest;
 import org.geotools.tile.TileService;
 import org.geotools.tile.impl.WebMercatorTileFactory;
+import org.geotools.tile.impl.WebMercatorTileService;
 import org.geotools.tile.impl.WebMercatorZoomLevel;
 import org.geotools.tile.impl.bing.BingService;
 import org.junit.Assert;
@@ -38,6 +39,16 @@ public class OSMTileFactoryTest extends TileFactoryTest {
 
         TileService service = createService();
         OSMTile expectedTile = new OSMTile(20, 15, new WebMercatorZoomLevel(5), service);
+        Assert.assertEquals(expectedTile, tile);
+    }
+    @Test
+    public void testGetTileFromTopLeftCoordinate() {
+
+        Tile tile = factory.findTileAtCoordinate(WebMercatorTileService.MIN_LONGITUDE, WebMercatorTileService.MAX_LATITUDE, new WebMercatorZoomLevel(5),
+                createService());
+
+        TileService service = createService();
+        OSMTile expectedTile = new OSMTile(0, 0, new WebMercatorZoomLevel(5), service);
         Assert.assertEquals(expectedTile, tile);
     }
 


### PR DESCRIPTION
Fixes [GEOT-5938](https://osgeo-org.atlassian.net/browse/GEOT-5938) where sometimes rounding error caused the YTileIndex negative causing an exception to be thrown.