### PR TITLE
[GEOT-6103] Upgrade EJML to 0.34

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/transform/ProjectiveTransform.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import org.ejml.MatrixDimensionException;
 import org.geotools.metadata.iso.citation.Citations;
 import org.geotools.parameter.MatrixParameterDescriptors;
 import org.geotools.parameter.MatrixParameters;
@@ -475,7 +476,9 @@ public class ProjectiveTransform extends AbstractMathTransform
                 final XMatrix matrix = getGeneralMatrix();
                 try {
                     matrix.invert();
-                } catch (SingularMatrixException | IllegalArgumentException exception) {
+                } catch (SingularMatrixException
+                        | IllegalArgumentException
+                        | MatrixDimensionException exception) {
                     throw new NoninvertibleTransformException(
                             Errors.format(ErrorKeys.NONINVERTIBLE_TRANSFORM), exception);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -831,7 +831,7 @@
       <dependency>
         <groupId>org.ejml</groupId>
         <artifactId>ejml-ddense</artifactId>
-        <version>0.32</version>
+        <version>0.34</version>
       </dependency>
       <dependency>
         <groupId>org.locationtech.jts</groupId>


### PR DESCRIPTION
The EJML inverse function was changed to return a MatrixDimensionException if the input is not square:
https://github.com/lessthanoptimal/ejml/commit/ca9f8d528dd4a460658d3223b626a494de297f73#diff-16e60a287b7af132b57bfc757a7c8dc6R682
I kept the old catch for IllegalArgumentException just in case that still gets used somewhere.