### PR TITLE
Set the EntityResolver on the XML Validator.

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ParserHandler.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ParserHandler.java
@@ -253,12 +253,14 @@ public class ParserHandler extends DefaultHandler2 {
 
     public void setEntityResolver(EntityResolver entityResolver) {
         this.entityResolver = (EntityResolver2) entityResolver;
+        validator.setEntityResolver(entityResolver);
     }
 
     public EntityResolver getEntityResolver() {
         return entityResolver;
     }
 
+    @Override
     public InputSource resolveEntity(String publicId, String systemId)
             throws IOException, SAXException {
         if (entityResolver != null) {

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ValidatorHandler.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xml/impl/ValidatorHandler.java
@@ -16,11 +16,15 @@
  */
 package org.geotools.xml.impl;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-import org.xml.sax.helpers.DefaultHandler;
+import org.xml.sax.ext.DefaultHandler2;
+import org.xml.sax.ext.EntityResolver2;
 
 /**
  * Handler for validating a document.
@@ -30,10 +34,13 @@ import org.xml.sax.helpers.DefaultHandler;
  * @author Justin Deoliveira, OpenGeo
  * @source $URL$
  */
-public class ValidatorHandler extends DefaultHandler {
+public class ValidatorHandler extends DefaultHandler2 {
 
     /** flag to control if an exception is thrown on a validation error */
     boolean failOnValidationError = false;
+
+    /** entity resolver */
+    EntityResolver2 entityResolver;
 
     /** list of validation errors */
     List<Exception> errors;
@@ -44,6 +51,33 @@ public class ValidatorHandler extends DefaultHandler {
 
     public boolean isFailOnValidationError() {
         return failOnValidationError;
+    }
+
+    public void setEntityResolver(EntityResolver entityResolver) {
+        this.entityResolver = (EntityResolver2) entityResolver;
+    }
+
+    public EntityResolver getEntityResolver() {
+        return entityResolver;
+    }
+
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId)
+            throws IOException, SAXException {
+        if (entityResolver != null) {
+            return entityResolver.resolveEntity(publicId, systemId);
+        } else {
+            return super.resolveEntity(publicId, systemId);
+        }
+    }
+
+    @Override
+    public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId)
+            throws SAXException, IOException {
+        if (entityResolver != null) {
+            return entityResolver.resolveEntity(name, publicId, baseURI, systemId);
+        }
+        return super.resolveEntity(name, publicId, baseURI, systemId);
     }
 
     @Override

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xml/ParserTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xml/ParserTest.java
@@ -251,6 +251,13 @@ public class ParserTest extends TestCase {
             fail("parsing should throw an exception since referenced file does not exist");
         } catch (FileNotFoundException e) {
         }
+        try {
+            parser.validate(
+                    MLSchemaLocationResolver.class.getResourceAsStream(
+                            "mails-external-entities.xml"));
+            fail("validating should throw an exception since referenced file does not exist");
+        } catch (FileNotFoundException e) {
+        }
 
         // Set an EntityResolver implementation to prevent usage of external entities.
         // When parsing an XML entity, the empty InputSource returned by this resolver provokes
@@ -282,6 +289,13 @@ public class ParserTest extends TestCase {
                     MLSchemaLocationResolver.class.getResourceAsStream(
                             "mails-external-entities.xml"));
             fail("parsing an XML with external entities should throw a MalformedURLException");
+        } catch (MalformedURLException e) {
+        }
+        try {
+            parser.validate(
+                    MLSchemaLocationResolver.class.getResourceAsStream(
+                            "mails-external-entities.xml"));
+            fail("validating an XML with external entities should throw a MalformedURLException");
         } catch (MalformedURLException e) {
         }
 
@@ -319,6 +333,8 @@ public class ParserTest extends TestCase {
 
         // parsing shouldn't throw an exception
         parser.parse(
+                MLSchemaLocationResolver.class.getResourceAsStream("mails-external-entities.xml"));
+        parser.validate(
                 MLSchemaLocationResolver.class.getResourceAsStream("mails-external-entities.xml"));
     }
 }


### PR DESCRIPTION
This pull requests updates ValidatorHandler to handle XML entities in the same way as ParserHandler.  All of the ValidatorHandler changes were copied from ParserHandler.

This pull request can be backported to 18.x and 19.x.