### PR TITLE
Speed up NetCDF module build

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/crs/NetCDFCRSAuthorityFactory.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/crs/NetCDFCRSAuthorityFactory.java
@@ -34,31 +34,6 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 public class NetCDFCRSAuthorityFactory extends FactoryUsingWKT implements CRSAuthorityFactory {
     public static final String SYSTEM_DEFAULT_USER_PROJ_FILE = "netcdf.projections.file";
 
-    private static URL DEFINITION_URL;
-
-    static {
-        String cust_proj_file = System.getProperty(SYSTEM_DEFAULT_USER_PROJ_FILE);
-
-        // Attempt to load user-defined projections
-        if (cust_proj_file != null) {
-            File proj_file = new File(cust_proj_file);
-
-            if (proj_file.exists()) {
-                URL url = URLs.fileToUrl(proj_file);
-                if (url != null) {
-                    DEFINITION_URL = url;
-                } else {
-                    LOGGER.log(
-                            Level.SEVERE, "Had troubles converting " + cust_proj_file + " to URL");
-                }
-            }
-        } else {
-            // Use the built-in property definitions
-            cust_proj_file = "netcdf.projections.properties";
-            DEFINITION_URL = NetCDFCRSAuthorityFactory.class.getResource(cust_proj_file);
-        }
-    }
-
     public NetCDFCRSAuthorityFactory() {
         this(null);
     }
@@ -77,11 +52,32 @@ public class NetCDFCRSAuthorityFactory extends FactoryUsingWKT implements CRSAut
      * @return The URL, or {@code null} if none.
      */
     protected URL getDefinitionsURL() {
-        return DEFINITION_URL;
+        String cust_proj_file = System.getProperty(SYSTEM_DEFAULT_USER_PROJ_FILE);
+
+        // Attempt to load user-defined projections
+        if (cust_proj_file != null) {
+            File proj_file = new File(cust_proj_file);
+
+            if (proj_file.exists()) {
+                URL url = URLs.fileToUrl(proj_file);
+                if (url != null) {
+                    return url;
+                } else {
+                    LOGGER.log(
+                            Level.SEVERE, "Had troubles converting " + cust_proj_file + " to URL");
+                }
+            }
+        } else {
+            // Use the built-in property definitions
+            cust_proj_file = "netcdf.projections.properties";
+            return NetCDFCRSAuthorityFactory.class.getResource(cust_proj_file);
+        }
+
+        return null;
     }
 
     @Override
     public String toString() {
-        return super.toString() + "\nDefinition URL = " + DEFINITION_URL;
+        return super.toString() + "\nDefinition URL = " + getDefinitionsURL();
     }
 }

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFCRSTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFCRSTest.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.coverage.io.netcdf;
 
+import static org.junit.Assert.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -36,8 +38,8 @@ import org.geotools.referencing.operation.projection.RotatedPole;
 import org.geotools.referencing.operation.projection.TransverseMercator;
 import org.geotools.test.TestData;
 import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.coverage.grid.GridEnvelope;
 import org.opengis.parameter.ParameterValueGroup;
@@ -55,20 +57,27 @@ import org.opengis.referencing.operation.Projection;
  *
  * @author Daniele Romagnoli, GeoSolutions SAS
  */
-public class NetCDFCRSTest extends Assert {
+public class NetCDFCRSTest {
 
     private static final double DELTA = 1E-6;
 
     private static CoordinateReferenceSystem UTM32611;
 
     /** Sets up the custom definitions */
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         String netcdfPropertiesPath =
-                TestData.file(this, "netcdf.projections.properties").getCanonicalPath();
+                TestData.file(NetCDFCRSTest.class, "netcdf.projections.properties")
+                        .getCanonicalPath();
         System.setProperty(
                 NetCDFCRSAuthorityFactory.SYSTEM_DEFAULT_USER_PROJ_FILE, netcdfPropertiesPath);
+        CRS.reset("all");
         UTM32611 = CRS.decode("EPSG:32611");
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        System.clearProperty(NetCDFCRSAuthorityFactory.SYSTEM_DEFAULT_USER_PROJ_FILE);
     }
 
     @Test

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -92,7 +92,7 @@ import org.geotools.util.factory.Hints;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1581,9 +1581,8 @@ public class NetCDFMosaicReaderTest extends Assert {
         TestRunner.run(NetCDFMosaicReaderTest.suite());
     }
 
-    @Before
-    public void init() {
-
+    @BeforeClass
+    public static void init() {
         // make sure CRS ordering is correct
         System.setProperty("org.geotools.referencing.forceXY", "true");
         System.setProperty("user.timezone", "GMT");

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFStationsTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFStationsTest.java
@@ -36,7 +36,7 @@ import org.geotools.referencing.CRS;
 import org.geotools.test.TestData;
 import org.geotools.util.factory.Hints;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.parameter.GeneralParameterValue;
 import org.opengis.parameter.ParameterValue;
@@ -49,8 +49,8 @@ import org.opengis.parameter.ParameterValue;
  */
 public final class NetCDFStationsTest extends Assert {
 
-    @Before
-    public void init() {
+    @BeforeClass
+    public static void init() {
         // make sure CRS ordering is correct
         System.setProperty("org.geotools.referencing.forceXY", "true");
         CRS.reset("all");


### PR DESCRIPTION
When running a full build the property file location of the custom NetCDF authority factory is looked up during the first test, that does not have the location of the custom property file set yet, which results in codes not being found quickly later, causing H2 postCreateTable to go though a full CRS scan in the EPSG database.

Since CRS factories are cached, there is no reason to keep the location of the property file there forever, just look it up every time needed instead (in a normal application, it will happen only a few times at startup).