### PR TITLE
Add ROUND_HALF_EVEN case to AngleFormat.doRounding as an AssertionError

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/measure/AngleFormat.java
+++ b/modules/library/referencing/src/main/java/org/geotools/measure/AngleFormat.java
@@ -386,6 +386,10 @@ public class AngleFormat extends Format {
                 case ROUND_HALF_UP:
                     rounded = Math.round(scaledValue);
                     return rounded / scale;
+
+                    // Include impossible case to allow detection of new entries in RoundingMethod.
+                case ROUND_HALF_EVEN:
+                    throw new AssertionError(rm);
             }
         }
 


### PR DESCRIPTION
A version of ErrorProne complains if all test cases are not covered, even if it is obvious to the reader that they are.  I think the idea being that if someone were to add another ROUND_*, you would want to check all the places where it might not be covered.