### PR TITLE
[GEOT-6070] Copy existing defaultGeometry on SimpleFeatureTypeBuilder.init(SimpleFeatureType)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
@@ -185,6 +185,9 @@ public class SimpleFeatureTypeBuilder {
         restrictions().addAll(type.getRestrictions());
         this.defaultCrs = type.getCoordinateReferenceSystem();
         this.defaultCrsSet = true;
+        if (type.getGeometryDescriptor() != null) {
+            this.defaultGeometry = type.getGeometryDescriptor().getLocalName();
+        }
         attributes = null;
         attributes().addAll(type.getAttributeDescriptors());
 
@@ -607,6 +610,9 @@ public class SimpleFeatureTypeBuilder {
             AttributeDescriptor descriptor = iterator.next();
             if (descriptor.getLocalName().equals(attributeName)) {
                 iterator.remove();
+                if (attributeName.equals(defaultGeometry)) {
+                    defaultGeometry = null;
+                }
                 return descriptor;
             }
         }
@@ -847,7 +853,7 @@ public class SimpleFeatureTypeBuilder {
                 String msg =
                         "'"
                                 + this.defaultGeometry
-                                + " specified as default"
+                                + "' specified as default"
                                 + " but could find no such attribute.";
                 throw new IllegalArgumentException(msg);
             }
@@ -1000,6 +1006,8 @@ public class SimpleFeatureTypeBuilder {
         GeometryDescriptor defaultGeometry = original.getGeometryDescriptor();
         if (defaultGeometry != null && types.contains(defaultGeometry.getLocalName())) {
             b.setDefaultGeometry(defaultGeometry.getLocalName());
+        } else {
+            b.setDefaultGeometry(null);
         }
 
         return b.buildFeatureType();

--- a/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleTypeBuilderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleTypeBuilderTest.java
@@ -121,7 +121,7 @@ public class SimpleTypeBuilderTest extends TestCase {
         assertNull(featureType.getDescriptor("attrWithoutDefault").getDefaultValue());
     }
 
-    public void testMaintainDefaultGeometry() {
+    public void testMaintainDefaultGeometryOnRetype() {
         builder.setName("testGeometries");
         builder.add("geo1", Point.class, DefaultGeographicCRS.WGS84);
         builder.add("geo2", Polygon.class, DefaultGeographicCRS.WGS84);
@@ -133,5 +133,67 @@ public class SimpleTypeBuilderTest extends TestCase {
         SimpleFeatureType retyped =
                 SimpleFeatureTypeBuilder.retype(type, new String[] {"geo2", "geo1"});
         assertEquals("geo1", retyped.getGeometryDescriptor().getLocalName());
+    }
+
+    public void testRetypeGeometryless() {
+        builder.setName("testGeometryless");
+        builder.add("geo1", Point.class, DefaultGeographicCRS.WGS84);
+        builder.add("integer", Integer.class);
+        builder.setDefaultGeometry("geo1");
+        SimpleFeatureType type = builder.buildFeatureType();
+
+        // performing an attribute selection, even changing order, should not change
+        // the default geometry, that had a special meaning in the original source
+        SimpleFeatureType retyped = SimpleFeatureTypeBuilder.retype(type, new String[] {"integer"});
+        assertNotNull(retyped);
+        assertNull(retyped.getGeometryDescriptor());
+        assertEquals(1, retyped.getAttributeCount());
+        assertEquals("integer", retyped.getAttributeDescriptors().get(0).getLocalName());
+    }
+
+    public void testInitGeometryless() {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("testGeometryless");
+        builder.add("integer", Integer.class);
+        SimpleFeatureType type1 = builder.buildFeatureType();
+
+        builder = new SimpleFeatureTypeBuilder();
+        builder.init(type1);
+        SimpleFeatureType type2 = builder.buildFeatureType();
+
+        assertEquals(type1, type2);
+    }
+
+    public void testMaintainDefaultGeometryOnInit() {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("testGeometries");
+        builder.add("geo1", Point.class, DefaultGeographicCRS.WGS84);
+        builder.add("geo2", Polygon.class, DefaultGeographicCRS.WGS84);
+        builder.setDefaultGeometry("geo2");
+        SimpleFeatureType type1 = builder.buildFeatureType();
+
+        builder = new SimpleFeatureTypeBuilder();
+        builder.init(type1);
+        SimpleFeatureType type2 = builder.buildFeatureType();
+
+        assertEquals("geo2", type1.getGeometryDescriptor().getLocalName());
+        assertEquals("geo2", type2.getGeometryDescriptor().getLocalName());
+    }
+
+    public void testRemoveDefaultGeometryAfterInit() {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("testGeometries");
+        builder.add("geo1", Point.class, DefaultGeographicCRS.WGS84);
+        builder.add("geo2", Polygon.class, DefaultGeographicCRS.WGS84);
+        builder.setDefaultGeometry("geo2");
+        SimpleFeatureType type1 = builder.buildFeatureType();
+
+        builder = new SimpleFeatureTypeBuilder();
+        builder.init(type1);
+        builder.remove("geo2");
+        SimpleFeatureType type2 = builder.buildFeatureType();
+
+        assertEquals("geo2", type1.getGeometryDescriptor().getLocalName());
+        assertEquals("geo1", type2.getGeometryDescriptor().getLocalName());
     }
 }


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-6070 and https://github.com/geoserver/geoserver/pull/3014

Changes
* Copy defaultGeometry from existing featureType
* Unset defaultGeometry if that attribute is removed
* Unset defaultGeometry if the FeatureType is retyped such that the geometry is no longer included (preserve it if it is merely renamed)