### PR TITLE
[GEOT-6063] Allow extracting EnvFunction local values as a read only map

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/EnvFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/EnvFunction.java
@@ -183,6 +183,15 @@ public class EnvFunction extends FunctionExpressionImpl {
         }
     }
 
+    /**
+     * Returns the local values as a read only map
+     *
+     * @return A read only view of the local values
+     */
+    public static Map<String, Object> getLocalValues() {
+        return Collections.unmodifiableMap(localLookup.getTable());
+    }
+
     /** Clear all values from the local (to this thread) lookup table. */
     public static void clearLocalValues() {
         localLookup.getTable().clear();

--- a/modules/library/main/src/test/java/org/geotools/filter/function/EnvFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/EnvFunctionTest.java
@@ -20,9 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -407,5 +409,22 @@ public class EnvFunctionTest {
     private void assertEvalStringEquals(final String expectedString, final Function function) {
         String result = (String) function.evaluate(null);
         assertEquals(expectedString, result);
+    }
+
+    @Test
+    public void testGetLocalValues() {
+        final String varName = "foo";
+        final String varValue = "clearLocal";
+
+        EnvFunction.setLocalValue(varName, varValue);
+        Map<String, Object> localValues = EnvFunction.getLocalValues();
+        assertEquals(localValues, Collections.singletonMap(varName.toUpperCase(), varValue));
+
+        try {
+            localValues.put(varName, "fooBar");
+            fail("Should have been read only");
+        } catch (UnsupportedOperationException e) {
+            // as expected
+        }
     }
 }


### PR DESCRIPTION
This change is not very interesting per se, but supports the fix in https://github.com/geoserver/geoserver/pull/3002