### PR TITLE
Additional type mappings for jts geometry types

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -234,27 +234,43 @@ public class DataUtilities {
 
         typeEncode.put(Geometry.class, "Geometry");
         typeMap.put("Geometry", Geometry.class);
+        typeMap.put("com.vividsolutions.jts.geom.Geometry", Geometry.class);
+        typeMap.put("org.locationtech.jts.geom.Geometry", Geometry.class);
 
         typeEncode.put(Point.class, "Point");
         typeMap.put("Point", Point.class);
+        typeMap.put("com.vividsolutions.jts.geom.Point", Point.class);
+        typeMap.put("org.locationtech.jts.geom.Point", Point.class);
 
         typeEncode.put(LineString.class, "LineString");
         typeMap.put("LineString", LineString.class);
+        typeMap.put("com.vividsolutions.jts.geom.LineString", LineString.class);
+        typeMap.put("org.locationtech.jts.geom.LineString", LineString.class);
 
         typeEncode.put(Polygon.class, "Polygon");
         typeMap.put("Polygon", Polygon.class);
+        typeMap.put("com.vividsolutions.jts.geom.Polygon", Polygon.class);
+        typeMap.put("org.locationtech.jts.geom.Polygon", Polygon.class);
 
         typeEncode.put(MultiPoint.class, "MultiPoint");
         typeMap.put("MultiPoint", MultiPoint.class);
+        typeMap.put("com.vividsolutions.jts.geom.MultiPoint", MultiPoint.class);
+        typeMap.put("org.locationtech.jts.geom.MultiPoint", MultiPoint.class);
 
         typeEncode.put(MultiLineString.class, "MultiLineString");
         typeMap.put("MultiLineString", MultiLineString.class);
+        typeMap.put("com.vividsolutions.jts.geom.MultiPoint", MultiLineString.class);
+        typeMap.put("org.locationtech.jts.geom.MultiPoint", MultiLineString.class);
 
         typeEncode.put(MultiPolygon.class, "MultiPolygon");
         typeMap.put("MultiPolygon", MultiPolygon.class);
+        typeMap.put("com.vividsolutions.jts.geom.MultiPolygon", MultiPolygon.class);
+        typeMap.put("org.locationtech.jts.geom.MultiPolygon", MultiPolygon.class);
 
         typeEncode.put(GeometryCollection.class, "GeometryCollection");
         typeMap.put("GeometryCollection", GeometryCollection.class);
+        typeMap.put("com.vividsolutions.jts.geom.GeometryCollection", GeometryCollection.class);
+        typeMap.put("org.locationtech.jts.geom.GeometryCollection", GeometryCollection.class);
 
         typeEncode.put(Date.class, "Date");
         typeMap.put("Date", Date.class);
@@ -2582,7 +2598,7 @@ public class DataUtilities {
                     if (h.equals("nillable")) {
                         nillable = true;
                     }
-                    // spatial reference identieger?
+                    // spatial reference identifier
                     if (h.startsWith("srid=")) {
                         String srid = h.split("=")[1];
                         Integer.parseInt(srid);
@@ -2596,7 +2612,7 @@ public class DataUtilities {
                 }
             }
 
-            Class clazz = type(type);
+            Class<?> clazz = type(type);
             if (Geometry.class.isAssignableFrom(clazz)) {
                 GeometryType at =
                         new GeometryTypeImpl(
@@ -2605,7 +2621,7 @@ public class DataUtilities {
                                 crs,
                                 false,
                                 false,
-                                Collections.EMPTY_LIST,
+                                Collections.emptyList(),
                                 null,
                                 null);
                 return new GeometryDescriptorImpl(at, new NameImpl(name), 0, 1, nillable, null);
@@ -2616,7 +2632,7 @@ public class DataUtilities {
                                 clazz,
                                 false,
                                 false,
-                                Collections.EMPTY_LIST,
+                                Collections.emptyList(),
                                 null,
                                 null);
                 return new AttributeDescriptorImpl(at, new NameImpl(name), 0, 1, nillable, null);

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -439,6 +439,41 @@ public class DataUtilitiesTest extends DataTestCase {
         String text = DataUtilities.encodeFeature(feature1);
         assertEquals("fid1=1|Jody Garnett\\nSteering Committee|POINT (1 2)", text);
     }
+    
+    /**
+     * Test createType and encode can handle com.vividsolutions.jts and org.locationtech.jts
+     * bindings.
+     */
+    public void testDecodeGeometrySpec() throws Exception {
+        SimpleFeatureType featureType1,featureType2;
+        
+        featureType1 =
+                DataUtilities.createType(
+                        "Contact", "id:Integer,party:String,geom:Geometry");
+        featureType2 =
+                DataUtilities.createType(
+                        "Contact", "id:Integer,party:String,geom:org.locationtech.jts.geom.Geometry");
+        
+        assertEquals( featureType1, featureType2);
+        featureType2 =
+                DataUtilities.createType(
+                        "Contact", "id:Integer,party:String,geom:com.vividsolutions.jts.geom.Geometry");
+        assertEquals( featureType1, featureType2);
+        
+        assertEquals(
+                DataUtilities.createAttribute("point:Point"),
+                DataUtilities.createAttribute("point:com.vividsolutions.jts.geom.Point")
+                );
+        assertEquals(
+                DataUtilities.createAttribute("point:Point"),
+                DataUtilities.createAttribute("point:org.locationtech.jts.geom.Point")
+                );
+        
+        assertEquals(
+                DataUtilities.createAttribute("area:Polygon"),
+                DataUtilities.createAttribute("area:com.vividsolutions.jts.geom.Polygon")
+                );
+    }
     /*
      * Test for Feature template(FeatureType)
      */

--- a/modules/plugin/imagemosaic/src/test/resources/org/geotools/gce/imagemosaic/test-data/tiff_rgba_extra/indexer.properties
+++ b/modules/plugin/imagemosaic/src/test/resources/org/geotools/gce/imagemosaic/test-data/tiff_rgba_extra/indexer.properties
@@ -1,2 +1,2 @@
 CoverageNameCollectorSPI=org.geotools.gce.imagemosaic.namecollector.FileNameRegexNameCollectorSPI:regex=(pass[A-Z])
-Schema=*the_geom:Polygon,location:String
+Schema=*the_geom:com.vividsolutions.jts.geom.Polygon,location:String


### PR DESCRIPTION
Maps both org.locationtech.jts.geom and com.vividsolutions.jts.geom for backwards compatibility.