### PR TITLE
fix for CodeListTest illegal reflective access

### DIFF
--- a/modules/library/opengis/src/test/java/org/opengis/util/CodeListTest.java
+++ b/modules/library/opengis/src/test/java/org/opengis/util/CodeListTest.java
@@ -17,8 +17,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import org.junit.*;
 import org.opengis.metadata.identification.CharacterSet;
@@ -31,12 +29,6 @@ import org.opengis.metadata.identification.CharacterSet;
 public final class CodeListTest {
     /** The logger to use. */
     private static final Logger LOGGER = Logger.getLogger("org.opengis");
-
-    /**
-     * For avoiding to pollute the output stream if {@code ArrayList.capacity()} method invocation
-     * failed.
-     */
-    private static boolean capacityFailed = false;
 
     /**
      * Tests the {@link CharacterSet} code list. At the difference of other code lists, its {@link
@@ -207,30 +199,6 @@ public final class CodeListTest {
                 return;
             }
             assertEquals(Arrays.asList(values), asList);
-            /*
-             * Verifies if the VALUES ArrayList size was properly sized. We need to access to
-             * private ArrayList.elementData field in order to perform this check.  Tested on
-             * Sun's JSE 6.0. It is not mandatory to have the VALUES list properly dimensioned;
-             * it just avoid a little bit of memory reallocation at application startup time.
-             */
-            if (!capacityFailed) {
-                final int capacity;
-                try {
-                    final Field candidate = ArrayList.class.getDeclaredField("elementData");
-                    candidate.setAccessible(true);
-                    final Object array = candidate.get(asList);
-                    capacity = ((Object[]) array).length;
-                } catch (Exception e) {
-                    // Not an error, since this test relies on an implementation-specific method.
-                    capacityFailed = true;
-                    final LogRecord record = new LogRecord(Level.WARNING, e.toString());
-                    record.setThrown(e);
-                    record.setLoggerName(LOGGER.getName());
-                    LOGGER.log(record);
-                    return;
-                }
-                assertEquals(fullName + " not properly sized.", asList.size(), capacity);
-            }
         }
         /*
          * Tries to create a new element.


### PR DESCRIPTION
This removes the check of capacity of arraylist, since it accesses an illegal field via reflection. 

My proposal here is to dump the test section, since there is no other way to get the capacity from the arraylist and the part doesn't seem relevant to the domain of the test (at least to me).