### PR TITLE
[GEOT-6092] Fix for Match action using uppercase names on encoding.

### DIFF
--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/FESConfiguration.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/FESConfiguration.java
@@ -57,6 +57,7 @@ import org.geotools.filter.v2_0.bindings.GeometryOperandsType_GeometryOperandBin
 import org.geotools.filter.v2_0.bindings.Id_CapabilitiesTypeBinding;
 import org.geotools.filter.v2_0.bindings.IntersectsBinding;
 import org.geotools.filter.v2_0.bindings.LiteralBinding;
+import org.geotools.filter.v2_0.bindings.MatchActionBinding;
 import org.geotools.filter.v2_0.bindings.MeetsBinding;
 import org.geotools.filter.v2_0.bindings.MetByBinding;
 import org.geotools.filter.v2_0.bindings.NotBinding;
@@ -132,6 +133,10 @@ public class FESConfiguration extends Configuration {
         // container.registerComponentImplementation(FES.AbstractSortingClauseType,AbstractSortingClauseTypeBinding.class);
         //
         // container.registerComponentImplementation(FES.AliasesType,AliasesTypeBinding.class);
+
+        // MatchActionType
+        container.registerComponentImplementation(FES.MatchActionType, MatchActionBinding.class);
+
         container.registerComponentImplementation(FES.ArgumentsType, ArgumentsTypeBinding.class);
         container.registerComponentImplementation(FES.ArgumentType, ArgumentTypeBinding.class);
         container.registerComponentImplementation(

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/MatchActionBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/MatchActionBinding.java
@@ -1,0 +1,20 @@
+package org.geotools.filter.v2_0.bindings;
+
+import org.apache.commons.lang3.StringUtils;
+import org.geotools.filter.v2_0.FES;
+import org.geotools.xsd.EnumSimpleBinding;
+import org.opengis.filter.MultiValuedFilter.MatchAction;
+
+/** Binding for encoding {@link MatchAction} enum values. */
+public class MatchActionBinding extends EnumSimpleBinding {
+
+    public MatchActionBinding() {
+        super(MatchAction.class, FES.MatchActionType);
+    }
+
+    @Override
+    public String encode(Object object, String value) throws Exception {
+        if (StringUtils.isBlank(value)) return value;
+        return StringUtils.capitalize(value.toLowerCase());
+    }
+}

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/TEqualsBindingTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/TEqualsBindingTest.java
@@ -1,10 +1,23 @@
 package org.geotools.filter.v2_0.bindings;
 
+import java.util.Iterator;
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import org.geotools.filter.FilterFactoryImpl;
+import org.geotools.filter.v2_0.FES;
 import org.geotools.filter.v2_0.FESTestSupport;
+import org.geotools.xsd.Configuration;
+import org.geotools.xsd.Encoder;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.MultiValuedFilter.MatchAction;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.temporal.TEquals;
 import org.opengis.temporal.Period;
+import org.w3c.dom.Document;
 
 public class TEqualsBindingTest extends FESTestSupport {
 
@@ -44,5 +57,45 @@ public class TEqualsBindingTest extends FESTestSupport {
 
         assertTrue(equals.getExpression2() instanceof Literal);
         assertTrue(equals.getExpression2().evaluate(null) instanceof Period);
+    }
+
+    /**
+     * Test for checking correct "Any" match action instead "ANY". <br>
+     * See issue GEOT-6092
+     */
+    @Test
+    public void testPropertyEqualsMatchEncoding() throws Exception {
+        FilterFactory2 ff = new FilterFactoryImpl();
+        Filter filter = ff.equal(ff.property("prop"), ff.literal("abc"), true, MatchAction.ANY);
+        Configuration configuration = new org.geotools.filter.v2_0.FESConfiguration();
+        Encoder encoder = new Encoder(configuration);
+        encoder.setIndenting(true);
+        Document encodedDoc = encoder.encodeAsDOM(filter, FES.Filter);
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        defaultNamespaceContext(xpath);
+        String matchAction =
+                xpath.evaluate("/fes:Filter/fes:PropertyIsEqualTo/@matchAction", encodedDoc);
+        assertEquals("Any", matchAction);
+    }
+
+    private void defaultNamespaceContext(XPath xpath) {
+        xpath.setNamespaceContext(
+                new NamespaceContext() {
+                    @Override
+                    public Iterator getPrefixes(String namespaceURI) {
+                        return null;
+                    }
+
+                    @Override
+                    public String getPrefix(String namespaceURI) {
+                        return null;
+                    }
+
+                    @Override
+                    public String getNamespaceURI(String prefix) {
+                        if ("fes".equals(prefix)) return "http://www.opengis.net/fes/2.0";
+                        return null;
+                    }
+                });
     }
 }


### PR DESCRIPTION
Encoding of the CQL "prop" = 'abc' as FES Filter results in invalid Filter:

```
<?xml version="1.0" encoding="UTF-8"?>
<fes:Filter xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:fes="http://www.opengis.net/fes/2.0"
            xmlns:gml="http://www.opengis.net/gml/3.2">
   <fes:PropertyIsEqualTo matchAction="ANY" matchCase="true">
      <fes:ValueReference>prop</fes:ValueReference>
      <fes:Literal>abc</fes:Literal>
   </fes:PropertyIsEqualTo>
</fes:Filter>
```

Error is on 'matchAction="ANY"' attribute value, since it should be "Any".

This PR fixes [GEOT-6092], registering a match action binding to XSD FES 2.0 configuration, so now encoding result attribute is 'matchAction="Any"'.

https://osgeo-org.atlassian.net/browse/GEOT-6092