### PR TITLE
[GEOT-6019] MongoDB plugin pom.xml has unsuported modules as parent pom.xml (19.x)

### DIFF
--- a/modules/plugin/mongodb/pom.xml
+++ b/modules/plugin/mongodb/pom.xml
@@ -13,7 +13,7 @@
 
   <parent>
     <groupId>org.geotools</groupId>
-    <artifactId>unsupported</artifactId>
+    <artifactId>plugin</artifactId>
     <version>19-SNAPSHOT</version>
   </parent>
 


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-6019