### PR TITLE
[GEOT-6209] App-schema Postgresql subquery: replace OR with UNION performance improvement

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
@@ -36,6 +36,7 @@ import org.geotools.data.Query;
 import org.geotools.data.Transaction;
 import org.geotools.data.complex.AttributeMapping;
 import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
 import org.geotools.data.complex.config.JdbcMultipleValue;
 import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.data.jdbc.FilterToSQLException;
@@ -686,9 +687,20 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
                                     getDataStore(),
                                     sortBySQL);
                             if (NestedFilterToSQL.isNestedFilter(filter)) {
-                                sortBySQL
-                                        .append(" WHERE ")
-                                        .append(createNestedFilter(filter, query, toSQL));
+                                sortBySQL.append(" WHERE ");
+                                // if it's postgis and replacement is enabled use UNION
+                                boolean replaceOrWithUnion =
+                                        isPostgisDialect() && isOrUnionReplacementEnabled();
+                                // get current select clause
+                                String selectClause =
+                                        sortBySQL.toString().replace(" INNER JOIN ( ", "");
+                                sortBySQL.append(
+                                        createNestedFilter(
+                                                filter,
+                                                query,
+                                                toSQL,
+                                                selectClause,
+                                                replaceOrWithUnion));
                             } else {
                                 sortBySQL.append(" ").append(toSQL.encodeToString(filter));
                             }
@@ -847,6 +859,20 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
             throws FilterToSQLException {
         NestedFilterToSQL nested = new NestedFilterToSQL(query.getRootMapping(), filterToSQL);
         nested.setInline(true);
+        return nested.encodeToString(filter);
+    }
+
+    private Object createNestedFilter(
+            Filter filter,
+            JoiningQuery query,
+            FilterToSQL filterToSQL,
+            String selectClause,
+            boolean replaceOrWithUnion)
+            throws FilterToSQLException {
+        NestedFilterToSQL nested = new NestedFilterToSQL(query.getRootMapping(), filterToSQL);
+        nested.setInline(true);
+        nested.setSelectClause(selectClause);
+        nested.setReplaceOrWithUnion(replaceOrWithUnion);
         return nested.encodeToString(filter);
     }
 
@@ -1285,5 +1311,18 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
         JoinQualifier jq = new JoinQualifier(featureType, alias);
         Filter resultFilter = (Filter) filter.accept(jq, null);
         return resultFilter;
+    }
+
+    protected boolean isPostgisDialect() {
+        String dialectClassName = getDataStore().getSQLDialect().getClass().getName();
+        if ("org.geotools.data.postgis.PostGISDialect".equals(dialectClassName)
+                || "org.geotools.data.postgis.PostGISPSDialect".equals(dialectClassName)) {
+            return true;
+        }
+        return false;
+    }
+
+    protected boolean isOrUnionReplacementEnabled() {
+        return AppSchemaDataAccessConfigurator.isOrUnionReplacementEnabled();
     }
 }

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
@@ -112,6 +112,8 @@ public class AppSchemaDataAccessConfigurator {
 
     public static String PROPERTY_ENCODE_NESTED_FILTERS = "app-schema.encodeNestedFilters";
 
+    public static final String PROPERTY_REPLACE_OR_UNION = "app-schema.orUnionReplace";
+
     /** DOCUMENT ME! */
     private AppSchemaDataAccessDTO config;
 
@@ -144,6 +146,13 @@ public class AppSchemaDataAccessConfigurator {
         String s =
                 AppSchemaDataAccessRegistry.getAppSchemaProperties().getProperty(PROPERTY_JOINING);
         return s != null;
+    }
+
+    public static boolean isOrUnionReplacementEnabled() {
+        final String orUnionReplacement =
+                AppSchemaDataAccessRegistry.getAppSchemaProperties()
+                        .getProperty(PROPERTY_REPLACE_OR_UNION);
+        return (!"false".equalsIgnoreCase(orUnionReplacement));
     }
 
     /**


### PR DESCRIPTION
Is known that OR queries are difficult to optimize for postgresql and are usually slow.

The fix for slow queries with OR involved is using UNION queries, so we need optimize certain complex subqueries. The slow appschema subquery involved is that generated by NestedFilterToSQL class so we need to change the use of OR clause in the root condition for UNION queries.

Since this performance issue affect postgresql, the fix should be isolated for this datasource only, and adding a system property for disable.

With UNION improvement enabled main binary operator on nested filter subquery will rebuild normal OR query like:
       SELECT id, name FROM table WHERE name = "Morty" OR name = "Rick"
       ->
       SELECT id, name FROM table WHERE name = "Morty" UNION SELECT id, name FROM table WHERE name = "Rick" 