### PR TITLE
[GEOT-6252] App-schema multiple sortBy support on SQL

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
@@ -658,106 +658,16 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
                 }
 
                 if (lastSortBy != null && (lastSortBy.length > 0 || !lastPkColumnNames.isEmpty())) {
-                    // we will use another join for the filter
-                    // assuming that the last sort by specifies the ID of the parent feature
-                    // this way we will ensure that if the table is denormalized, that all rows
-                    // with the same ID are included (for multi-valued features)
-
-                    StringBuffer sortBySQL = new StringBuffer();
-                    sortBySQL.append(" INNER JOIN ( SELECT DISTINCT ");
-                    boolean hasSortBy = false;
-                    for (int i = 0; i < lastSortBy.length; i++) {
-                        if (!ids.contains(lastSortBy[i].getPropertyName().toString())) {
-                            // skip if inner join is already done in paging
-                            getDataStore()
-                                    .dialect
-                                    .encodeColumnName(
-                                            lastTableName,
-                                            lastSortBy[i].getPropertyName().getPropertyName(),
-                                            sortBySQL);
-                            sortBySQL.append(" FROM ");
-                            getDataStore()
-                                    .encodeTableName(lastTableName, sortBySQL, query.getHints());
-                            // perform a left join with multi values tables of the root feature type
-                            encodeMultipleValueJoin(
-                                    query.getRootMapping(),
-                                    lastTableName,
-                                    getDataStore(),
-                                    sortBySQL);
-                            if (NestedFilterToSQL.isNestedFilter(filter)) {
-                                sortBySQL.append(" WHERE ");
-                                // if it's postgis and replacement is enabled use UNION
-                                boolean replaceOrWithUnion =
-                                        isPostgisDialect() && isOrUnionReplacementEnabled();
-                                // get current select clause
-                                String selectClause =
-                                        sortBySQL.toString().replace(" INNER JOIN ( ", "");
-                                sortBySQL.append(
-                                        createNestedFilter(
-                                                filter,
-                                                query,
-                                                toSQL,
-                                                selectClause,
-                                                replaceOrWithUnion));
-                            } else {
-                                sortBySQL.append(" ").append(toSQL.encodeToString(filter));
-                            }
-                            sortBySQL.append(" ) ");
-                            getDataStore().dialect.encodeTableName(TEMP_FILTER_ALIAS, sortBySQL);
-                            sortBySQL.append(" ON ( ");
-                            encodeColumnName2(
-                                    lastSortBy[i].getPropertyName().getPropertyName(),
-                                    lastTableAlias,
-                                    sortBySQL,
-                                    null);
-                            sortBySQL.append(" = ");
-                            encodeColumnName2(
-                                    lastSortBy[i].getPropertyName().getPropertyName(),
-                                    TEMP_FILTER_ALIAS,
-                                    sortBySQL,
-                                    null);
-                            if (i < lastSortBy.length - 1) {
-                                sortBySQL.append(" AND ");
-                            }
-                            hasSortBy = true;
-                        }
-                    }
-
-                    if (lastSortBy.length == 0) {
-                        // GEOT-4554: if ID expression is not specified, use PK
-                        int i = 0;
-                        for (String pk : lastPkColumnNames) {
-                            if (!ids.contains(pk)) {
-                                getDataStore().dialect.encodeColumnName(null, pk, sortBySQL);
-                                sortBySQL.append(" FROM ");
-                                getDataStore()
-                                        .encodeTableName(
-                                                lastTableName, sortBySQL, query.getHints());
-                                sortBySQL.append(" ").append(toSQL.encodeToString(filter));
-                                sortBySQL.append(" ) ");
-                                getDataStore()
-                                        .dialect
-                                        .encodeTableName(TEMP_FILTER_ALIAS, sortBySQL);
-                                sortBySQL.append(" ON ( ");
-                                encodeColumnName2(pk, lastTableAlias, sortBySQL, null);
-                                sortBySQL.append(" = ");
-                                encodeColumnName2(pk, TEMP_FILTER_ALIAS, sortBySQL, null);
-                                if (i < lastPkColumnNames.size() - 1) {
-                                    sortBySQL.append(" AND ");
-                                }
-                                i++;
-                                hasSortBy = true;
-                            }
-                        }
-                    }
-                    if (hasSortBy) {
-                        if (sortBySQL.toString().endsWith(" AND ")) {
-                            sql.append(sortBySQL.substring(0, sortBySQL.length() - 5))
-                                    .append(" ) ");
-                        } else {
-                            sql.append(sortBySQL).append(" ) ");
-                        }
-                    }
+                    buildFilter(
+                            query,
+                            sql,
+                            lastPkColumnNames,
+                            toSQL,
+                            filter,
+                            lastSortBy,
+                            lastTableName,
+                            lastTableAlias,
+                            ids);
                 } else if (!pagingApplied) {
                     toSQL.setFieldEncoder(new JoiningFieldEncoder(curTypeName, getDataStore()));
                     if (NestedFilterToSQL.isNestedFilter(filter)) {
@@ -820,6 +730,190 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
         }
 
         return sql.toString();
+    }
+
+    private void buildFilter(
+            JoiningQuery query,
+            StringBuffer sql,
+            Set<String> lastPkColumnNames,
+            FilterToSQL toSQL,
+            Filter filter,
+            SortBy[] lastSortBy,
+            String lastTableName,
+            String lastTableAlias,
+            Collection<String> ids)
+            throws SQLException, FilterToSQLException {
+        // we will use another join for the filter
+        // assuming that the last sort by specifies the ID of the parent feature
+        // this way we will ensure that if the table is denormalized, that all rows
+        // with the same ID are included (for multi-valued features)
+
+        StringBuffer sortBySQL = new StringBuffer();
+        sortBySQL.append(" INNER JOIN ( SELECT DISTINCT ");
+        boolean hasSortBy = false;
+        boolean isMultiSort = lastSortBy.length > 1 && ids.isEmpty();
+        hasSortBy =
+                isMultiSort
+                        ? buildFiterBasedOnPk(
+                                query,
+                                toSQL,
+                                filter,
+                                lastSortBy,
+                                lastTableName,
+                                lastTableAlias,
+                                lastPkColumnNames,
+                                sortBySQL,
+                                hasSortBy)
+                        : buildFiterBasedOnSortBy(
+                                query,
+                                toSQL,
+                                filter,
+                                lastSortBy,
+                                lastTableName,
+                                lastTableAlias,
+                                ids,
+                                sortBySQL,
+                                hasSortBy);
+
+        if (lastSortBy.length == 0) {
+            // GEOT-4554: if ID expression is not specified, use PK
+            int i = 0;
+            for (String pk : lastPkColumnNames) {
+                if (!ids.contains(pk)) {
+                    getDataStore().dialect.encodeColumnName(null, pk, sortBySQL);
+                    sortBySQL.append(" FROM ");
+                    getDataStore().encodeTableName(lastTableName, sortBySQL, query.getHints());
+                    sortBySQL.append(" ").append(toSQL.encodeToString(filter));
+                    sortBySQL.append(" ) ");
+                    getDataStore().dialect.encodeTableName(TEMP_FILTER_ALIAS, sortBySQL);
+                    sortBySQL.append(" ON ( ");
+                    encodeColumnName2(pk, lastTableAlias, sortBySQL, null);
+                    sortBySQL.append(" = ");
+                    encodeColumnName2(pk, TEMP_FILTER_ALIAS, sortBySQL, null);
+                    if (i < lastPkColumnNames.size() - 1) {
+                        sortBySQL.append(" AND ");
+                    }
+                    i++;
+                    hasSortBy = true;
+                }
+            }
+        }
+        if (hasSortBy) {
+            if (sortBySQL.toString().endsWith(" AND ")) {
+                sql.append(sortBySQL.substring(0, sortBySQL.length() - 5)).append(" ) ");
+            } else {
+                sql.append(sortBySQL).append(" ) ");
+            }
+        }
+    }
+
+    private boolean buildFiterBasedOnSortBy(
+            JoiningQuery query,
+            FilterToSQL toSQL,
+            Filter filter,
+            SortBy[] lastSortBy,
+            String lastTableName,
+            String lastTableAlias,
+            Collection<String> ids,
+            StringBuffer sortBySQL,
+            boolean hasSortBy)
+            throws SQLException, FilterToSQLException {
+        for (int i = 0; i < lastSortBy.length; i++) {
+            if (!ids.contains(lastSortBy[i].getPropertyName().toString())) {
+                hasSortBy =
+                        processSortByKey(
+                                query,
+                                toSQL,
+                                filter,
+                                lastSortBy,
+                                lastTableName,
+                                lastTableAlias,
+                                sortBySQL,
+                                i);
+            }
+        }
+        return hasSortBy;
+    }
+
+    /**
+     * Alternative builder used for generating join on clause on presence of multiple sortBy
+     * expressions unsupported by normal builder.
+     */
+    private boolean buildFiterBasedOnPk(
+            JoiningQuery query,
+            FilterToSQL toSQL,
+            Filter filter,
+            SortBy[] lastSortBy,
+            String lastTableName,
+            String lastTableAlias,
+            Set<String> lastPkColumnNames,
+            StringBuffer sortBySQL,
+            boolean hasSortBy)
+            throws SQLException, FilterToSQLException {
+        for (int i = lastSortBy.length - lastPkColumnNames.size(); i < lastSortBy.length; i++) {
+            hasSortBy =
+                    processSortByKey(
+                            query,
+                            toSQL,
+                            filter,
+                            lastSortBy,
+                            lastTableName,
+                            lastTableAlias,
+                            sortBySQL,
+                            i);
+        }
+        return hasSortBy;
+    }
+
+    private boolean processSortByKey(
+            JoiningQuery query,
+            FilterToSQL toSQL,
+            Filter filter,
+            SortBy[] lastSortBy,
+            String lastTableName,
+            String lastTableAlias,
+            StringBuffer sortBySQL,
+            int i)
+            throws SQLException, FilterToSQLException {
+        boolean hasSortBy;
+        // skip if inner join is already done in paging
+        getDataStore()
+                .dialect
+                .encodeColumnName(
+                        lastTableName,
+                        lastSortBy[i].getPropertyName().getPropertyName(),
+                        sortBySQL);
+        sortBySQL.append(" FROM ");
+        getDataStore().encodeTableName(lastTableName, sortBySQL, query.getHints());
+        // perform a left join with multi values tables of the root feature type
+        encodeMultipleValueJoin(query.getRootMapping(), lastTableName, getDataStore(), sortBySQL);
+        if (NestedFilterToSQL.isNestedFilter(filter)) {
+            sortBySQL.append(" WHERE ");
+            // if it's postgis and replacement is enabled use UNION
+            boolean replaceOrWithUnion = isPostgisDialect() && isOrUnionReplacementEnabled();
+            // get current select clause
+            String selectClause = sortBySQL.toString().replace(" INNER JOIN ( ", "");
+            sortBySQL.append(
+                    createNestedFilter(filter, query, toSQL, selectClause, replaceOrWithUnion));
+        } else {
+            sortBySQL.append(" ").append(toSQL.encodeToString(filter));
+        }
+        sortBySQL.append(" ) ");
+        getDataStore().dialect.encodeTableName(TEMP_FILTER_ALIAS, sortBySQL);
+        sortBySQL.append(" ON ( ");
+        encodeColumnName2(
+                lastSortBy[i].getPropertyName().getPropertyName(), lastTableAlias, sortBySQL, null);
+        sortBySQL.append(" = ");
+        encodeColumnName2(
+                lastSortBy[i].getPropertyName().getPropertyName(),
+                TEMP_FILTER_ALIAS,
+                sortBySQL,
+                null);
+        if (i < lastSortBy.length - 1) {
+            sortBySQL.append(" AND ");
+        }
+        hasSortBy = true;
+        return hasSortBy;
     }
 
     private void encodeMultipleValueJoin(


### PR DESCRIPTION
Executing a WFS query with nested filter and multiple sortBy expressions throws an malformed SQL exception on App-schema and Postgresql.

This PR fix SQL nested filter building on multiple sortBy expressions scenario, also adds some method delegating refactoring due to a too big method doing all.

https://osgeo-org.atlassian.net/browse/GEOT-6252