### PR TITLE
Removing gml:id on geometry encoding, only for GML 3.1

### DIFF
--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GeometryEncoder.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/simple/GeometryEncoder.java
@@ -33,8 +33,16 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public abstract class GeometryEncoder<T extends Geometry> extends ObjectEncoder<T> {
 
+    /** Flag for to encode gml:id as attribute if is true. */
+    private boolean encodeGmlId = true;
+
     protected GeometryEncoder(Encoder encoder) {
         super(encoder);
+    }
+
+    protected GeometryEncoder(Encoder encoder, boolean encodeGmlId) {
+        super(encoder);
+        this.encodeGmlId = encodeGmlId;
     }
 
     /**
@@ -64,7 +72,7 @@ public abstract class GeometryEncoder<T extends Geometry> extends ObjectEncoder<
      *     gml:id attribute otherwise
      */
     protected AttributesImpl cloneWithGmlId(AttributesImpl atts, String gmlId) {
-        if (gmlId == null) {
+        if (gmlId == null || !encodeGmlId) {
             return atts;
         }
         AttributesImpl result;

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/CurveEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/CurveEncoder.java
@@ -53,6 +53,15 @@ class CurveEncoder extends GeometryEncoder<LineString> {
 
     protected CurveEncoder(Encoder e, String gmlPrefix, String gmlUri) {
         super(e);
+        init(gmlPrefix, gmlUri);
+    }
+
+    protected CurveEncoder(Encoder e, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(e, encodeGmlId);
+        init(gmlPrefix, gmlUri);
+    }
+
+    private void init(String gmlPrefix, String gmlUri) {
         this.curve = CURVE.derive(gmlPrefix, gmlUri);
         this.segments = SEGMENTS.derive(gmlPrefix, gmlUri);
         this.lineStringSegment = LINE_STRING_SEGMENT.derive(gmlPrefix, gmlUri);

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML3FeatureCollectionEncoderDelegate.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GML3FeatureCollectionEncoderDelegate.java
@@ -240,24 +240,29 @@ public class GML3FeatureCollectionEncoderDelegate
         @Override
         public void registerGeometryEncoders(
                 Map<Class, GeometryEncoder> encoders, Encoder encoder) {
-            encoders.put(Point.class, new PointEncoder(encoder, gmlPrefix, gmlUri));
-            encoders.put(MultiPoint.class, new MultiPointEncoder(encoder, gmlPrefix, gmlUri));
-            encoders.put(LineString.class, new LineStringEncoder(encoder, gmlPrefix, gmlUri));
-            encoders.put(LinearRing.class, new LinearRingEncoder(encoder, gmlPrefix, gmlUri));
+            encoders.put(Point.class, new PointEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(
+                    MultiPoint.class, new MultiPointEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(
+                    LineString.class, new LineStringEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(
+                    LinearRing.class, new LinearRingEncoder(encoder, gmlPrefix, gmlUri, false));
             encoders.put(
                     MultiLineString.class,
-                    new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, false));
+                    new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, false, false));
             encoders.put(
-                    MultiCurve.class, new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, true));
-            encoders.put(Polygon.class, new PolygonEncoder(encoder, gmlPrefix, gmlUri));
-            encoders.put(MultiPolygon.class, new MultiPolygonEncoder(encoder, gmlPrefix, gmlUri));
-            encoders.put(CircularString.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
-            encoders.put(CompoundCurve.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
-            encoders.put(CircularRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
-            encoders.put(CompoundRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri));
+                    MultiCurve.class,
+                    new MultiLineStringEncoder(encoder, gmlPrefix, gmlUri, true, false));
+            encoders.put(Polygon.class, new PolygonEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(
+                    MultiPolygon.class, new MultiPolygonEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(CircularString.class, new CurveEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(CompoundCurve.class, new CurveEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(CircularRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri, false));
+            encoders.put(CompoundRing.class, new CurveEncoder(encoder, gmlPrefix, gmlUri, false));
             encoders.put(
                     GeometryCollection.class,
-                    new GeometryCollectionEncoder(encoder, gmlPrefix, gmlUri));
+                    new GeometryCollectionEncoder(encoder, gmlPrefix, gmlUri, false));
         }
 
         @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GenericGeometryEncoder.java
@@ -55,6 +55,16 @@ public class GenericGeometryEncoder extends GeometryEncoder<Geometry> {
      */
     public GenericGeometryEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
+        init(encoder, gmlPrefix, gmlUri);
+    }
+
+    public GenericGeometryEncoder(
+            Encoder encoder, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(encoder, encodeGmlId);
+        init(encoder, gmlPrefix, gmlUri);
+    }
+
+    private void init(Encoder encoder, String gmlPrefix, String gmlUri) {
         this.encoder = encoder;
         this.gmlPrefix = gmlPrefix;
         this.gmlUri = gmlUri;

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/GeometryCollectionEncoder.java
@@ -46,6 +46,17 @@ class GeometryCollectionEncoder extends GeometryEncoder<GeometryCollection> {
     protected GeometryCollectionEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
         gge = new GenericGeometryEncoder(encoder, gmlPrefix, gmlUri);
+        init(gmlPrefix, gmlUri);
+    }
+
+    protected GeometryCollectionEncoder(
+            Encoder encoder, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(encoder, encodeGmlId);
+        gge = new GenericGeometryEncoder(encoder, gmlPrefix, gmlUri, encodeGmlId);
+        init(gmlPrefix, gmlUri);
+    }
+
+    private void init(String gmlPrefix, String gmlUri) {
         multiGeometry = MULTI_GEOMETRY.derive(gmlPrefix, gmlUri);
         geometryMember = GEOMETRY_MEMBER.derive(gmlPrefix, gmlUri);
     }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LineStringEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LineStringEncoder.java
@@ -40,8 +40,18 @@ class LineStringEncoder extends GeometryEncoder<LineString> {
         this(encoder, LINE_STRING.derive(gmlPrefix, gmlUri));
     }
 
+    protected LineStringEncoder(
+            Encoder encoder, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        this(encoder, LINE_STRING.derive(gmlPrefix, gmlUri), encodeGmlId);
+    }
+
     protected LineStringEncoder(Encoder encoder, QualifiedName element) {
         super(encoder);
+        this.element = element;
+    }
+
+    protected LineStringEncoder(Encoder encoder, QualifiedName element, boolean encodeGmlId) {
+        super(encoder, encodeGmlId);
         this.element = element;
     }
 

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LinearRingEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/LinearRingEncoder.java
@@ -37,6 +37,11 @@ class LinearRingEncoder extends LineStringEncoder {
         super(encoder, LINEAR_RING.derive(gmlPrefix, gmlUri));
     }
 
+    protected LinearRingEncoder(
+            Encoder encoder, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(encoder, LINEAR_RING.derive(gmlPrefix, gmlUri), encodeGmlId);
+    }
+
     @Override
     public void encode(LineString geometry, AttributesImpl atts, GMLWriter handler, String gmlId)
             throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiLineStringEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiLineStringEncoder.java
@@ -65,6 +65,23 @@ class MultiLineStringEncoder extends GeometryEncoder<Geometry> {
         lse = new LineStringEncoder(encoder, gmlPrefix, gmlUri);
         lre = new LinearRingEncoder(encoder, gmlPrefix, gmlUri);
         ce = new CurveEncoder(encoder, gmlPrefix, gmlUri);
+        init(encoder, gmlPrefix, gmlUri, curveEncoding);
+    }
+
+    protected MultiLineStringEncoder(
+            Encoder encoder,
+            String gmlPrefix,
+            String gmlUri,
+            boolean curveEncoding,
+            boolean encodeGmlId) {
+        super(encoder, encodeGmlId);
+        lse = new LineStringEncoder(encoder, gmlPrefix, gmlUri, encodeGmlId);
+        lre = new LinearRingEncoder(encoder, gmlPrefix, gmlUri, encodeGmlId);
+        ce = new CurveEncoder(encoder, gmlPrefix, gmlUri, encodeGmlId);
+        init(encoder, gmlPrefix, gmlUri, curveEncoding);
+    }
+
+    private void init(Encoder encoder, String gmlPrefix, String gmlUri, boolean curveEncoding) {
         this.curveEncoding = curveEncoding;
         if (curveEncoding) {
             multiContainer = MULTI_CURVE.derive(gmlPrefix, gmlUri);

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPointEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPointEncoder.java
@@ -46,6 +46,17 @@ class MultiPointEncoder extends GeometryEncoder<MultiPoint> {
     protected MultiPointEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
         pe = new PointEncoder(encoder, gmlPrefix, gmlUri);
+        init(gmlPrefix, gmlUri);
+    }
+
+    protected MultiPointEncoder(
+            Encoder encoder, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(encoder, encodeGmlId);
+        pe = new PointEncoder(encoder, gmlPrefix, gmlUri, encodeGmlId);
+        init(gmlPrefix, gmlUri);
+    }
+
+    private void init(String gmlPrefix, String gmlUri) {
         multiPoint = MULTI_POINT.derive(gmlPrefix, gmlUri);
         pointMember = POINT_MEMBER.derive(gmlPrefix, gmlUri);
     }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPolygonEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/MultiPolygonEncoder.java
@@ -48,6 +48,17 @@ class MultiPolygonEncoder extends GeometryEncoder<MultiPolygon> {
     protected MultiPolygonEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
         pe = new PolygonEncoder(encoder, gmlPrefix, gmlUri);
+        init(gmlPrefix, gmlUri);
+    }
+
+    protected MultiPolygonEncoder(
+            Encoder encoder, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(encoder, encodeGmlId);
+        pe = new PolygonEncoder(encoder, gmlPrefix, gmlUri, encodeGmlId);
+        init(gmlPrefix, gmlUri);
+    }
+
+    private void init(String gmlPrefix, String gmlUri) {
         multiSurface = MULTI_SURFACE.derive(gmlPrefix, gmlUri);
         surfaceMember = SURFACE_MEMBER.derive(gmlPrefix, gmlUri);
     }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PointEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PointEncoder.java
@@ -41,6 +41,15 @@ class PointEncoder extends GeometryEncoder<Point> {
 
     protected PointEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
+        init(gmlPrefix, gmlUri);
+    }
+
+    protected PointEncoder(Encoder encoder, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(encoder, encodeGmlId);
+        init(gmlPrefix, gmlUri);
+    }
+
+    private void init(String gmlPrefix, String gmlUri) {
         point = POINT.derive(gmlPrefix, gmlUri);
         pos = POS.derive(gmlPrefix, gmlUri);
     }

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PolygonEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/PolygonEncoder.java
@@ -51,11 +51,23 @@ class PolygonEncoder extends GeometryEncoder<Polygon> {
 
     protected PolygonEncoder(Encoder encoder, String gmlPrefix, String gmlUri) {
         super(encoder);
+        init(encoder, gmlPrefix, gmlUri);
+        lre = new LinearRingEncoder(encoder, gmlPrefix, gmlUri);
+        re = new RingEncoder(encoder, gmlPrefix, gmlUri);
+    }
+
+    protected PolygonEncoder(
+            Encoder encoder, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(encoder, encodeGmlId);
+        init(encoder, gmlPrefix, gmlUri);
+        lre = new LinearRingEncoder(encoder, gmlPrefix, gmlUri, encodeGmlId);
+        re = new RingEncoder(encoder, gmlPrefix, gmlUri, encodeGmlId);
+    }
+
+    private void init(Encoder encoder, String gmlPrefix, String gmlUri) {
         polygon = POLYGON.derive(gmlPrefix, gmlUri);
         exterior = EXTERIOR.derive(gmlPrefix, gmlUri);
         interior = INTERIOR.derive(gmlPrefix, gmlUri);
-        lre = new LinearRingEncoder(encoder, gmlPrefix, gmlUri);
-        re = new RingEncoder(encoder, gmlPrefix, gmlUri);
     }
 
     @Override

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/RingEncoder.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/simple/RingEncoder.java
@@ -36,6 +36,15 @@ public class RingEncoder extends MultiLineStringEncoder {
 
     protected RingEncoder(Encoder e, String gmlPrefix, String gmlUri) {
         super(e, gmlPrefix, gmlUri, true);
+        init(gmlPrefix, gmlUri);
+    }
+
+    protected RingEncoder(Encoder e, String gmlPrefix, String gmlUri, boolean encodeGmlId) {
+        super(e, gmlPrefix, gmlUri, true, encodeGmlId);
+        init(gmlPrefix, gmlUri);
+    }
+
+    private void init(String gmlPrefix, String gmlUri) {
         this.ring = RING.derive(gmlPrefix, gmlUri);
     }
 

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiPointTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiPointTest.java
@@ -41,4 +41,15 @@ public class MultiPointTest extends GeometryEncoderTestSupport {
                 "points.2",
                 xpath.evaluate("/gml:MultiPoint/gml:pointMember[2]/gml:Point/@gml:id", doc));
     }
+
+    /** no encode gml:id test */
+    public void testEncodeMultiPointNoGmlId() throws Exception {
+        MultiPointEncoder encoder = new MultiPointEncoder(gtEncoder, "gml", GML.NAMESPACE, false);
+        Geometry geometry = new WKTReader2().read("MULTIPOINT(0 0, 1 1)");
+        Document doc = encode(encoder, geometry, "points");
+
+        assertEquals(
+                "0",
+                xpath.evaluate("count(//gml:MultiPoint/gml:pointMember/gml:Point/@gml:id)", doc));
+    }
 }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiPolygonTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/MultiPolygonTest.java
@@ -46,4 +46,20 @@ public class MultiPolygonTest extends GeometryEncoderTestSupport {
                 "mpoly.2",
                 xpath.evaluate("/gml:MultiSurface/gml:surfaceMember[2]/gml:Polygon/@gml:id", doc));
     }
+
+    /** No encode gml:id test */
+    public void testEncodeMultiPolygonNoGmlId() throws Exception {
+        MultiPolygonEncoder encoder =
+                new MultiPolygonEncoder(gtEncoder, "gml", GML.NAMESPACE, false);
+        Geometry geometry =
+                new WKTReader2()
+                        .read(
+                                "MULTIPOLYGON(((1 1,5 1,5 5,1 5,1 1),(2 2, 3 2, 3 3, 2 3,2 2)),((3 3,6 2,6 4,3 3)))");
+        Document doc = encode(encoder, geometry, "mpoly");
+
+        assertEquals(
+                "0",
+                xpath.evaluate(
+                        "count(/gml:MultiSurface/gml:surfaceMember/gml:Polygon/@gml:id)", doc));
+    }
 }


### PR DESCRIPTION
Removing gml:id on geometry encoding for WFS 1.1.0 GML 3.1