### PR TITLE
GEOT-6018 - Fix for WMTS doesn't correctly handle `image/jpgpng` format

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/map/WMTSCoverageReader.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/map/WMTSCoverageReader.java
@@ -20,6 +20,7 @@ import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.data.wms.xml.Dimension;
 import org.geotools.data.wmts.WebMapTileServer;
 import org.geotools.data.wmts.model.WMTSLayer;
+import org.geotools.data.wmts.request.AbstractGetTileRequest;
 import org.geotools.data.wmts.request.GetTileRequest;
 import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -435,6 +436,8 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
         // requestEnvelope?
         tileRequest.setRequestedTime(time);
 
+        // Set format for output
+        tileRequest.setProperty(AbstractGetTileRequest.FORMAT, format);
         try {
             this.requestCRS = CRS.decode(requestSrs);
         } catch (Exception e) {

--- a/modules/extension/wmts/src/test/java/org/geotools/map/WMTSCoverageReaderOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/map/WMTSCoverageReaderOnlineTest.java
@@ -1,0 +1,79 @@
+package org.geotools.map;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import java.net.URL;
+import java.util.Set;
+
+import org.geotools.data.wmts.WebMapTileServer;
+import org.geotools.data.wmts.client.WMTSTileService;
+import org.geotools.data.wmts.model.WMTSLayer;
+import org.geotools.data.wmts.request.AbstractGetTileRequest;
+import org.geotools.data.wmts.request.GetTileRequest;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.geotools.tile.Tile;
+import org.geotools.tile.Tile.RenderState;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * 
+ * @author Christian Marsch
+ */
+@Ignore("Do not know what to do when creating an online test")
+public class WMTSCoverageReaderOnlineTest {
+
+	/**
+	 * Testing the behavior of {@link WMTSCoverageReader} when accessing a layer
+	 * only providing image/jpeg.<br>
+	 * This test ensures the {@link AbstractGetTileRequest#FORMAT} was set in
+	 * {@link WMTSCoverageReader#initTileRequest(ReferencedEnvelope, int, int, String)}
+	 * and is delegated by {@link AbstractGetTileRequest#getTiles()} to
+	 * {@link WMTSTileService}.
+	 */
+	@Test
+	public void testKVPInitMapRequest_JPEGFormatOnly() throws Exception {
+		WebMapTileServer server = new WebMapTileServer(
+				new URL("https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi"));
+		WMTSLayer layer = (WMTSLayer) server.getCapabilities().getLayer("VIIRS_CityLights_2012");
+		WMTSCoverageReader wcr = new WMTSCoverageReader(server, layer);
+		ReferencedEnvelope bbox = new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
+		int width = 400;
+		int height = 200;
+		ReferencedEnvelope grid = wcr.initTileRequest(bbox, width, height, null);
+		assertNotNull(grid);
+		GetTileRequest mapRequest = wcr.getTileRequest();
+		mapRequest.setCRS(grid.getCoordinateReferenceSystem());
+		Set<Tile> responses = wcr.wmts.issueRequest(mapRequest);
+		assertFalse("At least one response must be done", responses.isEmpty());
+		Tile firstTile = responses.stream().findFirst().get();
+		firstTile.getBufferedImage();
+		assertNotEquals(RenderState.INVALID, firstTile.getRenderState());
+	}
+
+	/**
+	 * Test case for server described in ticket GEOT-6018.
+	 */
+	@Test
+	public void testKVPInitMapRequest_PNGJPEGFormatOnly() throws Exception {
+		WebMapTileServer server = new WebMapTileServer(
+				new URL("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Toronto/ImageServer/WMTS"));
+		WMTSLayer layer = (WMTSLayer) server.getCapabilities().getLayer("Toronto");
+		WMTSCoverageReader wcr = new WMTSCoverageReader(server, layer);
+		ReferencedEnvelope bbox = new ReferencedEnvelope(-8837500.0 - 300.0, -8837500.0 + 300.0, 5405478 - 300.0,
+				5405478 + 300.0, CRS.decode("EPSG:3857"));
+		int width = 400;
+		int height = 200;
+		ReferencedEnvelope grid = wcr.initTileRequest(bbox, width, height, null);
+		assertNotNull(grid);
+		GetTileRequest mapRequest = wcr.getTileRequest();
+		mapRequest.setCRS(grid.getCoordinateReferenceSystem());
+		Set<Tile> responses = wcr.wmts.issueRequest(mapRequest);
+		assertFalse("At least one response must be done", responses.isEmpty());
+		Tile firstTile = responses.stream().findFirst().get();
+		firstTile.getBufferedImage();
+		assertNotEquals(RenderState.INVALID, firstTile.getRenderState());
+	}
+}

--- a/modules/extension/wmts/src/test/java/org/geotools/map/WMTSCoverageReaderOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/map/WMTSCoverageReaderOnlineTest.java
@@ -1,11 +1,11 @@
 package org.geotools.map;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertFalse;
+
 import java.net.URL;
 import java.util.Set;
-
 import org.geotools.data.wmts.WebMapTileServer;
 import org.geotools.data.wmts.client.WMTSTileService;
 import org.geotools.data.wmts.model.WMTSLayer;
@@ -18,62 +18,65 @@ import org.geotools.tile.Tile.RenderState;
 import org.junit.Ignore;
 import org.junit.Test;
 
-/**
- * 
- * @author Christian Marsch
- */
+/** @author Christian Marsch */
 @Ignore("Do not know what to do when creating an online test")
 public class WMTSCoverageReaderOnlineTest {
 
-	/**
-	 * Testing the behavior of {@link WMTSCoverageReader} when accessing a layer
-	 * only providing image/jpeg.<br>
-	 * This test ensures the {@link AbstractGetTileRequest#FORMAT} was set in
-	 * {@link WMTSCoverageReader#initTileRequest(ReferencedEnvelope, int, int, String)}
-	 * and is delegated by {@link AbstractGetTileRequest#getTiles()} to
-	 * {@link WMTSTileService}.
-	 */
-	@Test
-	public void testKVPInitMapRequest_JPEGFormatOnly() throws Exception {
-		WebMapTileServer server = new WebMapTileServer(
-				new URL("https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi"));
-		WMTSLayer layer = (WMTSLayer) server.getCapabilities().getLayer("VIIRS_CityLights_2012");
-		WMTSCoverageReader wcr = new WMTSCoverageReader(server, layer);
-		ReferencedEnvelope bbox = new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-		int width = 400;
-		int height = 200;
-		ReferencedEnvelope grid = wcr.initTileRequest(bbox, width, height, null);
-		assertNotNull(grid);
-		GetTileRequest mapRequest = wcr.getTileRequest();
-		mapRequest.setCRS(grid.getCoordinateReferenceSystem());
-		Set<Tile> responses = wcr.wmts.issueRequest(mapRequest);
-		assertFalse("At least one response must be done", responses.isEmpty());
-		Tile firstTile = responses.stream().findFirst().get();
-		firstTile.getBufferedImage();
-		assertNotEquals(RenderState.INVALID, firstTile.getRenderState());
-	}
+    /**
+     * Testing the behavior of {@link WMTSCoverageReader} when accessing a layer only providing
+     * image/jpeg.<br>
+     * This test ensures the {@link AbstractGetTileRequest#FORMAT} was set in {@link
+     * WMTSCoverageReader#initTileRequest(ReferencedEnvelope, int, int, String)} and is delegated by
+     * {@link AbstractGetTileRequest#getTiles()} to {@link WMTSTileService}.
+     */
+    @Test
+    public void testKVPInitMapRequest_JPEGFormatOnly() throws Exception {
+        WebMapTileServer server =
+                new WebMapTileServer(
+                        new URL("https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi"));
+        WMTSLayer layer = (WMTSLayer) server.getCapabilities().getLayer("VIIRS_CityLights_2012");
+        WMTSCoverageReader wcr = new WMTSCoverageReader(server, layer);
+        ReferencedEnvelope bbox =
+                new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
+        int width = 400;
+        int height = 200;
+        ReferencedEnvelope grid = wcr.initTileRequest(bbox, width, height, null);
+        assertNotNull(grid);
+        GetTileRequest mapRequest = wcr.getTileRequest();
+        mapRequest.setCRS(grid.getCoordinateReferenceSystem());
+        Set<Tile> responses = wcr.wmts.issueRequest(mapRequest);
+        assertFalse("At least one response must be done", responses.isEmpty());
+        Tile firstTile = responses.stream().findFirst().get();
+        firstTile.getBufferedImage();
+        assertNotEquals(RenderState.INVALID, firstTile.getRenderState());
+    }
 
-	/**
-	 * Test case for server described in ticket GEOT-6018.
-	 */
-	@Test
-	public void testKVPInitMapRequest_PNGJPEGFormatOnly() throws Exception {
-		WebMapTileServer server = new WebMapTileServer(
-				new URL("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Toronto/ImageServer/WMTS"));
-		WMTSLayer layer = (WMTSLayer) server.getCapabilities().getLayer("Toronto");
-		WMTSCoverageReader wcr = new WMTSCoverageReader(server, layer);
-		ReferencedEnvelope bbox = new ReferencedEnvelope(-8837500.0 - 300.0, -8837500.0 + 300.0, 5405478 - 300.0,
-				5405478 + 300.0, CRS.decode("EPSG:3857"));
-		int width = 400;
-		int height = 200;
-		ReferencedEnvelope grid = wcr.initTileRequest(bbox, width, height, null);
-		assertNotNull(grid);
-		GetTileRequest mapRequest = wcr.getTileRequest();
-		mapRequest.setCRS(grid.getCoordinateReferenceSystem());
-		Set<Tile> responses = wcr.wmts.issueRequest(mapRequest);
-		assertFalse("At least one response must be done", responses.isEmpty());
-		Tile firstTile = responses.stream().findFirst().get();
-		firstTile.getBufferedImage();
-		assertNotEquals(RenderState.INVALID, firstTile.getRenderState());
-	}
+    /** Test case for server described in ticket GEOT-6018. */
+    @Test
+    public void testKVPInitMapRequest_PNGJPEGFormatOnly() throws Exception {
+        WebMapTileServer server =
+                new WebMapTileServer(
+                        new URL(
+                                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Toronto/ImageServer/WMTS"));
+        WMTSLayer layer = (WMTSLayer) server.getCapabilities().getLayer("Toronto");
+        WMTSCoverageReader wcr = new WMTSCoverageReader(server, layer);
+        ReferencedEnvelope bbox =
+                new ReferencedEnvelope(
+                        -8837500.0 - 300.0,
+                        -8837500.0 + 300.0,
+                        5405478 - 300.0,
+                        5405478 + 300.0,
+                        CRS.decode("EPSG:3857"));
+        int width = 400;
+        int height = 200;
+        ReferencedEnvelope grid = wcr.initTileRequest(bbox, width, height, null);
+        assertNotNull(grid);
+        GetTileRequest mapRequest = wcr.getTileRequest();
+        mapRequest.setCRS(grid.getCoordinateReferenceSystem());
+        Set<Tile> responses = wcr.wmts.issueRequest(mapRequest);
+        assertFalse("At least one response must be done", responses.isEmpty());
+        Tile firstTile = responses.stream().findFirst().get();
+        firstTile.getBufferedImage();
+        assertNotEquals(RenderState.INVALID, firstTile.getRenderState());
+    }
 }


### PR DESCRIPTION
Found this issue when trying to include a WMTS which only serves 'image/jpeg'.
As this is a very small fix, I did not discuss this with others.

That is what I have done:
Centralized parameter FORMAT for GetTile Requests to find out easily when it has been set.
Setting this parameter by the coverage reader as it has been computed there already in constructor.
Set this value also for GetTileRequest when working with KVP.

My provided test is set to ignore, as it depends on online data. I do not know how to test this the right way in GEOTOOLS.

There is a test failure in _org.geotools.data.wmts.client.WMTSTransparentTileTest.testTransparentTile()_ that seams to have nothing to do with my work.