### PR TITLE
Java 11 quickstart

### DIFF
--- a/docs/user/tutorial/quickstart/artifacts/module-info.java
+++ b/docs/user/tutorial/quickstart/artifacts/module-info.java
@@ -1,0 +1,7 @@
+module org.geotools.tutorial.quickstart {
+    requires java.desktop;
+    requires org.geotools.main;
+    requires org.geotools.shapefile;
+    requires org.geotools.swing;
+    requires org.geotools.render;
+}

--- a/docs/user/tutorial/quickstart/artifacts/pom-jdk11.xml
+++ b/docs/user/tutorial/quickstart/artifacts/pom-jdk11.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.geotools</groupId>
+  <artifactId>tutorial</artifactId>
+  <packaging>jar</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>tutorial</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <geotools.version>21-SNAPSHOT</geotools.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-shapefile</artifactId>
+      <version>${geotools.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-swing</artifactId>
+      <version>${geotools.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-render</artifactId>
+      <version>${geotools.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-main</artifactId>
+      <version>${geotools.version}</version>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>maven2-repository.dev.java.net</id>
+      <name>Java.net repository</name>
+      <url>http://download.java.net/maven/2</url>
+    </repository>
+    <repository>
+      <id>osgeo</id>
+      <name>Open Source Geospatial Foundation Repository</name>
+      <url>http://download.osgeo.org/webdav/geotools/</url>
+    </repository>
+    <repository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>boundless</id>
+      <name>Boundless Maven Repository</name>
+      <url>http://repo.boundlessgeo.com/main</url>
+    </repository>
+  </repositories>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+          <configuration>
+              <release>11</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/docs/user/tutorial/quickstart/index.rst
+++ b/docs/user/tutorial/quickstart/index.rst
@@ -13,6 +13,7 @@ This tutorial is available for:
    netbeans
    intellij
    maven
+   java11
 
 If you are interested in porting this tutorial to an additional IDE please `contact us <http://geotools.org/getinvolved.html>`_ on the
 users list.

--- a/docs/user/tutorial/quickstart/intellij.rst
+++ b/docs/user/tutorial/quickstart/intellij.rst
@@ -14,7 +14,7 @@ Pre-Requisites
 --------------
 This guide assumes the following:
 
-* You have the latest JDK installed (8 at the time this article was written) installed. If not the TODO Eclipse Quickstart
+* You have the latest JDK installed (8 at the time this article was written) installed. If not the `Eclipse Quickstart <./eclipse.html>`_
   provides instructions on how to do this.
 * You have IntelliJ installed. This article targets IntelliJ CE 2016; however, previous versions at least as far back as
   13 should work fine. Ultimate versions should also work fine. IntelliJ can be downloaded from JetBrains_ and generally
@@ -202,7 +202,7 @@ shapefile on the screen.
    * We are using a very basic display style here that just shows feature outlines. In the examples that follow we will see how to specify more sophisticated styles.
   
 Things to Try
-=============
+-------------
 
 Each tutorial consists of very detailed steps followed by a series of extra questions. If you get
 stuck at any point please ask your instructor; or sign up to the geotools-users_ email list.

--- a/docs/user/tutorial/quickstart/java11.rst
+++ b/docs/user/tutorial/quickstart/java11.rst
@@ -1,0 +1,152 @@
+:Author: Torben Barsballe
+:Thanks: geotools-user list
+:Version: |release|
+:License: Creative Commons with attribution
+
+**********************
+ Java 11 Quickstart 
+**********************
+
+.. sectionauthor:: Torben Barsballe <tbarsballe@boundlessgeo.com>
+
+Welcome 
+=======
+
+GeoTools 21.0 and newer can be used in a Java 11 modular application. This requires a few additions on top of the regular tutorial application.
+
+This quickstart assumes you have already run through one of the regular quickstarts:
+
+ * `Eclipse <./eclipse.html>`_
+ * `NetBeans <./netbeans.html>`_
+ * `IntelliJ <./intellij.html>`_
+ * `Maven <./maven.html>`_
+
+Java Install
+============
+
+Instead of Java 8, we will want to install Java 11.
+
+#. Download the latest Java 11 JDK:
+
+   * OpenJDK: http://jdk.java.net/11/
+
+   .. info:
+
+      OpenJDK updates every six months, for longer term support consider:
+      
+      * Adopt OpenJDK: https://adoptopenjdk.net
+      
+      Oracle distributes a supported JDK 11 for their customers, which is available for development and testing. It is **not** available for production use without a license:
+      
+      * http://www.oracle.com/technetwork/java/javase/downloads/
+   
+#. At the time of writing the latest Java 11 release was:
+   
+   * jdk-11.0.1
+   
+#. Click through the installer you will need to set an acceptance a license agreement and so forth.
+   By default this will install to:
+   
+   * :file:`C:\\Program Files\\Java\jdk-11.0.1`
+
+#. Update the ``JAVA_HOME`` system variable so that maven uses the newly installed Java 11:
+
+   * JAVA_HOME = :file:`C:\\Program Files\\Java\\jdk-11.0.1`
+
+#. Verify mvn is using the correct Java version by running:
+
+   .. code-block:: sh
+
+       mvn -version
+
+   It should report a Java version of 11.0.1.
+
+.. Note::
+
+   In this tutorial we refer to file and directory paths as used by Windows. If you are fortunate
+   enough to be using another operating system such as Linux or OSX all of the commands and source
+   code below will work, just modify the paths to suit. 
+
+Updating the POM
+----------------
+
+A few changes are required to compile and run on Java 11:
+
+#. Add dependencies for **gt-render** and **gt-main**, since we import packages from them:
+
+    .. literalinclude:: artifacts/pom-jdk11.xml
+        :language: xml
+        :start-after: </properties>
+        :end-before: <repositories>
+
+#. Update the Maven plugin versions. We want to ensure we use the most recent, Java 11-compatible, versions. We will also update the configuration of the Maven compile plugin to target Java 11:
+
+    .. literalinclude:: artifacts/pom-jdk11.xml
+        :language: xml
+        :start-after: </repositories>
+        :end-before: </project>
+
+Adding Module Info
+------------------
+
+Java 9 introduced the concept of modules to the JVM. 
+
+A module is a named, self-contained bundle of Java code. Modules may depend upon other modules, and may export packages from themselves to other modules that depend upon them. Module configuration is controled by the :file:`module-info.java` file.
+
+For a more detailed overview of the module system, refer to the `State of the Module System <http://openjdk.java.net/projects/jigsaw/spec/sotms/>`_.
+
+#. Add a :file:`module-info.java` file under :file:`tutorial\src\main\java`. 
+
+#. Name our module ``org.geotools.tutorial.quickstart``:
+
+   .. code-block:: java
+
+        module org.geotools.tutorial.quickstart { }
+
+#. Then, add the modules we depend upon:
+
+   .. literalinclude:: artifacts/module-info.java
+      :language: java
+
+   You'll notice the four geotools modules match those added as dependencies in the :file:`pom.xml`. We also include the ``java.desktop`` module, which contains user interface components required for the app to function.
+
+Running the application
+-----------------------
+        
+#. If you need some shapefiles to work with you will find a selection of data at the
+   http://www.naturalearthdata.com/ project which is supported by the North American Cartographic
+   Information Society. Head to the link below and download some cultural vectors. You can use the 'Download all 50m cultural themes' at top.
+   
+   * `1:50m Cultural Vectors <http://www.naturalearthdata.com/downloads/50m-cultural-vectors/>`_
+   
+   Unzip the above data into a location you can find easily such as the desktop.
+
+#. You can run the application using Maven on the command line::
+   
+     mvn exec:java -Dexec.mainClass=org.geotools.tutorial.quickstart.Quickstart
+   
+#. The application will connect to your shapefile, produce a map context, and display the shapefile.
+
+   .. image:: images/QuickstartMap.png
+      :scale: 60
+   
+#. A couple of things to note about the code example:
+   
+* The shapefile is not loaded into memory. Instead it is read from disk each and every time it is needed.
+  This approach allows you to work with data sets larger than available memory.
+      
+* We are using a very basic display style here that just shows feature outlines. In the examples
+  that follow we will see how to specify more sophisticated styles.
+
+
+Things to Try
+=============
+
+* Try out the different sample data sets.
+
+* Try adding a different profiles to your :file:`pom.xml` for running on Java 8 and Java 11
+
+  .. Hint::
+     You'll want to exclude the module-info,java file from the build when running on Java 8.
+
+* Advanced: Try to get another tutorial to run on Java 11 using the module system.

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
@@ -648,7 +648,7 @@ public class Hints extends RenderingHints {
     public static final Key GEOMETRY_SIMPLIFICATION = new Key(Double.class);
 
     /** The rendering aid used to avoid painting tiny features over and over in the same pixel */
-    public static final Key SCREENMAP = new ClassKey("org.geotools.renderer.ScreenMap");
+    public static final Key SCREENMAP = new ClassKey("org.geotools.data.util.ScreenMap");
 
     /**
      * The actual coordinate dimensions of the geometry (to be used in the GeometryDescriptor user


### PR DESCRIPTION
Basic Quickstart for running the Quickstart tutorial app on Java 11 under the module system. I've tested it out and it runs fine without the need for any additional runtime arguments.

Depends upon https://github.com/geotools/geotools/pull/2154 to run.

Also includes a fix to Hints that I discovered when running the tutorial - looks like this was missed during the refactor of ScreenMap