### PR TITLE
[GEOT-5822] Improve ImageMosaic's NetCDF performances

### DIFF
--- a/modules/plugin/coverage-multidim/coverage-api/src/main/java/org/geotools/coverage/io/catalog/DataStoreConfiguration.java
+++ b/modules/plugin/coverage-multidim/coverage-api/src/main/java/org/geotools/coverage/io/catalog/DataStoreConfiguration.java
@@ -40,6 +40,8 @@ import org.geotools.util.Utilities;
  * A new attribute LOCATION is used to distinguish granules coming from specific
  * file/reader instances.
  * 
+ * Starting with 19.x, it is also possible to use a {@link org.geotools.data.Repository} providing an externally
+ * managed store identified by name
  *  
  * @author Daniele Romagnoli, GeoSolutions
  */
@@ -47,6 +49,20 @@ public class DataStoreConfiguration {
 
     private final static H2DataStoreFactory INTERNAL_STORE_SPI = new H2DataStoreFactory();
 
+    /** The Datastore factory spi used to create the Datastore instance */
+    private DataStoreFactorySpi datastoreSpi;
+
+    /** The connection params */
+    private Map<String, Serializable> params;
+
+    /**
+     * a boolean stating whether the granules index is stored "the classic way", 
+     * which is using an internal H2 DB for each file or it's a shared DB.
+     */
+    private boolean shared = false;
+
+    private String storeName;
+    
     /** Default instance is using a H2 DB for each file */
     public DataStoreConfiguration(Map<String, Serializable> datastoreParams) {
         this(INTERNAL_STORE_SPI, datastoreParams);
@@ -58,6 +74,10 @@ public class DataStoreConfiguration {
         this.params = datastoreParams;
     }
 
+    public DataStoreConfiguration(String storeName) {
+        this.storeName = storeName;
+    }
+
     public DataStoreFactorySpi getDatastoreSpi() {
         return datastoreSpi;
     }
@@ -67,6 +87,9 @@ public class DataStoreConfiguration {
     }
 
     public Map<String, Serializable> getParams() {
+        if (params == null) {
+            params = new HashMap<>();
+        }
         return params;
     }
 
@@ -82,11 +105,9 @@ public class DataStoreConfiguration {
         this.shared = shared;
     }
 
-    /** The Datastore factory spi used to create the Datastore instance */
-    private DataStoreFactorySpi datastoreSpi;
-
-    /** The connection params */
-    private Map<String, Serializable> params;
+    public String getStoreName() {
+        return storeName;
+    }
 
     /**
      * Return default params for the 1 File <-> 1 H2 DB classic configuration. 
@@ -116,9 +137,4 @@ public class DataStoreConfiguration {
         return params;
     }
 
-    /**
-     * a boolean stating whether the granules index is stored "the classic way", 
-     * which is using an internal H2 DB for each file or it's a shared DB.
-     */
-    private boolean shared = false;
 }

--- a/modules/plugin/coverage-multidim/coverage-api/src/main/java/org/geotools/imageio/GeoSpatialImageReader.java
+++ b/modules/plugin/coverage-multidim/coverage-api/src/main/java/org/geotools/imageio/GeoSpatialImageReader.java
@@ -34,6 +34,7 @@ import org.geotools.coverage.io.catalog.CoverageSlicesCatalog;
 import org.geotools.coverage.io.catalog.CoverageSlicesCatalog.WrappedCoverageSlicesCatalog;
 import org.geotools.coverage.io.catalog.DataStoreConfiguration;
 import org.geotools.data.Query;
+import org.geotools.data.Repository;
 import org.opengis.feature.type.Name;
 
 /**
@@ -59,6 +60,7 @@ public abstract class GeoSpatialImageReader extends ImageReader implements FileS
      * low level granules index 
      */
     private String auxiliaryDatastorePath = null;
+    private Repository repository;
 
     protected GeoSpatialImageReader(ImageReaderSpi originatingProvider) {
         super(originatingProvider);
@@ -170,6 +172,10 @@ public abstract class GeoSpatialImageReader extends ImageReader implements FileS
     public void setAuxiliaryDatastorePath(String auxiliaryDatastorePath) {
         this.auxiliaryDatastorePath = auxiliaryDatastorePath;
     }
+    
+    public void setRepository(Repository repository) {
+        this.repository = repository;
+    }
 
     /**
      * Returns the underlying slicesCatalog. 
@@ -190,7 +196,7 @@ public abstract class GeoSpatialImageReader extends ImageReader implements FileS
      * @deprecated: use the {@link #initCatalog(DataStoreConfiguration)} instead 
      */
     protected void initCatalog(File parentLocation, String databaseName) throws IOException {
-        slicesCatalog = new CoverageSlicesCatalog(databaseName, parentLocation);
+        slicesCatalog = new CoverageSlicesCatalog(databaseName, parentLocation, repository);
     }
 
     /**
@@ -201,8 +207,8 @@ public abstract class GeoSpatialImageReader extends ImageReader implements FileS
      */
     protected void initCatalog(DataStoreConfiguration datastoreConfig) throws IOException {
         slicesCatalog = datastoreConfig.isShared() ?
-                new WrappedCoverageSlicesCatalog(datastoreConfig, file) :
-                    new CoverageSlicesCatalog(datastoreConfig);
+                new WrappedCoverageSlicesCatalog(datastoreConfig, file, repository) :
+                    new CoverageSlicesCatalog(datastoreConfig, repository);
     }
 
     @Override

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFAccess.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/NetCDFAccess.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -40,12 +42,14 @@ import org.geotools.coverage.io.impl.DefaultFileDriver;
 import org.geotools.data.DataSourceException;
 import org.geotools.data.DefaultServiceInfo;
 import org.geotools.data.Parameter;
+import org.geotools.data.Repository;
 import org.geotools.data.ServiceInfo;
 import org.geotools.factory.Hints;
 import org.geotools.feature.NameImpl;
 import org.geotools.gce.imagemosaic.Utils;
 import org.geotools.imageio.GeoSpatialImageReader;
 import org.geotools.imageio.netcdf.NetCDFImageReader;
+import org.geotools.imageio.netcdf.utilities.NetCDFUtilities;
 import org.geotools.util.NullProgressListener;
 import org.geotools.util.URLs;
 import org.geotools.util.logging.Logging;
@@ -140,14 +144,26 @@ public class NetCDFAccess extends DefaultFileCoverageAccess implements CoverageA
                 prefix = (String) hints.get(Utils.PARENT_DIR) + File.separatorChar;
             }
             if (hints.containsKey(Utils.AUXILIARY_FILES_PATH)) {
-                String filePath = prefix + (String) hints.get(Utils.AUXILIARY_FILES_PATH);
+                String filePath = (String) hints.get(Utils.AUXILIARY_FILES_PATH);
+                filePath = makeAbsolute(prefix, filePath);
                 reader.setAuxiliaryFilesPath(filePath);
             }
             if (hints.containsKey(Utils.AUXILIARY_DATASTORE_PATH)) {
-                String filePath = prefix + (String) hints.get(Utils.AUXILIARY_DATASTORE_PATH);
+                String filePath = (String) hints.get(Utils.AUXILIARY_DATASTORE_PATH);
+                filePath = makeAbsolute(prefix, filePath);
                 reader.setAuxiliaryDatastorePath(filePath);
             }
+            if (hints.containsKey(Hints.REPOSITORY)) {
+                reader.setRepository((Repository) hints.get(Hints.REPOSITORY));
+            }
         }
+    }
+
+    private String makeAbsolute(String prefix, String filePath) {
+        if (!Paths.get(filePath).isAbsolute()) {
+            filePath = prefix + filePath;
+        }
+        return filePath;
     }
 
     @Override

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/AncillaryFileManager.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/AncillaryFileManager.java
@@ -803,24 +803,29 @@ public class AncillaryFileManager implements FileSetManager{
             URL datastoreURL = URLs.fileToUrl(datastoreIndexFile);
             Properties properties = CoverageUtilities.loadPropertiesFromURL(datastoreURL);
             if (properties != null) {
-                final String SPIClass = properties.getProperty("SPI");
-                try {
-                    // create a datastore as instructed
-                    final DataStoreFactorySpi spi = (DataStoreFactorySpi) Class.forName(SPIClass)
-                            .newInstance();
-                    Map<String, Serializable> datastoreParams = Utils.filterDataStoreParams(
-                            properties, spi);
+                String storeName = properties.getProperty(NetCDFUtilities.STORE_NAME);
+                if (storeName != null) {
+                    return new DataStoreConfiguration(storeName);
+                } else {
+                    final String SPIClass = properties.getProperty("SPI");
+                    try {
+                        // create a datastore as instructed
+                        final DataStoreFactorySpi spi = (DataStoreFactorySpi) Class.forName(SPIClass)
+                                .newInstance();
+                        Map<String, Serializable> datastoreParams = Utils.filterDataStoreParams(
+                                properties, spi);
 
-                    // create a datastore configuration using the specified SPI and datastoreParams
-                    datastoreConfiguration = new DataStoreConfiguration(spi, datastoreParams);
-                    datastoreConfiguration.setDatastoreSpi(spi);
-                    datastoreConfiguration.setParams(datastoreParams);
-                    datastoreConfiguration.setShared(true);
-                    // update params for the shared case
-                    checkStoreWrapping(datastoreConfiguration);
-                } catch (Exception e) {
-                    final IOException ioe = new IOException();
-                    throw (IOException) ioe.initCause(e);
+                        // create a datastore configuration using the specified SPI and datastoreParams
+                        datastoreConfiguration = new DataStoreConfiguration(spi, datastoreParams);
+                        datastoreConfiguration.setDatastoreSpi(spi);
+                        datastoreConfiguration.setParams(datastoreParams);
+                        datastoreConfiguration.setShared(true);
+                        // update params for the shared case
+                        checkStoreWrapping(datastoreConfiguration);
+                    } catch (Exception e) {
+                        final IOException ioe = new IOException();
+                        throw (IOException) ioe.initCause(e);
+                    }
                 }
             }
         } else {

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/utilities/NetCDFUtilities.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/utilities/NetCDFUtilities.java
@@ -274,6 +274,8 @@ public class NetCDFUtilities {
     public static final String ENHANCE_SCALE_MISSING_DEFER = "org.geotools.coverage.io.netcdf.enhance.ScaleMissingDefer";
 
     public static boolean ENHANCE_SCALE_OFFSET = false;
+
+    public final static String STORE_NAME = "StoreName";
     
     /**
      * Number of bytes at the start of a file to search for a GRIB signature. Some GRIB files have WMO headers prepended by a telecommunications

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
@@ -65,7 +65,7 @@ import org.geotools.coverage.grid.io.footprint.MultiLevelROI;
 import org.geotools.coverage.grid.io.imageio.MaskOverviewProvider;
 import org.geotools.coverage.grid.io.imageio.MaskOverviewProvider.SpiHelper;
 import org.geotools.coverage.grid.io.imageio.ReadType;
-import org.geotools.data.DataUtilities;
+import org.geotools.data.Repository;
 import org.geotools.factory.Hints;
 import org.geotools.factory.Hints.Key;
 import org.geotools.geometry.GeneralEnvelope;
@@ -556,6 +556,11 @@ public class GranuleDescriptor {
                         "setAuxiliaryFilesPath");
                 updateReaderWithAuxiliaryPath(hints, reader, Utils.AUXILIARY_DATASTORE_PATH,
                         "setAuxiliaryDatastorePath");
+                if (hints.get(Hints.REPOSITORY) != null &&
+                        MethodUtils.getAccessibleMethod(reader.getClass(), "setRepository",
+                                new Class[]{Repository.class}) != null) {
+                    MethodUtils.invokeMethod(reader, "setRepository", hints.get(Hints.REPOSITORY));
+                }
                 return true;
             } catch (NoSuchMethodException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
The NetCDFImageReader initialization spends most of its time setting up the index datastore.
This pull request allows to use a repository provided datastore, thus allowing a pre-existing store to be used, thus dodging the expensive init. The machinery has been setup to that if available, it can use the GeoServer CatalogRepository already provided to the image mosaic for the image mosaic index. The
configuration parameter has the same name.