### PR TITLE
[GEOT-6055] Upgrade commons-io dependency to 2.6 (backport 19.x)

### DIFF
--- a/modules/unsupported/geojsonstore/pom.xml
+++ b/modules/unsupported/geojsonstore/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -904,7 +904,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.1</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>


### PR DESCRIPTION
Backport of https://github.com/geotools/geotools/pull/1952