### PR TITLE
Add findOperations method to CoordinateOperationFactory to find all t…

### DIFF
--- a/modules/library/opengis/src/main/java/org/opengis/referencing/operation/CoordinateOperationFactory.java
+++ b/modules/library/opengis/src/main/java/org/opengis/referencing/operation/CoordinateOperationFactory.java
@@ -9,15 +9,17 @@
  */
 package org.opengis.referencing.operation;
 
-import java.util.Map;
-import org.opengis.referencing.ObjectFactory;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.parameter.ParameterValueGroup;
-import org.opengis.annotation.UML;
-import org.opengis.annotation.Extension;
+import static org.opengis.annotation.Specification.OGC_01009;
 
-import static org.opengis.annotation.Specification.*;
+import java.util.Map;
+import java.util.Set;
+
+import org.opengis.annotation.Extension;
+import org.opengis.annotation.UML;
+import org.opengis.parameter.ParameterValueGroup;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.ObjectFactory;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 
 /**
@@ -162,4 +164,19 @@ public interface CoordinateOperationFactory extends ObjectFactory {
                                         OperationMethod     method,
                                         ParameterValueGroup parameters)
             throws FactoryException;
+    
+    /**
+     * Returns all the available operations for conversion or transformation between two
+     * coordinate reference systems. An empty set is returned if no operation exists.
+     *
+     * @param  sourceCRS Input coordinate reference system.
+     * @param  targetCRS Output coordinate reference system.
+     * @return A set of coordinate operations from {@code sourceCRS} to {@code targetCRS}.
+     * @throws FactoryException if there was a failure retrieving or creating the operations.
+     */
+    @UML(identifier="createFromCoordinateSystems", specification=OGC_01009)
+    Set<CoordinateOperation> findOperations(CoordinateReferenceSystem sourceCRS,
+                                        CoordinateReferenceSystem targetCRS)
+            throws FactoryException;
+    
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/AbstractCoordinateOperationFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/AbstractCoordinateOperationFactory.java
@@ -538,6 +538,26 @@ public abstract class AbstractCoordinateOperationFactory extends ReferencingFact
     }
     
     /**
+     * Concatenate two operation steps. If an operation is an {@link #AXIS_CHANGES}, it will be included as part of the second operation instead of
+     * creating an {@link ConcatenatedOperation}. If a concatenated operation is created, it will get an automatically generated name.
+     *
+     * @param step1 The first step, or {@code null} for the identity operation.
+     * @param step2 The second step, or {@code null} for the identity operation.
+     * @return A concatenated operation, or {@code null} if all arguments was nul.
+     * @throws FactoryException if the operation can't be constructed.
+     */
+    protected Set<CoordinateOperation> concatenate(final Set<CoordinateOperation> candidatesStep1,
+            final Set<CoordinateOperation> candidatesStep2) throws FactoryException {
+        HashSet<CoordinateOperation> result = new HashSet<CoordinateOperation>();
+        for (CoordinateOperation step1 : candidatesStep1) {
+            for (CoordinateOperation step2 : candidatesStep2) {
+                result.add(concatenate(step1, step2));
+            }
+        }
+        return result;
+    }
+
+    /**
      * Concatenate two sets of operation steps. The result is the concatenation
      * of all the steps on the firt set with all the steps on the second set
      * (cartesian product), which will be then concatenated with all the steps

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/BufferedCoordinateOperationFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/BufferedCoordinateOperationFactory.java
@@ -17,19 +17,19 @@
 package org.geotools.referencing.operation;
 
 import java.util.Map;
+import java.util.Set;
 
+import org.geotools.factory.BufferedFactory;
+import org.geotools.factory.Hints;
+import org.geotools.referencing.ReferencingFactoryFinder;
+import org.geotools.util.SoftValueHashMap;
+import org.geotools.util.Utilities;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.CoordinateOperation;
 import org.opengis.referencing.operation.CoordinateOperationFactory;
 import org.opengis.referencing.operation.OperationMethod;
 import org.opengis.referencing.operation.OperationNotFoundException;
-
-import org.geotools.factory.Hints;
-import org.geotools.factory.BufferedFactory;
-import org.geotools.util.Utilities;
-import org.geotools.util.SoftValueHashMap;
-import org.geotools.referencing.ReferencingFactoryFinder;
 
 
 /**
@@ -260,6 +260,26 @@ public class BufferedCoordinateOperationFactory extends AbstractCoordinateOperat
         }
         return op;
     }
+    
+    /**
+     * Returns all available operations for conversion or transformation between two coordinate reference systems. The operation creation is delegated
+     * to the {@linkplain CoordinateOperationFactory coordinate operation factory} specified at construction time and the result is not cached.
+     *
+     * @param sourceCRS Input coordinate reference system.
+     * @param targetCRS Output coordinate reference system.
+     * @return A Set of coordinate operations from {@code sourceCRS} to {@code targetCRS}.
+     * @throws FactoryException if there was a failure retrieving or creating the operations.
+     */
+    @Override
+    public Set<CoordinateOperation> findOperations(final CoordinateReferenceSystem sourceCRS,
+                                               final CoordinateReferenceSystem targetCRS)
+            throws FactoryException
+    {
+        ensureNonNull("sourceCRS", sourceCRS);
+        ensureNonNull("targetCRS", targetCRS);
+        return getBackingFactory().findOperations(sourceCRS, targetCRS);
+    }
+
 
     /**
      * Returns an operation for conversion or transformation between two coordinate reference

--- a/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/factory/epsg/OperationFactoryTest.java
+++ b/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/factory/epsg/OperationFactoryTest.java
@@ -17,11 +17,8 @@
 package org.geotools.referencing.factory.epsg;
 
 import java.util.Iterator;
+import java.util.Set;
 import java.util.logging.Level;
-
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 
 import org.geotools.factory.Hints;
 import org.geotools.geometry.DirectPosition2D;
@@ -31,6 +28,7 @@ import org.geotools.referencing.ReferencingFactoryFinder;
 import org.geotools.referencing.operation.AbstractCoordinateOperation;
 import org.geotools.referencing.operation.AuthorityBackedFactory;
 import org.geotools.referencing.operation.BufferedCoordinateOperationFactory;
+import org.geotools.referencing.operation.TransformTestBase;
 import org.geotools.resources.Arguments;
 import org.geotools.resources.Classes;
 import org.opengis.geometry.DirectPosition;
@@ -42,7 +40,12 @@ import org.opengis.referencing.operation.ConcatenatedOperation;
 import org.opengis.referencing.operation.Conversion;
 import org.opengis.referencing.operation.CoordinateOperation;
 import org.opengis.referencing.operation.CoordinateOperationFactory;
+import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.Transformation;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 
 /**
@@ -209,4 +212,158 @@ public class OperationFactoryTest extends TestCase {
         assertEquals(expected.getOrdinate(0), arbitraryToInternal.getOrdinate(0), 1e-9);
         assertEquals(expected.getOrdinate(1), arbitraryToInternal.getOrdinate(1), 1e-9);
     }
+
+    /**
+     * Tests findOperations method for a pair of known CRSs. 23030 (Projected) to 4326 (geographic 2D) with different datum
+     */
+    public void testFindOperations1() throws Exception {
+        final CRSAuthorityFactory crsFactory;
+        final CoordinateOperationFactory opFactory;
+        CoordinateReferenceSystem sourceCRS;
+        CoordinateReferenceSystem targetCRS;
+
+        crsFactory = ReferencingFactoryFinder.getCRSAuthorityFactory("EPSG", null);
+        opFactory = ReferencingFactoryFinder.getCoordinateOperationFactory(null);
+        targetCRS = crsFactory.createCoordinateReferenceSystem("EPSG:4326");
+        sourceCRS = crsFactory.createCoordinateReferenceSystem("EPSG:23030");
+
+        Set<CoordinateOperation> operations = opFactory.findOperations(sourceCRS, targetCRS);
+        int size = operations.size();
+        assertTrue(size >= 37); // at least 37 operations should be registered in the database for this CRS pair
+
+        for (CoordinateOperation operation : operations) {
+            assertSame(sourceCRS, operation.getSourceCRS());
+            assertSame(targetCRS, operation.getTargetCRS());
+            final MathTransform transform = operation.getMathTransform();
+            TransformTestBase.assertInterfaced(transform);
+        }
+
+        // try reverse order
+        operations = opFactory.findOperations(targetCRS, sourceCRS);
+        assertEquals(size, operations.size());
+
+        for (CoordinateOperation operation : operations) {
+            assertSame(targetCRS, operation.getSourceCRS());
+            assertSame(sourceCRS, operation.getTargetCRS());
+            final MathTransform transform = operation.getMathTransform();
+            TransformTestBase.assertInterfaced(transform);
+        }
+
+    }
+
+    /**
+     * Tests findOperations method for a pair of known CRSs. 25830 (Projected) to 3035 (Projected), same datum
+     */
+    public void testFindOperations2() throws Exception {
+        final CRSAuthorityFactory crsFactory;
+        final CoordinateOperationFactory opFactory;
+        CoordinateReferenceSystem sourceCRS;
+        CoordinateReferenceSystem targetCRS;
+
+        crsFactory = ReferencingFactoryFinder.getCRSAuthorityFactory("EPSG", null);
+        opFactory = ReferencingFactoryFinder.getCoordinateOperationFactory(null);
+        targetCRS = crsFactory.createCoordinateReferenceSystem("EPSG:3035");
+        sourceCRS = crsFactory.createCoordinateReferenceSystem("EPSG:25830");
+
+        Set<CoordinateOperation> operations = opFactory.findOperations(sourceCRS, targetCRS);
+        int size = operations.size();
+        assertTrue(size == 1); // only one operation since they have the same datum
+
+        for (CoordinateOperation operation : operations) {
+            assertSame(sourceCRS, operation.getSourceCRS());
+            assertSame(targetCRS, operation.getTargetCRS());
+            final MathTransform transform = operation.getMathTransform();
+            TransformTestBase.assertInterfaced(transform);
+        }
+
+        // try reverse order
+        operations = opFactory.findOperations(targetCRS, sourceCRS);
+        assertEquals(size, operations.size());
+
+        for (CoordinateOperation operation : operations) {
+            assertSame(targetCRS, operation.getSourceCRS());
+            assertSame(sourceCRS, operation.getTargetCRS());
+            final MathTransform transform = operation.getMathTransform();
+            TransformTestBase.assertInterfaced(transform);
+        }
+
+    }
+
+    /**
+     * Tests findOperations method for a pair of known CRSs. 23030 (Projected) to 3034 (Projected), with different datum
+     * 
+     */
+    public void testFindOperations3() throws Exception {
+        final CRSAuthorityFactory crsFactory;
+        final CoordinateOperationFactory opFactory;
+        CoordinateReferenceSystem sourceCRS;
+        CoordinateReferenceSystem targetCRS;
+
+        crsFactory = ReferencingFactoryFinder.getCRSAuthorityFactory("EPSG", null);
+        opFactory = ReferencingFactoryFinder.getCoordinateOperationFactory(null);
+        targetCRS = crsFactory.createCoordinateReferenceSystem("EPSG:3034");
+        sourceCRS = crsFactory.createCoordinateReferenceSystem("EPSG:23030");
+
+        Set<CoordinateOperation> operations = opFactory.findOperations(sourceCRS, targetCRS);
+        int size = operations.size();
+        assertTrue(size >= 9); // at least 9 operation should be registered in the database for this CRS pair
+
+        for (CoordinateOperation operation : operations) {
+            assertSame(sourceCRS, operation.getSourceCRS());
+            assertSame(targetCRS, operation.getTargetCRS());
+            final MathTransform transform = operation.getMathTransform();
+            TransformTestBase.assertInterfaced(transform);
+        }
+
+        // try reverse order
+        operations = opFactory.findOperations(targetCRS, sourceCRS);
+        assertEquals(size, operations.size());
+
+        for (CoordinateOperation operation : operations) {
+            assertSame(targetCRS, operation.getSourceCRS());
+            assertSame(sourceCRS, operation.getTargetCRS());
+            final MathTransform transform = operation.getMathTransform();
+            TransformTestBase.assertInterfaced(transform);
+        }
+
+    }
+
+    /**
+     * Tests findOperations method for a pair of known CRSs. 4258 (Geographic2D) to 4326 (Geographic2D), with different datum
+     */
+    public void testFindOperations4() throws Exception {
+        final CRSAuthorityFactory crsFactory;
+        final CoordinateOperationFactory opFactory;
+        CoordinateReferenceSystem sourceCRS;
+        CoordinateReferenceSystem targetCRS;
+
+        crsFactory = ReferencingFactoryFinder.getCRSAuthorityFactory("EPSG", null);
+        opFactory = ReferencingFactoryFinder.getCoordinateOperationFactory(null);
+        targetCRS = crsFactory.createCoordinateReferenceSystem("EPSG:4326");
+        sourceCRS = crsFactory.createCoordinateReferenceSystem("EPSG:4258");
+
+        Set<CoordinateOperation> operations = opFactory.findOperations(sourceCRS, targetCRS);
+        int size = operations.size();
+        assertTrue(size >= 2); // at least 2 operation should be registered in the database for this CRS pair
+
+        for (CoordinateOperation operation : operations) {
+            assertSame(sourceCRS, operation.getSourceCRS());
+            assertSame(targetCRS, operation.getTargetCRS());
+            final MathTransform transform = operation.getMathTransform();
+            TransformTestBase.assertInterfaced(transform);
+        }
+
+        // try reverse order
+        operations = opFactory.findOperations(targetCRS, sourceCRS);
+        assertEquals(size, operations.size());
+
+        for (CoordinateOperation operation : operations) {
+            assertSame(targetCRS, operation.getSourceCRS());
+            assertSame(sourceCRS, operation.getTargetCRS());
+            final MathTransform transform = operation.getMathTransform();
+            TransformTestBase.assertInterfaced(transform);
+        }
+
+    }
+
 }


### PR DESCRIPTION
…he available operations from a source to a target CRS. It was only possible to get the default operation till now. New method signature:

    Set<CoordinateOperation> findOperations(CoordinateReferenceSystem sourceCRS,
                                        CoordinateReferenceSystem targetCRS)

The goal of the method is to be able to find all the available operations from a source to a target CRS (by contrast with the existing "createOperation" method, which only returns the default operation). This is particularly useful for CRSs having different datums, for which many operations are sometimes defined, producing very different results.