### PR TITLE
Fix DataStore leaks in H2 tests

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCJNDIDataSourceOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCJNDIDataSourceOnlineTest.java
@@ -45,10 +45,17 @@ public abstract class JDBCJNDIDataSourceOnlineTest extends JDBCTestSupport {
         params.put(JDBCDataStoreFactory.DBTYPE.key, dbtype);
         params.put(JDBCJNDIDataStoreFactory.JNDI_REFNAME.key, "ds");
 
-        JDBCDataStore dataStore = (JDBCDataStore) DataStoreFinder.getDataStore(params);
-        try (Connection con = dataStore.getDataSource().getConnection()) {
-            assertTrue(con != null);
-            assertFalse(con.isClosed());
+        JDBCDataStore dataStore = null;
+        try {
+            dataStore = (JDBCDataStore) DataStoreFinder.getDataStore(params);
+            try (Connection con = dataStore.getDataSource().getConnection()) {
+                assertTrue(con != null);
+                assertFalse(con.isClosed());
+            }
+        } finally {
+            if (dataStore != null) {
+                dataStore.dispose();
+            }
         }
     }
 


### PR DESCRIPTION
An attempt to fix the inexplicable failure of `H2DataStoreFactoryTest` in [Jenkins geotools-master-online-postgis](https://build.geoserver.org/view/geotools/job/geotools-master-online-postgis/596/consoleText) when it passes everywhere else. Something strange going on with H2 and the finalizer thread? First: fix the DataStore leaks.