### PR TITLE
[GEOT-5983] App-Schema complex filter splitter doesn't take into account multiple nested attributes matches

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
@@ -320,6 +320,10 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
                         }
                     }
                 }
+            } else {
+                // we may have a direct match, so lets push this filter to the post stack right away
+                postStack.push(expression);
+                return null;
             }
         }
 


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-5983

Related PR:
https://github.com/geotools/geotools/pull/1846#issuecomment-377697840