### PR TITLE
[GEOS-8477] Support null values in WMSComplexTypes$_LegendURLType

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/data/wms/xml/WMSComplexTypes.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/wms/xml/WMSComplexTypes.java
@@ -4349,7 +4349,7 @@ public class WMSComplexTypes {
 				Attributes attrs, Map hints) throws SAXException,
 				OperationNotSupportedException {
                     
-                    String legendURL = value[1].getValue().toString();
+                    String legendURL = value[1].getValue() == null ? null : value[1].getValue().toString();
                     return legendURL;
 			// throw new OperationNotSupportedException();
 		}

--- a/modules/extension/wms/src/test/java/org/geotools/data/wms/xml/test/WMSComplexTypesTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/data/wms/xml/test/WMSComplexTypesTest.java
@@ -1,0 +1,112 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2018, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.wms.xml.test;
+
+import junit.framework.TestCase;
+import org.geotools.data.ows.Layer;
+import org.geotools.data.ows.StyleImpl;
+import org.geotools.data.ows.WMSCapabilities;
+import org.geotools.data.wms.xml.Attribution;
+import org.geotools.data.wms.xml.LogoURL;
+import org.geotools.data.wms.xml.MetadataURL;
+import org.geotools.data.wms.xml.WMSSchema;
+import org.geotools.test.TestData;
+import org.geotools.xml.DocumentFactory;
+import org.geotools.xml.handlers.DocumentHandler;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+
+public class WMSComplexTypesTest extends TestCase {
+
+    //GEOS-8477
+    public void testLegendURLType() throws Exception {
+
+        File getCaps = TestData.file(this, "1.1.0CapabilitiesInvalid.xml");
+        URL getCapsURL = getCaps.toURI().toURL();
+        Map<String,Object> hints = new HashMap<>();
+        hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+        Object object = null;
+
+        try {
+            object = DocumentFactory.getInstance(getCapsURL.openStream(), hints, Level.WARNING);
+        } catch (NullPointerException e) {
+            fail("Parsing document with invalid xlink URL should not cause NPE");
+        }
+
+        assertTrue("Capabilities failed to parse", object instanceof WMSCapabilities);
+
+        WMSCapabilities capabilities = (WMSCapabilities) object;
+
+        assertEquals(capabilities.getVersion(), "1.1.0");
+        assertEquals(capabilities.getService().getName(), "OGC:WMS");
+        assertEquals(capabilities.getService().getTitle(), "GMap WMS Demo Server");
+        //invalid xlink URL will cause most online resources to be null
+        assertNull(capabilities.getService().getOnlineResource());
+
+        assertEquals(capabilities.getRequest().getGetCapabilities().getFormats().get(0),
+                "application/vnd.ogc.wms_xml");
+
+        Layer topLayer = (Layer) capabilities.getLayerList().get(0);
+        assertNotNull(topLayer);
+        assertNull(topLayer.getParent());
+        assertEquals(topLayer.getTitle(), "GMap WMS Demo Server");
+        assertEquals(topLayer.getSrs().size(), 4);
+
+        Attribution attribution = topLayer.getAttribution();
+        assertNotNull(attribution);
+        assertEquals(attribution.getTitle(), "test");
+        //invalid xlink URL will cause most online resources to be null
+        assertNull(attribution.getOnlineResource());
+
+        LogoURL logoURL = attribution.getLogoURL();
+        assertNotNull(logoURL);
+        assertEquals(logoURL.getFormat(), "image/png");
+        //invalid xlink URL will cause most online resources to be null
+        assertNull(logoURL.getOnlineResource());
+        assertEquals(logoURL.getHeight(), 100);
+        assertEquals(logoURL.getWidth(), 100);
+
+        Layer layer = capabilities.getLayerList().get(1);
+        assertEquals(layer.getParent(), topLayer);
+        assertFalse(layer.isQueryable());
+        assertEquals(layer.getName(), "bathymetry");
+        assertEquals(layer.getTitle(), "Elevation/Bathymetry");
+
+        attribution = layer.getAttribution();
+        assertNotNull(attribution);
+        assertEquals(attribution.getTitle(), "test");
+
+        //invalid xlink URL will cause most online resources to be null
+        assertNull(attribution.getOnlineResource());
+        logoURL = attribution.getLogoURL();
+        assertNull(logoURL);
+
+        MetadataURL metadataURL = layer.getMetadataURL().get(0);
+        //invalid xlink URL will cause most online resources to be null
+        assertNull(metadataURL.getUrl());
+
+        StyleImpl style = layer.getStyles().get(0);
+        assertNotNull(style);
+        Object legendURL = style.getLegendURLs().get(0);
+        //invalid xlink URL will cause most online resources to be null
+        assertNull(legendURL);
+    }
+}

--- a/modules/extension/wms/src/test/resources/org/geotools/data/wms/xml/test/test-data/1.1.0CapabilitiesInvalid.xml
+++ b/modules/extension/wms/src/test/resources/org/geotools/data/wms/xml/test/test-data/1.1.0CapabilitiesInvalid.xml
@@ -1,0 +1,131 @@
+<?xml version='1.0' encoding="ISO-8859-1" standalone="no" ?>
+<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://www.digitalearth.gov/wmt/xml/capabilities_1_1_0.dtd"
+ [
+ <!ELEMENT VendorSpecificCapabilities EMPTY>
+ ]>  <!-- end of DOCTYPE declaration -->
+
+<WMT_MS_Capabilities version="1.1.0">
+
+<!-- MapServer version 4.2.0 OUTPUT=GIF OUTPUT=PNG OUTPUT=JPEG OUTPUT=WBMP OUTPUT=PDF SUPPORTS=PROJ SUPPORTS=FREETYPE SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT INPUT=EPPL7 INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE -->
+
+<Service>
+  <Name>OGC:WMS</Name>
+  <Title>GMap WMS Demo Server</Title>
+  <Abstract>This demonstration server was setup by DM Solutions Group (http://www.dmsolutions.ca/) and is powered by the UMN MapServer (http://mapserver.gis.umn.edu/).  This server uses Canadian source data (c)2000, Government of Canada with permission from Natural Resources Canada from NRCan's GeoGratis 
+web site (http://geogratis.cgdi.gc.ca/).</Abstract>
+  <OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/>
+</Service>
+
+<Capability>
+  <Request>
+    <GetCapabilities>
+      <Format>application/vnd.ogc.wms_xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Get>
+          <Post><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <GetMap>
+      <Format>image/gif</Format>
+      <Format>image/png</Format>
+      <Format>image/jpeg</Format>
+      <Format>image/wbmp</Format>
+      <Format>text/html</Format>
+      <Format>application/x-pdf</Format>
+      <Format>image/tiff</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Get>
+          <Post><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetMap>
+    <GetFeatureInfo>
+      <Format>text/plain</Format>
+      <Format>text/html</Format>
+      <Format>application/vnd.ogc.gml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Get>
+          <Post><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
+    <DescribeLayer>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Get>
+          <Post><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Post>
+        </HTTP>
+      </DCPType>
+    </DescribeLayer>
+    <GetLegendGraphic>
+      <Format>image/gif</Format>
+      <Format>image/png</Format>
+      <Format>image/jpeg</Format>
+      <Format>image/wbmp</Format>
+      <Format>text/html</Format>
+      <Format>application/x-pdf</Format>
+      <Format>image/tiff</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Get>
+          <Post><OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://dev1.dmsolutions.ca/cgi-bin/mswms_gmap?"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetLegendGraphic>
+  </Request>
+  <Exception>
+    <Format>application/vnd.ogc.se_xml</Format>
+    <Format>application/vnd.ogc.se_inimage</Format>
+    <Format>application/vnd.ogc.se_blank</Format>
+  </Exception>
+  <VendorSpecificCapabilities />
+  <UserDefinedSymbolization SupportSLD="1" UserLayer="0" UserStyle="1" RemoteWFS="0"/>
+  <Layer>
+    <Name>DEMO</Name>
+    <Title>GMap WMS Demo Server</Title>
+    <Abstract>Abstract Test</Abstract>
+    <KeywordList>
+    	<Keyword>word1</Keyword>
+    	<Keyword>word2</Keyword>
+    </KeywordList>
+    <SRS>EPSG:42304 EPSG:42101 EPSG:4269 EPSG:4326</SRS>   
+    <LatLonBoundingBox minx="-172.367" miny="35.6673" maxx="-11.5624" maxy="83.8293" />
+    <BoundingBox SRS="EPSG:42304"
+                minx="-2.2e+06" miny="-712631" maxx="3.0728e+06" maxy="3.84e+06" />
+    <Attribution>
+      <Title>test</Title>
+      <OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.example.com"/>
+      <LogoURL height="100" width="100">
+        <Format>image/png</Format>
+        <OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.osgeo.org/sites/all/themes/osgeo/logo.png"/>
+      </LogoURL>
+    </Attribution>      
+    <Layer queryable="0" opaque="0" cascaded="0">
+        <Name>bathymetry</Name>
+        <Title>Elevation/Bathymetry</Title>
+        <SRS>EPSG:42304</SRS>
+    <Attribution>
+      <Title>test</Title>
+      <OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.example.com"/>
+    </Attribution>
+    <MetadataURL type="TC211">
+        <Format>text/xml</Format>
+        <OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://www.example.com" xlink:type="simple"/>
+    </MetadataURL>
+    <Style>
+        <Name>default</Name>
+        <Title>teststyle</Title>
+        <LegendURL height="21" width="119">
+            <Format>image/png</Format>
+            <OnlineResource xmlns:xlink="https://www.w3.org/1999/xlink" xlink:href="http://www.example.com" xlink:type="simple"/>
+        </LegendURL>
+    </Style>
+    </Layer>
+  </Layer>
+</Capability>
+</WMT_MS_Capabilities>


### PR DESCRIPTION
Fix for https://osgeo-org.atlassian.net/browse/GEOS-8477

(Bug was reported against GeoServer, but the actual fix is in GeoTools)

Modified _LegendURLType to support returning null values.
This is consistent with the behaviour of other Types in WMSComplexTypes, such as _OnlineResourceType.

Also tested manually in geoserver, to ensure the WMS store could be created.

