### PR TITLE
[GEOT-6212][GEOT-6213] Fix MongoDB complex feature nested properties usage in SLDs

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/spi/CustomSourceDataStore.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/spi/CustomSourceDataStore.java
@@ -17,6 +17,7 @@
 package org.geotools.data.complex.spi;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 import org.apache.commons.digester.Digester;
@@ -30,6 +31,7 @@ import org.geotools.data.complex.config.AppSchemaDataAccessDTO;
 import org.geotools.data.complex.config.SourceDataStore;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
+import org.opengis.filter.expression.PropertyName;
 
 /**
  * This interface allows data stores to take advantage of certain App-Schema extension points
@@ -82,6 +84,11 @@ public interface CustomSourceDataStore {
             FeatureTypeMapping featureTypeMapping,
             Query query,
             Transaction transaction);
+
+    default List<PropertyName> getSurrogatePropertyNames(
+            List<PropertyName> requested, FeatureTypeMapping mapping) {
+        return Collections.emptyList();
+    }
 
     /**
      * Helper method that loads all the custom data stores extensions.

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/appschema/util/ComplexAttributeConverterFactoryTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/appschema/util/ComplexAttributeConverterFactoryTest.java
@@ -17,9 +17,13 @@
 
 package org.geotools.appschema.util;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Set;
+import java.util.List;
 import junit.framework.TestCase;
 import org.geotools.data.complex.util.ComplexFeatureConstants;
 import org.geotools.data.util.ComplexAttributeConverterFactory;
@@ -32,9 +36,9 @@ import org.geotools.feature.type.GeometryDescriptorImpl;
 import org.geotools.feature.type.GeometryTypeImpl;
 import org.geotools.geometry.jts.EmptyGeometry;
 import org.geotools.gml3.GMLSchema;
-import org.geotools.util.ConverterFactory;
 import org.geotools.util.Converters;
 import org.geotools.xs.XSSchema;
+import org.hamcrest.CoreMatchers;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.Attribute;
 import org.opengis.feature.ComplexAttribute;
@@ -95,24 +99,6 @@ public class ComplexAttributeConverterFactoryTest extends TestCase {
         assertNotSame("rini", nameString);
     }
 
-    /** Test that normal Attribute shouldn't be affected by the converter. */
-    public void testAttribute() {
-        AttributeDescriptor descriptor =
-                new AttributeDescriptorImpl(
-                        XSSchema.STRING_TYPE,
-                        ComplexFeatureConstants.SIMPLE_CONTENT,
-                        1,
-                        1,
-                        true,
-                        (Object) null);
-        Attribute att = new AttributeImpl("rini", descriptor, null);
-        Set<ConverterFactory> factories =
-                Converters.getConverterFactories(att.getClass(), String.class);
-        for (ConverterFactory factory : factories) {
-            assertFalse(factory instanceof ComplexAttributeConverterFactory);
-        }
-    }
-
     /**
      * Test converting String to FeatureId successful. This is required by feature chaining.
      *
@@ -148,5 +134,56 @@ public class ComplexAttributeConverterFactoryTest extends TestCase {
                         null);
         Geometry geometry2 = Converters.convert(geoatt, Geometry.class);
         assertTrue(geometry == geometry2);
+    }
+
+    /** Checks that an attribute value is correctly converted to the expected type. */
+    public void testAttributeConversion() {
+        // create an attribute containing a double
+        AttributeDescriptor descriptor =
+                new AttributeDescriptorImpl(
+                        XSSchema.DOUBLE_TYPE,
+                        ComplexFeatureConstants.SIMPLE_CONTENT,
+                        1,
+                        1,
+                        true,
+                        null);
+        AttributeImpl attribute = new AttributeImpl(35.0, descriptor, null);
+        // convert the attribute to a number
+        Object result = Converters.convert(attribute, Double.class);
+        assertThat(result, instanceOf(Double.class));
+        assertThat(result, is(35.0));
+        // convert the attribute to a string
+        result = Converters.convert(attribute, String.class);
+        assertThat(result, instanceOf(String.class));
+        assertThat(result, is("35.0"));
+    }
+
+    /**
+     * Checks that a list of attributes is correctly convert to a concatenated string and that only
+     * string conversion is supported.
+     */
+    public void testAttributeListConversion() {
+        // create two attributes containing an itneger
+        AttributeDescriptor descriptor =
+                new AttributeDescriptorImpl(
+                        XSSchema.INTEGER_TYPE,
+                        ComplexFeatureConstants.SIMPLE_CONTENT,
+                        1,
+                        1,
+                        true,
+                        null);
+        AttributeImpl attribute1 = new AttributeImpl(35, descriptor, null);
+        AttributeImpl attribute2 = new AttributeImpl(40, descriptor, null);
+        // create a list of attributes
+        List<Attribute> attributes = new ArrayList<>();
+        attributes.add(attribute1);
+        attributes.add(attribute2);
+        // convert the list of attributes to a string
+        Object result = Converters.convert(attributes, String.class);
+        assertThat(result, instanceOf(String.class));
+        assertThat(result, is("35, 40"));
+        // try to convert to a integer, should yield NULL
+        result = Converters.convert(attributes, Integer.class);
+        assertThat(result, CoreMatchers.nullValue());
     }
 }

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/complex/JsonSelectFunction.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/complex/JsonSelectFunction.java
@@ -20,9 +20,11 @@ import static org.geotools.filter.capability.FunctionNameImpl.parameter;
 
 import org.geotools.feature.NameImpl;
 import org.geotools.filter.AttributeExpressionImpl;
+import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.filter.FunctionExpressionImpl;
 import org.geotools.filter.capability.FunctionNameImpl;
 import org.opengis.filter.capability.FunctionName;
+import org.opengis.filter.expression.ExpressionVisitor;
 import org.opengis.filter.expression.PropertyName;
 import org.xml.sax.helpers.NamespaceSupport;
 
@@ -57,7 +59,7 @@ public final class JsonSelectFunction extends FunctionExpressionImpl implements 
             }
         }
         if (object == null) {
-            // return an attribute describing this property usign the JSON path
+            // return an attribute describing this property using the JSON path
             return new AttributeExpressionImpl(new NameImpl(path));
         }
         // simple case, just return the value from the object that corresponds to the JSON path
@@ -79,5 +81,15 @@ public final class JsonSelectFunction extends FunctionExpressionImpl implements 
     public NamespaceSupport getNamespaceContext() {
         // static name space support
         return NAMESPACE_SUPPORT;
+    }
+
+    @Override
+    public Object accept(ExpressionVisitor visitor, Object extraData) {
+        if (visitor instanceof FilterAttributeExtractor) {
+            // we explicitly handle the attribute extractor filter
+            return visitor.visit((PropertyName) this, extraData);
+        }
+        // proceed with the normal behavior
+        return super.accept(visitor, extraData);
     }
 }

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexDataSource.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexDataSource.java
@@ -16,19 +16,36 @@
  */
 package org.geotools.data.mongodb.complex;
 
+import static org.geotools.data.complex.AppSchemaDataAccess.matchProperty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.digester.Digester;
 import org.geotools.data.DataAccess;
 import org.geotools.data.Query;
 import org.geotools.data.Transaction;
 import org.geotools.data.complex.AppSchemaDataAccess;
+import org.geotools.data.complex.AttributeMapping;
 import org.geotools.data.complex.DataAccessMappingFeatureIterator;
 import org.geotools.data.complex.FeatureTypeMapping;
+import org.geotools.data.complex.NestedAttributeMapping;
 import org.geotools.data.complex.config.AppSchemaDataAccessDTO;
 import org.geotools.data.complex.config.SourceDataStore;
+import org.geotools.data.complex.filter.XPath;
+import org.geotools.data.complex.spi.CustomImplementationsFinder;
 import org.geotools.data.complex.spi.CustomSourceDataStore;
+import org.geotools.data.complex.util.XPathUtil;
 import org.geotools.data.mongodb.MongoDataStore;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.FilterAttributeExtractor;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.PropertyName;
+import org.xml.sax.helpers.NamespaceSupport;
 
 /**
  * Class that builds an App-Schema iterator ready to be used with MongoDB. Data coming from MongoDB
@@ -36,6 +53,9 @@ import org.opengis.feature.type.FeatureType;
  * collections together.
  */
 public final class MongoComplexDataSource implements CustomSourceDataStore {
+
+    // filter factory use to create filters
+    private FilterFactory2 filterFactory = CommonFactoryFinder.getFilterFactory2(null);
 
     @Override
     public DataAccess<? extends FeatureType, ? extends Feature> buildDataStore(
@@ -74,5 +94,119 @@ public final class MongoComplexDataSource implements CustomSourceDataStore {
             throw new RuntimeException(
                     "Error creating App-Schema iterator for MongoDB data store.", exception);
         }
+    }
+
+    @Override
+    public List<PropertyName> getSurrogatePropertyNames(
+            List<PropertyName> requested, FeatureTypeMapping featureTypeMapping) {
+        // let's se if this is a feature type coming from MongoDB
+        if (!(featureTypeMapping.getSource() != null
+                && featureTypeMapping.getSource().getDataStore() instanceof MongoDataStore)) {
+            // not a MongoDB feature type mapping
+            return Collections.emptyList();
+        }
+        // let's iterate over the requested properties and try to get the matching JSON path
+        List<PropertyName> properties = new ArrayList<>();
+        for (PropertyName propertyName : requested) {
+            // get the JSON path matching the current requested property
+            properties.addAll(extractJsonPaths(featureTypeMapping, propertyName));
+        }
+        return properties;
+    }
+
+    /**
+     * Returns all the JSON paths associated with the provided property name as property names, in
+     * practice this method finds the source expression associated with the attribute mapping
+     * matching the provided property name and extracts its JSON path converting it to a property
+     * name. Since the source expression may use multiple attributes, multiple JSON paths may be
+     * found.
+     */
+    private List<PropertyName> extractJsonPaths(
+            FeatureTypeMapping featureTypeMapping, PropertyName propertyName) {
+        // get the expression of the mapping attribute matching the provided property name
+        Expression expression = findPropertyExpression(featureTypeMapping, propertyName);
+        if (expression == null) {
+            // no attribute matches the provided property, let's move on
+            return Collections.emptyList();
+        }
+        // extracts all the properties from the attribute mapping expression
+        FilterAttributeExtractor propertiesExtractor = new FilterAttributeExtractor();
+        expression.accept(propertiesExtractor, null);
+        // convert all properties \ attributes to a property name
+        return propertiesExtractor
+                .getAttributeNameSet()
+                .stream()
+                .map(attributeName -> filterFactory.property(attributeName))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Finds the mapping attribute matching the provided property name and gets its source
+     * expression or id expression. This method will navigate the feature type mapping in all its
+     * extend, including the nested mappings.
+     */
+    private Expression findPropertyExpression(
+            FeatureTypeMapping featureTypeMapping, PropertyName propertyName) {
+        // gets the property name steps, i.e. XML path parcels
+        XPathUtil.StepList propertySteps = buildPropertySteps(featureTypeMapping, propertyName);
+        // fidn the attribute mapping matching the provided proeprty name
+        AttributeMapping attributeMapping =
+                findAttributeMapping(featureTypeMapping, propertyName, propertySteps);
+        if (attributeMapping == null) {
+            // no attribute found we are done
+            return null;
+        }
+        // let's check if we have a nested attribute
+        if (attributeMapping instanceof MongoNestedMapping) {
+            // delegate the expression finding to MongoDB nested expression factories
+            return CustomImplementationsFinder.find(
+                    featureTypeMapping, propertySteps, (NestedAttributeMapping) attributeMapping);
+        }
+        // let's see if we have a source expression
+        Expression expression = attributeMapping.getSourceExpression();
+        // if the source expression let's try the identifier expression
+        return expression == null || expression == Expression.NIL
+                ? attributeMapping.getIdentifierExpression()
+                : expression;
+    }
+
+    /** Builds the property steps list, i.e. split the XML path into parcels. */
+    private XPathUtil.StepList buildPropertySteps(
+            FeatureTypeMapping featureTypeMapping, PropertyName propertyName) {
+        // get the correct namespace context, first we try the property name namespaces
+        NamespaceSupport nameSpaces = propertyName.getNamespaceContext();
+        if (nameSpaces == null) {
+            // let's fallback on the feature type namespaces
+            nameSpaces = featureTypeMapping.getNamespaces();
+        }
+        // build the property XML path steps list
+        return XPath.steps(
+                featureTypeMapping.getTargetFeature(), propertyName.getPropertyName(), nameSpaces);
+    }
+
+    /**
+     * Finds the attribute mapping from in the provided feature type that matches the property name
+     * steps. This method sticks to the feature type attributes mappings and doesn't follow the
+     * nested mappings.
+     */
+    private AttributeMapping findAttributeMapping(
+            FeatureTypeMapping featureTypeMapping,
+            PropertyName propertyName,
+            XPathUtil.StepList propertySteps) {
+        // let's check if any of the feature type attributes matches the property name
+        for (AttributeMapping attributeMapping : featureTypeMapping.getAttributeMappings()) {
+            // build the attribute mapping XML path steps list
+            XPathUtil.StepList attributeSteps = attributeMapping.getTargetXPath();
+            if (propertySteps == null
+                    // the property didn't had a valid XML path
+                    ? matchProperty(propertyName.getPropertyName(), attributeSteps)
+                    // the property had a valid XML path
+                    : matchProperty(propertySteps, attributeSteps)) {
+                // we found our attribute, we are done
+                return attributeMapping;
+            }
+        }
+        // no attribute matching the provided property found
+        return null;
     }
 }


### PR DESCRIPTION
Associated issues:
- https://osgeo-org.atlassian.net/browse/GEOT-6212
- https://osgeo-org.atlassian.net/browse/GEOT-6213

This pull requests fix several issue related with usage of MongoDB complex features nested properties in styling, more specifically:
- when using a filter in a rule, previously the filter was just ignored
- when using a complex feature property for labeling

Integration test for MongoDB, as usual, are implemented in GeoServer:  https://github.com/geoserver/geoserver/pull/3326