### PR TITLE
zip slip

### DIFF
--- a/modules/extension/graph/src/main/java/org/geotools/graph/util/ZipUtil.java
+++ b/modules/extension/graph/src/main/java/org/geotools/graph/util/ZipUtil.java
@@ -100,6 +100,9 @@ public class ZipUtil {
 
         while (entries.hasMoreElements()) {
             ZipEntry entry = (ZipEntry) entries.nextElement();
+			if(entry.getName().indexOf("..")!=-1){
+				System.out.println("非法的zip文件！");
+			}else{
             byte[] buffer = new byte[1024];
             int len;
 
@@ -112,6 +115,7 @@ public class ZipUtil {
             zipin.close();
             fileout.flush();
             fileout.close();
+			}
         }
     }
 }


### PR DESCRIPTION
Hello:
I am a staff member of 360 Code Guard. During the code audit of our open source project, we found that there is a zip_slip vulnerability in “geotools”. The details are as follows:
geotools-master\modules\extension\graph\src\main\java\org\geotools\graph\util\ZipUtil.java
![default](https://user-images.githubusercontent.com/39950310/52692331-943ee980-2f9e-11e9-8728-974a844376d8.png)

At 108 lines, without checking the zip entry name, the zip entry name is directly used to construct the file name of the decompressed file, resulting in the attacker being able to use “.. /” retrospective to overwrite arbitrary files.
The repairing methods are as follows:

while(e.hasMoreElements()) {
ZipEntry zipEntry = (ZipEntry)e.nextElement();
System.out.println(zipEntry.getName());
if(zipEntry.getName().indexOf("..") != -1 && !file.getCanonicalPath().startsWith(unZipAddress))
{ System.out.println("失败！"); }

else
{ ... } 