### PR TITLE
Fix maven warning dependency must be unique warning

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/pom.xml
+++ b/modules/plugin/coverage-multidim/netcdf/pom.xml
@@ -144,12 +144,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.geotools.jdbc</groupId>
-      <artifactId>gt-jdbc-postgis</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
       <version>1.1.6</version>


### PR DESCRIPTION
net-cdf was depending on gt-jdbc twice (once explicitly and once as a transitive dependency)