### PR TITLE
[GEOT-6182] Add the possibility to specify the target CRS for the ReprojectingFilterVisitor (backport 19.x).x)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/spatial/ReprojectingFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/spatial/ReprojectingFilterVisitor.java
@@ -64,9 +64,17 @@ import org.opengis.referencing.operation.TransformException;
 public class ReprojectingFilterVisitor extends DuplicatingFilterVisitor {
     FeatureType featureType;
 
+    private final CoordinateReferenceSystem targetCrs;
+
     public ReprojectingFilterVisitor(FilterFactory2 factory, FeatureType featureType) {
+        this(factory, featureType, null);
+    }
+
+    public ReprojectingFilterVisitor(
+            FilterFactory2 factory, FeatureType featureType, CoordinateReferenceSystem targetCrs) {
         super(factory);
         this.featureType = featureType;
+        this.targetCrs = targetCrs;
     }
 
     /**
@@ -77,6 +85,11 @@ public class ReprojectingFilterVisitor extends DuplicatingFilterVisitor {
      * @return
      */
     private CoordinateReferenceSystem findPropertyCRS(PropertyName propertyName) {
+        if (targetCrs != null) {
+            // an explicit target CRS was provided
+            return targetCrs;
+        }
+        // let's try to get the CRS from the provided property name
         Object o = propertyName.evaluate(featureType);
         if (o instanceof GeometryDescriptor) {
             GeometryDescriptor gat = (GeometryDescriptor) o;

--- a/modules/library/main/src/test/java/org/geotools/filter/spatial/ReprojectingFilterVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/spatial/ReprojectingFilterVisitorTest.java
@@ -274,6 +274,22 @@ public class ReprojectingFilterVisitorTest extends TestCase {
         assertEquals(CRS.decode("EPSG:4326"), clonedLs.getUserData());
     }
 
+    /** The provided target CRS (3857) should override the native one (4326). */
+    public void testBboxReprojectWithTargetCrsProvided() throws FactoryException {
+        ReprojectingFilterVisitor reprojector =
+                new ReprojectingFilterVisitor(ff, ft, CRS.decode("EPSG:3857"));
+        BBOX bbox = ff.bbox(ff.property("geom"), 10, 15, 20, 25, "EPSG:4326");
+        Filter clone = (Filter) bbox.accept(reprojector, null);
+        assertNotSame(bbox, clone);
+        BBOX clonedBbox = (BBOX) clone;
+        assertEquals(bbox.getPropertyName(), clonedBbox.getPropertyName());
+        assertEquals(1113194.9079327357, clonedBbox.getMinX(), 0.1);
+        assertEquals(1689200.1396078924, clonedBbox.getMinY(), 0.1);
+        assertEquals(2226389.8158654715, clonedBbox.getMaxX(), 0.1);
+        assertEquals(2875744.6243522423, clonedBbox.getMaxY(), 0.1);
+        assertEquals("EPSG:3857", clonedBbox.getSRS());
+    }
+
     private final class GeometryFunction implements Function {
         final LineString ls;
 


### PR DESCRIPTION
Backport of:
https://github.com/geotools/geotools/pull/2177

Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-6182