### PR TITLE
[GEOT-6161][19.x] Fails to read MBTiles with JPG file format

### DIFF
--- a/modules/unsupported/mbtiles/src/main/java/org/geotools/mbtiles/MBTilesMetadata.java
+++ b/modules/unsupported/mbtiles/src/main/java/org/geotools/mbtiles/MBTilesMetadata.java
@@ -41,6 +41,7 @@ public class MBTilesMetadata {
     };
 
     public enum t_format {
+        JPG,
         JPEG,
         PNG,
 

--- a/modules/unsupported/mbtiles/src/test/java/org/geotools/mbtiles/MBTilesFileTest.java
+++ b/modules/unsupported/mbtiles/src/test/java/org/geotools/mbtiles/MBTilesFileTest.java
@@ -50,6 +50,12 @@ public class MBTilesFileTest {
     }
 
     @Test
+    public void testMBTilesMetadataJPG() {
+        MBTilesMetadata m = new MBTilesMetadata();
+        m.setFormatStr("jpg"); // threw exception before JPG was added to enum
+    }
+
+    @Test
     public void testMBTilesInitTwice() throws IOException {
         MBTilesFile file = new MBTilesFile();
         file.init();


### PR DESCRIPTION
I've targeted this to the `19.x` branch in hope that this may be merged in before the 19.4 maintenance release on 18 Dec 2018.

Fix for https://osgeo-org.atlassian.net/projects/GEOT/issues/GEOT-6161

The spec confirms "jpg" is a valid format here:

https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md