### PR TITLE
Fix some spelling mistakes in docs/user.

### DIFF
--- a/docs/user/build/maven/snapshots.rst
+++ b/docs/user/build/maven/snapshots.rst
@@ -76,4 +76,4 @@ The build server ares is watching the repository, and will build and deploy a sn
       
       mvn deploy -Dmaven.test.skip=true
 
-6. Let your community know via email! (The email can ask them to build iwth -U).
+6. Let your community know via email! (The email can ask them to build with -U).

--- a/docs/user/build/maven/testing.rst
+++ b/docs/user/build/maven/testing.rst
@@ -6,7 +6,7 @@ To just run tests for a module::
    cd modules/library/main
    mvn test
 
-Several of the "profiles" described on this page can be used on conjuction::
+Several of the "profiles" described on this page can be used in conjunction::
    
    mvn test -o -P interactive,stress
 

--- a/docs/user/extension/wms/wms.rst
+++ b/docs/user/extension/wms/wms.rst
@@ -159,7 +159,7 @@ Making a GetMap request is more interesting than looking at WMSCapabilities.
      GetMapResponse response = (GetMapResponse) wms.issueRequest(request);
      BufferedImage image = ImageIO.read(response.getInputStream());
 
-Other common activites:
+Other common activities:
 
 * Requesting with a style
   

--- a/docs/user/library/coverage/pyramid.rst
+++ b/docs/user/library/coverage/pyramid.rst
@@ -52,7 +52,7 @@ The format of that pyramid.properties file is magic, while we can look at the ja
   #where all the levels reside
   LevelsDirs=0 2 4 8 16 32
   
-  #number of levels availaible
+  #number of levels available
   LevelsNum=6
   
   #envelope for this pyramid

--- a/docs/user/library/cql/ecql.rst
+++ b/docs/user/library/cql/ecql.rst
@@ -29,7 +29,7 @@ As you can see above the ECQL class can be run on the command line.
 It allows you to try out the ECQL examples on this page; and produces the XML Filter representation of the result.::
     
     ECQL Filter Tester
-    "Seperate with \";\" or \"quit\" to finish)
+    "Separate with \";\" or \"quit\" to finish)
     >attr > 10
     <?xml version="1.0" encoding="UTF-8"?>
     <ogc:PropertyIsGreaterThan xmlns="http://www.opengis.net/ogc" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml">

--- a/docs/user/library/data/csv.rst
+++ b/docs/user/library/data/csv.rst
@@ -1,7 +1,7 @@
 CSV Plugin
 ----------
 
-Support for common seperated value files.
+Support for common separated value files.
 
 This unsupported plugin is under development; in support of a tutorial on the use
 of **ContentDataStore**.

--- a/docs/user/library/data/datastore.rst
+++ b/docs/user/library/data/datastore.rst
@@ -114,7 +114,7 @@ If you are working with GeoServer or uDig you have access to some great faciliti
   ServiceFinder finder = new DefaultServiceFactory( catalog );
   
   File file = new File("example.shp");
-  Service service = finder.aquire( file.toURI() );
+  Service service = finder.acquire( file.toURI() );
   
   // Getting information about the Shapefile (BEFORE making the DataStore)
   IServiceInfo info = service.getInfo( new NullProgressListener() );

--- a/docs/user/library/main/collection.rst
+++ b/docs/user/library/main/collection.rst
@@ -514,7 +514,7 @@ will be translated to raw SQL optimizing significantly is execution. In particul
 to JDBC data stores:
 
 * Aggregations and grouping on property names is support
-* Simple math expressions of the above are also supported (substract, add, multiply, divide)
+* Simple math expressions of the above are also supported (subtract, add, multiply, divide)
 * Functions may be supported, or not, depending on the filter capabilities of the data store. At the time
   of writing only PostgreSQL supports a small set of functions (e.g., dateDifference, floor, ceil, 
   string concatenation and the like).

--- a/docs/user/library/main/filter.rst
+++ b/docs/user/library/main/filter.rst
@@ -590,7 +590,7 @@ There is a small utility class **Filters** that packages up some common Filter o
 * Filters.removeFilter(Filter, Filter)
 * Filters.removeFilter(Filter, Filter, boolean)
   
-  Used to seperate out a child from the provided filter.
+  Used to separate out a child from the provided filter.
   
   Much like *and* and *or* above these methods return a modified
   filter.

--- a/docs/user/library/main/repository.rst
+++ b/docs/user/library/main/repository.rst
@@ -150,7 +150,7 @@ Both GeoServer and and uDig offer some form of Catalog API. Here is an example o
   Catalog catalog = new DefaultCatalog();
   ServiceFinder finder = new DefaultServiceFactory( catalog );
   
-  WFSService service = finder.aquire( uri ); // uri of your GetCapabilities document
+  WFSService service = finder.acquire( uri ); // uri of your GetCapabilities document
   
   IServiceInfo info = service.getInfo( new NullProgressListener() );
   

--- a/docs/user/library/opengis/filter.rst
+++ b/docs/user/library/opengis/filter.rst
@@ -230,7 +230,7 @@ at all. In the simple case PropertyIsNull can be used to check that a property e
 that the value is empty.
 
 We also have the situation where a property is allowed to occur zero or many times; in this case
-we want a nice clear way to check that a Property does not exsit at all (that is occure = zero).
+we want a nice clear way to check that a Property does not exsit at all (that is occur = zero).
 
 .. literalinclude:: /../src/main/java/org/geotools/opengis/FilterExamples.java
    :language: java

--- a/docs/user/library/referencing/extension.rst
+++ b/docs/user/library/referencing/extension.rst
@@ -1,7 +1,7 @@
 EPSG Extension Plugin
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The plugin an Coordinate Reference System Authority that adds common extra or unoffical EPSG
+The plugin an Coordinate Reference System Authority that adds common extra or unofficial EPSG
 codes into the mix. Internally it uses the same java property file as the :doc:`wkt` plugin.
 
 This plugin is compatible with a restricted environment and does not require disk access.

--- a/docs/user/library/render/gtrenderer.rst
+++ b/docs/user/library/render/gtrenderer.rst
@@ -38,7 +38,7 @@ consider the following ideas:
 * Experiment with different Java 2D graphics settings such as
   anti-aliasing
 * Use background threads to draw tiles, and allowing your swing control
-  to pull the tiles onto the screen for a smooth "slippy" map
+  to pull the tiles onto the screen for a smooth "slippery" map
 
 3D
 ^^

--- a/docs/user/library/render/map.rst
+++ b/docs/user/library/render/map.rst
@@ -137,7 +137,7 @@ Used to render a GridCoverage.
 
 .. image:: /images/gridcoverage_layer.PNG
 
-Note that direct use of a GridCoverage in this fashion is generally not as efficent 
+Note that direct use of a GridCoverage in this fashion is generally not as efficient 
 as using GridReaderLayer below.
 
 GridReaderLayer

--- a/docs/user/library/xml/geometry.rst
+++ b/docs/user/library/xml/geometry.rst
@@ -295,7 +295,7 @@ XDO allows you to declare w/ Objects the Schema you are interested in, and how i
 * reuse occurs on a schema by schema basis
 * You can "generated" a schema explicitly out into code
 * Code has been generated for GML2, WFS, and WMS
-* Custom documents, based on an extention of a known schema can be parsed
+* Custom documents, based on an extension of a known schema can be parsed
 * generated code also includes support for the production of XML documents.
 * validation of content is supported
 

--- a/docs/user/library/xml/internal/bindings.rst
+++ b/docs/user/library/xml/internal/bindings.rst
@@ -121,7 +121,7 @@ The default execution behaviour is to execute after its "parent" binding has exe
    
    You may have asked yourself the question Whats the point of the binding for "integerElement". If you did give yourself a gold star because the binding indeed unnecessary. Transforming the string "25" to the integer 25 can really be done with a single binding. Which brings the next question Which binding should do the job?.
    
-   The answer depends on the java object model being mapped to. Suppose we chose the binding for "integerElement" to perform the mapping and removed the binding for "integer" from the chain. This would be perfectly valid, but lets assume that we have other elements and attributes in our schema that are of type "xs:integer". Do we want to create bindings indentical to the "integerElement" binding? Probably not.
+   The answer depends on the java object model being mapped to. Suppose we chose the binding for "integerElement" to perform the mapping and removed the binding for "integer" from the chain. This would be perfectly valid, but lets assume that we have other elements and attributes in our schema that are of type "xs:integer". Do we want to create bindings identical to the "integerElement" binding? Probably not.
    
    In this case, it makes more sense to have the "integer" binding do the work, and remove the "integerElement" completley (that is, remove the element binding from the configuration, so that the chain will be built only up to the type handler):
    
@@ -376,7 +376,7 @@ The interface for complex bindings looks like::
         return null;
      }
    
-   In this example, all the work is done in the encode method. However it is evident that the second example results in much more work for the binding implementor which is why teh first method is often preferred.
+   In this example, all the work is done in the encode method. However it is evident that the second example results in much more work for the binding implementor which is why the first method is often preferred.
 
 * AbstractComplexBinding
   

--- a/docs/user/library/xml/internal/overview.rst
+++ b/docs/user/library/xml/internal/overview.rst
@@ -38,7 +38,7 @@ During parsing an XML schema is used to assist in the transformation. The parser
    As an example, consider processing the "purchaseOrder" element shown above. The following bindings would be derived:
    
    * The "purchaseOrder" global element declaration
-   * The "PurchaseOrderType" type defintion ( the declared type of the "purchaseOrder" element )
+   * The "PurchaseOrderType" type definition ( the declared type of the "purchaseOrder" element )
    * The "anyType" type definition ( the base type of all complex type definitions )
    
    Once a set of bindings has been located, they are executed in a defined order, and the element or attribute is transformed into an object. Binding derivation and execution is explained in greater detail here.
@@ -90,7 +90,7 @@ Encoding is the process of serializing a hierarchy of objects as xml.
 
      .. image:: /images/xml/encoderOverview.png
 
-During encoding an xml schema is used to determine how various objects should be encoded as elemements / attributes, and to navigate through the hierachy of objects.
+During encoding an xml schema is used to determine how various objects should be encoded as elemements / attributes, and to navigate through the hierarchy of objects.
 
 1. Element and Attribute Binding
    

--- a/docs/user/library/xml/internal/tutorial.rst
+++ b/docs/user/library/xml/internal/tutorial.rst
@@ -252,11 +252,11 @@ SKU (Simple Type)
 
 2. From the schema definition, we see that the SKU type is a Simple Type,
    which extends xsd:string. In the realm of xml schema, the following diagram
-   depicts the inheritance hierachy of the SKU type:
+   depicts the inheritance hierarchy of the SKU type:
 
    .. image:: /images/xml/skuHierachy.png
 
-3. The parser takes this hierachy into account when executing bindings. The
+3. The parser takes this hierarchy into account when executing bindings. The
    bindings are executed in order from the top down. The output of each binding
    is passed on to the next binding in the chain. The following diagram depicts
    the binding execution chain:

--- a/docs/user/tutorial/datastore/strategy.rst
+++ b/docs/user/tutorial/datastore/strategy.rst
@@ -144,7 +144,7 @@ The CSVFeatureWriter handles the writing functionality for our CSVFeatureStore. 
       :start-after: import com.csvreader.CsvWriter;
       :end-before: public CSVFeatureWriter(CSVFileState csvFileState, CSVStrategy csvStrategy)
 
-The feature type we grab for writing is dependent on our strategy; therefore, we must feed CSVFeatureWriter our CSVStrategy and grab the feature type from it. We'll aslo get our iterator, which reads the file, from our CSVStrategy. Finally, we'll set up a CsvWriter to write to a new file, temp, with the same headers from our current file.
+The feature type we grab for writing is dependent on our strategy; therefore, we must feed CSVFeatureWriter our CSVStrategy and grab the feature type from it. We'll also get our iterator, which reads the file, from our CSVStrategy. Finally, we'll set up a CsvWriter to write to a new file, temp, with the same headers from our current file.
 
    .. literalinclude:: /../../modules/unsupported/csv/src/main/java/org/geotools/data/csv/CSVFeatureWriter.java
       :language: java

--- a/docs/user/tutorial/quickstart/eclipse.rst
+++ b/docs/user/tutorial/quickstart/eclipse.rst
@@ -158,7 +158,7 @@ To use M2E plugin to create a create a new maven project:
    .. image:: images/archetype.png
       :scale: 60
 
-#. The archtype acts a template using the parameters we supply to create the project.
+#. The archetype acts a template using the parameters we supply to create the project.
    
    * Group Id: org.geotools
    * Artifact Id: tutorial
@@ -396,7 +396,7 @@ Here are some additional challenges for you to try:
      :end-before: </project>
 
 * So what jars did maven actually use for the Quickstart application? Open up your :file:`pom.xml`
-  and switch to the :guilabel:`dependency heirarchy` or :guilabel:`dependency graph` tabs to see
+  and switch to the :guilabel:`dependency hierarchy` or :guilabel:`dependency graph` tabs to see
   what is going on.
   
   .. image:: images/quickstart-dependency.png

--- a/docs/user/tutorial/quickstart/java11.rst
+++ b/docs/user/tutorial/quickstart/java11.rst
@@ -91,7 +91,7 @@ Adding Module Info
 
 Java 9 introduced the concept of modules to the JVM. 
 
-A module is a named, self-contained bundle of Java code. Modules may depend upon other modules, and may export packages from themselves to other modules that depend upon them. Module configuration is controled by the :file:`module-info.java` file.
+A module is a named, self-contained bundle of Java code. Modules may depend upon other modules, and may export packages from themselves to other modules that depend upon them. Module configuration is controlled by the :file:`module-info.java` file.
 
 For a more detailed overview of the module system, refer to the `State of the Module System <http://openjdk.java.net/projects/jigsaw/spec/sotms/>`_.
 

--- a/docs/user/unsupported/arcgis-rest.rst
+++ b/docs/user/unsupported/arcgis-rest.rst
@@ -13,7 +13,7 @@ Specifically, only the FeatureServer services on either ArcGIS Online (Open Data
 ArcGIS Server FeatureServers are covered so far.
 
 FeatureServers, non entire services, are used as endpoints for ArcGIS
-Servers, beacuse there may be hundreds of different layers, and it seems ESRI throttlea back 
+Servers, because there may be hundreds of different layers, and it seems ESRI throttlea back 
 requests, leading to very long times for building feature types.
 
 

--- a/docs/user/unsupported/process/process.rst
+++ b/docs/user/unsupported/process/process.rst
@@ -97,7 +97,7 @@ Using a ProcessorExecutor
 '''''''''''''''''''''''''
 
 The real fun with using the Processes utility class is that you can set up work and then schedule
-the work in two separate steps. This is a great way to use todays multi-core processors in
+the work in two separate steps. This is a great way to use multi-core processors in
 your application.
 
 1. You can then use a ProcessorExecutor is going to be in charge of running your processes - you

--- a/docs/user/unsupported/swt/rcp.rst
+++ b/docs/user/unsupported/swt/rcp.rst
@@ -95,7 +95,7 @@ Adding the map tools as view actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Right now we have only the map view. The best place to put the tools like pan and zoom is probably
-the toolbar of the map view. To do so, we can add a viewActions extention point to our view, then
+the toolbar of the map view. To do so, we can add a viewActions extension point to our view, then
 add a viewContribution to the viewActions and finally all the actions we need there.
 
 1. To add the Info Tool action, you add::

--- a/docs/user/welcome/geomajas.rst
+++ b/docs/user/welcome/geomajas.rst
@@ -71,7 +71,7 @@ For defining coordinate systems and transformations between those coordinate sys
 GeoTools library is used. That being said, Geomajas provides the ability to register extra
 coordinate systems through the Spring configuration. As a result those new coordinate systems
 are available only through Geomajas **GeoService** interface (and not when
-directly using the GeoTools **CRS** helper clas).
+directly using the GeoTools **CRS** helper class).
 
 This GeoService specifically handles CRS transformations with support for *transformable* areas.
 These transformable areas define the boundaries wherein transformations between 2 coordinate

--- a/docs/user/welcome/upgrade.rst
+++ b/docs/user/welcome/upgrade.rst
@@ -1332,7 +1332,7 @@ Name
 ^^^^
 
 In order to better support app-schema work we can no longer assume names are a simple String. The
-**Name** class has been introduced to make this easier and is availble
+**Name** class has been introduced to make this easier and is available
 throughout the library: example FeatureSource.getName().
 
 * BEFORE  (GeoTools 2.4 Code)::


### PR DESCRIPTION
activites aquire archtype aslo availaible availble beacuse clas
conjuction controled defintion efficent extention heirarchy hierachy
indentical iwth occure seperate seperated slippy substract teh todays
unoffical

Found and fixed via codespell