### PR TITLE
[docs] Add a missing double quote in the sed command

### DIFF
--- a/docs/user/welcome/upgrade.rst
+++ b/docs/user/welcome/upgrade.rst
@@ -50,7 +50,7 @@ Using the command line to update your own pom.xml files::
    
 And codebase::
 
-   git grep -l com.vividsolutions | xargs sed -i "s/com.vividsolutions/org.locationtech/
+   git grep -l com.vividsolutions | xargs sed -i "s/com.vividsolutions/org.locationtech/"
 
 **Use of copy rather than clone**
 


### PR DESCRIPTION
Trivial fix for the 20.x migration docs