### PR TITLE
[GEOT-6209] App-schema Postgresql subquery: replace OR with UNION performance improvement (20.x backport)

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
@@ -115,6 +115,8 @@ public class AppSchemaDataAccessConfigurator {
 
     public static String PROPERTY_ENCODE_NESTED_FILTERS = "app-schema.encodeNestedFilters";
 
+    public static final String PROPERTY_REPLACE_OR_UNION = "app-schema.orUnionReplace";
+
     /** DOCUMENT ME! */
     private AppSchemaDataAccessDTO config;
 
@@ -147,6 +149,13 @@ public class AppSchemaDataAccessConfigurator {
         String s =
                 AppSchemaDataAccessRegistry.getAppSchemaProperties().getProperty(PROPERTY_JOINING);
         return s != null;
+    }
+
+    public static boolean isOrUnionReplacementEnabled() {
+        final String orUnionReplacement =
+                AppSchemaDataAccessRegistry.getAppSchemaProperties()
+                        .getProperty(PROPERTY_REPLACE_OR_UNION);
+        return "true".equalsIgnoreCase(orUnionReplacement);
     }
 
     /**

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/jdbc/JoiningJDBCFeatureSource.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/jdbc/JoiningJDBCFeatureSource.java
@@ -36,6 +36,7 @@ import org.geotools.data.Query;
 import org.geotools.data.Transaction;
 import org.geotools.data.complex.AttributeMapping;
 import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
 import org.geotools.data.complex.config.JdbcMultipleValue;
 import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.data.jdbc.FilterToSQLException;
@@ -687,9 +688,20 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
                                     getDataStore(),
                                     sortBySQL);
                             if (NestedFilterToSQL.isNestedFilter(filter)) {
-                                sortBySQL
-                                        .append(" WHERE ")
-                                        .append(createNestedFilter(filter, query, toSQL));
+                                sortBySQL.append(" WHERE ");
+                                // if it's postgis and replacement is enabled use UNION
+                                boolean replaceOrWithUnion =
+                                        isPostgisDialect() && isOrUnionReplacementEnabled();
+                                // get current select clause
+                                String selectClause =
+                                        sortBySQL.toString().replace(" INNER JOIN ( ", "");
+                                sortBySQL.append(
+                                        createNestedFilter(
+                                                filter,
+                                                query,
+                                                toSQL,
+                                                selectClause,
+                                                replaceOrWithUnion));
                             } else {
                                 sortBySQL.append(" ").append(toSQL.encodeToString(filter));
                             }
@@ -848,6 +860,20 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
             throws FilterToSQLException {
         NestedFilterToSQL nested = new NestedFilterToSQL(query.getRootMapping(), filterToSQL);
         nested.setInline(true);
+        return nested.encodeToString(filter);
+    }
+
+    private Object createNestedFilter(
+            Filter filter,
+            JoiningQuery query,
+            FilterToSQL filterToSQL,
+            String selectClause,
+            boolean replaceOrWithUnion)
+            throws FilterToSQLException {
+        NestedFilterToSQL nested = new NestedFilterToSQL(query.getRootMapping(), filterToSQL);
+        nested.setInline(true);
+        nested.setSelectClause(selectClause);
+        nested.setReplaceOrWithUnion(replaceOrWithUnion);
         return nested.encodeToString(filter);
     }
 
@@ -1286,5 +1312,18 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
         JoinQualifier jq = new JoinQualifier(featureType, alias);
         Filter resultFilter = (Filter) filter.accept(jq, null);
         return resultFilter;
+    }
+
+    protected boolean isPostgisDialect() {
+        String dialectClassName = getDataStore().getSQLDialect().getClass().getName();
+        if ("org.geotools.data.postgis.PostGISDialect".equals(dialectClassName)
+                || "org.geotools.data.postgis.PostGISPSDialect".equals(dialectClassName)) {
+            return true;
+        }
+        return false;
+    }
+
+    protected boolean isOrUnionReplacementEnabled() {
+        return AppSchemaDataAccessConfigurator.isOrUnionReplacementEnabled();
     }
 }

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/jdbc/NestedFilterToSQL.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/jdbc/NestedFilterToSQL.java
@@ -40,6 +40,7 @@ import org.geotools.filter.NestedAttributeExpression;
 import org.geotools.jdbc.JoiningJDBCFeatureSource.JoiningFieldEncoder;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.filter.BinaryLogicOperator;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.PropertyIsBetween;
@@ -109,6 +110,14 @@ public class NestedFilterToSQL extends FilterToSQL {
 
     FilterToSQL original;
     FilterFactory ff;
+    // A deep tracking variable over binary operators, should maintain on true only for the first
+    // level
+    private boolean rootBinaryOperator = true;
+    // Parent select clause for this nested subquery build, used when the OR->UNION replacement is
+    // enabled
+    private String selectClause;
+    // OR->UNION replacement performance improvement flag.  Enabled if true
+    private boolean replaceOrWithUnion = false;
 
     /**
      * Constructor.
@@ -464,6 +473,42 @@ public class NestedFilterToSQL extends FilterToSQL {
         return visitNestedFilter(filter, extraData, nestedAttr.getPropertyName());
     }
 
+    /**
+     * If replaceOrWithUnion flag is enabled this method will build main OR condition in the form of
+     * UNION queries like: SELECT id, name FROM table WHERE name = "Alf" OR name = "Rick" -> SELECT
+     * id, name FROM table WHERE name = "Alf" UNION SELECT id, name FROM table WHERE name = "Rick"
+     */
+    @Override
+    protected Object visit(BinaryLogicOperator filter, Object extraData) {
+        String operator = (String) extraData;
+        if (!replaceOrWithUnion
+                || "AND".equalsIgnoreCase(operator)
+                || selectClause == null
+                || !rootBinaryOperator) {
+            rootBinaryOperator = false;
+            return super.visit(filter, extraData);
+        }
+        if ("OR".equalsIgnoreCase(operator)) {
+            rootBinaryOperator = false;
+            // build UNION query instead main OR
+            try {
+                java.util.Iterator list = filter.getChildren().iterator();
+
+                while (list.hasNext()) {
+                    ((Filter) list.next()).accept(this, extraData);
+                    if (list.hasNext()) {
+                        // selectClause will carry the parent SELECT FROM clauses, so we use it to
+                        // build UNION
+                        out.write(" UNION " + selectClause + " ");
+                    }
+                }
+            } catch (java.io.IOException ioe) {
+                throw new RuntimeException(IO_ERROR, ioe);
+            }
+        }
+        return extraData;
+    }
+
     @Override
     public Object visit(DWithin filter, Object extraData) {
         NestedAttributeExpression nestedAttr = getNestedAttributeExpression(filter);
@@ -591,6 +636,10 @@ public class NestedFilterToSQL extends FilterToSQL {
         return null;
     }
 
+    public void setSelectClause(String selectClause) {
+        this.selectClause = selectClause;
+    }
+
     private Filter unrollFilter(Filter complexFilter, FeatureTypeMapping mappings) {
         UnmappingFilterVisitorExcludingNestedMappings visitor =
                 new UnmappingFilterVisitorExcludingNestedMappings(mappings);
@@ -622,5 +671,13 @@ public class NestedFilterToSQL extends FilterToSQL {
 
             return matchingMappings;
         }
+    }
+
+    public boolean isReplaceOrWithUnion() {
+        return replaceOrWithUnion;
+    }
+
+    public void setReplaceOrWithUnion(boolean replaceOrWithUnion) {
+        this.replaceOrWithUnion = replaceOrWithUnion;
     }
 }


### PR DESCRIPTION
Is known that OR queries are difficult to optimize for postgresql and are usually slow.

The fix for slow queries with OR involved is using UNION queries, so we need optimize certain complex subqueries. The slow appschema subquery involved is that generated by NestedFilterToSQL class so we need to change the use of OR clause in the root condition for UNION queries.

Since this performance issue affect postgresql, the fix should be isolated for this datasource only, and adding a system property for disable.

With UNION improvement enabled main binary operator on nested filter subquery will rebuild normal OR query like:
SELECT id, name FROM table WHERE name = "Morty" OR name = "Rick"
->
SELECT id, name FROM table WHERE name = "Morty" UNION SELECT id, name FROM table WHERE name = "Rick"

Improvement is disabled by default on backport.