### PR TITLE
[GEOT-6175] stop CSVWriter leaving temp files lying around

### DIFF
--- a/modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
+++ b/modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
@@ -64,7 +64,8 @@ public class CSVFeatureWriter implements FeatureWriter<SimpleFeatureType, Simple
         File file = csvFileState.getFile();
         File directory = file.getParentFile();
         String typeName = query.getTypeName();
-        this.temp = File.createTempFile(typeName + System.currentTimeMillis(), "csv", directory);
+        this.temp = File.createTempFile(typeName + System.currentTimeMillis(), ".csv", directory);
+        this.temp.deleteOnExit();
         this.featureType = csvStrategy.getFeatureType();
         this.iterator = csvStrategy.iterator();
         this.csvStrategy = csvStrategy;
@@ -168,5 +169,6 @@ public class CSVFeatureWriter implements FeatureWriter<SimpleFeatureType, Simple
         File file = this.csvFileState.getFile();
 
         Files.copy(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        temp.delete();
     }
 }

--- a/modules/unsupported/csv/src/test/java/org/geotools/data/csv/CSVWriteTest.java
+++ b/modules/unsupported/csv/src/test/java/org/geotools/data/csv/CSVWriteTest.java
@@ -104,6 +104,17 @@ public class CSVWriteTest {
         tmp.delete();
     }
 
+    //Make sure any temp files were cleaned up.
+    public boolean cleanedup() {
+      File list[] = tmp.listFiles((dir, name) -> name.endsWith(".csv") );
+      for (int i = 0; i < list.length; i++) {
+          if (list[i].getName().equalsIgnoreCase("locations.csv")) {
+            continue;
+          }
+          return false;
+      }
+      return true;
+    }
     @Test
     public void featureStoreExample() throws Exception {
         Map<String, Serializable> params = new HashMap<String, Serializable>();
@@ -113,6 +124,7 @@ public class CSVWriteTest {
         SimpleFeatureSource featureSource = store.getFeatureSource("locations");
 
         assertTrue("Modification not supported", (featureSource instanceof SimpleFeatureStore));
+        assertTrue("Temp files being left behind", cleanedup());
     }
 
     @Test
@@ -213,6 +225,7 @@ public class CSVWriteTest {
         t1.close();
         t2.close();
         store.dispose(); // clear out any listeners
+        assertTrue("Temp files being left behind", cleanedup());
     }
 
     @Test
@@ -248,6 +261,7 @@ public class CSVWriteTest {
             t.close();
             store.dispose();
         }
+        assertTrue("Temp files being left behind", cleanedup());
     }
 
     @Test
@@ -304,6 +318,7 @@ public class CSVWriteTest {
                 "Ensure the file has only the one feature we created",
                 contents.trim(),
                 checkFileContents(statesfile).trim());
+        assertTrue("Temp files being left behind", cleanedup());
     }
 
     @Test
@@ -342,7 +357,7 @@ public class CSVWriteTest {
             reader.close();
             writer.close();
         }
-
+        assertTrue("Temp files being left behind", cleanedup());
         // Test that content was appended
         SimpleFeatureStore featureStore = (SimpleFeatureStore) store.getFeatureSource("locations");
         assertEquals(9, featureStore.getFeatures().size());
@@ -368,6 +383,7 @@ public class CSVWriteTest {
         FileDataStore store = FileDataStoreFinder.getDataStore(states);
         assertNotNull("couldn't create store", store);
         File file2 = File.createTempFile("CSVTest", ".csv");
+        file2.deleteOnExit();
         Map<String, Serializable> params2 = new HashMap<String, Serializable>();
         params2.put("file", file2);
         params2.put(
@@ -400,12 +416,14 @@ public class CSVWriteTest {
             reader.close();
             writer.close();
         }
+        assertTrue("Temp files being left behind", cleanedup());
         String contents = checkFileContents(file2);
         BufferedReader lineReader = new BufferedReader(new CharArrayReader(contents.toCharArray()));
         String line = lineReader.readLine(); // header
         assertFalse("Geom is included", line.toLowerCase().contains("the_geom"));
         line = lineReader.readLine();
         assertFalse("Geom is included", line.toLowerCase().contains("multipolygon"));
+        file2.delete();
     }
 
     @Test
@@ -463,6 +481,7 @@ public class CSVWriteTest {
             reader.close();
             writer.close();
         }
+        assertTrue("Temp files being left behind", cleanedup());
         String contents = checkFileContents(file2);
         BufferedReader lineReader = new BufferedReader(new CharArrayReader(contents.toCharArray()));
         String line = lineReader.readLine(); // header
@@ -471,6 +490,7 @@ public class CSVWriteTest {
         assertTrue("No Lon", line.contains("LON"));
         line = lineReader.readLine();
         assertEquals("11.116667,46.066667,Trento,140,2002", line);
+        file2.delete();
     }
 
     @Test
@@ -512,12 +532,14 @@ public class CSVWriteTest {
             reader.close();
             writer.close();
         }
+        assertTrue("Temp files being left behind", cleanedup());
         String contents = checkFileContents(file2);
         BufferedReader lineReader = new BufferedReader(new CharArrayReader(contents.toCharArray()));
         String line = lineReader.readLine(); // header
         assertTrue("Geom is not included", line.toLowerCase().contains("the_geom_wkt"));
         line = lineReader.readLine();
         assertTrue("Geom is not included", line.toLowerCase().contains("multipolygon"));
+        file2.delete();
     }
 
     public static void assertEqualsIgnoreWhitespace(

--- a/modules/unsupported/csv/src/test/java/org/geotools/data/csv/CSVWriteTest.java
+++ b/modules/unsupported/csv/src/test/java/org/geotools/data/csv/CSVWriteTest.java
@@ -104,17 +104,18 @@ public class CSVWriteTest {
         tmp.delete();
     }
 
-    //Make sure any temp files were cleaned up.
+    // Make sure any temp files were cleaned up.
     public boolean cleanedup() {
-      File list[] = tmp.listFiles((dir, name) -> name.endsWith(".csv") );
-      for (int i = 0; i < list.length; i++) {
-          if (list[i].getName().equalsIgnoreCase("locations.csv")) {
-            continue;
-          }
-          return false;
-      }
-      return true;
+        File list[] = tmp.listFiles((dir, name) -> name.endsWith(".csv"));
+        for (int i = 0; i < list.length; i++) {
+            if (list[i].getName().equalsIgnoreCase("locations.csv")) {
+                continue;
+            }
+            return false;
+        }
+        return true;
     }
+
     @Test
     public void featureStoreExample() throws Exception {
         Map<String, Serializable> params = new HashMap<String, Serializable>();


### PR DESCRIPTION
CSVWriter creates a temporary file when writing but never deletes it.
Also clean up the temp files in the tests in general.