### PR TITLE
fix(docs): Fix "Moasic" typo.

### DIFF
--- a/docs/user/library/coverage/jdbc/faq.rst
+++ b/docs/user/library/coverage/jdbc/faq.rst
@@ -1,4 +1,4 @@
-Image Moasic JDBC FAQ
+Image Mosaic JDBC FAQ
 ---------------------
 
 Q: How to Build image pyramids and tiles?
@@ -18,11 +18,11 @@ The output of gdal_retile.py can be imported into the database with the import u
 
 A good practice is to use a color table for your source image(s). Less memory consumption and a
 better performance are the results. If you have an already tiled source image, be sure that each
-source tile uses the same color table, otherwise use gdal_merge.py (Gdal utility) to produce a big
+source tile uses the same color table, otherwise use gdal_merge.py (GDAL utility) to produce a big
 single image and apply rgb2pct.py (GDAL utility).
 
 Q: How to import the tiles and the georeferencing information?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Importing the data is database dependent. If you have a spatial extension, the gdal_retile.py utility
-produces the proper world,shape or csv files which you can import with a database utility.
+produces the proper world,shape or CSV files which you can import with a database utility.

--- a/docs/user/library/coverage/jdbc/index.rst
+++ b/docs/user/library/coverage/jdbc/index.rst
@@ -1,9 +1,9 @@
 .. _im-jdbc:
 
-Image Moasic JDBC
+Image Mosaic JDBC
 -----------------
 
-This **gt-imagemoasic-jdbc** plugin is intended to handle large images stored as tiles in a JDBC
+This **gt-imagemosaic-jdbc** plugin is intended to handle large images stored as tiles in a JDBC
 database. Tiles created by pyramids are also stored in the database. The utility uses the indexing
 of databases to speed up access to the requested tiles, the plugin for itself has a multithreaded
 architecture to make use of dual/quad core CPUs and multiprocessor systems.
@@ -81,7 +81,7 @@ This example shows how to use the module::
 Mapping of table and attribute names
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Since there a lot of naming conventions in different enterprises, I is not idea to force the use of predefined table and attribute names. In our example, the names of the spatial and tile tables is selectable, the name of the meta table and all the attribute names were assumed. The mapping of these names is part of the XML configuration. The corresponding XML fragment shows the mapping of the assumed names.
+Since there a lot of naming conventions in different enterprises, it is not ideal to force the use of predefined table and attribute names. In our example, the names of the spatial and tile tables is selectable, the name of the meta table and all the attribute names were assumed. The mapping of these names is part of the XML configuration. The corresponding XML fragment shows the mapping of the assumed names.
 
 A sample XML fragment file **mapping.xml.inc**::
   
@@ -117,7 +117,7 @@ The structure of this XML Fragment is kept very simple, use it as a pattern.
 
 The name attribute of the <spatialExtension> has to be one of the following values
 
-* universal (a vendor neutral JDBC approach which should work with any jdbc database with BLOB support)
+* universal (a vendor neutral JDBC approach which should work with any JDBC database with BLOB support)
 * db2 (use spatial extender)
 * mysql (use the spatial features of mysql)
 * postgis (use the spatial features of postgis)

--- a/docs/user/library/coverage/jdbc/internal.rst
+++ b/docs/user/library/coverage/jdbc/internal.rst
@@ -1,4 +1,4 @@
-Image Moasic JDBC Design
+Image Mosaic JDBC Design
 ------------------------
 
 

--- a/docs/user/library/coverage/mosaic.rst
+++ b/docs/user/library/coverage/mosaic.rst
@@ -9,7 +9,7 @@ list the filename of the "images" to display and the location in which they shou
 * `ImageMosaicFormat <http://docs.geotools.org/latest/javadocs/org/geotools/gce/imagemosaic/ImageMosaicFormat.html>`_ (javadoc)
 * `ImageMosaicJDBCReader <http://docs.geotools.org/latest/javadocs/org/geotools/gce/imagemosaic/jdbc/ImageMosaicJDBCReader.html>`_ (javadoc)
 * :doc:`pyramid`
-* `Using the ImageMoasic plugin <http://docs.geoserver.org/stable/en/user/tutorials/image_mosaic_plugin/imagemosaic.html>`_
+* `Using the ImageMosaic plugin <http://docs.geoserver.org/stable/en/user/tutorials/image_mosaic_plugin/imagemosaic.html>`_
 
 **Maven**::
    


### PR DESCRIPTION
Includes a few other trivial fixes in the same files.