### PR TITLE
[GEOT-6073] When loading or saving a fes:DWithin filter, the units of measure attribute is ignored

### DIFF
--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/DWithinBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/DWithinBinding.java
@@ -18,9 +18,13 @@ package org.geotools.filter.v2_0.bindings;
 
 import javax.xml.namespace.QName;
 import org.geotools.filter.v1_0.OGCDWithinBinding;
+import org.geotools.filter.v1_0.OGCUtils;
 import org.geotools.filter.v2_0.FES;
+import org.geotools.xml.ElementInstance;
+import org.geotools.xml.Node;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.Expression;
 
 /**
  * Binding object for the element http://www.opengis.net/ogc:DWithin.
@@ -39,11 +43,26 @@ import org.opengis.filter.FilterFactory2;
  */
 public class DWithinBinding extends OGCDWithinBinding {
 
+    private final FilterFactory2 localFilterFactory;
+
+    private final GeometryFactory localGeometryFactory;
+
     public DWithinBinding(FilterFactory2 filterFactory, GeometryFactory geometryFactory) {
         super(filterFactory, geometryFactory);
+        this.localFilterFactory = filterFactory;
+        this.localGeometryFactory = geometryFactory;
     }
 
     public QName getTarget() {
         return FES.DWithin;
+    }
+
+    @Override
+    public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
+        Expression[] operands = OGCUtils.spatial(node, localFilterFactory, localGeometryFactory);
+        double distance = ((Double) node.getChildValue("Distance")).doubleValue();
+        Object units = node.getChild("Distance").getAttributeValue("uom");
+        return localFilterFactory.dwithin(
+                operands[0], operands[1], distance, units == null ? null : units.toString());
     }
 }

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/DistanceBufferTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/DistanceBufferTypeBinding.java
@@ -20,8 +20,10 @@ import java.util.List;
 import javax.xml.namespace.QName;
 import org.eclipse.xsd.XSDElementDeclaration;
 import org.geotools.filter.v2_0.FES;
-import org.geotools.xml.*;
+import org.geotools.xml.AbstractComplexBinding;
 import org.opengis.filter.spatial.DistanceBufferOperator;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 /**
  * Binding object for the type http://www.opengis.net/fes/2.0:DistanceBufferType.
@@ -69,6 +71,18 @@ public class DistanceBufferTypeBinding extends AbstractComplexBinding {
     //    public Object getProperty(Object object, QName name) throws Exception {
     //        return FESParseEncodeUtil.getProperty((DistanceBufferOperator) object, name);
     //    }
+
+    @Override
+    public Element encode(Object object, Document document, Element value) throws Exception {
+        DistanceBufferOperator buffer = (DistanceBufferOperator) object;
+        Element e = document.createElementNS(value.getNamespaceURI(), "fes:Distance");
+        e.setTextContent(Double.toString(buffer.getDistance()));
+        if (buffer.getDistanceUnits() != null) {
+            e.setAttribute("uom", buffer.getDistanceUnits());
+        }
+        value.appendChild(e);
+        return value;
+    }
 
     @Override
     public List getProperties(Object object, XSDElementDeclaration element) throws Exception {

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/DWithinBindingTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/DWithinBindingTest.java
@@ -1,16 +1,83 @@
 package org.geotools.filter.v2_0.bindings;
 
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.parsers.ParserConfigurationException;
+import org.geotools.filter.FilterFactoryImpl;
+import org.geotools.filter.spatial.DWithinImpl;
 import org.geotools.filter.v1_1.FilterMockData;
 import org.geotools.filter.v2_0.FES;
+import org.geotools.filter.v2_0.FESConfiguration;
 import org.geotools.filter.v2_0.FESTestSupport;
+import org.geotools.xml.Configuration;
+import org.geotools.xml.Encoder;
+import org.geotools.xml.Parser;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
 import org.opengis.filter.spatial.DWithin;
-import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
-public class DWithinBindingTest extends FESTestSupport {
+public class DWithinBindingTest {
 
+    private static final Configuration CONFIGURATION = new FESConfiguration();
+
+    private static final Parser PARSER = new Parser(CONFIGURATION);
+
+    private static final Encoder ENCODER = new Encoder(CONFIGURATION);
+
+    // TODO: Nothing being asserted - remove?
     public void testEncode() throws Exception {
         DWithin dwithin = FilterMockData.dwithin();
-        Document dom = encode(dwithin, FES.DWithin);
+        //    Document dom = encode(dwithin, FES.DWithin);
         // print(dom);
+    }
+
+    @Test
+    public void testDWithinBindingEncodesUnits() throws Exception {
+        FilterFactory ff = new FilterFactoryImpl();
+        DWithinImpl dWithin = new DWithinImpl(ff.property("location"), ff.literal("WKT (10, 30)"));
+        dWithin.setDistance(542.3231);
+        dWithin.setUnits("meters");
+        String xml = writeFilter(dWithin);
+        assertTrue(
+                format("XML was not written correctly, expected DWithin operator %n%s", xml),
+                xml.contains("<fes:DWithin>"));
+        assertTrue(
+                format("XML was not written correctly, expected units to be non-null %n%s", xml),
+                xml.contains("<fes:Distance uom=\"meters\">542.3231</fes:Distance>"));
+    }
+
+    @Test
+    public void testDWithinBindingParsesUnits() throws Exception {
+        Filter filter = loadFilter("dwithin-units.xml");
+        DWithin dWithin = assertType(filter, DWithin.class);
+        assertEquals(542.3231, dWithin.getDistance(), 0.0);
+        assertEquals("meters", dWithin.getDistanceUnits());
+    }
+
+    private static <T> T assertType(Object object, Class<T> clazz) {
+        assertTrue(clazz.isInstance(object));
+        return clazz.cast(object);
+    }
+
+    private static Filter loadFilter(String resource)
+            throws IOException, SAXException, ParserConfigurationException {
+        try (InputStream data =
+                FESTestSupport.class.getClassLoader().getResourceAsStream(resource)) {
+            return (Filter) PARSER.parse(data);
+        }
+    }
+
+    private static String writeFilter(Filter filter) throws IOException {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            ENCODER.encode(filter, FES.Filter, out);
+            return new String(out.toByteArray());
+        }
     }
 }

--- a/modules/extension/xsd/xsd-fes/src/test/resources/dwithin-units.xml
+++ b/modules/extension/xsd/xsd-fes/src/test/resources/dwithin-units.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.opengis.net/fes/2.0 http://schemas.opengis.net/filter/2.0/filterAll.xsd">
+    <fes:DWithin>
+        <fes:Distance uom="meters">542.3231</fes:Distance>
+        <fes:ValueReference>location</fes:ValueReference>
+        <fes:Literal>POINT (30 10)</fes:Literal>
+    </fes:DWithin>
+</fes:Filter>

--- a/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCUtils.java
+++ b/modules/extension/xsd/xsd-filter/src/main/java/org/geotools/filter/v1_0/OGCUtils.java
@@ -99,7 +99,7 @@ public class OGCUtils {
      * @param node The parse tree.
      * @return A two element array of expressions for a BinarySpatialOp type.
      */
-    static Expression[] spatial(Node node, FilterFactory2 ff, GeometryFactory gf) {
+    public static Expression[] spatial(Node node, FilterFactory2 ff, GeometryFactory gf) {
         List names = node.getChildValues(PropertyName.class);
         if (names.size() == 2) {
             // join


### PR DESCRIPTION
This PR is early experimentation to address the following issue: 
https://osgeo-org.atlassian.net/browse/GEOT-6073

>When loading or saving a fes:DWithin filter, the "uom" (units of measure) attribute is ignored

The current solution works "as-is" but is not technically schema-compliant. The `<Distance ... >` element should occur **after** the two expressions, not before. I've tried adding bindings for `FES.UomIdentifier` and `FES.UomSymbol` but could not trigger a breakpoint in the `parse(...)` or `encode(...)` methods of the respective `AbstractComplexBinding` (even after wiring things up through Pico container). 

Currently, the `DWithinBinding` handles parsing directly, just like its OGC counterpart. For encoding, the `DistanceBufferTypeBinding` was updated to directly encode the `<Distance ... >` element. During encoding the child is appended to the front of the list, not the back. 

I'm concerned about this solution. This can't be the "correct" way to go about it or the resultant XML would pass validation. I feel like I lack a lot of context about `xsd-core` as a whole. There is **a lot** of custom XML infrastructure here. Did I miss any developer documentation? 