### PR TITLE
GEOT-3942: version conflict on xerces is resolved

### DIFF
--- a/modules/extension/xsd/xsd-wps/pom.xml
+++ b/modules/extension/xsd/xsd-wps/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- =======================================================================    
         Maven Project Configuration File                                        

--- a/pom.xml
+++ b/pom.xml
@@ -836,24 +836,12 @@
       <dependency>
         <groupId>org.locationtech.jts</groupId>
         <artifactId>jts-core</artifactId>
-	<version>${jts.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-          </exclusion>
-        </exclusions>
+	      <version>${jts.version}</version>
       </dependency>
       <dependency>
         <groupId>org.locationtech.jts</groupId>
         <artifactId>jts-example</artifactId>
-	<version>${jts.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>${jts.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wkb4j</groupId>


### PR DESCRIPTION
JTS doesn't depend on xerces anymore. Threre's no need to declare this exclusion any longer.

The xerces dependency was removed from the pom file in JTS version 1.13 and later.
This fixes GEOT-3942.

Details:

The 19.x branch of geotools uses the jts distibution from vividsolutions. The migration to JTS from locationtech removed this dependency. 
```
|    |    |    |    |    |    |    +--- org.geotools:gt-coverage:19.2
...
|    |    |    |    |    |    |    |    +--- com.vividsolutions:jts-example:1.14.0
|    |    |    |    |    |    |    |    |    +--- com.vividsolutions:jts-core:1.14.0
|    |    |    |    |    |    |    |    |    \--- com.vividsolutions:jts-io:1.14.0
|    |    |    |    |    |    |    |    |         +--- com.vividsolutions:jts-core:1.14.0
|    |    |    |    |    |    |    |    |         \--- com.googlecode.json-simple:json-simple:1.1
|    |    |    |    |    |    |    |    +--- org.jaitools:jt-zonalstats:1.4.0
|    |    |    |    |    |    |    |    |    \--- org.jaitools:jt-utils:1.4.0
|    |    |    |    |    |    |    |    |         \--- com.vividsolutions:jts:1.12
|    |    |    |    |    |    |    |    |              \--- xerces:xercesImpl:2.4.0 -> 2.11.0 (*)
```
