### PR TITLE
[GEOT-6177] NEAREST spatial predicate for Postgis

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/util/FeatureStreams.java
+++ b/modules/library/main/src/main/java/org/geotools/data/util/FeatureStreams.java
@@ -48,7 +48,7 @@ public final class FeatureStreams {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(fi, 0), false)
                 .onClose(
                         () -> {
-                            fc.features().close();
+                            fi.close();
                         });
     }
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.geotools.data.jdbc.FilterToSQL;
+import org.geotools.data.postgis.filter.FilterFunction_pgNearest;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.function.DateDifferenceFunction;
@@ -188,6 +189,9 @@ class FilterToSqlHelper {
 
             // time related functions
             caps.addType(DateDifferenceFunction.class);
+
+            // n nearest function
+            caps.addType(FilterFunction_pgNearest.class);
         }
 
         // native filter support

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisPSFilterToSql.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisPSFilterToSql.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2018, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -17,11 +17,20 @@
 package org.geotools.data.postgis;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.geotools.data.postgis.filter.FilterFunction_pgNearest;
 import org.geotools.filter.FilterCapabilities;
+import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.PreparedFilterToSQL;
+import org.geotools.jdbc.PrimaryKeyColumn;
+import org.geotools.util.factory.Hints;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LinearRing;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.filter.BinaryComparisonOperator;
 import org.opengis.filter.PropertyIsBetween;
+import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.Literal;
@@ -161,6 +170,138 @@ public class PostgisPSFilterToSql extends PreparedFilterToSQL {
             return extraData;
         } else {
             return super.visit(filter, extraData);
+        }
+    }
+
+    public Object visit(PropertyIsEqualTo filter, Object extraData) {
+        Optional<FilterFunction_pgNearest> nearestOpt = getNearestFilter(filter);
+        if (nearestOpt.isPresent()) {
+            return visit(nearestOpt.get(), extraData);
+        } else {
+            return super.visit(filter, extraData);
+        }
+    }
+
+    /**
+     * Detects and return a FilterFunction_pgNearest if found, otherwise an empty optional
+     *
+     * @param filter filter to evaluate
+     * @return optional of FilterFunction_pgNearest if found
+     */
+    private Optional<FilterFunction_pgNearest> getNearestFilter(PropertyIsEqualTo filter) {
+        Expression expr1 = filter.getExpression1();
+        Expression expr2 = filter.getExpression2();
+        // if expr2 is nearest filter, switch positions
+        if (expr2 instanceof FilterFunction_pgNearest) {
+            Expression tmp = expr1;
+            expr1 = expr2;
+            expr2 = tmp;
+        }
+        if (expr1 instanceof FilterFunction_pgNearest) {
+            if (!(expr2 instanceof Literal)) {
+                throw new UnsupportedOperationException(
+                        "Unsupported usage of Nearest Operator: it can be compared only to a Boolean \"true\" value");
+            }
+            Boolean nearest = (Boolean) evaluateLiteral((Literal) expr2, Boolean.class);
+            if (nearest == null || !nearest.booleanValue()) {
+                throw new UnsupportedOperationException(
+                        "Unsupported usage of Nearest Operator: it can be compared only to a Boolean \"true\" value");
+            }
+            return Optional.of((FilterFunction_pgNearest) expr1);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private Object visit(FilterFunction_pgNearest filter, Object extraData) {
+        Expression geometryExp = getParameter(filter, 0, true);
+        Expression numNearest = getParameter(filter, 1, true);
+        try {
+            List<PrimaryKeyColumn> pkColumns = getPrimaryKey().getColumns();
+            if (pkColumns == null || pkColumns.size() == 0) {
+                throw new UnsupportedOperationException(
+                        "Unsupported usage of Postgis Nearest Operator: table with no primary key");
+            }
+
+            String pkColumnsAsString = getPrimaryKeyColumnsAsCommaSeparatedList(pkColumns);
+            StringBuffer sb = new StringBuffer();
+            sb.append(" (")
+                    .append(pkColumnsAsString)
+                    .append(")")
+                    .append(" in (select ")
+                    .append(pkColumnsAsString)
+                    .append(" from ");
+            if (getDatabaseSchema() != null) {
+                dialect.encodeSchemaName(getDatabaseSchema(), sb);
+                sb.append(".");
+            }
+            dialect.encodeTableName(getPrimaryKey().getTableName(), sb);
+            sb.append(" order by ");
+            // geometry column name
+            dialect.encodeColumnName(null, featureType.getGeometryDescriptor().getLocalName(), sb);
+            sb.append(" <-> ");
+            // reference geometry
+            Geometry geomValue = (Geometry) evaluateLiteral((Literal) geometryExp, Geometry.class);
+            bufferGeom(geomValue, sb);
+            // num of features
+            sb.append(" limit ");
+            int numFeatures = numNearest.evaluate(null, Number.class).intValue();
+            sb.append(numFeatures);
+            sb.append(")");
+
+            out.write(sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return extraData;
+    }
+
+    private String getPrimaryKeyColumnsAsCommaSeparatedList(List<PrimaryKeyColumn> pkColumns) {
+        StringBuffer sb = new StringBuffer();
+        boolean first = true;
+        for (PrimaryKeyColumn c : pkColumns) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(",");
+            }
+            dialect.encodeColumnName(c.getName(), sb);
+        }
+        return sb.toString();
+    }
+
+    private Integer getFeatureTypeGeometrySRID() {
+        return (Integer)
+                featureType
+                        .getGeometryDescriptor()
+                        .getUserData()
+                        .get(JDBCDataStore.JDBC_NATIVE_SRID);
+    }
+
+    private Integer getFeatureTypeGeometryDimension() {
+        GeometryDescriptor descriptor = featureType.getGeometryDescriptor();
+        return (Integer) descriptor.getUserData().get(Hints.COORDINATE_DIMENSION);
+    }
+
+    private void bufferGeom(Geometry geom, StringBuffer sb) {
+        if (geom instanceof LinearRing) {
+            // postgis does not handle linear rings, convert to just a line string
+            geom = geom.getFactory().createLineString(((LinearRing) geom).getCoordinateSequence());
+        }
+
+        Object typename =
+                featureType
+                        .getGeometryDescriptor()
+                        .getUserData()
+                        .get(JDBCDataStore.JDBC_NATIVE_TYPENAME);
+        if ("geography".equals(typename)) {
+            sb.append("ST_GeogFromText('");
+            sb.append(geom.toText());
+            sb.append("')");
+        } else {
+            sb.append("ST_GeomFromText('");
+            sb.append(geom.toText());
+            sb.append("', " + getFeatureTypeGeometrySRID() + ")");
         }
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/filter/FilterFunction_pgNearest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/filter/FilterFunction_pgNearest.java
@@ -1,0 +1,52 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2018, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis.filter;
+
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+import org.opengis.filter.expression.VolatileFunction;
+import org.opengis.geometry.Geometry;
+
+/**
+ * NEAREST function implementation for Postgis <br>
+ * Function name: pgNearest <br>
+ * example:
+ *
+ * <pre>     pgNearest(POINT(16.36 48.205),30)=true </pre>
+ *
+ * @author Fernando Mino, Geosolutions
+ */
+public class FilterFunction_pgNearest extends FunctionExpressionImpl implements VolatileFunction {
+
+    public static FunctionName NAME =
+            new FunctionNameImpl(
+                    "pgNearest",
+                    Boolean.class,
+                    // required parameters:
+                    FunctionNameImpl.parameter("geometry", Geometry.class),
+                    FunctionNameImpl.parameter("num_features", Integer.class));
+
+    public FilterFunction_pgNearest() {
+        super(NAME);
+    }
+
+    @Override
+    public Object evaluate(Object feature) {
+        throw new UnsupportedOperationException("Unsupported usage of Nearest operator");
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -1,0 +1,1 @@
+org.geotools.data.postgis.filter.FilterFunction_pgNearest

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisNativeFilterOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisNativeFilterOnlineTest.java
@@ -16,8 +16,23 @@
  */
 package org.geotools.data.postgis;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentFeatureCollection;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.data.util.FeatureStreams;
 import org.geotools.jdbc.JDBCNativeFilterOnlineTest;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.FilterFactory;
 import org.opengis.filter.NativeFilter;
+import org.opengis.filter.expression.Function;
 
 public final class PostgisNativeFilterOnlineTest extends JDBCNativeFilterOnlineTest {
 
@@ -29,5 +44,51 @@ public final class PostgisNativeFilterOnlineTest extends JDBCNativeFilterOnlineT
     @Override
     protected NativeFilter getNativeFilter() {
         return filterFactory.nativeFilter("(TYPE = 'temperature' OR TYPE = 'wind') AND value > 15");
+    }
+
+    /** Check pgNearest filter with 1 result */
+    @Test
+    public void testNearestNativeFilterFirst() throws IOException {
+        ContentFeatureSource fs = dataStore.getFeatureSource(tname("gt_jdbc_test_measurements"));
+        FilterFactory ff = dataStore.getFilterFactory();
+        GeometryFactory gf = dataStore.getGeometryFactory();
+        Function nearest =
+                ff.function(
+                        "pgNearest",
+                        ff.literal(gf.createPoint(new Coordinate(0, 0))),
+                        ff.literal(1));
+        Query q =
+                new Query(tname("gt_jdbc_test_measurements"), ff.equals(nearest, ff.literal(true)));
+        SimpleFeature feature = DataUtilities.first(fs.getFeatures(q));
+        assertEquals("POINT (1 2)", feature.getDefaultGeometryProperty().getValue().toString());
+    }
+
+    /** Check pgNearest filter with 3 results */
+    @Test
+    public void testNearestNativeFilterNumResults() throws IOException {
+        ContentFeatureSource fs = dataStore.getFeatureSource(tname("gt_jdbc_test_measurements"));
+        FilterFactory ff = dataStore.getFilterFactory();
+        GeometryFactory gf = dataStore.getGeometryFactory();
+        Function nearest =
+                ff.function(
+                        "pgNearest",
+                        ff.literal(gf.createPoint(new Coordinate(0, 0))),
+                        ff.literal(3));
+        Query q =
+                new Query(tname("gt_jdbc_test_measurements"), ff.equals(nearest, ff.literal(true)));
+        ContentFeatureCollection fc = fs.getFeatures(q);
+        try (Stream<SimpleFeature> featuresStream = FeatureStreams.toFeatureStream(fc)) {
+            List<SimpleFeature> featuresList = featuresStream.collect(Collectors.toList());
+            assertEquals(3, featuresList.size());
+            assertEquals(
+                    "POINT (1 2)",
+                    featuresList.get(0).getDefaultGeometryProperty().getValue().toString());
+            assertEquals(
+                    "POINT (2 2)",
+                    featuresList.get(1).getDefaultGeometryProperty().getValue().toString());
+            assertEquals(
+                    "POINT (1 4)",
+                    featuresList.get(2).getDefaultGeometryProperty().getValue().toString());
+        }
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSpatialFiltersOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSpatialFiltersOnlineTest.java
@@ -16,13 +16,65 @@
  */
 package org.geotools.data.postgis;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentFeatureCollection;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.data.util.FeatureStreams;
 import org.geotools.jdbc.JDBCDataStoreAPITestSetup;
 import org.geotools.jdbc.JDBCSpatialFiltersOnlineTest;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.expression.Function;
 
 public class PostgisSpatialFiltersOnlineTest extends JDBCSpatialFiltersOnlineTest {
 
     @Override
     protected JDBCDataStoreAPITestSetup createTestSetup() {
         return new PostgisDataStoreAPITestSetup(new PostGISTestSetup());
+    }
+
+    /** Check pgNearest filter with 1 result */
+    @Test
+    public void testNearestNativeFilterFirst() throws IOException {
+        ContentFeatureSource fs = dataStore.getFeatureSource(tname("road"));
+        FilterFactory ff = dataStore.getFilterFactory();
+        GeometryFactory gf = dataStore.getGeometryFactory();
+        Function nearest =
+                ff.function(
+                        "pgNearest",
+                        ff.literal(gf.createPoint(new Coordinate(-0.5, -0.5))),
+                        ff.literal(1));
+        Query q = new Query(tname("road"), ff.equals(nearest, ff.literal(true)));
+        SimpleFeature feature = DataUtilities.first(fs.getFeatures(q));
+        assertEquals(0, (int) feature.getAttribute("id"));
+    }
+
+    /** Check pgNearest filter with 2 results */
+    @Test
+    public void testNearestNativeFilterNumResults() throws IOException {
+        ContentFeatureSource fs = dataStore.getFeatureSource(tname("road"));
+        FilterFactory ff = dataStore.getFilterFactory();
+        GeometryFactory gf = dataStore.getGeometryFactory();
+        Function nearest =
+                ff.function(
+                        "pgNearest",
+                        ff.literal(gf.createPoint(new Coordinate(-0.5, -0.5))),
+                        ff.literal(2));
+        Query q = new Query(tname("road"), ff.equals(nearest, ff.literal(true)));
+        ContentFeatureCollection fc = fs.getFeatures(q);
+        try (Stream<SimpleFeature> featuresStream = FeatureStreams.toFeatureStream(fc)) {
+            List<SimpleFeature> featuresList = featuresStream.collect(Collectors.toList());
+            assertEquals(2, featuresList.size());
+            assertEquals(0, (int) featuresList.get(0).getAttribute("id"));
+            assertEquals(1, (int) featuresList.get(1).getAttribute("id"));
+        }
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisSpatialFiltersOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisSpatialFiltersOnlineTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2009, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2018, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -16,14 +16,66 @@
  */
 package org.geotools.data.postgis.ps;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.Query;
 import org.geotools.data.postgis.PostgisDataStoreAPITestSetup;
+import org.geotools.data.store.ContentFeatureCollection;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.data.util.FeatureStreams;
 import org.geotools.jdbc.JDBCDataStoreAPITestSetup;
 import org.geotools.jdbc.JDBCSpatialFiltersOnlineTest;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.expression.Function;
 
 public class PostgisSpatialFiltersOnlineTest extends JDBCSpatialFiltersOnlineTest {
 
     @Override
     protected JDBCDataStoreAPITestSetup createTestSetup() {
         return new PostgisDataStoreAPITestSetup(new PostGISPSTestSetup());
+    }
+
+    /** Check pgNearest filter with 1 result */
+    @Test
+    public void testNearestNativeFilterFirst() throws IOException {
+        ContentFeatureSource fs = dataStore.getFeatureSource(tname("road"));
+        FilterFactory ff = dataStore.getFilterFactory();
+        GeometryFactory gf = dataStore.getGeometryFactory();
+        Function nearest =
+                ff.function(
+                        "pgNearest",
+                        ff.literal(gf.createPoint(new Coordinate(-0.5, -0.5))),
+                        ff.literal(1));
+        Query q = new Query(tname("road"), ff.equals(nearest, ff.literal(true)));
+        SimpleFeature feature = DataUtilities.first(fs.getFeatures(q));
+        assertEquals(0, (int) feature.getAttribute("id"));
+    }
+
+    /** Check pgNearest filter with 2 results */
+    @Test
+    public void testNearestNativeFilterNumResults() throws IOException {
+        ContentFeatureSource fs = dataStore.getFeatureSource(tname("road"));
+        FilterFactory ff = dataStore.getFilterFactory();
+        GeometryFactory gf = dataStore.getGeometryFactory();
+        Function nearest =
+                ff.function(
+                        "pgNearest",
+                        ff.literal(gf.createPoint(new Coordinate(-0.5, -0.5))),
+                        ff.literal(2));
+        Query q = new Query(tname("road"), ff.equals(nearest, ff.literal(true)));
+        ContentFeatureCollection fc = fs.getFeatures(q);
+        try (Stream<SimpleFeature> featuresStream = FeatureStreams.toFeatureStream(fc)) {
+            List<SimpleFeature> featuresList = featuresStream.collect(Collectors.toList());
+            assertEquals(2, featuresList.size());
+            assertEquals(0, (int) featuresList.get(0).getAttribute("id"));
+            assertEquals(1, (int) featuresList.get(1).getAttribute("id"));
+        }
     }
 }


### PR DESCRIPTION
NEAREST spatial predicate implementation in ECQL, with the usage being something similar to NEAREST(POINT(21707 6558912),10), returning the nearest 10 features to POINT.

Uses postgis `<->` operator with a subquery.

https://osgeo-org.atlassian.net/browse/GEOT-6177