### PR TITLE
[GEOT-6067] Cannot correctly load Filter 2.0 documents that have a fes:PropertyIsLike with a child fes:Function

### DIFF
--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/LikeFilterFesImpl.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/LikeFilterFesImpl.java
@@ -1,0 +1,53 @@
+package org.geotools.filter;
+
+import org.opengis.filter.expression.Expression;
+
+/**
+ * An implementation of {@link org.opengis.filter.PropertyIsLike} that supports expressions on the
+ * right hand side, in accordance to the Filter 2.0 schema. Permits visitors to traverse a function
+ * chain if necessary.
+ */
+public class LikeFilterFesImpl extends LikeFilterImpl {
+    private final Expression valueExpression;
+
+    public LikeFilterFesImpl(Expression valueExpression) {
+        super();
+        this.valueExpression = valueExpression;
+    }
+
+    public LikeFilterFesImpl(
+            Expression expr,
+            String pattern,
+            String wildcardMulti,
+            String wildcardSingle,
+            String escape,
+            Expression valueExpression) {
+        super(expr, pattern, wildcardMulti, wildcardSingle, escape);
+        this.valueExpression = valueExpression;
+    }
+
+    public LikeFilterFesImpl(MatchAction matchAction, Expression valueExpression) {
+        super(matchAction);
+        this.valueExpression = valueExpression;
+    }
+
+    public LikeFilterFesImpl(
+            Expression expr,
+            String pattern,
+            String wildcardMulti,
+            String wildcardSingle,
+            String escape,
+            MatchAction matchAction,
+            Expression valueExpression) {
+        super(expr, pattern, wildcardMulti, wildcardSingle, escape, matchAction);
+        this.valueExpression = valueExpression;
+    }
+
+    public Expression getExpression1() {
+        return super.getExpression();
+    }
+
+    public Expression getExpression2() {
+        return valueExpression;
+    }
+}

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/PropertyIsLikeTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/PropertyIsLikeTypeBinding.java
@@ -16,11 +16,20 @@
  */
 package org.geotools.filter.v2_0.bindings;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.xml.namespace.QName;
+import org.geotools.filter.LikeFilterFesImpl;
 import org.geotools.filter.v1_0.OGCPropertyIsLikeTypeBinding;
 import org.geotools.filter.v2_0.FES;
+import org.geotools.xml.ElementInstance;
+import org.geotools.xml.Node;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Function;
+import org.opengis.filter.expression.Literal;
+import org.opengis.filter.expression.PropertyName;
 
 /**
  * Binding object for the type http://www.opengis.net/fes/2.0:PropertyIsLikeType.
@@ -55,12 +64,19 @@ public class PropertyIsLikeTypeBinding extends OGCPropertyIsLikeTypeBinding {
         this.factory = factory;
     }
 
+    @Override
     public QName getTarget() {
         return FES.PropertyIsLikeType;
     }
 
+    @Override
     public Object getProperty(Object object, QName name) throws Exception {
         PropertyIsLike isLike = (PropertyIsLike) object;
+
+        if (FES.expression.equals(name) && isLike instanceof LikeFilterFesImpl) {
+            LikeFilterFesImpl isLikeFes = (LikeFilterFesImpl) isLike;
+            return new Object[] {isLikeFes.getExpression1(), isLikeFes.getExpression2()};
+        }
 
         if (FES.expression.equals(name)) {
             return new Object[] {
@@ -70,5 +86,66 @@ public class PropertyIsLikeTypeBinding extends OGCPropertyIsLikeTypeBinding {
         }
 
         return super.getProperty(object, name);
+    }
+
+    @Override
+    public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
+        String wildcard = (String) node.getAttributeValue("wildCard");
+        String single = (String) node.getAttributeValue("singleChar");
+        String escape = (String) node.getAttributeValue("escape");
+        boolean matchCase = true;
+
+        if (node.getAttributeValue("matchCase") != null) {
+            matchCase = (Boolean) node.getAttributeValue("matchCase");
+        }
+
+        if (escape == null) {
+            // 1.1 uses "escapeChar", suppot that too
+            escape = (String) node.getAttributeValue("escapeChar");
+        }
+
+        // With the 2.0 schema, must support "expression" on RHS
+        List<?> childValues = node.getChildValues(Function.class);
+        List<Function> functions =
+                childValues
+                        .stream()
+                        .filter(Function.class::isInstance)
+                        .map(Function.class::cast)
+                        .collect(Collectors.toList());
+
+        if (functions.size() == 2) {
+            return createFesLike(
+                    functions.get(0), functions.get(1), matchCase, wildcard, single, escape);
+        }
+
+        PropertyName name = (PropertyName) node.getChildValue(PropertyName.class);
+        Literal literal = (Literal) node.getChildValue(Literal.class);
+
+        if (name == null) {
+            return createFesLike(functions.get(0), literal, matchCase, wildcard, single, escape);
+        }
+
+        if (literal == null) {
+            return createFesLike(name, functions.get(0), matchCase, wildcard, single, escape);
+        }
+
+        return factory.like(name, literal.toString(), wildcard, single, escape, matchCase);
+    }
+
+    private LikeFilterFesImpl createFesLike(
+            Expression propertyExpression,
+            Expression valueExpression,
+            boolean matchCase,
+            String wildcard,
+            String single,
+            String escape) {
+        LikeFilterFesImpl like = new LikeFilterFesImpl(valueExpression);
+        like.setExpression(propertyExpression);
+        like.setLiteral(valueExpression.evaluate(valueExpression).toString());
+        like.setMatchCase(matchCase);
+        like.setWildCard(wildcard);
+        like.setSingleChar(single);
+        like.setEscape(escape);
+        return like;
     }
 }

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/LikeBindingTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/LikeBindingTest.java
@@ -1,0 +1,113 @@
+package org.geotools.filter.v2_0.bindings;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.parsers.ParserConfigurationException;
+import org.geotools.filter.FilterFactoryImpl;
+import org.geotools.filter.LikeFilterFesImpl;
+import org.geotools.filter.LikeFilterImpl;
+import org.geotools.filter.v2_0.FES;
+import org.geotools.filter.v2_0.FESConfiguration;
+import org.geotools.filter.v2_0.FESTestSupport;
+import org.geotools.xml.Configuration;
+import org.geotools.xml.Encoder;
+import org.geotools.xml.Parser;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.filter.expression.Function;
+import org.opengis.filter.expression.Literal;
+import org.opengis.filter.expression.PropertyName;
+import org.xml.sax.SAXException;
+
+public class LikeBindingTest {
+
+    private static final Configuration FES_CONFIGURATION = new FESConfiguration();
+
+    private static final Parser PARSER = new Parser(FES_CONFIGURATION);
+
+    private static final Encoder ENCODER = new Encoder(FES_CONFIGURATION);
+
+    @Test
+    public void testParseLikeNoFunctions() throws Exception {
+        Filter filter = loadFilter("like-func-none.xml");
+        LikeFilterImpl like = assertType(filter, LikeFilterImpl.class);
+        PropertyName property = assertType(like.getExpression(), PropertyName.class);
+        assertEquals(property.getPropertyName(), "property");
+        assertEquals(like.getLiteral(), "value");
+    }
+
+    @Test
+    public void testParseLikeFunctionBoth() throws Exception {
+        Filter filter = loadFilter("like-func-both.xml");
+        LikeFilterFesImpl like = assertType(filter, LikeFilterFesImpl.class);
+        Function property = assertType(like.getExpression1(), Function.class);
+        Function value = assertType(like.getExpression2(), Function.class);
+        assertEquals(property.getParameters().get(0).toString(), "property");
+        assertEquals(value.getParameters().get(0).toString(), "value");
+    }
+
+    @Test
+    public void testParseLikeFunctionProperty() throws Exception {
+        Filter filter = loadFilter("like-func-property.xml");
+        LikeFilterFesImpl like = assertType(filter, LikeFilterFesImpl.class);
+        Function property = assertType(like.getExpression1(), Function.class);
+        Literal value = assertType(like.getExpression2(), Literal.class);
+        assertEquals(property.getParameters().get(0).toString(), "property");
+        assertEquals(value.getValue(), "value");
+    }
+
+    @Test
+    public void testParseLikeFunctionValue() throws Exception {
+        Filter filter = loadFilter("like-func-value.xml");
+        LikeFilterFesImpl like = assertType(filter, LikeFilterFesImpl.class);
+        PropertyName property = assertType(like.getExpression1(), PropertyName.class);
+        Function value = assertType(like.getExpression2(), Function.class);
+        assertEquals(property.getPropertyName(), "property");
+        assertEquals(value.getParameters().get(0).toString(), "value");
+    }
+
+    @Test
+    public void testEncodeLikeFunctionBoth() throws Exception {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        LikeFilterFesImpl like =
+                new LikeFilterFesImpl(
+                        ff.function("strURLEncode", ff.literal("value"), ff.literal(false)));
+        like.setExpression(ff.function("strURLEncode", ff.property("property"), ff.literal(true)));
+        String xml = writeFilter(like);
+        assertTrue(
+                "XML was not written correctly, expected the expressions to be functions",
+                xml.contains(
+                        "<fes:Function name=\"strURLEncode\">"
+                                + "<fes:ValueReference>property</fes:ValueReference>"
+                                + "<fes:Literal>true</fes:Literal>"
+                                + "</fes:Function>"
+                                + "<fes:Function name=\"strURLEncode\">"
+                                + "<fes:Literal>value</fes:Literal>"
+                                + "<fes:Literal>false</fes:Literal>"
+                                + "</fes:Function>"));
+    }
+
+    private static <T> T assertType(Object object, Class<T> clazz) {
+        assertTrue(clazz.isInstance(object));
+        return clazz.cast(object);
+    }
+
+    private static Filter loadFilter(String resource)
+            throws IOException, SAXException, ParserConfigurationException {
+        try (InputStream data =
+                FESTestSupport.class.getClassLoader().getResourceAsStream(resource)) {
+            return (Filter) PARSER.parse(data);
+        }
+    }
+
+    private static String writeFilter(Filter filter) throws IOException {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            ENCODER.encode(filter, FES.Filter, out);
+            return new String(out.toByteArray());
+        }
+    }
+}

--- a/modules/extension/xsd/xsd-fes/src/test/resources/like-func-both.xml
+++ b/modules/extension/xsd/xsd-fes/src/test/resources/like-func-both.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.opengis.net/fes/2.0 http://schemas.opengis.net/filter/2.0/filterAll.xsd">
+    <fes:PropertyIsLike matchCase="false" wildCard="*" singleChar="%" escapeChar="\">
+        <fes:Function name="strURLEncode">
+            <fes:ValueReference>property</fes:ValueReference>
+            <fes:Literal>true</fes:Literal>
+        </fes:Function>
+        <fes:Function name="strURLEncode">
+            <fes:Literal>value</fes:Literal>
+            <fes:Literal>false</fes:Literal>
+        </fes:Function>
+    </fes:PropertyIsLike>
+</fes:Filter>

--- a/modules/extension/xsd/xsd-fes/src/test/resources/like-func-none.xml
+++ b/modules/extension/xsd/xsd-fes/src/test/resources/like-func-none.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.opengis.net/fes/2.0 http://schemas.opengis.net/filter/2.0/filterAll.xsd">
+    <fes:PropertyIsLike matchCase="false" wildCard="%" singleChar="_" escapeChar="\">
+        <fes:ValueReference>property</fes:ValueReference>
+        <fes:Literal>value</fes:Literal>
+    </fes:PropertyIsLike>
+</fes:Filter>

--- a/modules/extension/xsd/xsd-fes/src/test/resources/like-func-property.xml
+++ b/modules/extension/xsd/xsd-fes/src/test/resources/like-func-property.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.opengis.net/fes/2.0 http://schemas.opengis.net/filter/2.0/filterAll.xsd">
+    <fes:PropertyIsLike matchCase="false" wildCard="*" singleChar="%" escapeChar="\">
+        <fes:Function name="strURLEncode">
+            <fes:ValueReference>property</fes:ValueReference>
+            <fes:Literal>true</fes:Literal>
+        </fes:Function>
+        <fes:Literal>value</fes:Literal>
+    </fes:PropertyIsLike>
+</fes:Filter>

--- a/modules/extension/xsd/xsd-fes/src/test/resources/like-func-value.xml
+++ b/modules/extension/xsd/xsd-fes/src/test/resources/like-func-value.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.opengis.net/fes/2.0 http://schemas.opengis.net/filter/2.0/filterAll.xsd">
+    <fes:PropertyIsLike matchCase="false" wildCard="*" singleChar="%" escapeChar="\">
+        <fes:ValueReference>property</fes:ValueReference>
+        <fes:Function name="strURLEncode">
+            <fes:Literal>value</fes:Literal>
+            <fes:Literal>false</fes:Literal>
+        </fes:Function>
+    </fes:PropertyIsLike>
+</fes:Filter>


### PR DESCRIPTION
This PR is early experimentation to address the following issue: 
https://osgeo-org.atlassian.net/browse/GEOT-6067

>Cannot correctly load Filter 2.0 documents that have a fes:PropertyIsLike with a child fes:Function

Per the Filter 2.0 schema, I'm in need of expression support on *both* sides of the PropertyIsLike operator. I've accomplished this with the following: 

- Created a new `LikeFilterFesImpl extends LikeFilterImpl` that holds an additional `Expression` (only available in the xsd-fes module; didn't make sense to promote to the library)
- The `PropertyIsLikeTypeBinding` was updated to use the new impl under the correct circumstances
- Unit tests were added

Not sure this is the final solution, but it appears to solve the problem. I'm fully prepared to rework it as necessary. 