### PR TITLE
LabelSplitter index-out-of-bounds bug.

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelSplitter.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelSplitter.java
@@ -369,9 +369,10 @@ class LabelSplitter {
                             foundFont = true;
                             result.add(new FontRange(text, base, start, fonts[0]));
                             break;
-                        } else {
-                            start++;
                         }
+                    }
+                    if (!foundFont) {
+                        start++;
                     }
                 }
             }
@@ -389,7 +390,7 @@ class LabelSplitter {
      *
      * @author Andrea Aime - GeoSolutions
      */
-    private static class FontRange {
+    static class FontRange {
         int startChar;
 
         int endChar;

--- a/modules/library/render/src/test/java/org/geotools/renderer/label/LabelSplitterTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/label/LabelSplitterTest.java
@@ -1,0 +1,91 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2014 - 2018 , Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.label;
+
+import static org.junit.Assert.assertEquals;
+
+import java.awt.Font;
+import java.util.List;
+import org.geotools.renderer.label.LabelSplitter.FontRange;
+import org.junit.Test;
+
+public class LabelSplitterTest {
+
+    @Test
+    public void testFontRangeWithUnrenderableCharsInMiddle() {
+        LabelSplitter splitter = new LabelSplitter();
+        String text = "Some text ነ𐩬 here";
+        Font[] fonts = {
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10)
+        };
+
+        List<FontRange> ranges = splitter.buildFontRanges(text, fonts);
+        assertEquals(3, ranges.size());
+
+        FontRange startRange = ranges.get(0);
+        assertEquals(0, startRange.startChar);
+        assertEquals(10, startRange.endChar);
+        assertEquals(fonts[0], startRange.font);
+        assertEquals("Some text ", startRange.text);
+
+        FontRange middleRange = ranges.get(1);
+        assertEquals(10, middleRange.startChar);
+        assertEquals(13, middleRange.endChar);
+        assertEquals(fonts[0], middleRange.font);
+        assertEquals("ነ𐩬", middleRange.text);
+
+        FontRange endRange = ranges.get(2);
+        assertEquals(13, endRange.startChar);
+        assertEquals(18, endRange.endChar);
+        assertEquals(fonts[0], endRange.font);
+        assertEquals(" here", endRange.text);
+    }
+
+    @Test
+    public void testFontRangeWithRenderableCharAtStartAndSpecialCharsAtEnd() {
+        LabelSplitter splitter = new LabelSplitter();
+        String text = "𦘦字字字字字字字字";
+        Font[] fonts = {
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Times New Roman", Font.PLAIN, 10),
+            new Font("Lucida", Font.PLAIN, 10)
+        };
+
+        List<FontRange> ranges = splitter.buildFontRanges(text, fonts);
+        assertEquals(2, ranges.size());
+
+        FontRange startRange = ranges.get(0);
+        assertEquals(0, startRange.startChar);
+        assertEquals(2, startRange.endChar);
+        assertEquals(fonts[0], startRange.font);
+        assertEquals("𦘦", startRange.text);
+
+        FontRange endRange = ranges.get(1);
+        assertEquals(2, endRange.startChar);
+        assertEquals(10, endRange.endChar);
+        assertEquals(fonts[5], endRange.font);
+        assertEquals("字字字字字字字字", endRange.text);
+    }
+}


### PR DESCRIPTION
- Fixed a bug in the LabelSplitter class where the start index would be
  incorrectly advanced at the end of the buildFontRanges() method. This
  happened when a font could not be found to display the character at
  the current index, the start-index would then be incremented in the
  else. This can lead to an incorrect font-range from being created, or
  at worst a StringIndexOutOfBoundsException.
  The fix for this is to not increment the start-index inside the
  for-loop, but to keep it fixed and allow all fonts to be checked
  whether they can render the current character. Only after the loop has
  iterated through all fonts; and no font has been found; do we
  increment the start-index.
- A new unit test class called LabelSplitterTest was added. These tests
  were written to illustrate the abovementioned bug. With the first test,
  we have a string with some special characters in the middle. If the
  bug-fix is not applied to the LabelSplitter the ranges will be
  completely messed up. The second test has a character at the start,
  that can be renderered by the "Times New Roman" font. However, the
  rest of the characters can only be rendered by the "Lucida" font. If
  the bug-fix is not applied the LabelSplitter will create a second-font
  range that will cause a StringIndexOutOfBoundsException.