### PR TITLE
[GEOT-6200] Reproject fitler tries to reproject non geometry properties (backport 19.x)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/spatial/ReprojectingFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/spatial/ReprojectingFilterVisitor.java
@@ -85,12 +85,17 @@ public class ReprojectingFilterVisitor extends DuplicatingFilterVisitor {
      * @return
      */
     private CoordinateReferenceSystem findPropertyCRS(PropertyName propertyName) {
+        Object o = propertyName.evaluate(featureType);
+        if (!propertyName.getPropertyName().isEmpty()
+                && !(propertyName.evaluate(featureType) instanceof GeometryDescriptor)) {
+            // not the default geometry or a geometry property
+            return null;
+        }
         if (targetCrs != null) {
             // an explicit target CRS was provided
             return targetCrs;
         }
         // let's try to get the CRS from the provided property name
-        Object o = propertyName.evaluate(featureType);
         if (o instanceof GeometryDescriptor) {
             GeometryDescriptor gat = (GeometryDescriptor) o;
             return gat.getCoordinateReferenceSystem();

--- a/modules/library/main/src/test/java/org/geotools/filter/spatial/ReprojectingFilterVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/spatial/ReprojectingFilterVisitorTest.java
@@ -290,6 +290,25 @@ public class ReprojectingFilterVisitorTest extends TestCase {
         assertEquals("EPSG:3857", clonedBbox.getSRS());
     }
 
+    /**
+     * The provided target CRS (3857) should not override the native one (4326) since the use
+     * property is not a geometry.
+     */
+    public void testTargetCrsProvidedButNoGeometryProperty() throws FactoryException {
+        ReprojectingFilterVisitor reprojector =
+                new ReprojectingFilterVisitor(ff, ft, CRS.decode("EPSG:3857"));
+        BBOX bbox = ff.bbox(ff.property("name"), 10, 15, 20, 25, "EPSG:4326");
+        BBOX clone = (BBOX) bbox.accept(reprojector, null);
+        assertNotSame(bbox, clone);
+        // check that no reprojection was applied
+        assertEquals(bbox.getPropertyName(), clone.getPropertyName());
+        assertEquals(10.0, clone.getMinX(), 0.1);
+        assertEquals(15.0, clone.getMinY(), 0.1);
+        assertEquals(20.0, clone.getMaxX(), 0.1);
+        assertEquals(25.0, clone.getMaxY(), 0.1);
+        assertEquals("EPSG:4326", clone.getSRS());
+    }
+
     private final class GeometryFunction implements Function {
         final LineString ls;
 


### PR DESCRIPTION
Associated issue:
https://osgeo-org.atlassian.net/browse/GEOT-6200

Backport of: https://github.com/geotools/geotools/pull/2205