### PR TITLE
opengis VersionTest.java: Remove unnecessary cast

### DIFF
--- a/modules/library/opengis/src/test/java/org/opengis/filter/identity/VersionTest.java
+++ b/modules/library/opengis/src/test/java/org/opengis/filter/identity/VersionTest.java
@@ -19,7 +19,7 @@ public class VersionTest {
             long encoded = Version.UNION_ACTION | ((long) action.ordinal());
 
             assertTrue((encoded & Version.UNION_ACTION) > 0);
-            long decoded = Version.UNION_MASK & ((long) encoded);
+            long decoded = Version.UNION_MASK & encoded;
 
             Action found = Action.lookup((int) decoded);
             assertEquals(action, found);


### PR DESCRIPTION
Found with refaster.  It wanted the following, but the extra parens do not appear to help anything.

`long decoded = Version.UNION_MASK & (encoded);`