### PR TITLE
[GEOT-5920] WFSClient fails when a function is used in a query

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/test/XMLTestSupport.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/test/XMLTestSupport.java
@@ -312,7 +312,7 @@ public abstract class XMLTestSupport extends TestCase {
         }
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        encoder.write(object, element, output);
+        encoder.encode(object, element, output);
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);

--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
@@ -24,7 +24,6 @@ import org.opengis.filter.FilterFactory;
 import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
-import org.opengis.filter.expression.PropertyName;
 
 /**
  * Binding object for the type http://www.opengis.net/ogc:PropertyIsLikeType.

--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
@@ -22,6 +22,7 @@ import org.geotools.xml.ElementInstance;
 import org.geotools.xml.Node;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 
@@ -83,7 +84,7 @@ public class OGCPropertyIsLikeTypeBinding extends AbstractComplexBinding {
      * @generated modifiable
      */
     public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
-        PropertyName name = (PropertyName) node.getChildValue(PropertyName.class);
+        Expression name = (Expression) node.getChildValue(Expression.class);
         Literal literal = (Literal) node.getChildValue(Literal.class);
 
         String wildcard = (String) node.getAttributeValue("wildCard");

--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBinding.java
@@ -106,6 +106,10 @@ public class OGCPropertyIsLikeTypeBinding extends AbstractComplexBinding {
     public Object getProperty(Object object, QName name) throws Exception {
         PropertyIsLike isLike = (PropertyIsLike) object;
 
+        if (OGC.expression.equals(name)) {
+            return isLike.getExpression();
+        }
+
         if (OGC.PropertyName.equals(name)) {
             return isLike.getExpression();
         }

--- a/modules/extension/xsd/xsd-filter/src/main/resources/org/geotools/filter/v1_0/filter.xsd
+++ b/modules/extension/xsd/xsd-filter/src/main/resources/org/geotools/filter/v1_0/filter.xsd
@@ -74,7 +74,7 @@
 		<xsd:complexContent>
 			<xsd:extension base="ogc:ComparisonOpsType">
 				<xsd:sequence>
-					<xsd:element ref="ogc:PropertyName"/>
+					<xsd:element ref="ogc:expression"/>
 					<xsd:element ref="ogc:Literal"/>
 				</xsd:sequence>
 				<xsd:attribute name="wildCard" type="xsd:string" use="required"/>

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
@@ -180,22 +180,28 @@ public class BinaryComparisonOpTypeBindingTest extends FilterTestSupport {
         PropertyIsGreaterThan equalTo = FilterMockData.propertyIsGreaterThan();
 
         Document dom = encode(equalTo, OGC.PropertyIsGreaterThan);
-        
-        assertEquals(1,
-            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart()).getLength());
-        assertEquals(1,
-            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+
+        assertEquals(
+                1,
+                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart())
+                        .getLength());
+        assertEquals(
+                1,
+                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
     }
-    
+
     public void testPropertyFunctionIsGreaterThanEncode() throws Exception {
         PropertyIsGreaterThan equalTo = FilterMockData.propertyFuncIsGreaterThan();
 
         Document dom = encode(equalTo, OGC.PropertyIsGreaterThan);
         print(dom);
-        assertEquals(1,
-            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart()).getLength());
-        assertEquals(1,
-            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+        assertEquals(
+                1,
+                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart())
+                        .getLength());
+        assertEquals(
+                1,
+                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
     }
 
     public void testPropertyIsGreaterThanOrEqualToType() {

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
@@ -194,7 +194,7 @@ public class BinaryComparisonOpTypeBindingTest extends FilterTestSupport {
         PropertyIsGreaterThan equalTo = FilterMockData.propertyFuncIsGreaterThan();
 
         Document dom = encode(equalTo, OGC.PropertyIsGreaterThan);
-        print(dom);
+        // print(dom);
         assertEquals(
                 1,
                 dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart())

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/BinaryComparisonOpTypeBindingTest.java
@@ -180,13 +180,22 @@ public class BinaryComparisonOpTypeBindingTest extends FilterTestSupport {
         PropertyIsGreaterThan equalTo = FilterMockData.propertyIsGreaterThan();
 
         Document dom = encode(equalTo, OGC.PropertyIsGreaterThan);
-        assertEquals(
-                1,
-                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart())
-                        .getLength());
-        assertEquals(
-                1,
-                dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+        
+        assertEquals(1,
+            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart()).getLength());
+        assertEquals(1,
+            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
+    }
+    
+    public void testPropertyFunctionIsGreaterThanEncode() throws Exception {
+        PropertyIsGreaterThan equalTo = FilterMockData.propertyFuncIsGreaterThan();
+
+        Document dom = encode(equalTo, OGC.PropertyIsGreaterThan);
+        print(dom);
+        assertEquals(1,
+            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.PropertyName.getLocalPart()).getLength());
+        assertEquals(1,
+            dom.getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart()).getLength());
     }
 
     public void testPropertyIsGreaterThanOrEqualToType() {

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
@@ -81,6 +81,11 @@ public class FilterMockData {
     static PropertyName propertyName() {
         return propertyName("foo");
     }
+    
+    private static Expression propertyNameIsFunc() {
+
+        return f.function("strToLowerCase", propertyName("foo"));
+    }
 
     static PropertyName propertyName(String property) {
         return f.property(property);
@@ -145,6 +150,10 @@ public class FilterMockData {
         return f.greater(propertyName(), literal());
     }
 
+    static PropertyIsGreaterThan propertyFuncIsGreaterThan() {
+        return f.greater(propertyNameIsFunc(), literal());
+    }
+    
     static Element propertyIsGreaterThanOrEqualTo(Document document, Node parent) {
         return binaryComparisonOp(document, parent, OGC.PropertyIsGreaterThanOrEqualTo);
     }
@@ -193,7 +202,12 @@ public class FilterMockData {
     static PropertyIsLike propertyIsLike() {
         return f.like(propertyName(), "foo", "x", "y", "z");
     }
+    
+    static PropertyIsLike propertyIsLike2() {
+        return f.like(propertyNameIsFunc(), "foo", "x", "y", "z");
+    }
 
+   
     static Element propertyIsLike(Document document, Node parent) {
         Element isLike = element(document, parent, OGC.PropertyIsLike);
 

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
@@ -37,6 +37,7 @@ import org.opengis.filter.PropertyIsNotEqualTo;
 import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.expression.Add;
 import org.opengis.filter.expression.Divide;
+import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.Multiply;
@@ -81,7 +82,7 @@ public class FilterMockData {
     static PropertyName propertyName() {
         return propertyName("foo");
     }
-    
+
     private static Expression propertyNameIsFunc() {
 
         return f.function("strToLowerCase", propertyName("foo"));
@@ -153,7 +154,7 @@ public class FilterMockData {
     static PropertyIsGreaterThan propertyFuncIsGreaterThan() {
         return f.greater(propertyNameIsFunc(), literal());
     }
-    
+
     static Element propertyIsGreaterThanOrEqualTo(Document document, Node parent) {
         return binaryComparisonOp(document, parent, OGC.PropertyIsGreaterThanOrEqualTo);
     }
@@ -202,12 +203,11 @@ public class FilterMockData {
     static PropertyIsLike propertyIsLike() {
         return f.like(propertyName(), "foo", "x", "y", "z");
     }
-    
+
     static PropertyIsLike propertyIsLike2() {
         return f.like(propertyNameIsFunc(), "foo", "x", "y", "z");
     }
 
-   
     static Element propertyIsLike(Document document, Node parent) {
         Element isLike = element(document, parent, OGC.PropertyIsLike);
 

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/FilterMockData.java
@@ -205,7 +205,9 @@ public class FilterMockData {
     }
 
     static PropertyIsLike propertyIsLike2() {
-        return f.like(propertyNameIsFunc(), "foo", "x", "y", "z");
+        PropertyIsLike filter = f.like(propertyNameIsFunc(), "foo", "x", "y", "z");
+
+        return filter;
     }
 
     static Element propertyIsLike(Document document, Node parent) {

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_0/OGCPropertyIsLikeTypeBindingTest.java
@@ -20,6 +20,7 @@ import org.geotools.xml.Binding;
 import org.opengis.filter.PropertyIsLike;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /** @source $URL$ */
 public class OGCPropertyIsLikeTypeBindingTest extends FilterTestSupport {
@@ -78,5 +79,34 @@ public class OGCPropertyIsLikeTypeBindingTest extends FilterTestSupport {
         assertEquals("x", e.getAttribute("wildCard"));
         assertEquals("y", e.getAttribute("singleChar"));
         assertEquals("z", e.getAttribute("escape"));
+    }
+
+    public void testEncodeWithFunctionAsFilter() throws Exception {
+        Document doc = encode(FilterMockData.propertyIsLike2(), OGC.Filter);
+        // print(doc);
+
+        NodeList property =
+                doc.getDocumentElement()
+                        .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Function.getLocalPart());
+        assertEquals(1, property.getLength());
+
+        assertNotNull(property.item(0).getChildNodes());
+        assertNotSame("", property.item(0).getNodeValue());
+        assertEquals(
+                1,
+                doc.getDocumentElement()
+                        .getElementsByTagNameNS(OGC.NAMESPACE, OGC.Literal.getLocalPart())
+                        .getLength());
+
+        Element e = getElementByQName(doc, OGC.PropertyIsLike);
+        assertEquals("x", e.getAttribute("wildCard"));
+        assertEquals("y", e.getAttribute("singleChar"));
+        assertEquals("z", e.getAttribute("escape"));
+
+        Element p = getElementByQName(e, OGC.Function);
+        assertEquals("strToLowerCase", p.getAttribute("name"));
+        Element pn = getElementByQName(p, OGC.PropertyName);
+
+        assertEquals("foo", pn.getTextContent());
     }
 }


### PR DESCRIPTION
Infact anything that encodes/decodes a Like filter with a LHS function will fail.