### PR TITLE
GEOT-6122: Fix for NPE in KML encoder

### DIFF
--- a/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/v22/bindings/DataTypeBinding.java
+++ b/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/v22/bindings/DataTypeBinding.java
@@ -71,7 +71,11 @@ public class DataTypeBinding extends AbstractComplexBinding {
             return data.getKey().toString();
         }
         if ("value".equals(name.getLocalPart())) {
-            return data.getValue().toString();
+            if (data.getValue() != null) {
+                return data.getValue().toString();
+            } else {
+                return null;
+            }
         }
 
         return super.getProperty(object, name);

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLEncodingTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLEncodingTest.java
@@ -105,4 +105,27 @@ public class KMLEncodingTest extends KMLTestSupport {
         assertTrue("name".equals(attrName1.getValue()));
         assertTrue("attr2".equals(attrName2.getValue()));
     }
+
+    public void testEncodeNullAttribute() throws Exception {
+        GeometryFactory geomFactory = new GeometryFactory();
+        DefaultFeatureCollection collection = new DefaultFeatureCollection("internal", null);
+        SimpleFeatureType type =
+                DataUtilities.createType("location", "geom:Point,name:String,attr2:Integer");
+
+        Point point1 = geomFactory.createPoint(new Coordinate(40, 50));
+        Point point2 = geomFactory.createPoint(new Coordinate(30, 45));
+        Point point3 = geomFactory.createPoint(new Coordinate(35, 46));
+        collection.add(SimpleFeatureBuilder.build(type, new Object[] {point1, null, 17}, null));
+        collection.add(
+                SimpleFeatureBuilder.build(type, new Object[] {point2, "feature #2", null}, null));
+        collection.add(
+                SimpleFeatureBuilder.build(type, new Object[] {point3, "third feature", 42}, null));
+
+        Encoder encoder = new Encoder(new KMLConfiguration());
+        // Note: if indenting is set to true, this will give weird results
+        // when parsed as XML (extra text XML elements)
+        // encoder.setIndenting(true);
+        // this will throw a NPE without GEOT-6122 fix
+        Document kmlDoc = encoder.encodeAsDOM(collection, KML.kml);
+    }
 }


### PR DESCRIPTION
See [GEOT-6122](https://osgeo-org.atlassian.net/projects/GEOT/issues/GEOT-6122) for detail. KML encoder could not export features with null attributes.