### PR TITLE
[GEOT-6034] Allow the usage of a place holder for the :where: clause created by GeoServer in virtual tables

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -16,6 +16,10 @@
  */
 package org.geotools.jdbc;
 
+import static org.geotools.jdbc.VirtualTable.WHERE_CLAUSE_PLACE_HOLDER;
+import static org.geotools.jdbc.VirtualTable.WHERE_CLAUSE_PLACE_HOLDER_LENGTH;
+import static org.geotools.jdbc.VirtualTable.setKeepWhereClausePlaceHolderHint;
+
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
@@ -3344,13 +3348,12 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
 
         // from
         sql.append(" FROM ");
-        encodeTableName(featureType.getTypeName(), sql, query.getHints());
+        encodeTableName(featureType.getTypeName(), sql, setKeepWhereClausePlaceHolderHint(query));
 
         // filtering
         Filter filter = query.getFilter();
         if (filter != null && !Filter.INCLUDE.equals(filter)) {
             sql.append(" WHERE ");
-
             // encode filter
             filter(featureType, filter, sql);
         }
@@ -3480,7 +3483,17 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
             // that uses attributes that aren't returned in the results
             SimpleFeatureType fullSchema = getSchema(featureType.getTypeName());
             toSQL.setInline(true);
-            sql.append(" ").append(toSQL.encodeToString(filter));
+            String filterSql = toSQL.encodeToString(filter);
+            int whereClauseIndex = sql.indexOf(WHERE_CLAUSE_PLACE_HOLDER);
+            if (whereClauseIndex != -1) {
+                sql.replace(
+                        whereClauseIndex,
+                        whereClauseIndex + WHERE_CLAUSE_PLACE_HOLDER_LENGTH,
+                        "AND " + filterSql);
+                sql.append("1 = 1");
+            } else {
+                sql.append(filterSql);
+            }
             return toSQL;
         } catch (FilterToSQLException e) {
             throw new RuntimeException(e);
@@ -3562,7 +3575,7 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
         dialect.encodePostSelect(featureType, sql);
 
         sql.append(" FROM ");
-        encodeTableName(featureType.getTypeName(), sql, query.getHints());
+        encodeTableName(featureType.getTypeName(), sql, setKeepWhereClausePlaceHolderHint(query));
 
         // filtering
         PreparedFilterToSQL toSQL = null;
@@ -3717,7 +3730,7 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
         }
 
         sql.append(" FROM ");
-        encodeTableName(featureType.getTypeName(), sql, query.getHints());
+        encodeTableName(featureType.getTypeName(), sql, setKeepWhereClausePlaceHolderHint(query));
 
         Filter filter = query.getFilter();
         if (filter != null && !Filter.INCLUDE.equals(filter)) {
@@ -3774,7 +3787,7 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
         }
 
         sql.append(" FROM ");
-        encodeTableName(featureType.getTypeName(), sql, query.getHints());
+        encodeTableName(featureType.getTypeName(), sql, setKeepWhereClausePlaceHolderHint(query));
 
         // encode the filter
         PreparedFilterToSQL toSQL = null;
@@ -3783,7 +3796,17 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
             // encode filter
             try {
                 toSQL = createPreparedFilterToSQL(featureType);
-                sql.append(" ").append(toSQL.encodeToString(filter));
+                int whereClauseIndex = sql.indexOf(WHERE_CLAUSE_PLACE_HOLDER);
+                if (whereClauseIndex != -1) {
+                    toSQL.setInline(true);
+                    sql.replace(
+                            whereClauseIndex,
+                            whereClauseIndex + WHERE_CLAUSE_PLACE_HOLDER_LENGTH,
+                            "AND " + toSQL.encodeToString(filter));
+                    toSQL.setInline(false);
+                } else {
+                    sql.append(toSQL.encodeToString(filter));
+                }
             } catch (FilterToSQLException e) {
                 throw new RuntimeException(e);
             }
@@ -3954,7 +3977,8 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
         if (join != null) {
             encodeTableJoin(featureType, join, query, sql);
         } else {
-            encodeTableName(featureType.getTypeName(), sql, query.getHints());
+            encodeTableName(
+                    featureType.getTypeName(), sql, setKeepWhereClausePlaceHolderHint(query));
         }
 
         if (join != null) {
@@ -4615,7 +4639,10 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
             dialect.encodeJoin(part.getJoin().getType(), sql);
             sql.append(" ");
             encodeAliasedTableName(
-                    part.getQueryFeatureType().getTypeName(), sql, null, part.getAlias());
+                    part.getQueryFeatureType().getTypeName(),
+                    sql,
+                    setKeepWhereClausePlaceHolderHint(null, true),
+                    part.getAlias());
             sql.append(" ON ");
 
             Filter j = part.getJoinFilter();
@@ -4627,6 +4654,12 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
             } catch (FilterToSQLException e) {
                 throw new RuntimeException(e);
             }
+        }
+        if (sql.indexOf(WHERE_CLAUSE_PLACE_HOLDER) >= 0) {
+            // this means that one of the joined table provided a placeholder
+            throw new RuntimeException(
+                    "Joins between virtual tables that provide a :where_placeholder: are not supported: "
+                            + sql);
         }
     }
 

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/VirtualTable.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/VirtualTable.java
@@ -29,8 +29,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geotools.data.Query;
 import org.geotools.factory.Hints;
 import org.geotools.util.logging.Logging;
+import org.opengis.filter.Filter;
 
 /**
  * Describes a virtual table, that is, a feature type created starting from a generic SQL query.
@@ -51,6 +53,13 @@ import org.geotools.util.logging.Logging;
  * @source $URL$
  */
 public class VirtualTable implements Serializable {
+
+    private static final Hints.Key KEEP_WHERE_CLAUSE_PLACE_HOLDER_KEY =
+            new Hints.Key(Boolean.class);
+
+    public static String WHERE_CLAUSE_PLACE_HOLDER = ":where_clause:";
+    public static int WHERE_CLAUSE_PLACE_HOLDER_LENGTH = 14;
+
     static final Logger LOGGER = Logging.getLogger(VirtualTable.class);
 
     String name;
@@ -70,6 +79,40 @@ public class VirtualTable implements Serializable {
             new ConcurrentHashMap<String, VirtualTableParameter>();
 
     boolean escapeSql = false;
+
+    /**
+     * If the provided query has a filter of a where clause place holder exists it will be
+     * preserved.
+     *
+     * @param query the query to test
+     * @return a query hints map that will contain an entry specifying if the the where clause place
+     *     holder should be keep or not
+     */
+    public static Hints setKeepWhereClausePlaceHolderHint(Query query) {
+        Filter filter = query.getFilter();
+        return setKeepWhereClausePlaceHolderHint(
+                query.getHints(), filter != null && filter != Filter.INCLUDE);
+    }
+
+    /**
+     * Will add an entry to query hints specifying if the the where clause place holder should be
+     * keep or not. If the provided hints is NULL a new one will be instantiated and returned.
+     *
+     * @param hints query hints to update, if NULL a new hints map will be created
+     * @param keepWhereClausePlaceHolder TRUE if the where clause place holder should be keep
+     * @return a query hints map that will contain an entry specifying if the the where clause place
+     *     holder should be keep or not
+     */
+    public static Hints setKeepWhereClausePlaceHolderHint(
+            Hints hints, boolean keepWhereClausePlaceHolder) {
+        if (hints == null) {
+            // create the hints map
+            hints = new Hints();
+        }
+        // just put the provide value in the hints overriding any existing value
+        hints.put(KEEP_WHERE_CLAUSE_PLACE_HOLDER_KEY, keepWhereClausePlaceHolder);
+        return hints;
+    }
 
     /**
      * Builds a new virtual table stating its name and the query to be executed to work on it
@@ -173,8 +216,13 @@ public class VirtualTable implements Serializable {
 
     public String expandParameters(Hints hints) throws SQLException {
         // no need for expansion if we don't have parameters
+        String result = sql;
+        if (!keepWhereClausePlaceHolder(hints)) {
+            // remove the where clause place holder
+            result = removeWhereClausePlaceHolder(result);
+        }
         if (parameters.size() == 0) {
-            return sql;
+            return result;
         }
 
         // grab the parameter values
@@ -187,7 +235,6 @@ public class VirtualTable implements Serializable {
         }
 
         // perform the expansion, checking for validity and applying default values as needed
-        String result = sql;
         for (VirtualTableParameter param : parameters.values()) {
             String value = values.get(param.getName());
             if (value == null) {
@@ -393,5 +440,38 @@ public class VirtualTable implements Serializable {
     @Override
     public String toString() {
         return "VirtualTable [name=" + name + ", sql=" + sql + "]";
+    }
+
+    /**
+     * Helper method that return TRUE if the where clause place holder should be keep, otherwise
+     * FALSE if it should be removed.
+     */
+    private static boolean keepWhereClausePlaceHolder(Hints hints) {
+        if (hints == null) {
+            // no hints provided, we are done
+            return false;
+        }
+        // let's see if the where clause place holder needs to be removed
+        Object value = hints.get(KEEP_WHERE_CLAUSE_PLACE_HOLDER_KEY);
+        return value != null && value instanceof Boolean && (boolean) value;
+    }
+
+    /**
+     * Helper method that will remove, if present, the where clause place holder from the provided
+     * SQL query. If multiple where clause place holders are present an exception will be throw.
+     */
+    private static String removeWhereClausePlaceHolder(String sql) {
+        int whereClauseIndex = sql.indexOf(WHERE_CLAUSE_PLACE_HOLDER);
+        if (whereClauseIndex < 0) {
+            // no where clause place holder provided
+            return sql;
+        }
+        if (whereClauseIndex != sql.lastIndexOf(WHERE_CLAUSE_PLACE_HOLDER)) {
+            // only a single where clause place holder is supported
+            throw new RuntimeException(
+                    String.format("SQL contains multiple where clause placeholders: %s.", sql));
+        }
+        // remove the where clause place holder
+        return sql.replace(WHERE_CLAUSE_PLACE_HOLDER, "");
     }
 }


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-6034

There is nod documentation about virtual tables in GeoTools, the relevant documentation for this use case is added in GeoServer documentation.