### PR TITLE
[GEOT-6102] Upgrade GeographicLib to 1.49

### DIFF
--- a/modules/library/referencing/pom.xml
+++ b/modules/library/referencing/pom.xml
@@ -191,7 +191,7 @@
    <dependency>
      <groupId>net.sf.geographiclib</groupId>
      <artifactId>GeographicLib-Java</artifactId>
-     <version>1.44</version>
+     <version>1.49</version>
    </dependency>
 
 

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/GeodeticCalculatorTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/GeodeticCalculatorTest.java
@@ -67,7 +67,7 @@ public final class GeodeticCalculatorTest {
         calculator.setDestinationGeographicPoint(11, 20);
         assertEquals("West", -90, calculator.getAzimuth(), EPS);
         calculator.setDestinationGeographicPoint(12, 19);
-        assertEquals("South", -180, calculator.getAzimuth(), EPS);
+        assertEquals("South", 180, calculator.getAzimuth(), EPS);
     }
 
     /**


### PR DESCRIPTION
The reason for the test change is that GeographicLib 1.48 (and a little in 1.47) has
a change in behaviour. From the release notes:
"The default range for longitude and azimuth is now (-180d, 180d],
instead of [-180d, 180d). This was already the case for the C++
library; now the change has been made to the other implementations
(C, Fortran, Java, JavaScript, Python, MATLAB, and Maxima)."