### PR TITLE
gtrenderer.rst: Revert "slippery" map back to "slippy" map

### DIFF
--- a/docs/user/library/render/gtrenderer.rst
+++ b/docs/user/library/render/gtrenderer.rst
@@ -38,7 +38,7 @@ consider the following ideas:
 * Experiment with different Java 2D graphics settings such as
   anti-aliasing
 * Use background threads to draw tiles, and allowing your swing control
-  to pull the tiles onto the screen for a smooth "slippery" map
+  to pull the tiles onto the screen for a smooth "slippy" map
 
 3D
 ^^


### PR DESCRIPTION
Fixes #2186 / c3e90a9a8fa29cfc2c5a166e6a012cff1b85c648
Found by @bradh