### PR TITLE
[GEOT-5920] WFSClient fails when a function is used in a query

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/test/XMLTestSupport.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/test/XMLTestSupport.java
@@ -312,7 +312,7 @@ public abstract class XMLTestSupport extends TestCase {
         }
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        encoder.write(object, element, output);
+        encoder.encode(object, element, output);
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);

--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
@@ -112,6 +112,10 @@ public class OGCPropertyIsLikeTypeBinding extends AbstractComplexBinding {
             return isLike.getExpression();
         }
 
+        if (OGC.PropertyName.equals(name)) {
+            return isLike.getExpression();
+        }
+        
         if (OGC.Literal.equals(name)) {
             return isLike.getLiteral() != null ? factory.literal(isLike.getLiteral()) : null;
         }

--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
@@ -22,6 +22,7 @@ import org.geotools.xml.ElementInstance;
 import org.geotools.xml.Node;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 
@@ -82,8 +83,9 @@ public class OGCPropertyIsLikeTypeBinding extends AbstractComplexBinding {
      *
      * @generated modifiable
      */
-    public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
-        PropertyName name = (PropertyName) node.getChildValue(PropertyName.class);
+    public Object parse(ElementInstance instance, Node node, Object value)
+        throws Exception {
+        Expression name = (Expression) node.getChildValue(Expression.class);
         Literal literal = (Literal) node.getChildValue(Literal.class);
 
         String wildcard = (String) node.getAttributeValue("wildCard");

--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
@@ -108,7 +108,7 @@ public class OGCPropertyIsLikeTypeBinding extends AbstractComplexBinding {
     public Object getProperty(Object object, QName name) throws Exception {
         PropertyIsLike isLike = (PropertyIsLike) object;
 
-        if (OGC.PropertyName.equals(name)) {
+        if (OGC.expression.equals(name)) {
             return isLike.getExpression();
         }
 

--- a/modules/extension/xsd/xsd-filter/src/main/resources/org/geotools/filter/v1_0/filter.xsd
+++ b/modules/extension/xsd/xsd-filter/src/main/resources/org/geotools/filter/v1_0/filter.xsd
@@ -74,7 +74,7 @@
 		<xsd:complexContent>
 			<xsd:extension base="ogc:ComparisonOpsType">
 				<xsd:sequence>
-					<xsd:element ref="ogc:PropertyName"/>
+					<xsd:element ref="ogc:expression"/>
 					<xsd:element ref="ogc:Literal"/>
 				</xsd:sequence>
 				<xsd:attribute name="wildCard" type="xsd:string" use="required"/>

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
@@ -191,7 +191,7 @@ public class BinaryComparisonOpTypeBindingTest extends FilterTestSupport {
         PropertyIsGreaterThan equalTo = FilterMockData.propertyFuncIsGreaterThan();
 
         Document dom = encode(equalTo, OGC.PropertyIsGreaterThan);
-        print(dom);
+        
         assertEquals(1,
             dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart()).getLength());
         assertEquals(1,

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
@@ -180,13 +180,22 @@ public class BinaryComparisonOpTypeBindingTest extends FilterTestSupport {
         PropertyIsGreaterThan equalTo = FilterMockData.propertyIsGreaterThan();
 
         Document dom = encode(equalTo, OGC.PropertyIsGreaterThan);
-        assertEquals(
-                1,
-                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart())
-                        .getLength());
-        assertEquals(
-                1,
-                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+        
+        assertEquals(1,
+            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart()).getLength());
+        assertEquals(1,
+            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+    }
+    
+    public void testPropertyFunctionIsGreaterThanEncode() throws Exception {
+        PropertyIsGreaterThan equalTo = FilterMockData.propertyFuncIsGreaterThan();
+
+        Document dom = encode(equalTo, OGC.PropertyIsGreaterThan);
+        print(dom);
+        assertEquals(1,
+            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart()).getLength());
+        assertEquals(1,
+            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
     }
 
     public void testPropertyIsGreaterThanOrEqualToType() {

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
@@ -37,6 +37,7 @@ import org.opengis.filter.PropertyIsNotEqualTo;
 import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.expression.Add;
 import org.opengis.filter.expression.Divide;
+import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.Multiply;
@@ -80,6 +81,11 @@ public class FilterMockData {
 
     static PropertyName propertyName() {
         return propertyName("foo");
+    }
+    
+    private static Expression propertyNameFunc() {
+
+        return f.function("strToLowerCase", propertyName("foo"));
     }
 
     static PropertyName propertyName(String property) {
@@ -193,6 +199,12 @@ public class FilterMockData {
     static PropertyIsLike propertyIsLike() {
         return f.like(propertyName(), "foo", "x", "y", "z");
     }
+    
+    static PropertyIsLike propertyIsLike2() {
+        return f.like(propertyNameFunc(), "strToLowerCase(STATE_NAME)", "x", "y", "z");
+    }
+
+   
 
     static Element propertyIsLike(Document document, Node parent) {
         Element isLike = element(document, parent, OGC.PropertyIsLike);

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
@@ -83,7 +83,7 @@ public class FilterMockData {
         return propertyName("foo");
     }
     
-    private static Expression propertyNameFunc() {
+    private static Expression propertyNameIsFunc() {
 
         return f.function("strToLowerCase", propertyName("foo"));
     }
@@ -151,6 +151,10 @@ public class FilterMockData {
         return f.greater(propertyName(), literal());
     }
 
+    static PropertyIsGreaterThan propertyFuncIsGreaterThan() {
+        return f.greater(propertyNameIsFunc(), literal());
+    }
+    
     static Element propertyIsGreaterThanOrEqualTo(Document document, Node parent) {
         return binaryComparisonOp(document, parent, OGC.PropertyIsGreaterThanOrEqualTo);
     }
@@ -201,7 +205,7 @@ public class FilterMockData {
     }
     
     static PropertyIsLike propertyIsLike2() {
-        return f.like(propertyNameFunc(), "strToLowerCase(STATE_NAME)", "x", "y", "z");
+        return f.like(propertyNameIsFunc(), "foo", "x", "y", "z");
     }
 
    

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
@@ -205,7 +205,9 @@ public class FilterMockData {
     }
     
     static PropertyIsLike propertyIsLike2() {
-        return f.like(propertyNameIsFunc(), "foo", "x", "y", "z");
+        PropertyIsLike filter = f.like(propertyNameIsFunc(), "foo", "x", "y", "z");
+        
+        return filter;
     }
 
    

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBindingTest.java
@@ -24,89 +24,90 @@ import org.w3c.dom.NodeList;
 import org.opengis.filter.PropertyIsLike;
 import org.geotools.xml.Binding;
 
-
 /** @source $URL$ */
 public class OGCPropertyIsLikeTypeBindingTest extends FilterTestSupport {
-    public void testType() {
-        assertEquals(PropertyIsLike.class, binding(OGC.PropertyIsLikeType).getType());
-    }
+  public void testType() {
+    assertEquals(PropertyIsLike.class, binding(OGC.PropertyIsLikeType).getType());
+  }
 
-    public void testExecutionMode() {
-        assertEquals(Binding.OVERRIDE, binding(OGC.PropertyIsLikeType).getExecutionMode());
-    }
+  public void testExecutionMode() {
+    assertEquals(Binding.OVERRIDE, binding(OGC.PropertyIsLikeType).getExecutionMode());
+  }
 
-    public void testParse() throws Exception {
-        FilterMockData.propertyIsLike(document, document);
+  public void testParse() throws Exception {
+    FilterMockData.propertyIsLike(document, document);
 
-        PropertyIsLike isLike = (PropertyIsLike) parse();
+    PropertyIsLike isLike = (PropertyIsLike) parse();
 
-        assertNotNull(isLike.getExpression());
-        assertNotNull(isLike.getLiteral());
+    assertNotNull(isLike.getExpression());
+    assertNotNull(isLike.getLiteral());
 
-        assertEquals("x", isLike.getWildCard());
-        assertEquals("y", isLike.getSingleChar());
-        assertEquals("z", isLike.getEscape());
-    }
+    assertEquals("x", isLike.getWildCard());
+    assertEquals("y", isLike.getSingleChar());
+    assertEquals("z", isLike.getEscape());
+  }
 
-    public void testEncode() throws Exception {
-        Document doc = encode(FilterMockData.propertyIsLike(), OGC.PropertyIsLike);
+  public void testEncode() throws Exception {
+    Document doc = encode(FilterMockData.propertyIsLike(), OGC.PropertyIsLike);
 
-        Element pn = getElementByQName(doc, OGC.PropertyName);
-        assertNotNull(pn);
-        assertEquals("foo", pn.getFirstChild().getNodeValue());
+    Element pn = getElementByQName(doc, OGC.PropertyName);
+    assertNotNull(pn);
+    assertEquals("foo", pn.getFirstChild().getNodeValue());
 
-        Element l = getElementByQName(doc, OGC.Literal);
-        assertEquals("foo", l.getFirstChild().getNodeValue());
+    Element l = getElementByQName(doc, OGC.Literal);
+    assertEquals("foo", l.getFirstChild().getNodeValue());
 
-        assertEquals("x", doc.getDocumentElement().getAttribute("wildCard"));
-        assertEquals("y", doc.getDocumentElement().getAttribute("singleChar"));
-        assertEquals("z", doc.getDocumentElement().getAttribute("escape"));
-    }
+    assertEquals("x", doc.getDocumentElement().getAttribute("wildCard"));
+    assertEquals("y", doc.getDocumentElement().getAttribute("singleChar"));
+    assertEquals("z", doc.getDocumentElement().getAttribute("escape"));
+  }
 
-    public void testEncodeAsFilter() throws Exception {
-        Document doc = encode(FilterMockData.propertyIsLike(), OGC.Filter);
-        // print(doc);
+  public void testEncodeAsFilter() throws Exception {
+    Document doc = encode(FilterMockData.propertyIsLike(), OGC.Filter);
+    // print(doc);
 
-        assertEquals(
-                1,
-                doc.getDocumentElement()
-                        .getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart())
-                        .getLength());
-        assertEquals(
-                1,
-                doc.getDocumentElement()
-                        .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart())
-                        .getLength());
+    assertEquals(
+        1,
+        doc.getDocumentElement()
+            .getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart())
+            .getLength());
+    assertEquals(
+        1,
+        doc.getDocumentElement()
+            .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart())
+            .getLength());
 
-        Element e = getElementByQName(doc, OGC.PropertyIsLike);
-        assertEquals("x", e.getAttribute("wildCard"));
-        assertEquals("y", e.getAttribute("singleChar"));
-        assertEquals("z", e.getAttribute("escape"));
-    }
-    public void testEncodeWithFunctionAsFilter() throws Exception {
-        Document doc = encode(FilterMockData.propertyIsLike2(), OGC.Filter);
-        //print(doc);
-        
-        NodeList property = doc.getDocumentElement()
-           .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Function.getLocalPart());
-        assertEquals(1,
-            property.getLength());
-       
-        assertNotNull(property.item(0).getChildNodes());
-        assertNotSame("", property.item(0).getNodeValue());
-        assertEquals(1,
-            doc.getDocumentElement()
-               .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+    Element e = getElementByQName(doc, OGC.PropertyIsLike);
+    assertEquals("x", e.getAttribute("wildCard"));
+    assertEquals("y", e.getAttribute("singleChar"));
+    assertEquals("z", e.getAttribute("escape"));
+  }
 
-        Element e = getElementByQName( doc, OGC.PropertyIsLike);
-        assertEquals("x", e.getAttribute("wildCard"));
-        assertEquals("y", e.getAttribute("singleChar"));
-        assertEquals("z", e.getAttribute("escape"));
-        
-        Element p = getElementByQName(e, OGC.Function);
-        assertEquals("strToLowerCase", p.getAttribute("name"));
-        Element pn = getElementByQName(p, OGC.PropertyName);
-        
-        assertEquals("foo", pn.getTextContent());
-    }
+  public void testEncodeWithFunctionAsFilter() throws Exception {
+    Document doc = encode(FilterMockData.propertyIsLike2(), OGC.Filter);
+    //print(doc);
+
+    NodeList property =
+        doc.getDocumentElement().getElementsByTagNameNS(OGC.NAMESPACE, OGC.Function.getLocalPart());
+    assertEquals(1, property.getLength());
+
+    assertNotNull(property.item(0).getChildNodes());
+    assertNotSame("", property.item(0).getNodeValue());
+    assertEquals(
+        1,
+        doc.getDocumentElement()
+            .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart())
+            .getLength());
+
+    Element e = getElementByQName(doc, OGC.PropertyIsLike);
+    assertEquals("x", e.getAttribute("wildCard"));
+    assertEquals("y", e.getAttribute("singleChar"));
+    assertEquals("z", e.getAttribute("escape"));
+
+    Element p = getElementByQName(e, OGC.Function);
+    assertEquals("strToLowerCase", p.getAttribute("name"));
+    Element pn = getElementByQName(p, OGC.PropertyName);
+
+    assertEquals("foo", pn.getTextContent());
+  }
 }

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBindingTest.java
@@ -20,6 +20,10 @@ import org.geotools.xml.Binding;
 import org.opengis.filter.PropertyIsLike;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.opengis.filter.PropertyIsLike;
+import org.geotools.xml.Binding;
+
 
 /** @source $URL$ */
 public class OGCPropertyIsLikeTypeBindingTest extends FilterTestSupport {
@@ -78,5 +82,28 @@ public class OGCPropertyIsLikeTypeBindingTest extends FilterTestSupport {
         assertEquals("x", e.getAttribute("wildCard"));
         assertEquals("y", e.getAttribute("singleChar"));
         assertEquals("z", e.getAttribute("escape"));
+    }
+    public void testEncodeWithFunctionAsFilter() throws Exception {
+        Document doc = encode(FilterMockData.propertyIsLike2(), OGC.Filter);
+        print(doc);
+        
+        NodeList property = doc.getDocumentElement()
+           .getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart());
+        assertEquals(1,
+            property.getLength());
+        System.out.println(property.item(0).getNodeValue());
+        assertNotNull(property.item(0).getNodeValue());
+        assertNotSame("", property.item(0).getNodeValue());
+        assertEquals(1,
+            doc.getDocumentElement()
+               .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+
+        Element e = getElementByQName( doc, OGC.PropertyIsLike);
+        assertEquals("x", e.getAttribute("wildCard"));
+        assertEquals("y", e.getAttribute("singleChar"));
+        assertEquals("z", e.getAttribute("escape"));
+        
+        Element p = getElementByQName(doc, OGC.PropertyName);
+        
     }
 }

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBindingTest.java
@@ -85,14 +85,14 @@ public class OGCPropertyIsLikeTypeBindingTest extends FilterTestSupport {
     }
     public void testEncodeWithFunctionAsFilter() throws Exception {
         Document doc = encode(FilterMockData.propertyIsLike2(), OGC.Filter);
-        print(doc);
+        //print(doc);
         
         NodeList property = doc.getDocumentElement()
-           .getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart());
+           .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Function.getLocalPart());
         assertEquals(1,
             property.getLength());
-        System.out.println(property.item(0).getNodeValue());
-        assertNotNull(property.item(0).getNodeValue());
+       
+        assertNotNull(property.item(0).getChildNodes());
         assertNotSame("", property.item(0).getNodeValue());
         assertEquals(1,
             doc.getDocumentElement()
@@ -103,7 +103,10 @@ public class OGCPropertyIsLikeTypeBindingTest extends FilterTestSupport {
         assertEquals("y", e.getAttribute("singleChar"));
         assertEquals("z", e.getAttribute("escape"));
         
-        Element p = getElementByQName(doc, OGC.PropertyName);
+        Element p = getElementByQName(e, OGC.Function);
+        assertEquals("strToLowerCase", p.getAttribute("name"));
+        Element pn = getElementByQName(p, OGC.PropertyName);
         
+        assertEquals("foo", pn.getTextContent());
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
@@ -71,6 +71,12 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
         return ff.intersects(ff.property("the_geom"), ff.literal(polygon));
     }
 
+    
+    /**
+     * Test to demonstrate GEOT-5921
+     * WFSClient passes ILIKE to 1.0.0 servers that can't handle it
+     * https://osgeo-org.atlassian.net/browse/GEOT-5921
+     */
     @Test
     public void testFeatureSourceGetFeaturesILikeFilter() throws IOException, CQLException {
         if (Boolean.FALSE.equals(serviceAvailable)) {
@@ -100,6 +106,11 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
 
     }
     
+    /**
+     * Test to demonstrate GEOT-5920
+     * WFSClient fails when a function is used in a query
+     * https://osgeo-org.atlassian.net/browse/GEOT-5920
+     */
     @Test
     public void testFeatureSourceGetFeaturesFunctionFilter() throws IOException, CQLException {
         if (Boolean.FALSE.equals(serviceAvailable)) {

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
@@ -18,23 +18,16 @@
 package org.geotools.data.wfs.online.v1_0;
 
 import static org.geotools.data.wfs.WFSTestData.GEOS_STATES_11;
-import static org.junit.Assert.*;
 
-import java.io.IOException;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LinearRing;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Polygon;
 import java.util.Collections;
-
-import org.geotools.data.Query;
-import org.geotools.data.simple.SimpleFeatureCollection;
-import org.geotools.data.simple.SimpleFeatureIterator;
-import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.online.AbstractWfsDataStoreOnlineTest;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.filter.text.cql2.CQLException;
-import org.geotools.filter.text.ecql.ECQL;
-import org.junit.Test;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 
@@ -70,71 +63,4 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
         return ff.intersects(ff.property("the_geom"), ff.literal(polygon));
     }
-
-    
-    /**
-     * Test to demonstrate GEOT-5921
-     * WFSClient passes ILIKE to 1.0.0 servers that can't handle it
-     * https://osgeo-org.atlassian.net/browse/GEOT-5921
-     */
-    @Test
-    public void testFeatureSourceGetFeaturesILikeFilter() throws IOException, CQLException {
-        if (Boolean.FALSE.equals(serviceAvailable)) {
-            return;
-        }
-        
-        
-        SimpleFeatureSource featureSource;
-        featureSource = wfs.getFeatureSource(testType.FEATURETYPENAME);
-        assertNotNull(featureSource);
-
-        Query query = new Query(testType.FEATURETYPENAME);
-        
-        Filter filter = ECQL.toFilter("STATE_NAME ILIKE 'north%'");
-        
-        //ILIKE (or matchCase) is not supported in WFS 1.0.0 and the client should know this!
-        
-        query.setFilter(filter);
-        System.out.println(query);
-        System.out.println(((org.geotools.filter.LikeFilterImpl)query.getFilter()).isMatchingCase());
-        SimpleFeatureCollection features;
-        features = featureSource.getFeatures(query);
-        assertNotNull(features);
-        assertEquals(2,features.size());
-        SimpleFeatureType schema = features.getSchema();
-        assertNotNull(schema);
-
-    }
-    
-    /**
-     * Test to demonstrate GEOT-5920
-     * WFSClient fails when a function is used in a query
-     * https://osgeo-org.atlassian.net/browse/GEOT-5920
-     */
-    @Test
-    public void testFeatureSourceGetFeaturesFunctionFilter() throws IOException, CQLException {
-        if (Boolean.FALSE.equals(serviceAvailable)) {
-            return;
-        }
-        
-        
-        SimpleFeatureSource featureSource;
-        featureSource = wfs.getFeatureSource(testType.FEATURETYPENAME);
-        assertNotNull(featureSource);
-
-        Query query = new Query(testType.FEATURETYPENAME);
-        Filter filter = ECQL.toFilter("strToLowerCase(STATE_NAME) LIKE 'north%'");
-        query.setFilter(filter);
-        System.out.println(query);
-        System.out.println(((org.geotools.filter.LikeFilterImpl)query.getFilter()).isMatchingCase());
-        SimpleFeatureCollection features;
-        features = featureSource.getFeatures(query);
-        assertNotNull(features);
-        assertEquals(2,features.size());
-        SimpleFeatureType schema = features.getSchema();
-        assertNotNull(schema);
-
-    }
-
-
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
@@ -18,16 +18,23 @@
 package org.geotools.data.wfs.online.v1_0;
 
 import static org.geotools.data.wfs.WFSTestData.GEOS_STATES_11;
+import static org.junit.Assert.*;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Polygon;
+import java.io.IOException;
 import java.util.Collections;
+
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.online.AbstractWfsDataStoreOnlineTest;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.filter.text.ecql.ECQL;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 
@@ -63,4 +70,60 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
         return ff.intersects(ff.property("the_geom"), ff.literal(polygon));
     }
+
+    @Test
+    public void testFeatureSourceGetFeaturesILikeFilter() throws IOException, CQLException {
+        if (Boolean.FALSE.equals(serviceAvailable)) {
+            return;
+        }
+        
+        
+        SimpleFeatureSource featureSource;
+        featureSource = wfs.getFeatureSource(testType.FEATURETYPENAME);
+        assertNotNull(featureSource);
+
+        Query query = new Query(testType.FEATURETYPENAME);
+        
+        Filter filter = ECQL.toFilter("STATE_NAME ILIKE 'north%'");
+        
+        //ILIKE (or matchCase) is not supported in WFS 1.0.0 and the client should know this!
+        
+        query.setFilter(filter);
+        System.out.println(query);
+        System.out.println(((org.geotools.filter.LikeFilterImpl)query.getFilter()).isMatchingCase());
+        SimpleFeatureCollection features;
+        features = featureSource.getFeatures(query);
+        assertNotNull(features);
+        assertEquals(2,features.size());
+        SimpleFeatureType schema = features.getSchema();
+        assertNotNull(schema);
+
+    }
+    
+    @Test
+    public void testFeatureSourceGetFeaturesFunctionFilter() throws IOException, CQLException {
+        if (Boolean.FALSE.equals(serviceAvailable)) {
+            return;
+        }
+        
+        
+        SimpleFeatureSource featureSource;
+        featureSource = wfs.getFeatureSource(testType.FEATURETYPENAME);
+        assertNotNull(featureSource);
+
+        Query query = new Query(testType.FEATURETYPENAME);
+        Filter filter = ECQL.toFilter("strToLowerCase(STATE_NAME) LIKE 'north%'");
+        query.setFilter(filter);
+        System.out.println(query);
+        System.out.println(((org.geotools.filter.LikeFilterImpl)query.getFilter()).isMatchingCase());
+        SimpleFeatureCollection features;
+        features = featureSource.getFeatures(query);
+        assertNotNull(features);
+        assertEquals(2,features.size());
+        SimpleFeatureType schema = features.getSchema();
+        assertNotNull(schema);
+
+    }
+
+
 }


### PR DESCRIPTION
Infact anything that encodes/decodes a Like filter with a LHS function will fail.