### PR TITLE
ClientStreamAbortedException logged at SEVERE level, should be at lower level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <test.forkMode>once</test.forkMode>
     <test.args></test.args>
     <src.output>${basedir}/target</src.output>
-    <imageio.ext.version>1.1.27</imageio.ext.version>
+    <imageio.ext.version>1.1.28</imageio.ext.version>
     <jts.version>1.16.0</jts.version>
     <jaiext.version>1.1.6</jaiext.version>
     <netcdf.version>4.6.6</netcdf.version>


### PR DESCRIPTION
Upgrade to imageio-ext 1.1.28:

https://github.com/geosolutions-it/imageio-ext/issues/181