### PR TITLE
GEOT-6071, CSV strategies should save the featureType in createSchema

### DIFF
--- a/modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVLatLonStrategy.java
+++ b/modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVLatLonStrategy.java
@@ -135,6 +135,8 @@ public class CSVLatLonStrategy extends CSVStrategy {
     // docs start createSchema
     @Override
     public void createSchema(SimpleFeatureType featureType) throws IOException {
+        this.featureType = featureType;
+
         List<String> header = new ArrayList<String>();
 
         GeometryDescriptor geometryDescrptor = featureType.getGeometryDescriptor();

--- a/modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVSpecifiedWKTStrategy.java
+++ b/modules/unsupported/csv/src/main/java/org/geotools/data/csv/parse/CSVSpecifiedWKTStrategy.java
@@ -69,6 +69,8 @@ public class CSVSpecifiedWKTStrategy extends CSVStrategy {
     // docs start createSchema
     @Override
     public void createSchema(SimpleFeatureType featureType) throws IOException {
+        this.featureType = featureType;
+
         List<String> header = new ArrayList<String>();
 
         for (AttributeDescriptor descriptor : featureType.getAttributeDescriptors()) {

--- a/modules/unsupported/csv/src/test/java/org/geotools/data/csv/parse/CSVLatLonStrategyTest.java
+++ b/modules/unsupported/csv/src/test/java/org/geotools/data/csv/parse/CSVLatLonStrategyTest.java
@@ -12,12 +12,16 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.geotools.data.csv.CSVFileState;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Point;
@@ -413,5 +417,30 @@ public class CSVLatLonStrategyTest {
         assertTrue("next value not read", iterator.hasNext());
         SimpleFeature feature = iterator.next();
         assertNull("Unexpected geometry", feature.getDefaultGeometry());
+    }
+
+    @Test
+    public void testCreateSchema() throws IOException {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setCRS(DefaultGeographicCRS.WGS84);
+        builder.setName("testCreateSchema");
+        builder.add("the_geom", Point.class);
+        builder.add("id", Integer.class);
+        builder.add("int_field", Integer.class);
+        builder.add("string_field", String.class);
+        SimpleFeatureType featureType = builder.buildFeatureType();
+
+        File csvFile = File.createTempFile("testCreateSchema", ".csv");
+        CSVFileState csvFileState = new CSVFileState(csvFile);
+        CSVStrategy strategy = new CSVLatLonStrategy(csvFileState, "lat_field", "long_field");
+        strategy.createSchema(featureType);
+
+        assertEquals(
+                "Stragegy does not have provided feature type",
+                featureType,
+                strategy.getFeatureType());
+        List<String> content = Files.readAllLines(csvFile.toPath());
+        assertEquals("long_field,lat_field,id,int_field,string_field", content.get(0));
+        csvFile.delete();
     }
 }

--- a/modules/unsupported/csv/src/test/java/org/geotools/data/csv/parse/CSVSpecifiedWKTStrategyTest.java
+++ b/modules/unsupported/csv/src/test/java/org/geotools/data/csv/parse/CSVSpecifiedWKTStrategyTest.java
@@ -9,8 +9,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
 import org.geotools.data.csv.CSVFileState;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -67,5 +72,30 @@ public class CSVSpecifiedWKTStrategyTest {
         SimpleFeature feature = iterator.next();
         assertEquals("Invalid feature property", "bar", feature.getAttribute("morx"));
         assertNull("Unexpected geometry", feature.getAttribute("fleem"));
+    }
+
+    @Test
+    public void testCreateSchema() throws IOException {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setCRS(DefaultGeographicCRS.WGS84);
+        builder.setName("testCreateSchema");
+        builder.add("the_geom", Point.class);
+        builder.add("id", Integer.class);
+        builder.add("int_field", Integer.class);
+        builder.add("string_field", String.class);
+        SimpleFeatureType featureType = builder.buildFeatureType();
+
+        File csvFile = File.createTempFile("testCreateSchema", ".csv");
+        CSVFileState csvFileState = new CSVFileState(csvFile);
+        CSVStrategy strategy = new CSVSpecifiedWKTStrategy(csvFileState, "the_geom_wkt");
+        strategy.createSchema(featureType);
+
+        assertEquals(
+                "Stragegy does not have provided feature type",
+                featureType,
+                strategy.getFeatureType());
+        List<String> content = Files.readAllLines(csvFile.toPath());
+        assertEquals("the_geom_wkt,id,int_field,string_field", content.get(0));
+        csvFile.delete();
     }
 }


### PR DESCRIPTION
Other wise the feature type is regenerated with default Integer attribute
types.