### PR TITLE
[GEOT-6025] NullPointerException fix on Shapefile http URL

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStoreFactory.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStoreFactory.java
@@ -279,7 +279,9 @@ public class ShapefileDataStoreFactory implements FileDataStoreFactorySpi {
                 Object fileType = FILE_TYPE.lookUp(params);
                 File dir = URLs.urlToFile(url);
                 // check for null fileType for backwards compatibility
-                return dir.isDirectory() && (fileType == null || "shapefile".equals(fileType));
+                return dir != null
+                        && dir.isDirectory()
+                        && (fileType == null || "shapefile".equals(fileType));
             }
         } catch (IOException e) {
             return false;

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreFactoryTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreFactoryTest.java
@@ -22,6 +22,7 @@ import static org.geotools.data.shapefile.ShapefileDataStoreFactory.URLP;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
 import java.util.HashMap;
@@ -163,5 +164,12 @@ public class ShapefileDataStoreFactoryTest extends TestCaseSupport {
         }
 
         return result;
+    }
+
+    /** Check non NullPointerException using a http URL instead Filesystem path */
+    @Test
+    public void testHttpUrl() throws IOException {
+        Map params = new KVP(URLP.key, "http://geo-solution.it/");
+        assertFalse(factory.canProcess(params));
     }
 }


### PR DESCRIPTION
Fix for a NullPointerException issue on ShapefileDataStoreFactory and its canProcess method when a HTTP URL is provided (instead a Filesystem path).

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOT-6025