### PR TITLE
[GEOT-6179] Delegate filter execution matching multiple same-xpath feature chained attribute names to database

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
@@ -316,7 +316,7 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
             checkAttributeFound(
                     expression, exprSteps, nestedAttrExtractor, existsAttrExtractor, fcAttrs);
             // encoding of filters on multiple nested attributes is not (yet) supported
-            if (fcAttrs.size() == 1) {
+            if (fcAttrs.size() >= 1) {
                 FeatureChainedAttributeDescriptor nestedAttrDescr = fcAttrs.get(0);
                 if (nestedAttrDescr.chainSize() > 1 && nestedAttrDescr.isJoiningEnabled()) {
                     FeatureTypeMapping featureMapping =


### PR DESCRIPTION
Currently app-schema plugin detect two posible attributes with same xpath and delegate filter execution to JVM runtime. This fix delegates filter execution to database using all available join-fields.

https://osgeo-org.atlassian.net/browse/GEOT-6179