### PR TITLE
[GEOT-6237] Support for big String (byte length > 65535) on SimpleFeatureIO (20.x backport)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/sort/SimpleFeatureIO.java
+++ b/modules/library/main/src/main/java/org/geotools/data/sort/SimpleFeatureIO.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -41,6 +43,9 @@ import org.opengis.feature.type.AttributeDescriptor;
  * @author Andrea Aime - GeoSolutions
  */
 public class SimpleFeatureIO {
+
+    public static final int MAX_BYTES_LENGTH = 65535;
+    public static final String BIG_STRING = "bigString";
 
     RandomAccessFile raf;
 
@@ -104,7 +109,26 @@ public class SimpleFeatureIO {
             } else if (binding == Double.class || binding == double.class) {
                 raf.writeDouble((Double) value);
             } else if (binding == String.class) {
-                raf.writeUTF((String) value);
+                if (isBigString(ad)) {
+                    // if attribute descriptor marked as Big String
+                    String strVal = (String) value;
+                    List<String> values = new ArrayList<>();
+                    // if bytes length is over the maximum allowed, calculate parts
+                    if (strVal.getBytes().length >= MAX_BYTES_LENGTH) {
+                        values.addAll(split(strVal, 32767));
+                    } else {
+                        values.add(strVal);
+                    }
+                    // write total parts
+                    raf.writeInt(values.size());
+                    // write every string chunk
+                    for (String evalue : values) {
+                        raf.writeUTF(evalue);
+                    }
+                } else {
+                    // normal string encoding
+                    raf.writeUTF((String) value);
+                }
             } else if (binding == java.sql.Date.class
                     || binding == java.sql.Time.class
                     || binding == java.sql.Timestamp.class
@@ -128,6 +152,13 @@ public class SimpleFeatureIO {
                 raf.write(bytes);
             }
         }
+    }
+
+    private boolean isBigString(AttributeDescriptor ad) {
+        return ad.getUserData() != null
+                && ad.getUserData().containsKey(BIG_STRING)
+                && ad.getUserData().get(BIG_STRING) instanceof Boolean
+                && ((Boolean) ad.getUserData().get(BIG_STRING));
     }
 
     /**
@@ -179,7 +210,18 @@ public class SimpleFeatureIO {
             } else if (binding == Double.class || binding == double.class) {
                 return raf.readDouble();
             } else if (binding == String.class) {
-                return raf.readUTF();
+                if (isBigString(ad)) {
+                    // read total parts
+                    int parts = raf.readInt();
+                    // read every part
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < parts; i++) {
+                        sb.append(raf.readUTF());
+                    }
+                    return sb.toString();
+                } else {
+                    return raf.readUTF();
+                }
             } else if (binding == java.sql.Date.class) {
                 return new java.sql.Date(raf.readLong());
             } else if (binding == java.sql.Time.class) {
@@ -199,17 +241,21 @@ public class SimpleFeatureIO {
                     throw new IOException("Failed to parse the geometry WKB", e);
                 }
             } else {
-                int length = raf.readInt();
-                byte[] buffer = new byte[length];
-                raf.read(buffer);
-                ByteArrayInputStream bis = new ByteArrayInputStream(buffer);
-                ObjectInputStream ois = new ObjectInputStream(bis);
-                try {
-                    return ois.readObject();
-                } catch (ClassNotFoundException e) {
-                    throw new IOException("Could not read back object", e);
-                }
+                return readObject();
             }
+        }
+    }
+
+    private Object readObject() throws IOException {
+        int length = raf.readInt();
+        byte[] buffer = new byte[length];
+        raf.read(buffer);
+        ByteArrayInputStream bis = new ByteArrayInputStream(buffer);
+        ObjectInputStream ois = new ObjectInputStream(bis);
+        try {
+            return ois.readObject();
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Could not read back object", e);
         }
     }
 
@@ -267,5 +313,15 @@ public class SimpleFeatureIO {
     @Override
     public String toString() {
         return "SimpleFeatureIO [schema=" + schema + ", file=" + file + "]";
+    }
+
+    private Collection<String> split(String value, int charSize) {
+        List<String> strings = new ArrayList<String>();
+        int index = 0;
+        while (index < value.length()) {
+            strings.add(value.substring(index, Math.min(index + charSize, value.length())));
+            index += charSize;
+        }
+        return strings;
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/data/sort/SimpleFeatureIOTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/sort/SimpleFeatureIOTest.java
@@ -1,0 +1,94 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.sort;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.geometry.jts.GeometryBuilder;
+import org.geotools.referencing.CRS;
+import org.junit.Test;
+import org.locationtech.jts.geom.Point;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.NoSuchAuthorityCodeException;
+
+/** Testing class for {@link SimpleFeatureIO} util type */
+public class SimpleFeatureIOTest {
+
+    private static final String NAME_FIELD = "name";
+    private static final String BASE_STRING = "Testing Simple Feature IO big string";
+    private static final int MULTIPLIER = 3333;
+
+    /** Test for big string (bytes > 65535) encoding/decoding */
+    @Test
+    public void testBigString() throws Exception {
+        String bigString = bigString();
+        checkStringNameEncodeDecode(bigString);
+    }
+
+    /** Tests a normal small String attribute */
+    @Test
+    public void testSmallString() throws Exception {
+        String smallString = "Hello geotools.";
+        checkStringNameEncodeDecode(smallString);
+    }
+
+    private void checkStringNameEncodeDecode(String name)
+            throws IOException, NoSuchAuthorityCodeException, FactoryException,
+                    FileNotFoundException {
+        File tempFile = File.createTempFile("temp", "simpleFeatureIO");
+        SimpleFeatureTypeBuilder typeBuilder = new SimpleFeatureTypeBuilder();
+        typeBuilder.setName("type1");
+        typeBuilder.add(NAME_FIELD, String.class);
+        typeBuilder.add("location", Point.class, CRS.decode("EPSG:4326"));
+        SimpleFeatureType type = typeBuilder.buildFeatureType();
+        if (name.getBytes().length >= SimpleFeatureIO.MAX_BYTES_LENGTH)
+            type.getDescriptor(NAME_FIELD)
+                    .getUserData()
+                    .put(SimpleFeatureIO.BIG_STRING, Boolean.TRUE);
+        // create a feature
+        SimpleFeatureBuilder fbuilder = new SimpleFeatureBuilder(type);
+        fbuilder.set(NAME_FIELD, name);
+        GeometryBuilder gb = new GeometryBuilder();
+        fbuilder.set("location", gb.point(10, 10));
+        SimpleFeature feature = fbuilder.buildFeature("1");
+        // io util
+        SimpleFeatureIO sfio = new SimpleFeatureIO(tempFile, type);
+        sfio.write(feature);
+        sfio.close(false);
+        // check reading
+        sfio = new SimpleFeatureIO(tempFile, type);
+        SimpleFeature readFeature = sfio.read();
+        assertEquals(name.length(), ((String) readFeature.getAttribute(NAME_FIELD)).length());
+        assertEquals(name, (String) readFeature.getAttribute(NAME_FIELD));
+        sfio.close(true);
+    }
+
+    private String bigString() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < MULTIPLIER; i++) {
+            sb.append(BASE_STRING);
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Writing a String attribute with a big size (String bytes greater than 65535 bytes) on SimpleFeatureIO we got an exception:
```
java.io.UTFDataFormatException: encoded string too long: 71530 bytes
```

Seems like due to DataOutputStream.writeUTF String size limit, SimpleFeatureIO doesn't allow to write/read big String sizes on Simple Features attributes.

This PR adds support for big String sizes using a flag on FeatureType Attribute Descriptor (userMap):
```java
SimpleFeatureType type = typeBuilder.buildFeatureType();
type.getDescriptor(NAME_FIELD)
                    .getUserData()
                    .put(SimpleFeatureIO.BIG_STRING, Boolean.TRUE);
```

https://osgeo-org.atlassian.net/browse/GEOT-6237