### PR TITLE
[GEOT-6162] Create empty arrays as default for array types

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -818,7 +818,7 @@ public class DataUtilities {
 
     /**
      * Returns a non-null default value for the class that is passed in. This is a helper class an
-     * can't create a default class for any type but it does support:
+     * can't create a default class for all types but it does support:
      *
      * <ul>
      *   <li>String
@@ -838,6 +838,7 @@ public class DataUtilities {
      *   <li>java.sql.Time
      *   <li>java.util.Date
      *   <li>JTS Geometries
+     *   <li>Arrays - will return an empty array of the appropriate type
      * </ul>
      *
      * @param type
@@ -918,6 +919,10 @@ public class DataUtilities {
         }
         if (type == MultiPolygon.class) {
             return fac.createMultiPolygon(new Polygon[] {polygon});
+        }
+
+        if (type.isArray()) {
+            return Array.newInstance(type.getComponentType(), 0);
         }
 
         throw new IllegalArgumentException(type + " is not supported by this method");

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.data;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -503,6 +505,11 @@ public class DataUtilitiesTest extends DataTestCase {
         assertNull(DataUtilities.defaultValue(roadType.getDescriptor("name")));
         assertNull(DataUtilities.defaultValue(roadType.getDescriptor("id")));
         assertNull(DataUtilities.defaultValue(roadType.getDescriptor("geom")));
+    }
+
+    public void testDefaultValueArray() throws Exception {
+        assertArrayEquals(new byte[] {}, (byte[]) DataUtilities.defaultValue(byte[].class));
+        assertArrayEquals(new String[] {}, (String[]) DataUtilities.defaultValue(String[].class));
     }
 
     public void testCollection() {


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-6162

Creates an empty array of the specified type as the default value for array types in DataUtils