### PR TITLE
Backport GEOT-6084 to 19.x

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/logging/CommonsLoggerFactory.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/logging/CommonsLoggerFactory.java
@@ -19,7 +19,6 @@ package org.geotools.util.logging;
 import java.util.logging.Logger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.logging.impl.Jdk14Logger;
 
 /**
  * A factory for loggers that redirect all Java logging events to the Apache's <A
@@ -61,7 +60,8 @@ public class CommonsLoggerFactory extends LoggerFactory<Log> {
      */
     protected Log getImplementation(final String name) {
         final Log log = LogFactory.getLog(name);
-        if (log instanceof Jdk14Logger) {
+        if (log != null
+                && log.getClass().getName().equals("org.apache.commons.logging.impl.Jdk14Logger")) {
             return null;
         }
         return log;


### PR DESCRIPTION
If uDig upgrades to 19.x (https://github.com/locationtech/udig-platform/pull/279) it requires to get this fix backported to 19.x branch

origin pull request was #1997 

Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>