### PR TITLE
[GEOT-5999] gt-wmts WMTSTile GetTile request casing

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/client/WMTSTile.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/client/WMTSTile.java
@@ -171,7 +171,7 @@ class WMTSTile extends Tile {
         HashMap<String, Object> params = new HashMap<>();
         params.put("service", "WMTS");
         params.put("version", "1.0.0");
-        params.put("request", "getTile");
+        params.put("request", "GetTile");
         params.put("layer", service.getLayerName());
         params.put("style", service.getStyleName());
         params.put("format", service.getFormat());


### PR DESCRIPTION
Concerning the class org.geotools.data.wmts.client.WMTSTile in the extesion gt-wmts:
This class sends a GetTile request as KVP to the WMTS server with request value 'getTile' instead of 'GetTile'.
The convention is to use 'GetTile'.