### PR TITLE
Set EPSG catalog version back to 8.6.0.0

### DIFF
--- a/modules/plugin/epsg-hsql/src/main/java/org/geotools/referencing/factory/epsg/hsql/ThreadedHsqlEpsgFactory.java
+++ b/modules/plugin/epsg-hsql/src/main/java/org/geotools/referencing/factory/epsg/hsql/ThreadedHsqlEpsgFactory.java
@@ -75,7 +75,7 @@ public class ThreadedHsqlEpsgFactory extends ThreadedEpsgFactory {
      * database itself (for example additional database index).
      */
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-    public static final Version VERSION = new Version("8.6.0.1");
+    public static final Version VERSION = new Version("8.6.0.0");
 
     /**
      * The key for fetching the database directory from {@linkplain System#getProperty(String)


### PR DESCRIPTION
046c0c102470f6b updated the version number, but the catalog was not changed.

unzip -p modules/plugin/epsg-hsql/src/main/resources/org/geotools/referencing/factory/epsg/hsql/EPSG.zip EPSG.properties
#EPSG database on HSQL
#Sat Jan 10 06:45:27 MST 2015
version=2.2.8
readonly=true
epsg.version=8.6.0.0
modified=no