### PR TITLE
DefaultCalendarEra.java equals(): Fix instanceof check before cast

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/temporal/reference/DefaultCalendarEra.java
+++ b/modules/library/main/src/main/java/org/geotools/temporal/reference/DefaultCalendarEra.java
@@ -110,7 +110,7 @@ public class DefaultCalendarEra implements CalendarEra {
 
     @Override
     public boolean equals(final Object object) {
-        if (object instanceof CalendarEra) {
+        if (object instanceof DefaultCalendarEra) {
             final DefaultCalendarEra that = (DefaultCalendarEra) object;
 
             return Utilities.equals(this.datingSystem, that.datingSystem)


### PR DESCRIPTION
The cast in this equals method could throw a ClassCastException if a non-comparable type is passed in, which would violate the equals contract: it should just return false.

http://errorprone.info/bugpattern/EqualsUnsafeCast