### PR TITLE
add additionalJOption to enable doclint directive properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1671,6 +1671,8 @@
           <encoding>UTF-8</encoding>
             <!-- Set an additional parameter for the command line. -->
           <additionalparam>-keywords -Xdoclint:none</additionalparam>
+          <additionalJOption>-Xdoclint:none</additionalJOption>
+
           <breakiterator>true</breakiterator>
           <excludePackageNames>
             org.geotools.resources:org.geotools.maven:com:net.opengis:org.w3:javax:it.geosolutions


### PR DESCRIPTION
After trying to fix 100 tons of javadoc, noticed that the plugin now requires additionalJOption to be set to enable the doclint directive.

So just submitting the pom fix, since the javadoc is in an "interesting" state and quick fixes might hurt people's work. 