### PR TITLE
Update datastore tutorial maven archetype command

### DIFF
--- a/docs/user/tutorial/datastore/intro.rst
+++ b/docs/user/tutorial/datastore/intro.rst
@@ -93,7 +93,7 @@ Time to create a new project making use of this library:
 #. Create a new project:
 
    * Using Eclipse: :menuselection:`New --> Project` to create a `Maven Project` with group `org.geotools.tutorial` and name `csv`.
-   * Using Maven: ``mvn archetype:create -DgroupId=org.geotools.tutorial -DartifactId=csv``
+   * Using Maven: ``mvn archetype:generate -DgroupId=org.geotools.tutorial -DartifactId=csv -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.apache.maven.archetypes -DarchetypeArtifactId=maven-archetype-quickstart``
 
 #. Fill in project details, paying careful attention to the *gt.version* property you wish to use. You can choose a stable release (recommended) or use |branch|-SNAPSHOT for access to the latest nightly build.
 


### PR DESCRIPTION
`archetype:create` does not work with recent maven plugins.