### PR TITLE
ReferencedEnvelope3D intersects: Fix z range check

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope3D.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope3D.java
@@ -388,7 +388,7 @@ public class ReferencedEnvelope3D extends ReferencedEnvelope implements Bounding
      */
     public boolean intersects(double x, double y, double z) {
         if (isNull()) return false;
-        return intersects(x, y) && !(z > maxz || z > maxz);
+        return intersects(x, y) && !(z > maxz || z < minz);
     }
 
     /** @deprecated Use #intersects instead. */

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/ReferencedEnvelope3DTest.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/ReferencedEnvelope3DTest.java
@@ -172,4 +172,41 @@ public class ReferencedEnvelope3DTest {
         ReferencedEnvelope3D b = new ReferencedEnvelope3D(0.0, 1.0, 0.0, 1.0, 0.0, 0.5, crs);
         assertEquals(Math.sqrt(1 * 1 + 1 * 1 + 1.5 * 1.5), a.distance(b), 0.00001);
     }
+
+    @Test
+    public void testIntersectXYZ() {
+        ReferencedEnvelope3D envelope = new ReferencedEnvelope3D();
+
+        // Nothing should intersect with the envelope when isNull() is true.
+        assertTrue(envelope.isNull());
+        assertFalse(envelope.intersects(1.0, 2.0, 3.0));
+
+        double x_min = 10.0;
+        double x_max = 20.0;
+        double x_ave = (x_min + x_max) / 2.0;
+        double y_min = 30.0;
+        double y_max = 40.0;
+        double y_ave = (y_min + y_max) / 2.0;
+        double z_min = 50.0;
+        double z_max = 60.0;
+        double z_ave = (z_min + z_max) / 2.0;
+
+        envelope.init(x_min, x_max, y_min, y_max, z_min, z_max);
+
+        assertTrue(envelope.intersects(x_ave, y_ave, z_ave));
+
+        // Extremes
+        assertTrue(envelope.intersects(x_min, y_min, z_min));
+        assertTrue(envelope.intersects(x_max, y_max, z_max));
+
+        assertFalse(envelope.intersects(-x_ave, -y_ave, -z_ave));
+
+        double delta = 0.1;
+        assertFalse(envelope.intersects(x_min - delta, y_ave, z_ave));
+        assertFalse(envelope.intersects(x_max + delta, y_ave, z_ave));
+        assertFalse(envelope.intersects(x_ave, y_min - delta, z_ave));
+        assertFalse(envelope.intersects(x_ave, y_max + delta, z_ave));
+        assertFalse(envelope.intersects(x_ave, y_ave, z_min - delta));
+        assertFalse(envelope.intersects(x_ave, y_ave, z_max + delta));
+    }
 }


### PR DESCRIPTION
Compiler complaint:
A binary expression where both operands are the same is usually incorrect;
the value of this expression is equivalent to `z > maxz`.