### PR TITLE
[GEOT-6236] (gt-swing) Remove white flash when pan/zooming map

### DIFF
--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/AbstractMapPane.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/AbstractMapPane.java
@@ -450,7 +450,6 @@ public abstract class AbstractMapPane extends JPanel
                                 afterImageMoved();
                                 clearLabelCache.set(true);
                                 drawLayers(false);
-                                repaint();
                             }
                         },
                         paintDelay,


### PR DESCRIPTION
The JMapPane drawLayers() method implementation clears the images viewport rectangle and kicks off an asynchronous rendering task.  Calling "repaint()" immediately after this call pretty much guarantees one will get a "white flash" when the user stops  panning.  Furthermore the "onRenderingComplete()" method of AbstractMapPane  contains a call to "repaint()" already so this one is not required.

Credit to @MurrayMcDonald16