### PR TITLE
[GEOT-5990] Oracle: Ignore spatial index statistics tables

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -459,6 +459,8 @@ public class OracleDialect extends PreparedStatementSQLDialect {
             return false;
         } else if (tableName.startsWith("DM$"))  {
             return false;
+        } else if (tableName.startsWith("MDXT_") && (tableName.endsWith("$_BKTS") || tableName.endsWith("$_MBR"))) {
+            return false;
         } 
         
         return true;

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDataStoreAPIOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDataStoreAPIOnlineTest.java
@@ -56,4 +56,19 @@ public class OracleDataStoreAPIOnlineTest extends JDBCDataStoreAPIOnlineTest {
         SequencedPrimaryKeyColumn seqPk = (SequencedPrimaryKeyColumn) pk;
         assertEquals("ROAD_FID_SEQ", seqPk.getSequenceName());
     }
+
+    /**
+     * Test if tables that should be hidden are absent in the list of type names.
+     *
+     * @throws IOException if any
+     * @see org.geotools.data.oracle.OracleDialect#includeTable(String, String, java.sql.Connection)
+     */
+    public void testHiddenTables() throws IOException {
+        String[] typenames = dataStore.getTypeNames();
+        for (String name:typenames) {
+            assertFalse("Name should not end with 'MDXT_'",name.startsWith("MDXT_"));
+            assertFalse("Name should not end with '$_BKTS'",name.endsWith("$_BKTS"));
+            assertFalse("Name should not end with '$'",name.endsWith("$"));
+        }
+    }
 }

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDataStoreAPITestSetup.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleDataStoreAPITestSetup.java
@@ -45,6 +45,8 @@ public class OracleDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
         run("INSERT INTO lake (fid,id,geom,name) VALUES (lake_fid_seq.nextval, 0,"
             + "MDSYS.SDO_GEOMETRY( 2003, 4326, NULL, SDO_ELEM_INFO_ARRAY(1,1003,1), "
             + "SDO_ORDINATE_ARRAY(12,6, 14,8, 16,6, 16,4, 14,4, 12,6)), 'muddy')");
+        
+        run ("ANALYZE INDEX LAKE_GEOM_IDX compute statistics");
     }
     
 
@@ -67,6 +69,8 @@ public class OracleDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
         run("INSERT INTO river (fid, id,geom,river, flow ) VALUES (river_fid_seq.nextval, 1,"
                 + "MDSYS.SDO_GEOMETRY( 2002, 4326, NULL, MDSYS.SDO_ELEM_INFO_ARRAY(1,2,1), "
                 + "MDSYS.SDO_ORDINATE_ARRAY(4,6, 4,8, 6,10))," + "'rv2', 3.0)");
+        
+        run ("ANALYZE INDEX RIVER_GEOM_IDX compute statistics");
     }
 
     @Override
@@ -91,6 +95,8 @@ public class OracleDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
         run("INSERT INTO road (fid,id,geom,name) VALUES (road_fid_seq.nextval, 3,"
                 + "MDSYS.SDO_GEOMETRY( 2002, 4326, NULL, MDSYS.SDO_ELEM_INFO_ARRAY(1,2,1), "
                 + "MDSYS.SDO_ORDINATE_ARRAY(3,2, 4,2, 5,3))," + "'r3')");
+
+        run ("ANALYZE INDEX ROAD_GEOM_IDX compute statistics");
     }
 
     @Override


### PR DESCRIPTION
This will ignore oracle spatial index statistics tables which have the form of `MDXT_<nnnn>$BKTS` and `MDXT<nnnn>$_MBR` eg. `MDXT_F9E0E$_BKTS` and `MDXT_F9E0E$_MBR`

fixes [GEOT-5990](https://osgeo-org.atlassian.net/browse/GEOT-5990)