### PR TITLE
[GEOT-5973] update MySql jdbc driver to a newer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -961,7 +961,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>5.1.17</version>
+        <version>5.1.40</version>
       </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -961,7 +961,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>5.1.40</version>
+        <version>5.1.46</version>
       </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
MySql driver updated to version 5.1.40
The pull request addresses the improvement proposed in jira issue  [[GEOT-5973]](https://osgeo-org.atlassian.net/browse/GEOT-5973)

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>