### PR TITLE
Enable GDAL on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ addons:
   apt:
     packages:
       - python-sphinx
-      - gdal-bin
+      - libgdal1h

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ addons:
   apt:
     packages:
       - python-sphinx
+      - gdal-bin


### PR DESCRIPTION
The current Travis CI setup for GeoTools doesn't actually run the OGR tests for neither Bridj nor JNI, they're are more or less silently skipped. This is because we're not installing the actual gdal shared object into the Travis container.

This small patch adresses this _partly_: It makes the Bridj tests run, but not the JNI tests:

> Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.444 sec - in org.geotools.data.ogr.bridj.BridjOGRDataStoreTest

I tried finding a relevant JIRA issue, but the closest I found was GEOT-4733. Hope you can use it!