### PR TITLE
remove swt from normal build

### DIFF
--- a/modules/unsupported/pom.xml
+++ b/modules/unsupported/pom.xml
@@ -232,7 +232,6 @@
 	<!-- Modules included in a normal build -->
 	<modules>
 		<module>swing</module>
-		<module>swt</module>
 		<module>process</module>
 		<module>process-geometry</module>
 		<module>process-raster</module>


### PR DESCRIPTION
remove swt from normal build since unsupported and gets warnings about swt jars accessing java.desktop for java 11