### PR TITLE
[GEOT-6150] FeatureUtilities.convertPolygonToPointArray fails to round correctly negative numbers

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/resources/coverage/FeatureUtilities.java
+++ b/modules/library/coverage/src/main/java/org/geotools/resources/coverage/FeatureUtilities.java
@@ -301,8 +301,8 @@ public final class FeatureUtilities {
             if (!isIdentity) worldToGridTransform.transform(coords, 0, coords, 0, 1);
 
             // send it back to the returned polygon
-            final int x = (int) (coords[0] + 0.5d);
-            final int y = (int) (coords[1] + 0.5d);
+            final int x = (int) Math.round(coords[0]);
+            final int y = (int) Math.round(coords[1]);
             if (points != null) points.add(new Point2D.Double(coords[0], coords[1]));
 
             // send it back to the returned polygon

--- a/modules/library/coverage/src/test/java/org/geotools/resources/coverage/FeatureUtilitiesTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/resources/coverage/FeatureUtilitiesTest.java
@@ -1,0 +1,44 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2018, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.resources.coverage;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.junit.Test;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.io.WKTReader;
+
+public class FeatureUtilitiesTest {
+
+    @Test
+    public void testConvertPolygonToPointArrayRounding() throws Exception {
+        Polygon polygon =
+                (Polygon)
+                        new WKTReader()
+                                .read(
+                                        "POLYGON((-9.9 -9.9, -9.9 9.9, 9.9 9.9, 9.9 -9.9, -9.9 -9.9))");
+        java.awt.Polygon poly =
+                FeatureUtilities.convertPolygonToPointArray(
+                        polygon, IdentityTransform.create(2), null);
+
+        assertEquals(-10, poly.getBounds().x);
+        assertEquals(-10, poly.getBounds().y);
+        assertEquals(20, poly.getBounds().width);
+        assertEquals(20, poly.getBounds().height);
+    }
+}


### PR DESCRIPTION
This is in turn used by Crop, causing images with a negative origin to be cut "off by one" pixel from the intended position.