### PR TITLE
WIP: Further casting of ByteBuffer for compatibility with Java 11 when running on Java 8

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/PrjFileReader.java
+++ b/modules/library/main/src/main/java/org/geotools/data/PrjFileReader.java
@@ -17,6 +17,7 @@
 package org.geotools.data;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.CharBuffer;
@@ -79,7 +80,7 @@ public class PrjFileReader {
 
             // ok, everything is ready...
             decoder.decode(buffer, charBuffer, true);
-            buffer.limit(buffer.capacity());
+            ((Buffer) buffer).limit(buffer.capacity());
             charBuffer.flip();
             crs =
                     ReferencingFactoryFinder.getCRSFactory(hints)
@@ -116,7 +117,7 @@ public class PrjFileReader {
             r = channel.read(buffer);
         }
         if (r == -1) {
-            buffer.limit(buffer.position());
+            ((Buffer) buffer).limit(buffer.position());
         }
         return r;
     }
@@ -127,7 +128,7 @@ public class PrjFileReader {
         if (channel instanceof FileChannel && USE_MEMORY_MAPPED_BUFFERS) {
             FileChannel fc = (FileChannel) channel;
             buffer = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
-            buffer.position((int) fc.position());
+            ((Buffer) buffer).position((int) fc.position());
         } else {
             // Some other type of channel
             // start with a 8K buffer, should be more than adequate
@@ -138,7 +139,7 @@ public class PrjFileReader {
             buffer = ByteBuffer.allocateDirect(size);
             // fill it and reset
             fill(buffer, channel);
-            buffer.flip();
+            ((Buffer) buffer).flip();
         }
 
         // The entire file is in little endian

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/gridshift/NADCONGridShiftFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/gridshift/NADCONGridShiftFactory.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
@@ -185,7 +186,7 @@ public class NADCONGridShiftFactory extends ReferencingFactory implements Buffer
             // read header info
             // //////////////////////
             // skip the header description
-            latBuffer.position(latBuffer.position() + DESCRIPTION_LENGTH);
+            ((Buffer) latBuffer).position(latBuffer.position() + DESCRIPTION_LENGTH);
 
             int nc = latBuffer.getInt();
             int nr = latBuffer.getInt();
@@ -201,7 +202,7 @@ public class NADCONGridShiftFactory extends ReferencingFactory implements Buffer
             float ymax = ymin + ((nr - 1) * dy);
 
             // skip the longitude header description
-            longBuffer.position(longBuffer.position() + DESCRIPTION_LENGTH);
+            ((Buffer) longBuffer).position(longBuffer.position() + DESCRIPTION_LENGTH);
 
             // check that latitude grid header is the same as for latitude grid
             if ((nc != longBuffer.getInt())
@@ -223,18 +224,19 @@ public class NADCONGridShiftFactory extends ReferencingFactory implements Buffer
             final int START_OF_DATA = RECORD_LENGTH - HEADER_BYTES;
 
             latBuffer = fillBuffer(latChannel, NUM_BYTES_LEFT);
-            latBuffer.position(START_OF_DATA); // start of second record (data)
+            ((Buffer) latBuffer).position(START_OF_DATA); // start of second record (data)
 
             longBuffer = fillBuffer(longChannel, NUM_BYTES_LEFT);
-            longBuffer.position(START_OF_DATA);
+            ((Buffer) longBuffer).position(START_OF_DATA);
 
             gridShift = new NADConGridShift(xmin, ymin, xmax, ymax, dx, dy, nc, nr);
 
             int i = 0;
             int j = 0;
             for (i = 0; i < nr; i++) {
-                latBuffer.position(latBuffer.position() + SEPARATOR_BYTES); // skip record separator
-                longBuffer.position(longBuffer.position() + SEPARATOR_BYTES);
+                ((Buffer) latBuffer)
+                        .position(latBuffer.position() + SEPARATOR_BYTES); // skip record separator
+                ((Buffer) longBuffer).position(longBuffer.position() + SEPARATOR_BYTES);
 
                 for (j = 0; j < nc; j++) {
                     gridShift.setLocalizationPoint(
@@ -273,7 +275,7 @@ public class NADCONGridShiftFactory extends ReferencingFactory implements Buffer
             throw new EOFException(Errors.format(ErrorKeys.END_OF_DATA_FILE));
         }
 
-        buf.flip();
+        ((Buffer) buf).flip();
         buf.order(ByteOrder.LITTLE_ENDIAN);
 
         return buf;
@@ -297,7 +299,7 @@ public class NADCONGridShiftFactory extends ReferencingFactory implements Buffer
         }
 
         if (r == -1) {
-            buffer.limit(buffer.position());
+            ((Buffer) buffer).limit(buffer.position());
         }
 
         return r;

--- a/modules/plugin/grassraster/src/main/java/org/geotools/gce/grassraster/core/CompressesRasterWriter.java
+++ b/modules/plugin/grassraster/src/main/java/org/geotools/gce/grassraster/core/CompressesRasterWriter.java
@@ -233,7 +233,7 @@ public class CompressesRasterWriter {
             //            System.out.println("row: " + (i+1) + " position: " +
             // pointerInFilePosition);
 
-            ((Buffer)rowAsByteBuffer).clear();
+            ((Buffer) rowAsByteBuffer).clear();
 
             progress = (float) (progress + 100f * i / dataWindowRows);
             monitor.progress(progress);

--- a/modules/plugin/grassraster/src/main/java/org/geotools/gce/grassraster/core/GrassBinaryRasterReadHandler.java
+++ b/modules/plugin/grassraster/src/main/java/org/geotools/gce/grassraster/core/GrassBinaryRasterReadHandler.java
@@ -24,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -325,7 +326,7 @@ public class GrassBinaryRasterReadHandler {
         monitor.complete();
 
         // prepare for reading
-        rasterByteBuffer.rewind();
+        ((Buffer) rasterByteBuffer).rewind();
 
         rowCacheRow = -1;
         nullRow = null;
@@ -772,7 +773,7 @@ public class GrassBinaryRasterReadHandler {
                     rowBuffer.putDouble(Double.NaN);
                 }
             } else {
-                rowCache.position((int) x * numberOfBytesPerValue);
+                ((Buffer) rowCache).position((int) x * numberOfBytesPerValue);
                 if (readerMapType > 0) {
                     /* Integers */
                     int cell = rowCache.getInt();

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -19,6 +19,7 @@ package org.geotools.data.shapefile;
 import static org.geotools.data.shapefile.files.ShpFileType.SHP;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
@@ -234,7 +235,7 @@ class ShapefileFeatureSource extends ContentFeatureSource {
             in = shpFiles.getReadChannel(SHP, reader);
             try {
                 in.read(buffer);
-                buffer.flip();
+                ((Buffer) buffer).flip();
 
                 ShapefileHeader header = new ShapefileHeader();
                 header.read(buffer, true);

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileHeader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileHeader.java
@@ -21,6 +21,7 @@ package org.geotools.data.shapefile.dbf;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.ReadableByteChannel;
@@ -523,10 +524,10 @@ public class DbaseFileHeader {
             in.order(ByteOrder.LITTLE_ENDIAN);
 
             // only want to read first 10 bytes...
-            in.limit(10);
+            ((Buffer) in).limit(10);
 
             read(in, channel);
-            in.position(0);
+            ((Buffer) in).position(0);
 
             // type of file.
             byte magic = in.get();
@@ -563,17 +564,17 @@ public class DbaseFileHeader {
                 NIOUtilities.clean(in, false);
                 in = NIOUtilities.allocate(headerLength - 10);
             }
-            in.limit(headerLength - 10);
-            in.position(0);
+            ((Buffer) in).limit(headerLength - 10);
+            ((Buffer) in).position(0);
             read(in, channel);
-            in.position(0);
+            ((Buffer) in).position(0);
 
             // read the length of a record
             // ahhh.. unsigned little-endian shorts
             recordLength = (in.get() & 0xff) | ((in.get() & 0xff) << 8);
 
             // skip the reserved bytes in the header.
-            in.position(in.position() + 20);
+            ((Buffer) in).position(in.position() + 20);
 
             // calculate the number of Fields in the header
             fieldCnt = (headerLength - FILE_DESCRIPTOR_SIZE - 1) / FILE_DESCRIPTOR_SIZE;
@@ -615,7 +616,7 @@ public class DbaseFileHeader {
 
                 // reserved bytes.
                 // in.skipBytes(14);
-                in.position(in.position() + 14);
+                ((Buffer) in).position(in.position() + 14);
 
                 // some broken shapefiles have 0-length attributes. The reference
                 // implementation
@@ -627,7 +628,7 @@ public class DbaseFileHeader {
 
             // Last byte is a marker for the end of the field definitions.
             // in.skipBytes(1);
-            in.position(in.position() + 1);
+            ((Buffer) in).position(in.position() + 1);
 
             fields = new DbaseField[lfields.size()];
             fields = (DbaseField[]) lfields.toArray(fields);
@@ -689,7 +690,7 @@ public class DbaseFileHeader {
         recordLength = (in.get() & 0xff) | ((in.get() & 0xff) << 8);
 
         // skip the reserved bytes in the header.
-        in.position(in.position() + 20);
+        ((Buffer) in).position(in.position() + 20);
 
         // calculate the number of Fields in the header
         fieldCnt = (headerLength - FILE_DESCRIPTOR_SIZE - 1) / FILE_DESCRIPTOR_SIZE;
@@ -731,7 +732,7 @@ public class DbaseFileHeader {
 
             // reserved bytes.
             // in.skipBytes(14);
-            in.position(in.position() + 14);
+            ((Buffer) in).position(in.position() + 14);
 
             // some broken shapefiles have 0-length attributes. The reference
             // implementation
@@ -743,7 +744,7 @@ public class DbaseFileHeader {
 
         // Last byte is a marker for the end of the field definitions.
         // in.skipBytes(1);
-        in.position(in.position() + 1);
+        ((Buffer) in).position(in.position() + 1);
 
         fields = new DbaseField[lfields.size()];
         fields = (DbaseField[]) lfields.toArray(fields);
@@ -804,7 +805,7 @@ public class DbaseFileHeader {
 
             // // write the reserved bytes in the header
             // for (int i=0; i<20; i++) out.writeByteLE(0);
-            buffer.position(buffer.position() + 20);
+            ((Buffer) buffer).position(buffer.position() + 20);
 
             // write all of the header records
             int tempOffset = 0;
@@ -834,13 +835,13 @@ public class DbaseFileHeader {
 
                 // write the reserved bytes.
                 // for (in j=0; jj<14; j++) out.writeByteLE(0);
-                buffer.position(buffer.position() + 14);
+                ((Buffer) buffer).position(buffer.position() + 14);
             }
 
             // write the end of the field definitions marker
             buffer.put((byte) 0x0D);
 
-            buffer.position(0);
+            ((Buffer) buffer).position(0);
 
             int r = buffer.remaining();
             while ((r -= out.write(buffer)) > 0) {; // do nothing

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileReader.java
@@ -23,6 +23,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
@@ -194,7 +195,7 @@ public class DbaseFileReader implements FileReader {
             } else {
                 buffer = fc.map(FileChannel.MapMode.READ_ONLY, 0, Integer.MAX_VALUE);
             }
-            buffer.position((int) fc.position());
+            ((Buffer) buffer).position((int) fc.position());
             header.readHeader(buffer);
 
             this.currentOffset = 0;
@@ -210,7 +211,7 @@ public class DbaseFileReader implements FileReader {
             buffer = NIOUtilities.allocate(header.getRecordLength());
             // fill it and reset
             fill(buffer, channel);
-            buffer.flip();
+            ((Buffer) buffer).flip();
             this.currentOffset = header.getHeaderLength();
         }
 
@@ -244,7 +245,7 @@ public class DbaseFileReader implements FileReader {
             r = channel.read(buffer);
         }
         if (r == -1) {
-            buffer.limit(buffer.position());
+            ((Buffer) buffer).limit(buffer.position());
         }
         return r;
     }
@@ -273,7 +274,7 @@ public class DbaseFileReader implements FileReader {
             this.currentOffset += buffer.position();
             buffer.compact();
             fill(buffer, channel);
-            buffer.position(0);
+            ((Buffer) buffer).position(0);
         }
     }
 
@@ -346,7 +347,7 @@ public class DbaseFileReader implements FileReader {
             final char tempDeleted = (char) buffer.get();
 
             // skip the next bytes
-            buffer.position(buffer.position() + header.getRecordLength() - 1); // the
+            ((Buffer) buffer).position(buffer.position() + header.getRecordLength() - 1); // the
             // 1 is
             // for
             // the
@@ -407,9 +408,9 @@ public class DbaseFileReader implements FileReader {
     /** Transfer, by bytes, the next record to the writer. */
     public void transferTo(final DbaseFileWriter writer) throws IOException {
         bufferCheck();
-        buffer.limit(buffer.position() + header.getRecordLength());
+        ((Buffer) buffer).limit(buffer.position() + header.getRecordLength());
         writer.channel.write(buffer);
-        buffer.limit(buffer.capacity());
+        ((Buffer) buffer).limit(buffer.capacity());
 
         cnt++;
     }
@@ -430,9 +431,9 @@ public class DbaseFileReader implements FileReader {
             final char deleted = (char) buffer.get();
             row.deleted = deleted == '*';
 
-            buffer.limit(buffer.position() + header.getRecordLength() - 1);
+            ((Buffer) buffer).limit(buffer.position() + header.getRecordLength() - 1);
             buffer.get(bytes); // SK: There is a side-effect here!!!
-            buffer.limit(buffer.capacity());
+            ((Buffer) buffer).limit(buffer.capacity());
 
             foundRecord = true;
         }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileWriter.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileWriter.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
@@ -159,7 +160,7 @@ public class DbaseFileWriter {
     }
 
     private void write() throws IOException {
-        buffer.position(0);
+        ((Buffer) buffer).position(0);
         int r = buffer.remaining();
         while ((r -= channel.write(buffer)) > 0) {; // do nothing
         }
@@ -181,7 +182,7 @@ public class DbaseFileWriter {
                             + header.getNumFields());
         }
 
-        buffer.position(0);
+        ((Buffer) buffer).position(0);
 
         // put the 'not-deleted' marker
         buffer.put((byte) ' ');
@@ -292,7 +293,7 @@ public class DbaseFileWriter {
         // 0x00 (which is wrong anyway) lets just do away with this :)
         // - produced dbf works in OpenOffice and ArcExplorer java, so it must
         // be okay.
-        // buffer.position(0);
+        // ((Buffer)buffer).position(0);
         // buffer.put((byte) 0).position(0).limit(1);
         // write();
         if (channel != null && channel.isOpen()) {

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/IndexedDbaseFileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/IndexedDbaseFileReader.java
@@ -19,6 +19,7 @@
 package org.geotools.data.shapefile.dbf;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 import java.nio.charset.Charset;
@@ -122,24 +123,24 @@ public class IndexedDbaseFileReader extends DbaseFileReader {
                         currentOffset = fc.size() - Integer.MAX_VALUE;
                     }
                     buffer = fc.map(MapMode.READ_ONLY, currentOffset, Integer.MAX_VALUE);
-                    buffer.position((int) (newPosition - currentOffset));
+                    ((Buffer) buffer).position((int) (newPosition - currentOffset));
                 } else {
-                    buffer.position((int) (newPosition - currentOffset));
+                    ((Buffer) buffer).position((int) (newPosition - currentOffset));
                 }
             } else {
                 if (this.currentOffset <= newPosition
                         && this.currentOffset + buffer.limit() >= newPosition) {
-                    buffer.position((int) (newPosition - this.currentOffset));
+                    ((Buffer) buffer).position((int) (newPosition - this.currentOffset));
                     // System.out.println("Hit");
                 } else {
                     // System.out.println("Jump");
                     FileChannel fc = (FileChannel) this.channel;
                     fc.position(newPosition);
                     this.currentOffset = newPosition;
-                    buffer.limit(buffer.capacity());
-                    buffer.position(0);
+                    ((Buffer) buffer).limit(buffer.capacity());
+                    ((Buffer) buffer).position(0);
                     fill(buffer, fc);
-                    buffer.position(0);
+                    ((Buffer) buffer).position(0);
                 }
             }
         } else {

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidReader.java
@@ -20,6 +20,7 @@ import static org.geotools.data.shapefile.files.ShpFileType.FIX;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
@@ -77,7 +78,7 @@ public class IndexedFidReader implements FIDReader, FileReader {
         getHeader(shpFiles);
 
         buffer = NIOUtilities.allocate(IndexedFidWriter.RECORD_SIZE * 1024);
-        buffer.position(buffer.limit());
+        ((Buffer) buffer).position(buffer.limit());
     }
 
     private void getHeader(ShpFiles shpFiles) throws IOException {
@@ -92,7 +93,7 @@ public class IndexedFidReader implements FIDReader, FileReader {
                 return;
             }
 
-            buffer.position(0);
+            ((Buffer) buffer).position(0);
 
             byte version = buffer.get();
 
@@ -192,7 +193,7 @@ public class IndexedFidReader implements FIDReader, FileReader {
         goTo(predictedRec);
         hasNext(); // force data reading
         next();
-        buffer.limit(buffer.capacity());
+        ((Buffer) buffer).limit(buffer.capacity());
         if (currentId == desired) {
             return currentShxIndex;
         }
@@ -231,10 +232,10 @@ public class IndexedFidReader implements FIDReader, FileReader {
             if (newPosition >= bufferStart + buffer.limit() || newPosition < bufferStart) {
                 FileChannel fc = (FileChannel) readChannel;
                 fc.position(newPosition);
-                buffer.limit(buffer.capacity());
-                buffer.position(buffer.limit());
+                ((Buffer) buffer).limit(buffer.capacity());
+                ((Buffer) buffer).position(buffer.limit());
             } else {
-                buffer.position((int) (newPosition - bufferStart));
+                ((Buffer) buffer).position((int) (newPosition - bufferStart));
             }
         } else {
             throw new IOException("Read Channel is not a File Channel so this is not possible.");
@@ -259,14 +260,14 @@ public class IndexedFidReader implements FIDReader, FileReader {
         }
 
         if (buffer.position() == buffer.limit()) {
-            buffer.position(0);
+            ((Buffer) buffer).position(0);
 
             FileChannel fc = (FileChannel) readChannel;
             bufferStart = fc.position();
             int read = ShapefileReader.fill(buffer, readChannel);
 
             if (read != 0) {
-                buffer.position(0);
+                ((Buffer) buffer).position(0);
             }
         }
 

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidWriter.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidWriter.java
@@ -20,6 +20,7 @@ import static org.geotools.data.shapefile.files.ShpFileType.*;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import org.geotools.data.shapefile.files.FileWriter;
@@ -95,7 +96,7 @@ public class IndexedFidWriter implements FileWriter {
         streamLogger.open();
         allocateBuffers();
         removes = reader.getRemoves();
-        writeBuffer.position(HEADER_SIZE);
+        ((Buffer) writeBuffer).position(HEADER_SIZE);
         closed = false;
         position = 0;
         current = -1;
@@ -116,7 +117,7 @@ public class IndexedFidWriter implements FileWriter {
      * @throws IOException DOCUMENT ME!
      */
     private void drain() throws IOException {
-        writeBuffer.flip();
+        ((Buffer) writeBuffer).flip();
 
         int written = 0;
 
@@ -124,7 +125,7 @@ public class IndexedFidWriter implements FileWriter {
 
         position += written;
 
-        writeBuffer.flip().limit(writeBuffer.capacity());
+        ((Buffer) writeBuffer).flip().limit(writeBuffer.capacity());
     }
 
     private void writeHeader() throws IOException {
@@ -135,7 +136,7 @@ public class IndexedFidWriter implements FileWriter {
 
             buffer.putLong(recordIndex);
             buffer.putInt(removes);
-            buffer.flip();
+            ((Buffer) buffer).flip();
             channel.write(buffer, 0);
         } finally {
             NIOUtilities.clean(buffer, false);

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/FileSystemIndexStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/FileSystemIndexStore.java
@@ -87,18 +87,18 @@ public class FileSystemIndexStore implements IndexStore {
 
                 IndexHeader header = new IndexHeader(byteOrder);
                 header.writeTo(buf);
-                buf.flip();
+                ((Buffer) buf).flip();
                 channel.write(buf);
             }
 
             ByteOrder order = byteToOrder(this.byteOrder);
 
-            ((Buffer)buf).clear();
+            ((Buffer) buf).clear();
             buf.order(order);
 
             buf.putInt(tree.getNumShapes());
             buf.putInt(tree.getMaxDepth());
-            buf.flip();
+            ((Buffer) buf).flip();
 
             channel.write(buf);
 
@@ -149,7 +149,7 @@ public class FileSystemIndexStore implements IndexStore {
         }
 
         buf.putInt(node.getNumSubNodes());
-        buf.flip();
+        ((Buffer) buf).flip();
 
         channel.write(buf);
 
@@ -202,7 +202,7 @@ public class FileSystemIndexStore implements IndexStore {
             ByteBuffer buf = ByteBuffer.allocate(8);
             buf.order(order);
             channel.read(buf);
-            buf.flip();
+            ((Buffer) buf).flip();
 
             tree =
                     new QuadTree(buf.getInt(), buf.getInt(), indexfile) {

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/FileSystemNode.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/FileSystemNode.java
@@ -214,7 +214,7 @@ public class FileSystemNode extends Node {
                 this.buffer = NIOUtilities.allocate(8 * 1024);
                 this.buffer.order(order);
                 channel.read(buffer);
-                buffer.flip();
+                ((Buffer) buffer).flip();
             }
         }
 
@@ -236,7 +236,7 @@ public class FileSystemNode extends Node {
             if (!useMemoryMapping && buffer.remaining() < 32) refillBuffer(32);
 
             buffer.asDoubleBuffer().get(envelope);
-            buffer.position(buffer.position() + 32);
+            ((Buffer) buffer).position(buffer.position() + 32);
             return new Envelope(envelope[0], envelope[2], envelope[1], envelope[3]);
         }
 
@@ -249,7 +249,7 @@ public class FileSystemNode extends Node {
             intView.get(array);
             // don't forget to update the original buffer position, since the
             // view is independent
-            buffer.position(buffer.position() + size);
+            ((Buffer) buffer).position(buffer.position() + size);
         }
 
         /**
@@ -271,9 +271,9 @@ public class FileSystemNode extends Node {
 
         private void readBuffer(long currentPosition) throws IOException {
             channel.position(currentPosition);
-            ((Buffer)buffer).clear();
+            ((Buffer) buffer).clear();
             channel.read(buffer);
-            buffer.flip();
+            ((Buffer) buffer).flip();
             bufferStart = currentPosition;
         }
 
@@ -289,7 +289,7 @@ public class FileSystemNode extends Node {
             // otherwise we have to reload it
             if (useMemoryMapping
                     || newPosition >= bufferStart && newPosition <= bufferStart + buffer.limit()) {
-                buffer.position((int) (newPosition - bufferStart));
+                ((Buffer) buffer).position((int) (newPosition - bufferStart));
             } else {
                 readBuffer(newPosition);
             }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/IndexHeader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/IndexHeader.java
@@ -17,6 +17,7 @@
 package org.geotools.data.shapefile.index.quadtree.fs;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
@@ -56,7 +57,7 @@ public class IndexHeader {
         ByteBuffer buf = ByteBuffer.allocate(8);
 
         channel.read(buf);
-        buf.flip();
+        ((Buffer) buf).flip();
 
         byte[] tmp = new byte[3];
         buf.get(tmp);
@@ -70,7 +71,7 @@ public class IndexHeader {
                             + "is deprecated; It is strongly recommended "
                             + "to regenerate it in new format.");
 
-            buf.position(0);
+            ((Buffer) buf).position(0);
             tmp = buf.array();
 
             boolean lsb;
@@ -91,7 +92,7 @@ public class IndexHeader {
         Charset charSet = Charset.forName("US-ASCII");
 
         ByteBuffer tmp = charSet.encode(SIGNATURE);
-        tmp.position(0);
+        ((Buffer) tmp).position(0);
         buf.put(tmp);
         buf.put(this.byteOrder);
         buf.put(VERSION);

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/IndexFile.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/IndexFile.java
@@ -84,7 +84,7 @@ public class IndexFile implements FileReader {
                     LOGGER.finest("Reading from file...");
                     this.buf = NIOUtilities.allocate(8 * RECS_IN_BUFFER);
                     channel.read(buf);
-                    buf.flip();
+                    ((Buffer) buf).flip();
                     this.channelOffset = 0;
                 }
 
@@ -125,7 +125,7 @@ public class IndexFile implements FileReader {
             while (buffer.remaining() > 0) {
                 channel.read(buffer);
             }
-            buffer.flip();
+            ((Buffer) buffer).flip();
             header = new ShapefileHeader();
             header.read(buffer, true);
         } finally {
@@ -142,7 +142,7 @@ public class IndexFile implements FileReader {
             while (buffer.remaining() > 0) {
                 channel.read(buffer);
             }
-            buffer.flip();
+            ((Buffer) buffer).flip();
             int records = remaining / 4;
             content = new int[records];
             IntBuffer ints = buffer.asIntBuffer();
@@ -164,13 +164,13 @@ public class IndexFile implements FileReader {
                 LOGGER.finest("Filling buffer...");
                 this.channelOffset = pos;
                 this.channel.position(pos);
-                ((Buffer)buf).clear();
+                ((Buffer) buf).clear();
                 this.channel.read(buf);
-                buf.flip();
+                ((Buffer) buf).flip();
             }
         }
 
-        buf.position(pos - this.channelOffset);
+        ((Buffer) buf).position(pos - this.channelOffset);
         this.recOffset = buf.getInt();
         this.recLen = buf.getInt();
         this.lastIndex = index;

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/MultiLineHandler.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/MultiLineHandler.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.data.shapefile.shp;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.util.ArrayList;
@@ -115,7 +116,7 @@ public class MultiLineHandler implements ShapeHandler {
         }
         int dimensions = (shapeType == ShapeType.ARCZ && !flatGeometry) ? 3 : 2;
         // read bounding box (not needed)
-        buffer.position(buffer.position() + 4 * 8);
+        ((Buffer) buffer).position(buffer.position() + 4 * 8);
 
         int numParts = buffer.getInt();
         int numPoints = buffer.getInt(); // total number of points
@@ -173,7 +174,7 @@ public class MultiLineHandler implements ShapeHandler {
         // sequences
         if (dimensions == 3) {
             // z min, max
-            // buffer.position(buffer.position() + 2 * 8);
+            // ((Buffer)buffer).position(buffer.position() + 2 * 8);
             doubleBuffer.position(doubleBuffer.position() + 2);
             for (int part = 0; part < numParts; part++) {
                 start = partOffsets[part];

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/MultiPointHandler.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/MultiPointHandler.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.data.shapefile.shp;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.util.ArrayList;
@@ -106,7 +107,7 @@ public class MultiPointHandler implements ShapeHandler {
         }
 
         // read bounding box (not needed)
-        buffer.position(buffer.position() + 4 * 8);
+        ((Buffer) buffer).position(buffer.position() + 4 * 8);
 
         int numpoints = buffer.getInt();
         int dimensions = shapeType == shapeType.MULTIPOINTZ && !flatGeometry ? 3 : 2;

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/PolygonHandler.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/PolygonHandler.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.data.shapefile.shp;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.util.ArrayList;
@@ -124,7 +125,7 @@ public class PolygonHandler implements ShapeHandler {
             return createNull();
         }
         // bounds
-        buffer.position(buffer.position() + 4 * 8);
+        ((Buffer) buffer).position(buffer.position() + 4 * 8);
 
         int[] partOffsets;
 

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileHeader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileHeader.java
@@ -17,6 +17,7 @@
 package org.geotools.data.shapefile.shp;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.logging.Logger;
@@ -79,7 +80,7 @@ public class ShapefileHeader {
         checkMagic(strict);
 
         // skip 5 ints...
-        file.position(file.position() + 20);
+        ((Buffer) file).position(file.position() + 20);
 
         fileLength = file.getInt();
 
@@ -96,7 +97,7 @@ public class ShapefileHeader {
         // skip remaining unused bytes
         file.order(ByteOrder.BIG_ENDIAN); // well they may not be unused
         // forever...
-        file.position(file.position() + 32);
+        ((Buffer) file).position(file.position() + 32);
     }
 
     public void write(

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileReader.java
@@ -17,6 +17,7 @@
 package org.geotools.data.shapefile.shp;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
@@ -104,7 +105,7 @@ public class ShapefileReader implements FileReader {
         /** Fetch the shape stored in this record. */
         public Object shape() {
             if (shape == null) {
-                buffer.position(start);
+                ((Buffer) buffer).position(start);
                 buffer.order(ByteOrder.LITTLE_ENDIAN);
                 if (type == ShapeType.NULL) {
                     shape = null;
@@ -321,7 +322,7 @@ public class ShapefileReader implements FileReader {
         while (buffer.remaining() > 0 && r != -1) {
             r = channel.read(buffer);
         }
-        buffer.limit(buffer.position());
+        ((Buffer) buffer).limit(buffer.position());
         return r;
     }
 
@@ -331,7 +332,7 @@ public class ShapefileReader implements FileReader {
         if (channel instanceof FileChannel && useMemoryMappedBuffer) {
             FileChannel fc = (FileChannel) channel;
             buffer = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
-            buffer.position(0);
+            ((Buffer) buffer).position(0);
             this.currentOffset = 0;
         } else {
             // force useMemoryMappedBuffer to false
@@ -339,7 +340,7 @@ public class ShapefileReader implements FileReader {
             // start small
             buffer = NIOUtilities.allocate(1024);
             fill(buffer, channel);
-            buffer.flip();
+            ((Buffer) buffer).flip();
             this.currentOffset = 0;
         }
         header = new ShapefileHeader();
@@ -441,7 +442,7 @@ public class ShapefileReader implements FileReader {
         }
 
         // reset things to as they were
-        buffer.position(position);
+        ((Buffer) buffer).position(position);
 
         return hasNext;
     }
@@ -463,7 +464,7 @@ public class ShapefileReader implements FileReader {
     public int transferTo(ShapefileWriter writer, int recordNum, double[] bounds)
             throws IOException {
 
-        buffer.position(this.toBufferOffset(record.end));
+        ((Buffer) buffer).position(this.toBufferOffset(record.end));
         buffer.order(ByteOrder.BIG_ENDIAN);
 
         buffer.getInt(); // record number
@@ -484,18 +485,18 @@ public class ShapefileReader implements FileReader {
         }
 
         // write header to shp and shx
-        headerTransfer.position(0);
-        headerTransfer.putInt(recordNum).putInt(rl).position(0);
+        ((Buffer) headerTransfer).position(0);
+        ((Buffer) headerTransfer.putInt(recordNum).putInt(rl)).position(0);
         writer.shpChannel.write(headerTransfer);
-        headerTransfer.putInt(0, writer.offset).position(0);
+        ((Buffer) headerTransfer.putInt(0, writer.offset)).position(0);
         writer.offset += rl + 4;
         writer.shxChannel.write(headerTransfer);
 
         // reset to mark and limit at end of record, then write
         int oldLimit = buffer.limit();
-        buffer.position(mark).limit(mark + len);
+        ((Buffer) buffer).position(mark).limit(mark + len);
         writer.shpChannel.write(buffer);
-        buffer.limit(oldLimit);
+        ((Buffer) buffer).limit(oldLimit);
 
         record.end = this.toFileOffset(buffer.position());
         record.number++;
@@ -505,14 +506,14 @@ public class ShapefileReader implements FileReader {
 
     private void positionBufferForOffset(ByteBuffer buffer, int offset) throws IOException {
         if (useMemoryMappedBuffer) {
-            buffer.position(offset);
+            ((Buffer) buffer).position(offset);
             return;
         }
 
         // Check to see if requested offset is already loaded; ensure that record header is in the
         // buffer
         if (currentOffset <= offset && currentOffset + buffer.limit() >= offset + 8) {
-            buffer.position(toBufferOffset(offset));
+            ((Buffer) buffer).position(toBufferOffset(offset));
         } else {
             if (!randomAccessEnabled) {
                 throw new UnsupportedOperationException("Random Access not enabled");
@@ -520,10 +521,10 @@ public class ShapefileReader implements FileReader {
             FileChannel fc = (FileChannel) this.channel;
             fc.position(offset);
             currentOffset = offset;
-            buffer.position(0);
-            buffer.limit(buffer.capacity());
+            ((Buffer) buffer).position(0);
+            ((Buffer) buffer).limit(buffer.capacity());
             fill(buffer, fc);
-            buffer.flip();
+            ((Buffer) buffer).flip();
         }
     }
 
@@ -560,7 +561,7 @@ public class ShapefileReader implements FileReader {
                 buffer.put(old);
                 NIOUtilities.clean(old, useMemoryMappedBuffer);
                 fill(buffer, channel);
-                buffer.position(0);
+                ((Buffer) buffer).position(0);
             } else
             // remaining is less than record length
             // compact the remaining data and read again,
@@ -569,7 +570,7 @@ public class ShapefileReader implements FileReader {
                 this.currentOffset += buffer.position();
                 buffer.compact();
                 fill(buffer, channel);
-                buffer.position(0);
+                ((Buffer) buffer).position(0);
             }
         }
 
@@ -589,7 +590,7 @@ public class ShapefileReader implements FileReader {
         // peek at bounds, then reset for handler
         // many handler's may ignore bounds reading, but we don't want to
         // second guess them...
-        buffer.mark();
+        ((Buffer) buffer).mark();
         if (recordType.isMultiPoint()) {
             record.minX = buffer.getDouble();
             record.minY = buffer.getDouble();
@@ -599,7 +600,7 @@ public class ShapefileReader implements FileReader {
             record.minX = record.maxX = buffer.getDouble();
             record.minY = record.maxY = buffer.getDouble();
         }
-        buffer.reset();
+        ((Buffer) buffer).reset();
 
         record.offset = record.end;
         // update all the record info.

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileWriter.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileWriter.java
@@ -17,6 +17,7 @@
 package org.geotools.data.shapefile.shp;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
@@ -101,17 +102,17 @@ public class ShapefileWriter {
 
     /** Drain internal buffers into underlying channels. */
     private void drain() throws IOException {
-        shapeBuffer.flip();
-        indexBuffer.flip();
+        ((Buffer) shapeBuffer).flip();
+        ((Buffer) indexBuffer).flip();
         while (shapeBuffer.remaining() > 0) shpChannel.write(shapeBuffer);
         while (indexBuffer.remaining() > 0) shxChannel.write(indexBuffer);
-        shapeBuffer.flip().limit(shapeBuffer.capacity());
-        indexBuffer.flip().limit(indexBuffer.capacity());
+        ((Buffer) shapeBuffer).flip().limit(shapeBuffer.capacity());
+        ((Buffer) indexBuffer).flip().limit(indexBuffer.capacity());
     }
 
     private void writeHeaders(GeometryCollection geometries, ShapeType type) throws IOException {
         // ShapefileHeader header = new ShapefileHeader();
-        // Envelope bounds = geometries.getEnvelopeInternal();
+        // Envelope bounds = geometries.getEnvelopeInternal();By
         // header.write(shapeBuffer, type, geometries.getNumGeometries(),
         // fileLength / 2,
         // bounds.getMinX(),bounds.getMinY(), bounds.getMaxX(),bounds.getMaxY()

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShpFilesTestStream.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShpFilesTestStream.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
@@ -209,7 +210,7 @@ public class ShpFilesTestStream implements org.geotools.data.shapefile.files.Fil
 
         ByteBuffer buffer = ByteBuffer.allocate(10);
         in.read(buffer);
-        buffer.flip();
+        ((Buffer) buffer).flip();
         String read = "";
         try {
             while (buffer.hasRemaining()) {
@@ -233,7 +234,7 @@ public class ShpFilesTestStream implements org.geotools.data.shapefile.files.Fil
         try {
             ByteBuffer buffer = ByteBuffer.allocate(10);
             buffer.put(shpFileType.name().getBytes());
-            buffer.flip();
+            ((Buffer) buffer).flip();
             out.write(buffer);
         } finally {
             out.close();

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/StorageFileTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/StorageFileTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Arrays;
@@ -90,7 +91,7 @@ public class StorageFileTest implements FileReader {
         try {
             ByteBuffer buffer = ByteBuffer.allocate(20);
             channel.read(buffer);
-            buffer.flip();
+            ((Buffer) buffer).flip();
             String data = new String(buffer.array()).trim();
             assertEquals(writtenToStorageFile, data);
         } finally {


### PR DESCRIPTION
Casting for all invocations of the following methods:

position(int newPosition)
limit(int newLimit)
flip()
clear()
mark()
reset()
rewind()