### PR TITLE
[GEOT-6167] Complex GeoJSON encoder ignores complex features (XML) attributes

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
@@ -306,17 +306,15 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
             FeatureChainedAttributeVisitor nestedAttrExtractor =
                     new FeatureChainedAttributeVisitor(mappings);
             nestedAttrExtractor.visit(expression, null);
+            // check expression exists
+            FeatureChainedAttributeVisitor existsAttrExtractor = existsExtractorVisitor();
+            existsAttrExtractor.visit(expression, null);
 
             List<FeatureChainedAttributeDescriptor> fcAttrs =
                     nestedAttrExtractor.getFeatureChainedAttributes();
-            if (fcAttrs.size() == 0
-                    && !nestedAttrExtractor.conditionalMappingWasFound()
-                    && !FeatureChainedAttributeVisitor.isXlinkHref(exprSteps)) {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "Attribute \"%s\" not found in type \"%s\"",
-                                expression, mappings.getTargetFeature().getName().toString()));
-            }
+            // error on attribute check
+            checkAttributeFound(
+                    expression, exprSteps, nestedAttrExtractor, existsAttrExtractor, fcAttrs);
             // encoding of filters on multiple nested attributes is not (yet) supported
             if (fcAttrs.size() == 1) {
                 FeatureChainedAttributeDescriptor nestedAttrDescr = fcAttrs.get(0);
@@ -404,6 +402,50 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
         return super.visit(expression, notUsed);
     }
 
+    /** Attribute error check */
+    protected void checkAttributeFound(
+            PropertyName expression,
+            StepList exprSteps,
+            FeatureChainedAttributeVisitor nestedAttrExtractor,
+            FeatureChainedAttributeVisitor existsAttrExtractor,
+            List<FeatureChainedAttributeDescriptor> fcAttrs) {
+        if (fcAttrs.size() == 0
+                && !nestedAttrExtractor.conditionalMappingWasFound()
+                && !isXlinkHRef(exprSteps)
+                && existsAttrExtractor.getFeatureChainedAttributes().isEmpty()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Attribute \"%s\" not found in type \"%s\"",
+                            expression, mappings.getTargetFeature().getName().toString()));
+        }
+    }
+
+    protected boolean isXlinkHRef(StepList exprSteps) {
+        return FeatureChainedAttributeVisitor.isXlinkHref(exprSteps);
+    }
+
+    private FeatureChainedAttributeVisitor existsExtractorVisitor() {
+        return new FeatureChainedAttributeVisitor(mappings) {
+            @Override
+            protected boolean startsWith(StepList one, StepList other) {
+                if (other.size() > one.size()) {
+                    return false;
+                }
+                boolean result = true;
+                for (int i = 0; i < other.size(); i++) {
+                    Step thisStep = one.get(i);
+                    Step otherStep = other.get(i);
+                    if (thisStep.isIndexed() && otherStep.isIndexed()) {
+                        result = result && thisStep.equals(otherStep);
+                    } else {
+                        result = result && thisStep.equalsIgnoreIndex(otherStep);
+                    }
+                }
+                return result;
+            }
+        };
+    }
+
     private void nestedAttributeSanityCheck(Filter filter) {
         if (nestedAttributes != null) {
             for (FeatureChainedAttributeDescriptor descr : nestedAttributes) {
@@ -441,8 +483,7 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
                     }
                 }
                 xpathSteps = removeIndexesAndPredicates(xpathSteps);
-                if (FeatureChainedAttributeVisitor.isXlinkHref(xpathSteps)
-                        || FeatureChainedAttributeVisitor.isFid(xpathSteps)) {
+                if (isXlinkHRef(xpathSteps) || FeatureChainedAttributeVisitor.isFid(xpathSteps)) {
                     // if XPath expression points to xlink:href or to a FID, the only reliable thing
                     // to is to check the existence of its parent attribute
                     xpathSteps.remove(xpathSteps.size() - 1);

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/FeatureChainedAttributeVisitor.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/FeatureChainedAttributeVisitor.java
@@ -114,7 +114,7 @@ public class FeatureChainedAttributeVisitor extends DefaultExpressionVisitor {
         for (NestedAttributeMapping nestedAttr : currentAttributes) {
             StepList targetXPath = nestedAttr.getTargetXPath();
 
-            if (currentXPath.startsWith(targetXPath)) {
+            if (startsWith(currentXPath, targetXPath)) {
                 if (nestedAttr.isConditional() && feature == null) {
                     logConditionalMappingFound(currentType, targetXPath);
                     // quit the search
@@ -128,7 +128,7 @@ public class FeatureChainedAttributeVisitor extends DefaultExpressionVisitor {
                         StepList nestedTypeXPath = targetXPath.clone();
                         nestedTypeXPath.add(nestedTypeStep);
 
-                        boolean xpathContainsNestedType = currentXPath.startsWith(nestedTypeXPath);
+                        boolean xpathContainsNestedType = startsWith(currentXPath, nestedTypeXPath);
                         boolean hasSimpleContent = Types.isSimpleContentType(nestedPropertyType);
 
                         // if this is feature chaining for simple content, the name of the nested
@@ -297,6 +297,10 @@ public class FeatureChainedAttributeVisitor extends DefaultExpressionVisitor {
         return conditionalMappingFound;
     }
 
+    protected boolean startsWith(StepList one, StepList other) {
+        return one.startsWith(other);
+    }
+
     /**
      * Descriptor class holding information about a feature chained attribute, i.e. an attribute
      * belonging to a feature type that is linked to a root feature type via feature chaining.
@@ -319,7 +323,7 @@ public class FeatureChainedAttributeVisitor extends DefaultExpressionVisitor {
 
         private StepList attributePath;
 
-        private FeatureChainedAttributeDescriptor() {
+        FeatureChainedAttributeDescriptor() {
             featureChain = new ArrayList<>();
         }
 


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-6167

Since this issue can only be reproduced with an SQL data source the integration tests where implemented in GeoServer: .