### PR TITLE
[GEOT-6106] Upgrade postgresql JDBC driver to 42.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <postgresql.jdbc.version>42.1.1</postgresql.jdbc.version>
+    <postgresql.jdbc.version>42.2.5</postgresql.jdbc.version>
     <solrj.version>7.2.1</solrj.version>
     <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>
     <git.commit.useNative>false</git.commit.useNative>


### PR DESCRIPTION
I did a full build of geoserver against the modified geotools, but I don't have an online test environment, and it really does need that kind of test.

@bencaradocdavies Can you run the tests?