### PR TITLE
Remove left-over geogit module dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1131,23 +1131,7 @@
 		<artifactId>org.eclipse.xsd</artifactId>
 		<version>2.12.0</version>
 	</dependency>
-	
-      <dependency>
-        <groupId>com.sleepycat</groupId>
-        <artifactId>je</artifactId>
-        <version>4.1.7</version>
-      </dependency> 
-      <dependency>
-        <groupId>com.caucho</groupId>
-        <artifactId>resin-hessian</artifactId>
-        <version>4.0.20</version>
-      </dependency>      
-      <dependency>
-        <groupId>com.fasterxml.uuid</groupId>
-        <artifactId>java-uuid-generator</artifactId>
-        <version>3.1.2</version>
-      </dependency>
-      
+	    
       <!-- Other random non test dependencies -->
       <dependency>
         <groupId>net.sf.ehcache</groupId>


### PR DESCRIPTION
These were added when geogit was added, and probably should have been removed as
part of commit 56f9bc507c76d05716e20fb.
