### PR TITLE
[GEOT-5986] SimplifyProcess: switch simplifiers

### DIFF
--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/SimplifyProcess.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/SimplifyProcess.java
@@ -110,10 +110,10 @@ public class SimplifyProcess implements VectorProcess {
             for (Object attribute : f.getAttributes()) {
                 if (attribute instanceof Geometry) {
                     if (preserveTopology) {
-                        attribute = DouglasPeuckerSimplifier.simplify((Geometry) attribute,
+                        attribute = TopologyPreservingSimplifier.simplify((Geometry) attribute,
                                 distance);
                     } else {
-                        attribute = TopologyPreservingSimplifier.simplify((Geometry) attribute,
+                        attribute = DouglasPeuckerSimplifier.simplify((Geometry) attribute,
                                 distance);
                     }
                 }


### PR DESCRIPTION
It seems that the two simplifiers in the `SimplifyProcess` class got mixed up. This commit fixes that.

I should note that I have just started working with your project and that therefore I did not know how to verify that `SimplifyProcess` really uses the wrong simplifier. I concluded that the simplifiers are mixed up only by reading the source code. So I *might* be wrong about this.