### PR TITLE
Backport GEOT-6107 to 20.x: Add AttributeDescriptor to descriptors list to fix filtering of geopackages

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgFilterToSQL.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgFilterToSQL.java
@@ -88,6 +88,8 @@ public class GeoPkgFilterToSQL extends PreparedFilterToSQL {
         literalValues.add(literalValue);
         SRIDs.add(currentSRID);
         dimensions.add(currentDimension);
+        descriptors.add(
+                context instanceof AttributeDescriptor ? (AttributeDescriptor) context : null);
 
         Class clazz = null;
         if (context instanceof Class) clazz = (Class) context;


### PR DESCRIPTION
Backport the GeoPackage filtering fix to 20.x.

Original pull request against master: https://github.com/geotools/geotools/pull/2024

JIRA: https://osgeo-org.atlassian.net/browse/GEOT-6107

Thanks!
Jared
