### PR TITLE
[GEOT-6131] Support GDAL 2.3.0 JNI binding 'gdalalljni' for OGR

### DIFF
--- a/modules/unsupported/ogr/ogr-jni/src/main/java/org/geotools/data/ogr/jni/JniOGRDataStoreFactory.java
+++ b/modules/unsupported/ogr/ogr-jni/src/main/java/org/geotools/data/ogr/jni/JniOGRDataStoreFactory.java
@@ -2,8 +2,15 @@ package org.geotools.data.ogr.jni;
 
 import org.geotools.data.ogr.OGR;
 import org.geotools.data.ogr.OGRDataStoreFactory;
+import org.geotools.util.logging.Logging;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 
 public class JniOGRDataStoreFactory extends OGRDataStoreFactory {
+
+    private static final Logger LOGGER = Logging.getLogger(JniOGRDataStoreFactory.class);
 
     @Override
     protected OGR createOGR() {
@@ -12,7 +19,14 @@ public class JniOGRDataStoreFactory extends OGRDataStoreFactory {
 
     @Override
     protected boolean doIsAvailable() throws Throwable {
-        System.loadLibrary("gdaljni");
+        try {
+            // GDAL version >= 2.3.0
+            System.loadLibrary("gdalalljni");
+        } catch (UnsatisfiedLinkError e) {
+            LOGGER.log(Level.FINE,  "Error initializing GDAL/OGR library from \"gdalalljni\". " +
+                    "Falling back to \"gdaljni\"", e);
+            System.loadLibrary("gdaljni");
+        }
         return true;
     }
 }


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOT-6131

This PR is based on https://github.com/geosolutions-it/imageio-ext/pull/170 (Since OGR does its own system call to load the libraries, I figured I'd fix it while I was at it)