### PR TITLE
exclude jts-core transitive dependency

### DIFF
--- a/modules/plugin/jdbc/jdbc-h2/pom.xml
+++ b/modules/plugin/jdbc/jdbc-h2/pom.xml
@@ -70,7 +70,7 @@
         </exclusion>
         <exclusion>
            <groupId>org.locationtech.jts</groupId>
-           <artifactId>jts</artifactId>
+           <artifactId>jts-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
This change excludes a broken hatbox transitive dependency on a nonexistent jts-core 1.15.1-SNAPSHOT.