### PR TITLE
[GEOT-6178] Invalid select bounds query generated for Oracle database

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -3834,7 +3834,7 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
                             "AND " + toSQL.encodeToString(filter));
                     toSQL.setInline(false);
                 } else {
-                    sql.append(toSQL.encodeToString(filter));
+                    sql.append(" ").append(toSQL.encodeToString(filter));
                 }
             } catch (FilterToSQLException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-6178

This issue can only be reproduced with Oracle. The tests where already there and failing, note that some Oracle tests are still failing but its unrelated to this issue cause.

Before this PR:

![image](https://user-images.githubusercontent.com/1590542/48382704-34545080-e6da-11e8-8841-3350d33c13db.png)

After this PR:

![image](https://user-images.githubusercontent.com/1590542/48382717-3fa77c00-e6da-11e8-8920-e89ba6de71a9.png)