### PR TITLE
fix for missing style name in WMTS requests [GEOT-6017]

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/data/ows/StyleImpl.java
+++ b/modules/extension/wms/src/main/java/org/geotools/data/ows/StyleImpl.java
@@ -34,6 +34,7 @@ public class StyleImpl {
     private URL styleURL;
     private List featureStyles;
     private List graphicStyles;
+    private boolean isDefault = false;
 
     public StyleImpl() {}
 
@@ -127,5 +128,15 @@ public class StyleImpl {
             if (other.name != null) return false;
         } else if (!name.equals(other.name)) return false;
         return true;
+    }
+
+    /** @return the isDefault */
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    /** @param isDefault the isDefault to set */
+    public void setDefault(boolean isDefault) {
+        this.isDefault = isDefault;
     }
 }

--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/client/WMTSTileService.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/client/WMTSTileService.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.data.ows.CRSEnvelope;
+import org.geotools.data.ows.StyleImpl;
 import org.geotools.data.wmts.model.TileMatrix;
 import org.geotools.data.wmts.model.TileMatrixSet;
 import org.geotools.data.wmts.model.TileMatrixSetLink;
@@ -120,7 +121,10 @@ public class WMTSTileService extends TileService {
         if (styleName != null && !styleName.isEmpty()) {
             setStyleName(styleName);
         } else {
-            setStyleName(layer.getDefaultStyle().getName());
+            StyleImpl defaultStyle = layer.getDefaultStyle();
+            if (defaultStyle != null) {
+                setStyleName(defaultStyle.getName());
+            }
         }
         setType(type);
         setMatrixSet(tileMatrixSet);

--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/client/WMTSTileService.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/client/WMTSTileService.java
@@ -117,7 +117,11 @@ public class WMTSTileService extends TileService {
 
         setTemplateURL(templateURL);
         setLayerName(layer.getName());
-        setStyleName(styleName);
+        if (styleName != null && !styleName.isEmpty()) {
+            setStyleName(styleName);
+        } else {
+            setStyleName(layer.getDefaultStyle().getName());
+        }
         setType(type);
         setMatrixSet(tileMatrixSet);
     }

--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/model/WMTSCapabilities.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/model/WMTSCapabilities.java
@@ -45,6 +45,7 @@ import net.opengis.wmts.v_1.CapabilitiesType;
 import net.opengis.wmts.v_1.ContentsType;
 import net.opengis.wmts.v_1.DimensionType;
 import net.opengis.wmts.v_1.LayerType;
+import net.opengis.wmts.v_1.StyleType;
 import net.opengis.wmts.v_1.TileMatrixLimitsType;
 import net.opengis.wmts.v_1.TileMatrixSetLimitsType;
 import net.opengis.wmts.v_1.TileMatrixSetLinkType;
@@ -56,12 +57,14 @@ import org.geotools.data.ows.CRSEnvelope;
 import org.geotools.data.ows.Capabilities;
 import org.geotools.data.ows.Layer;
 import org.geotools.data.ows.OperationType;
+import org.geotools.data.ows.StyleImpl;
 import org.geotools.data.wms.xml.Dimension;
 import org.geotools.data.wms.xml.Extent;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.ows.ServiceException;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.util.SimpleInternationalString;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.TransformException;
@@ -356,6 +359,23 @@ public class WMTSCapabilities extends Capabilities {
         }
         layer.getFormats().addAll(layerType.getFormat());
         layer.getInfoFormats().addAll(layerType.getInfoFormat());
+        EList<StyleType> styles = layerType.getStyle();
+        List<StyleImpl> sList = new ArrayList<>();
+        for (StyleType styleType : styles) {
+            StyleImpl style = new StyleImpl();
+            style.setName(styleType.getIdentifier().getValue());
+            StringBuilder t = new StringBuilder();
+            for (Object title1 : styleType.getTitle()) {
+                t.append(title1.toString());
+            }
+            style.setTitle(new SimpleInternationalString(t.toString()));
+            style.setDefault(styleType.isIsDefault());
+            if (styleType.isIsDefault()) {
+                layer.setDefaultStyle(style);
+            }
+            sList.add(style);
+        }
+        layer.setStyles(sList);
         @SuppressWarnings("unchecked")
         EList<BoundingBoxType> bboxes = layerType.getBoundingBox();
         Map<String, CRSEnvelope> boundingBoxes = new HashMap<>();

--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/model/WMTSLayer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/model/WMTSLayer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.geotools.data.ows.Layer;
+import org.geotools.data.ows.StyleImpl;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
@@ -43,6 +44,8 @@ public class WMTSLayer extends Layer {
     Map<String, String> templates = new HashMap<>();
 
     private CoordinateReferenceSystem preferredCRS = null;
+
+    private StyleImpl defaultStyle;
 
     /** @param title */
     public WMTSLayer(String title) {
@@ -117,5 +120,15 @@ public class WMTSLayer extends Layer {
     /** @param preferredCRS the preferredCRS to set */
     public void setPreferredCRS(CoordinateReferenceSystem preferredCRS) {
         this.preferredCRS = preferredCRS;
+    }
+
+    /** @param style */
+    public void setDefaultStyle(StyleImpl style) {
+        defaultStyle = style;
+    }
+
+    /** @return the defaultStyle */
+    public StyleImpl getDefaultStyle() {
+        return defaultStyle;
     }
 }

--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/request/AbstractGetTileRequest.java
@@ -129,7 +129,7 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
         this.layer = layer;
         if (styleName.isEmpty()) {
             StyleImpl defaultStyle = layer.getDefaultStyle();
-            if(defaultStyle != null) {
+            if (defaultStyle != null) {
                 styleName = defaultStyle.getName();
             }
         }

--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/request/AbstractGetTileRequest.java
@@ -31,6 +31,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.data.ows.HTTPResponse;
 import org.geotools.data.ows.Response;
+import org.geotools.data.ows.StyleImpl;
 import org.geotools.data.wmts.client.WMTSTileFactory;
 import org.geotools.data.wmts.client.WMTSTileService;
 import org.geotools.data.wmts.model.TileMatrixLimits;
@@ -127,7 +128,10 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
     public void setLayer(WMTSLayer layer) {
         this.layer = layer;
         if (styleName.isEmpty()) {
-            styleName = layer.getDefaultStyle().getName();
+            StyleImpl defaultStyle = layer.getDefaultStyle();
+            if(defaultStyle != null) {
+                styleName = defaultStyle.getName();
+            }
         }
     }
 

--- a/modules/extension/wmts/src/main/java/org/geotools/data/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/data/wmts/request/AbstractGetTileRequest.java
@@ -126,6 +126,9 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
     @Override
     public void setLayer(WMTSLayer layer) {
         this.layer = layer;
+        if (styleName.isEmpty()) {
+            styleName = layer.getDefaultStyle().getName();
+        }
     }
 
     @Override


### PR DESCRIPTION
ESRI WMTS servers require the style to be named and throw an http 400 server exception if it is missing (but no other clue). Sadly the WMTS specification seems to agree so I've fixed it rather than just blame ESRI.

Fix for [GEOT-6017](https://osgeo-org.atlassian.net/projects/GEOT/issues/GEOT-6017).