### PR TITLE
[GEOT-6142] Update netcdf to 4.6.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <imageio.ext.version>1.1.26</imageio.ext.version>
     <jts.version>1.16.0</jts.version>
     <jaiext.version>1.1.2</jaiext.version>
-    <netcdf.version>4.6.6</netcdf.version>
+    <netcdf.version>4.6.11</netcdf.version>
     <jt.version>1.5.0</jt.version>
     <java.awt.headless>true</java.awt.headless>
     <sun.java2d.d3d>true</sun.java2d.d3d>


### PR DESCRIPTION
We have 4.6.11 in the osgeo maven repo. I assume there is no reason we can't upgrade to that both here and over in geoserver.