### PR TITLE
WIP: make native styles available from ResourceInfo class

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/data/ResourceInfo.java
+++ b/modules/library/api/src/main/java/org/geotools/data/ResourceInfo.java
@@ -16,11 +16,14 @@
  */
 package org.geotools.data;
 
-import java.net.URI;
-import java.util.Set;
-
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
 
 
 /**
@@ -157,4 +160,21 @@ public interface ResourceInfo {
      * </p>
      */
     // ReferencedEnvelope getLatLongBbox();
+
+    /**
+     * @return list of native styles, if any.
+     */
+    List<String> getNativeStyles();
+
+    /**
+     * @return return the default native style, if there is one. For shapefiles, if the style exists, it is the default one.
+     */
+    StyledLayerDescriptor getDefaultStyle() throws IOException;
+
+    /**
+     * @param name of the native style.
+     * @return return the native style called name.
+     */
+    StyledLayerDescriptor getNativeStyle(String name) throws IOException;
+
 }

--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureSource.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureSource.java
@@ -17,12 +17,16 @@
 package org.geotools.data.memory;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import org.geotools.data.FeatureReader;
 import org.geotools.data.Query;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.Style;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -98,6 +102,22 @@ public class MemoryFeatureSource extends ContentFeatureSource {
     @Override
     protected SimpleFeatureType buildFeatureType() {
         return getState().getEntry().schema; // cache schema unchanged (as we do not retype/reproject)
+    }
+
+    @Override
+    protected List<String> getNativeStyles() {
+        List<String> emptyList = Collections.emptyList();
+        return emptyList;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getDefaultStyle() {
+        return null;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getNativeStyle(String name) {
+        return null;
     }
 
     @Override

--- a/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureStore.java
+++ b/modules/library/data/src/main/java/org/geotools/data/memory/MemoryFeatureStore.java
@@ -16,8 +16,6 @@
  */
 package org.geotools.data.memory;
 
-import java.io.IOException;
-
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureWriter;
 import org.geotools.data.Query;
@@ -26,9 +24,14 @@ import org.geotools.data.Transaction;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureStore;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 public class MemoryFeatureStore extends ContentFeatureStore {
     
@@ -105,4 +108,21 @@ public class MemoryFeatureStore extends ContentFeatureStore {
             }
         };
     }
+
+    @Override
+    protected List<String> getNativeStyles() {
+        List<String> emptyList = Collections.emptyList();
+        return emptyList;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getDefaultStyle() {
+        return null;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getNativeStyle(String name) {
+        return null;
+    }
+
 }

--- a/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
+++ b/modules/library/data/src/main/java/org/geotools/data/store/ContentFeatureSource.java
@@ -16,21 +16,6 @@
  */
 package org.geotools.data.store;
 
-import java.awt.RenderingHints;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.geotools.data.DataUtilities;
 import org.geotools.data.Diff;
 import org.geotools.data.DiffFeatureReader;
@@ -66,6 +51,7 @@ import org.geotools.filter.function.Collection_MinFunction;
 import org.geotools.filter.function.Collection_SumFunction;
 import org.geotools.filter.function.Collection_UniqueFunction;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.geotools.util.NullProgressListener;
 import org.opengis.feature.Feature;
 import org.opengis.feature.FeatureVisitor;
@@ -80,6 +66,21 @@ import org.opengis.filter.identity.FeatureId;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.geometry.BoundingBox;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.awt.*;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 /**
@@ -247,7 +248,7 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
      * @return description of features contents
      */
     public ResourceInfo getInfo() {
-        return new ResourceInfo(){
+        return new ResourceInfo() {
             final Set<String> words = new HashSet<String>();
             {
                 words.add("features");
@@ -291,7 +292,27 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
                 Name name = ContentFeatureSource.this.getSchema().getName();
                 return name.getLocalPart();
             }
-            
+
+            public List<String> getNativeStyles() {
+                List<String> styles = ContentFeatureSource.this.getNativeStyles();
+                return styles;
+            }
+
+            public StyledLayerDescriptor getDefaultStyle() {
+                StyledLayerDescriptor result = null;
+                try {
+                    result = ContentFeatureSource.this.getNativeStyle("");
+                } catch (Exception e) {
+                    // do nothing
+                }
+                return result;
+            }
+
+            public StyledLayerDescriptor getNativeStyle(String name) throws IOException {
+                StyledLayerDescriptor style = ContentFeatureSource.this.getNativeStyle(name);
+                return style;
+            }
+
         };
     }
     
@@ -481,7 +502,26 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
      * method.
      */
     protected abstract ReferencedEnvelope getBoundsInternal(Query query) throws IOException;
-    
+
+    /**
+     * Returns the list of available native styles, if any.
+     * Subclasses must implement this method.
+     */
+    protected abstract List<String> getNativeStyles();
+
+    /**
+     * @return The default native style
+     * Subclasses must implement this method.
+     */
+    protected abstract StyledLayerDescriptor getDefaultStyle();
+
+    /**
+     * @param name of the style to get
+     * @return The named native style
+     * Subclasses must implement this method.
+     */
+    protected abstract StyledLayerDescriptor getNativeStyle(String name) throws IOException;
+
     /**
      * Returns the count of the number of features of the feature source.
      * <p>

--- a/modules/library/data/src/test/java/org/geotools/data/store/AbstractContentTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/store/AbstractContentTest.java
@@ -16,10 +16,8 @@
  */
 package org.geotools.data.store;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.NoSuchElementException;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.LineString;
 
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureWriter;
@@ -30,13 +28,17 @@ import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.LineString;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 public abstract class AbstractContentTest {
 
@@ -174,6 +176,22 @@ public abstract class AbstractContentTest {
         protected FeatureWriter<SimpleFeatureType, SimpleFeature> getWriterInternal(Query query,
                 int flags) throws IOException {
             return new MockSimpleFeatureWriter();
+        }
+
+        @Override
+        protected List<String> getNativeStyles() {
+            List<String> emptyList = Collections.emptyList();
+            return emptyList;
+        }
+
+        @Override
+        protected StyledLayerDescriptor getDefaultStyle() {
+            return null;
+        }
+
+        @Override
+        protected StyledLayerDescriptor getNativeStyle(String name) {
+            return null;
         }
 
     }

--- a/modules/library/data/src/test/java/org/geotools/data/store/ContentFeatureSourceTest.java
+++ b/modules/library/data/src/test/java/org/geotools/data/store/ContentFeatureSourceTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.geotools.data.DataStore;
@@ -34,6 +35,8 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.Style;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -157,6 +160,23 @@ public class ContentFeatureSourceTest {
                     protected boolean canSort() {
                         return false;
                     }
+
+                    @Override
+                    protected List<String> getNativeStyles() {
+                        List<String> emptyList = Collections.emptyList();
+                        return emptyList;
+                    }
+
+                    @Override
+                    protected StyledLayerDescriptor getDefaultStyle() {
+                        return null;
+                    }
+
+                    @Override
+                    protected StyledLayerDescriptor getNativeStyle(String name) {
+                        return null;
+                    }
+
                 };
             }
 

--- a/modules/library/jdbc/pom.xml
+++ b/modules/library/jdbc/pom.xml
@@ -139,6 +139,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.geotools.xsd</groupId>
+          <artifactId>gt-xsd-sld</artifactId>
+          <version>20-SNAPSHOT</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureStore.java
@@ -16,15 +16,10 @@
  */
 package org.geotools.jdbc;
 
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import com.vividsolutions.jts.geom.Geometry;
 
 import org.geotools.data.FeatureEvent;
+import org.geotools.data.FeatureEvent.Type;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureWriter;
 import org.geotools.data.FilteringFeatureWriter;
@@ -32,12 +27,12 @@ import org.geotools.data.Query;
 import org.geotools.data.QueryCapabilities;
 import org.geotools.data.ResourceInfo;
 import org.geotools.data.Transaction;
-import org.geotools.data.FeatureEvent.Type;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureStore;
 import org.geotools.data.store.ContentState;
 import org.geotools.factory.Hints;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -45,7 +40,14 @@ import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 
-import com.vividsolutions.jts.geom.Geometry;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 
 /**
@@ -447,4 +449,21 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
             }
         }
     }
+
+    @Override
+    protected List<String> getNativeStyles() {
+        List<String> emptyList = Collections.emptyList();
+        return emptyList;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getDefaultStyle() {
+        return null;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getNativeStyle(String name) {
+        return null;
+    }
+
 }

--- a/modules/library/main/src/main/java/org/geotools/data/DefaultResourceInfo.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DefaultResourceInfo.java
@@ -16,12 +16,15 @@
  */
 package org.geotools.data;
 
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.Style;
+import org.geotools.styling.StyledLayerDescriptor;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
 import java.net.URI;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * Default implementation of ResourceInfo; a simple java bean.
@@ -41,6 +44,8 @@ public class DefaultResourceInfo implements ResourceInfo {
     private String description;
     private CoordinateReferenceSystem crs;
     private ReferencedEnvelope bounds;
+    private List<String> styles;
+    private Style defaultStyle;
 
     public DefaultResourceInfo(){        
     }
@@ -56,6 +61,7 @@ public class DefaultResourceInfo implements ResourceInfo {
         this.description = copy.getDescription();
         this.crs = copy.getCRS();
         this.bounds = copy.getBounds();                
+        this.styles = copy.getNativeStyles();
     }
     /**
      * @return the title
@@ -105,6 +111,25 @@ public class DefaultResourceInfo implements ResourceInfo {
     public CoordinateReferenceSystem getCRS() {
         return crs;
     }
+
+    /**
+     * @return the list of available native styles, if any
+     */
+    public List<String> getNativeStyles() {
+        return styles;
+    }
+
+
+    /**
+     * @return the default native style, if any.
+     */
+    public StyledLayerDescriptor getDefaultStyle() { return null; }
+
+    /**
+     * @param name of the style to get.
+     * @return the native style, if any.
+     */
+    public StyledLayerDescriptor getNativeStyle(String name) { return null; }
 
     /**
      * @param crs the crs to set

--- a/modules/library/main/src/main/java/org/geotools/data/view/DefaultView.java
+++ b/modules/library/main/src/main/java/org/geotools/data/view/DefaultView.java
@@ -16,15 +16,6 @@
  */
 package org.geotools.data.view;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import org.geotools.data.DataSourceException;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataUtilities;
@@ -43,11 +34,22 @@ import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.SchemaException;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * Wrapper for SimpleFeatureSource constrained by a Query.
@@ -515,7 +517,20 @@ public class DefaultView implements SimpleFeatureSource {
                 Name name = DefaultView.this.getSchema().getName();
                 return name.getLocalPart();
             }
-            
+
+            public StyledLayerDescriptor getDefaultStyle()  {
+                return null;
+            }
+
+            public List<String> getNativeStyles() {
+                List<String> emptyList = Collections.emptyList();
+                return emptyList;
+            }
+
+            public StyledLayerDescriptor getNativeStyle(String styleName) {
+                return null;
+            }
+
         };
     }
     

--- a/modules/library/sample-data/src/main/resources/org/geotools/test-data/shapes/statepop.sld
+++ b/modules/library/sample-data/src/main/resources/org/geotools/test-data/shapes/statepop.sld
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>USA states population</Name>
+    <UserStyle>
+      <Name>population</Name>
+      <Title>Population in the United States</Title>
+      <Abstract>A sample filter that filters the United States into three
+        categories of population, drawn in different colors</Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <Title>&lt; 2M</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsLessThan>
+             <ogc:PropertyName>PERSONS</ogc:PropertyName>
+             <ogc:Literal>2000000</ogc:Literal>
+            </ogc:PropertyIsLessThan>
+          </ogc:Filter>
+          <PolygonSymbolizer>
+             <Fill>
+                <GraphicFill>
+                <Graphic>
+                  <Mark>
+                    <WellKnownName>shape://slash</WellKnownName>
+                    <Stroke>
+                      <CssParameter name="stroke">0xAAAAAA</CssParameter>
+                    </Stroke>
+                  </Mark>
+                  <Size>16</Size>
+                </Graphic>
+              </GraphicFill>
+             </Fill>     
+          </PolygonSymbolizer>
+        </Rule>
+        <Rule>
+          <Title>2M - 4M</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsBetween>
+              <ogc:PropertyName>PERSONS</ogc:PropertyName>
+              <ogc:LowerBoundary>
+                <ogc:Literal>2000000</ogc:Literal>
+              </ogc:LowerBoundary>
+              <ogc:UpperBoundary>
+                <ogc:Literal>4000000</ogc:Literal>
+              </ogc:UpperBoundary>
+            </ogc:PropertyIsBetween>
+          </ogc:Filter>
+          <PolygonSymbolizer>
+             <Fill>
+                <GraphicFill>
+                <Graphic>
+                  <Mark>
+                    <WellKnownName>shape://slash</WellKnownName>
+                    <Stroke>
+                      <CssParameter name="stroke">0xAAAAAA</CssParameter>
+                    </Stroke>
+                  </Mark>
+                  <Size>8</Size>
+                </Graphic>
+              </GraphicFill>
+             </Fill>     
+          </PolygonSymbolizer>
+        </Rule>
+        <Rule>
+          <Title>&gt; 4M</Title>
+          <!-- like a linesymbolizer but with a fill too -->
+          <ogc:Filter>
+            <ogc:PropertyIsGreaterThan>
+             <ogc:PropertyName>PERSONS</ogc:PropertyName>
+             <ogc:Literal>4000000</ogc:Literal>
+            </ogc:PropertyIsGreaterThan>
+          </ogc:Filter>
+          <PolygonSymbolizer>
+             <Fill>
+             <GraphicFill>
+                <Graphic>
+                  <Mark>
+                    <WellKnownName>shape://slash</WellKnownName>
+                    <Stroke>
+                      <CssParameter name="stroke">0xAAAAAA</CssParameter>
+                    </Stroke>
+                  </Mark>
+                  <Size>4</Size>
+                </Graphic>
+              </GraphicFill>   
+              </Fill>
+          </PolygonSymbolizer>
+        </Rule>
+        <Rule>
+          <Title>Boundary</Title>
+          <LineSymbolizer>
+            <Stroke />
+          </LineSymbolizer>
+          <TextSymbolizer>
+            <Label>
+              <ogc:PropertyName>STATE_ABBR</ogc:PropertyName>
+            </Label>
+            <Font>
+              <CssParameter name="font-family">Times New Roman</CssParameter>
+              <CssParameter name="font-style">Normal</CssParameter>
+              <CssParameter name="font-size">14</CssParameter>
+            </Font>
+            <LabelPlacement>
+              <PointPlacement>
+                <AnchorPoint>
+                  <AnchorPointX>0.5</AnchorPointX>
+                  <AnchorPointY>0.5</AnchorPointY>
+                </AnchorPoint>
+              </PointPlacement>
+            </LabelPlacement>
+            <Halo>
+              <Radius>2</Radius>
+              <Fill>
+                <CssParameter name="fill">0xFFFFFF</CssParameter>
+              </Fill>
+            </Halo>
+          </TextSymbolizer>
+        </Rule>
+     </FeatureTypeStyle>
+    </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/modules/plugin/property/src/main/java/org/geotools/data/property/PropertyFeatureSource.java
+++ b/modules/plugin/property/src/main/java/org/geotools/data/property/PropertyFeatureSource.java
@@ -20,6 +20,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.geotools.data.DataSourceException;
@@ -33,6 +35,7 @@ import org.geotools.factory.Hints;
 import org.geotools.feature.SchemaException;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.geometry.jts.WKTReader2;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -187,4 +190,21 @@ public class PropertyFeatureSource extends ContentFeatureSource {
     protected boolean handleVisitor(Query query, FeatureVisitor visitor) throws IOException {
         return super.handleVisitor(query, visitor);
     }
+
+    @Override
+    protected List<String> getNativeStyles() {
+        List<String> emptyList = Collections.emptyList();
+        return emptyList;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getDefaultStyle() {
+        return null;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getNativeStyle(String name) {
+        return null;
+    }
+
 }

--- a/modules/plugin/property/src/main/java/org/geotools/data/property/PropertyFeatureStore.java
+++ b/modules/plugin/property/src/main/java/org/geotools/data/property/PropertyFeatureStore.java
@@ -17,6 +17,8 @@
 package org.geotools.data.property;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.geotools.data.FeatureReader;
@@ -30,6 +32,7 @@ import org.geotools.data.store.ContentFeatureStore;
 import org.geotools.data.store.ContentState;
 import org.geotools.factory.Hints;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.type.Name;
 import org.opengis.feature.simple.SimpleFeature;
@@ -164,4 +167,21 @@ public class PropertyFeatureStore extends ContentFeatureStore {
     public QueryCapabilities getQueryCapabilities() {
         return delegate.getQueryCapabilities();
     }
+
+    @Override
+    protected List<String> getNativeStyles() {
+        List<String> emptyList = Collections.emptyList();
+        return emptyList;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getDefaultStyle() {
+        return null;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getNativeStyle(String name) {
+        return null;
+    }
+
 }

--- a/modules/plugin/shapefile/pom.xml
+++ b/modules/plugin/shapefile/pom.xml
@@ -168,6 +168,11 @@
         <artifactId>commons-io</artifactId>
         <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.geotools.xsd</groupId>
+          <artifactId>gt-xsd-sld</artifactId>
+          <version>20-SNAPSHOT</version>
+      </dependency>
   </dependencies>
 
 </project>

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -17,19 +17,17 @@
 package org.geotools.data.shapefile;
 
 import static org.geotools.data.shapefile.files.ShpFileType.SHP;
+import static org.geotools.data.shapefile.files.ShpFileType.SLD;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.MultiLineString;
+import com.vividsolutions.jts.geom.MultiPoint;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
 
 import org.geotools.data.CloseableIterator;
 import org.geotools.data.DataSourceException;
@@ -63,7 +61,10 @@ import org.geotools.filter.visitor.ExtractBoundsFilterVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.renderer.ScreenMap;
 import org.geotools.resources.Classes;
+import org.geotools.sld.SLDConfiguration;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.Parser;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -84,16 +85,25 @@ import org.opengis.filter.spatial.Touches;
 import org.opengis.filter.temporal.TOverlaps;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * A {@link FeatureSource} for shapefiles based on {@link ContentFeatureSource}
@@ -597,6 +607,69 @@ class ShapefileFeatureSource extends ContentFeatureSource {
     @Override
     protected boolean handleVisitor(Query query, FeatureVisitor visitor) throws IOException {
         return super.handleVisitor(query, visitor);
+    }
+
+    @Override
+    protected List<String> getNativeStyles() {
+        List<String> list = new ArrayList<>();
+        if (this.shpFiles.exists(SLD)) {
+            list.add(this.shpFiles.getTypeName());
+        }
+        return list;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getDefaultStyle() {
+        StyledLayerDescriptor result = null;
+        try {
+            result = getNativeStyle("");
+        } catch (Exception e) {
+            // do nothing
+        }
+        return result;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getNativeStyle(String name) throws IOException {
+        ReadableByteChannel in = null;
+        try {
+            ByteBuffer buffer = ByteBuffer.allocate(4*1024);
+            FileReader reader = new FileReader() {
+                public String id() {
+                    return "Shapefile's getStyle method to read sidecar style file";
+                }
+            };
+            in = this.shpFiles.getReadChannel(SLD, reader);
+            try {
+                String sldstr = "";
+                while (in.read(buffer) > 0) {
+                    buffer.flip();
+                    sldstr += StandardCharsets.UTF_8.decode(buffer).toString();
+                    buffer.clear();
+                }
+                InputStream stream = new ByteArrayInputStream(sldstr.getBytes(StandardCharsets.UTF_8));
+                SLDConfiguration configuration = new SLDConfiguration();
+                Parser parser = new Parser(configuration);
+                StyledLayerDescriptor sld = (StyledLayerDescriptor) parser.parse(stream);
+                return sld;
+            } finally {
+                in.close();
+            }
+        } catch (IOException ioe) {
+            throw new DataSourceException("Problem getting style file " + this.shpFiles.get(SLD), ioe);
+        } catch (SAXException saxe) {
+            throw new DataSourceException("Problem getting style file " + this.shpFiles.get(SLD), saxe);
+        } catch (ParserConfigurationException pce) {
+            throw new DataSourceException("Problem getting style file " + this.shpFiles.get(SLD), pce);
+        } finally {
+            try {
+                if (in != null) {
+                    in.close();
+                }
+            } catch (IOException ioe) {
+                // do nothing
+            }
+        }
     }
 
 }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
@@ -17,6 +17,8 @@
 package org.geotools.data.shapefile;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.geotools.data.FeatureReader;
@@ -32,6 +34,8 @@ import org.geotools.data.store.ContentFeatureStore;
 import org.geotools.data.store.ContentState;
 import org.geotools.factory.Hints.Key;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.styling.Style;
+import org.geotools.styling.StyledLayerDescriptor;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -172,5 +176,21 @@ class ShapefileFeatureStore extends ContentFeatureStore {
     protected boolean handleVisitor(Query query, FeatureVisitor visitor) throws IOException {
         return delegate.handleVisitor(query, visitor);
     }
-    
+
+    @Override
+    protected List<String> getNativeStyles() {
+        List<String> emptyList = Collections.emptyList();
+        return emptyList;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getDefaultStyle() {
+        return null;
+    }
+
+    @Override
+    protected StyledLayerDescriptor getNativeStyle(String name) {
+        return null;
+    }
+
 }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/files/ShpFileType.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/files/ShpFileType.java
@@ -56,6 +56,10 @@ public enum ShpFileType {
      */
     FIX("fix"),
     /**
+     * the .sld file with styling (SLD or SE)
+     */
+    SLD("sld"),
+    /**
      * the .shp.xml file, it contains the metadata about the shapefile
      */
     SHP_XML("shp.xml");

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileWithSideCarStyleFileTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileWithSideCarStyleFileTest.java
@@ -1,0 +1,80 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.shapefile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.geotools.TestData;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.FileDataStore;
+import org.geotools.data.FileDataStoreFinder;
+import org.geotools.data.ResourceInfo;
+import org.geotools.styling.NamedLayer;
+import org.geotools.styling.Style;
+import org.geotools.styling.StyledLayerDescriptor;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.List;
+
+/**
+ * @author Jorge Gustavo Rocha
+ * @version $Id$
+ * @source $URL$
+ */
+public class ShapefileWithSideCarStyleFileTest extends TestCaseSupport {
+
+    public final String STATEPOP = "shapes/statepop.shp";
+    public final String POINTTEST = "shapes/pointtest.shp";
+
+    @Test
+    public void testNoDefaultStyle() throws Exception {
+        final URL url = TestData.url(POINTTEST);
+        FileDataStore store = FileDataStoreFinder.getDataStore(url);
+        FeatureSource featureSource = store.getFeatureSource();
+        ResourceInfo rinfo = featureSource.getInfo();
+        StyledLayerDescriptor styledld = rinfo.getDefaultStyle();
+        assertNull(styledld);
+    }
+
+    @Test
+    public void testGetNativeStyles() throws Exception {
+        final URL url = TestData.url(STATEPOP);
+        FileDataStore store = FileDataStoreFinder.getDataStore(url);
+        FeatureSource featureSource = store.getFeatureSource();
+        ResourceInfo rinfo = featureSource.getInfo();
+        List<String> nativeStylesList = rinfo.getNativeStyles();
+        assertEquals(1, nativeStylesList.size());
+        assertEquals("statepop", nativeStylesList.get(0));
+    }
+
+    @Test
+    public void testGetDefaultStyle() throws Exception {
+        final URL url = TestData.url(STATEPOP);
+        FileDataStore store = FileDataStoreFinder.getDataStore(url);
+        FeatureSource featureSource = store.getFeatureSource();
+        ResourceInfo rinfo = featureSource.getInfo();
+        StyledLayerDescriptor styledld = rinfo.getDefaultStyle();
+        assertNotNull(styledld);
+        NamedLayer nlayer = (NamedLayer) styledld.getStyledLayers()[0];
+        Style style = nlayer.getStyles()[0];
+        assertEquals("population", style.getName());
+    }
+
+}


### PR DESCRIPTION
This PR results from the [ResourceInfo with native style](https://github.com/geotools/geotools/wiki/ResourceInfo-with-native-style) proposal.

This adds 3 new methods to `ResourceInfo` class, as discussed in the proposal.

```java
    public interface ResourceInfo {
       StyledLayerDescriptor getDefaultStyle() {
          return null;
       }
       List<String> getNativeStyles(){
          return Collections.emptyList();
       }
       StyledLayerDescriptor getNativeStyle(String name) {
          return null;
       }
    }
```

The proposal is still under discussion. **Comments are very welcome.**

I've added one initial unit test regarding shapefiles with side car SLD, which is: `modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileWithSideCarStyleFileTest.java`.
I can add similar tests for geopackage and postgis datastores, if this test is ok.

![suricate-and-their-babies](https://user-images.githubusercontent.com/163681/38277264-b94f8e62-378f-11e8-8013-72ec41b0c919.jpg)

This is my first PR to Geotools. Please by gentle :-)
