### PR TITLE
[GEOT-6202] gt-jdbc-hana - Support for HANA 1

### DIFF
--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/HanaVersion.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/HanaVersion.java
@@ -1,0 +1,72 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2018, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+/**
+ * HANA version.
+ *
+ * <p>The version string has the format "version.00.revision.patchlevel.buildid".
+ *
+ * @author Stefan Uhrig, SAP SE
+ */
+class HanaVersion {
+
+    /**
+     * Constructor.
+     *
+     * @param versionString The version string in the format
+     *     "version.00.revision.patchlevel.buildid"..
+     */
+    public HanaVersion(String versionString) {
+        String[] components = versionString.split("\\.");
+        if (components.length != 5) {
+            throw new IllegalArgumentException("Invalid HANA version string " + versionString);
+        }
+        try {
+            this.version = Integer.parseInt(components[0]);
+            this.revision = Integer.parseInt(components[2]);
+            this.patchLevel = Integer.parseInt(components[3]);
+            this.buildId = Long.parseLong(components[4]);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid HANA version string " + versionString);
+        }
+    }
+
+    private int version;
+
+    private int revision;
+
+    private int patchLevel;
+
+    private long buildId;
+
+    public int getVersion() {
+        return version;
+    }
+
+    public int getRevision() {
+        return revision;
+    }
+
+    public int getPatchLevel() {
+        return patchLevel;
+    }
+
+    public long getBuildId() {
+        return buildId;
+    }
+}

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaCompound3DTestSetup.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaCompound3DTestSetup.java
@@ -134,9 +134,9 @@ public class HanaCompound3DTestSetup extends JDBCCompound3DTestSetup {
                         6377397.155,
                         null,
                         299.1528128,
-                        646.36,
+                        0.0,
                         276050.82,
-                        308975.28,
+                        0.0,
                         636456.31);
         htu.createSrs(srs);
     }


### PR DESCRIPTION
Currently, the gt-jdbc-hana plugin supports HANA 2 only.

If used with a HANA 1 instance, some queries work, but many fail
because some functions are not available in HANA 1 yet.

With this change, gt-jdbc-hana supports the revisions of HANA 1 that
are still supported by SAP (120 and later). gt-jdbc-hana will reject
older revisions (< 120) immediately on establishing a connection.