### PR TITLE
[GEOT-6072] close KML LinearRings automatically if they are invalid and not closed

### DIFF
--- a/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/bindings/LinearRingTypeBinding.java
+++ b/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/bindings/LinearRingTypeBinding.java
@@ -16,14 +16,15 @@
  */
 package org.geotools.kml.bindings;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import javax.xml.namespace.QName;
 import org.geotools.kml.KML;
 import org.geotools.xml.AbstractComplexBinding;
 import org.geotools.xml.ElementInstance;
 import org.geotools.xml.Node;
-import org.locationtech.jts.geom.CoordinateSequence;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.*;
 
 /**
  * Binding object for the type http://earth.google.com/kml/2.1:LinearRingType.
@@ -50,10 +51,13 @@ import org.locationtech.jts.geom.LinearRing;
  * @source $URL$
  */
 public class LinearRingTypeBinding extends AbstractComplexBinding {
+    CoordinateSequenceFactory csFactory;
     GeometryFactory geometryFactory;
 
-    public LinearRingTypeBinding(GeometryFactory geometryFactory) {
+    public LinearRingTypeBinding(
+            GeometryFactory geometryFactory, CoordinateSequenceFactory csFactory) {
         this.geometryFactory = geometryFactory;
+        this.csFactory = csFactory;
     }
 
     /** @generated */
@@ -82,6 +86,20 @@ public class LinearRingTypeBinding extends AbstractComplexBinding {
     public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
         CoordinateSequence coordinates =
                 (CoordinateSequence) node.getChildValue(KML.coordinates.getLocalPart());
+
+        // If the last point is not the same as the first point jts will throw an error
+        // where as other KML readers like google earth just auto close the polygon so
+        // here we manually fix it even though it's invalid so KMls that work elsewhere work here
+        Coordinate firstCoord = coordinates.getCoordinate(0);
+        Coordinate lastCoord = coordinates.getCoordinate(coordinates.size() - 1);
+
+        if (!firstCoord.equals3D(lastCoord)) {
+            List<Coordinate> updateCoords =
+                    new ArrayList<>(Arrays.asList(coordinates.toCoordinateArray()));
+            updateCoords.add((Coordinate) firstCoord.clone());
+
+            coordinates = csFactory.create(updateCoords.toArray(new Coordinate[0]));
+        }
 
         return geometryFactory.createLinearRing(coordinates);
     }

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/bindings/LinearRingTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/bindings/LinearRingTypeBindingTest.java
@@ -45,6 +45,17 @@ public class LinearRingTypeBindingTest extends KMLTestSupport {
         assertEquals(new Coordinate(1, 1), l.getCoordinateN(3));
     }
 
+    public void testParseInvalidNonClosedPolygon_parsesAndClosesAnyway() throws Exception {
+        buildDocument("<LinearRing><coordinates>1,1 2,2 3,3 4,4</coordinates></LinearRing>");
+
+        LinearRing l = (LinearRing) parse();
+
+        assertEquals(5, l.getNumPoints());
+        assertEquals(new Coordinate(1, 1), l.getCoordinateN(0));
+        assertEquals(new Coordinate(3, 3), l.getCoordinateN(2));
+        assertEquals(new Coordinate(4, 4), l.getCoordinateN(3));
+    }
+
     public void testEncode() throws Exception {
         LinearRing l =
                 new GeometryFactory()


### PR DESCRIPTION
If a KMLs polygon start point and end point are not the same it is considered invalid and JTS throws an exception saying it is not closed. Google earth and other KML viewers will still work with these invalid polygons and geoserver doesn't which is a problem.

So this commit rectifies it by closing unclosed linear rings by pushing a cloned start point to the end of the coordinate list if the polygon is unclosed.