### PR TITLE
Initial implementation of a coverage reader for PostGIS rasters.

### DIFF
--- a/modules/unsupported/pom.xml
+++ b/modules/unsupported/pom.xml
@@ -253,6 +253,7 @@
 		<module>mbtiles</module>
 		<module>wfs-ng</module>
 		<module>ogr</module>
+		<module>postgis-raster</module>
 	</modules>
 
 </project>

--- a/modules/unsupported/postgis-raster/README.md
+++ b/modules/unsupported/postgis-raster/README.md
@@ -1,0 +1,68 @@
+# PostGIS Raster Coverage Reader
+
+This module contains a coverage reader for reading rasters from a PostGIS Database.
+
+## Configuration
+
+The coverage reader is configured with an xml file containing information about the 
+database and table to read from. The format of the file is as follows:
+
+    <!-- 
+      postgis raster config format, * = required element 
+    -->
+    <pgraster>
+      <name></name>                       <!-- * name of the resulting coverage -->
+
+      <!-- 
+      database connection info, either name,host,port,etc... is required or jndi
+      -->
+      <database>                  
+        <host></host>                     <!-- db hostname, defaults to 'localhost' -->
+        <port></port>                     <!-- db port, defaults to '5432' -->
+        <name></name>                     <!-- database name -->
+        <user></user>                     <!-- database user -->
+        <passwd></passwd>.                <!-- database password -->
+        <jndi></jndi>                     <!-- JNDI data source name -->
+      </database>
+
+      <!--
+      raster table / column config
+      -->
+      <raster>
+        <table></table>                   <!-- * raster table name -->
+        <schema></schema>                 <!-- raster table schema, defaults to 'public' -->
+        <column></schema>                 <!-- raster table column, defaults to 'rast' -->
+      </raster>
+
+      <!--
+      time column config
+      -->
+      <time>                              <!-- time dimension configuration -->
+        <column>dstamp</column>           <!-- name of data/time column -->
+      </time>
+
+      <!-- 
+      https://postgis.net/docs/postgis_gdal_enabled_drivers.html 
+      -->
+      <enableDrivers></enabledDrivers>.   <!-- Example: ENABLE_ALL -->
+    </pgraster>
+
+
+## Test Data
+
+The tests in this module rely on some test data from the imagemosaic module. raster2pgsql was used to load it:
+
+Grayscale test:
+
+    raster2pgsql -s 32633 D220361A.tif pgraster.gray
+
+RGB test:
+
+    raster2pgsql -s 4326 world.200405.3x5400x2700.tiff pgraster.world
+
+Time test:
+
+    raster2pgsql -s 4326 -F world.*.tiff pgraster.world_with_time
+    ALTER TABLE pgraster.world_with_time ADD dstamp DATE;
+    UPDATE pgraster.world_with_time SET dstamp = TO_DATE(SUBSTRING(filename from 7 for 6), 'YYYYMM');
+

--- a/modules/unsupported/postgis-raster/pom.xml
+++ b/modules/unsupported/postgis-raster/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.geotools</groupId>
+    <artifactId>unsupported</artifactId>
+    <version>22-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geotools</groupId>
+  <artifactId>gt-postgis-raster</artifactId>
+  <packaging>jar</packaging>
+
+  <name>PostGIS Raster Plugin</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-coverage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools.jdbc</groupId>
+      <artifactId>gt-jdbc-postgis</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-epsg-hsql</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-sample-data</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/Mosaic.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/Mosaic.java
@@ -1,0 +1,167 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.geom.Point2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.util.Hashtable;
+import javax.media.jai.PlanarImage;
+import javax.media.jai.TiledImage;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridCoverageFactory;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.image.ImageWorker;
+import org.locationtech.jts.geom.Envelope;
+
+/** Mosaics {@link Tile}'s together into a final image / coverage in response to a read request. */
+class Mosaic {
+
+    final ReadRequest read;
+    final GridCoverageFactory factory;
+
+    Dimension size;
+    Point2D.Double rescale;
+    BufferedImage image;
+
+    /** Aggregate bounds of tiles */
+    Envelope bounds;
+
+    public Mosaic(ReadRequest read, GridCoverageFactory factory) {
+        this.read = read;
+        this.factory = factory;
+
+        // calculate image size
+        rescale =
+                new Point.Double(
+                        read.raster.scale.x / read.resolution.x,
+                        read.raster.scale.y / read.resolution.y);
+        this.size =
+                new Dimension(
+                        (int) Math.round(read.region.width / rescale.x),
+                        (int) Math.round(read.region.height / rescale.y));
+
+        bounds = new Envelope();
+        bounds.setToNull();
+    }
+
+    public void accept(Tile tile) {
+        if (image == null) {
+            image = initImage(tile);
+            fillBackground(image);
+        }
+
+        int x = (int) ((tile.bounds.getMinX() - read.nativeBounds.getMinX()) / read.raster.scale.x);
+        int y = (int) ((read.nativeBounds.getMaxY() - tile.bounds.getMaxY()) / read.raster.scale.y);
+
+        image.getRaster().setRect(x, y, tile.image.getRaster());
+
+        bounds.expandToInclude(tile.bounds);
+    }
+
+    BufferedImage initImage(Tile tile) {
+        BufferedImage from = tile.image;
+        // copy over properties of this tile
+        Hashtable<String, Object> props = null;
+        if (from.getPropertyNames() != null) {
+            props = new Hashtable<>();
+            for (String name : from.getPropertyNames()) {
+                props.put(name, from.getProperty(name));
+            }
+        }
+
+        SampleModel sm =
+                from.getSampleModel()
+                        .createCompatibleSampleModel((int) size.getWidth(), (int) size.getHeight());
+        WritableRaster raster = Raster.createWritableRaster(sm, null);
+
+        ColorModel colorModel = from.getColorModel();
+
+        return new BufferedImage(colorModel, raster, from.isAlphaPremultiplied(), props);
+    }
+
+    BufferedImage initImage(int type) {
+        return new BufferedImage((int) size.getWidth(), (int) size.getHeight(), type);
+    }
+
+    void fillBackground(BufferedImage image) {
+        if (read.backgroundColor != null) {
+            Graphics2D g = (Graphics2D) image.getGraphics();
+            Color current = g.getColor();
+            g.setColor(read.backgroundColor);
+            g.fillRect(0, 0, image.getWidth(), image.getHeight());
+            g.setColor(current);
+        }
+    }
+
+    public GridCoverage2D coverage() {
+        if (image == null) {
+            return null;
+        }
+
+        RenderedImage finalImage = rescale(image);
+
+        ReferencedEnvelope mapBounds = read.nativeBounds;
+
+        // if bounds of loaded tiles smaller than bounds of map crop it
+        // we do this so that the calling rendering code can handle filling
+        // in backound transparency, etc...
+        if (mapBounds.covers(bounds)) {
+            // crop
+            int x =
+                    (int)
+                            (finalImage.getWidth()
+                                    * (bounds.getMinX() - mapBounds.getMinX())
+                                    / mapBounds.getWidth());
+            int y =
+                    finalImage.getHeight()
+                            - (int)
+                                    (finalImage.getHeight()
+                                            * (bounds.getMaxY() - mapBounds.getMinY())
+                                            / mapBounds.getHeight());
+            int h = (int) (finalImage.getHeight() * bounds.getHeight() / mapBounds.getHeight());
+            int w = (int) (finalImage.getWidth() * bounds.getWidth() / mapBounds.getWidth());
+            finalImage = crop(finalImage, x, y, w, h);
+        }
+
+        return factory.create(
+                read.reader.name(),
+                finalImage,
+                new ReferencedEnvelope(bounds, mapBounds.getCoordinateReferenceSystem()));
+    }
+
+    RenderedImage crop(RenderedImage image, float x, float y, float w, float h) {
+        return new ImageWorker(image).crop(x, y, w, h).getRenderedImage();
+    }
+
+    RenderedImage rescale(RenderedImage image) {
+        PlanarImage planar = new TiledImage(image, image.getWidth(), image.getHeight());
+
+        ImageWorker w = new ImageWorker(planar);
+        w.scale((float) rescale.x, (float) rescale.y, 0.0f, 0.0f, read.interpolation());
+
+        return w.getRenderedImage();
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterConfig.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterConfig.java
@@ -1,0 +1,235 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.geotools.data.jdbc.datasource.DBCPDataSource;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.logging.Logging;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Configuration for a {@link PGRasterReader}.
+ *
+ * <p>Configuration is stored as XML with the following basic format:
+ *
+ * <pre>
+ *     &lt;pgraster>
+ *       &lt;name//>        // coverage name
+ *       &lt;database>     // database connection
+ *         &lt;host//>      // database host
+ *         &lt;port//>      // database port
+ *         &lt;name//>      // database name
+ *         &lt;user//>      // database username
+ *         &lt;pass//>      // database user password
+ *       &lt;/database>
+ *       &lt;raster>       // raster column config
+ *         &lt;column//>      // column name
+ *         &lt;table//>     // table name
+ *         &lt;schema//>    // table schema
+ *       &lt;/raster>
+ *       &lt;time>        // time column config
+ *         &lt;enabled//>  // enable / disable time
+ *         &lt;column//>     // column name
+ *       &lt;/time>
+ *     &lt;/pgraster>
+ *   </pre>
+ */
+class PGRasterConfig {
+
+    static final Logger LOG = Logging.getLogger(PGRasterConfig.class);
+
+    String name;
+    DataSource dataSource;
+    String schema;
+    String table;
+    String column;
+    String enableDrivers;
+
+    TimeConfig time = new TimeConfig();
+
+    static Document parse(File cfgfile) {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db;
+        try {
+            db = dbf.newDocumentBuilder();
+        } catch (Exception e) {
+            throw new RuntimeException("Error creating XML parser");
+        }
+
+        try {
+            return db.parse(cfgfile);
+        } catch (Exception e) {
+            throw new RuntimeException("Error parsing pgraster config", e);
+        }
+    }
+
+    PGRasterConfig(File configFile) {
+        this(parse(configFile));
+    }
+
+    PGRasterConfig(Document config) {
+        Element root = config.getDocumentElement();
+        if (!"pgraster".equalsIgnoreCase(root.getNodeName())) {
+            throw new IllegalArgumentException(
+                    "Not a postgis raster configuration, root element must be 'pgraster'");
+        }
+
+        this.name = first(root, "name").map(this::nodeValue).orElse(null);
+        this.enableDrivers = first(root, "enableDrivers").map(this::nodeValue).orElse(null);
+
+        Element db =
+                first(config.getDocumentElement(), "database")
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Config has no database element"));
+
+        DataSource dataSource = null;
+
+        String jndi = first(db, "jndi").map(this::nodeValue).orElse(null);
+        if (jndi != null) {
+            try {
+                dataSource =
+                        (DataSource)
+                                GeoTools.getInitialContext(GeoTools.getDefaultHints()).lookup(jndi);
+            } catch (NamingException e) {
+                throw new IllegalArgumentException("Error performing JNDI lookup for: " + jndi, e);
+            }
+        }
+
+        if (dataSource == null) {
+            BasicDataSource source = new BasicDataSource();
+            source.setDriverClassName("org.postgresql.Driver");
+
+            String host = first(db, "host").map(this::nodeValue).orElse("localhost");
+
+            Integer port =
+                    first(db, "port").map(this::nodeValue).map(Integer::parseInt).orElse(5432);
+
+            String name =
+                    first(db, "name")
+                            .map(this::nodeValue)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalArgumentException(
+                                                    "database 'name' not specified"));
+
+            source.setUrl("jdbc:postgresql://" + host + ":" + port + "/" + name);
+
+            first(db, "user").map(this::nodeValue).ifPresent(source::setUsername);
+
+            first(db, "passwd").map(this::nodeValue).ifPresent(source::setPassword);
+
+            first(db, "pool")
+                    .ifPresent(
+                            p -> {
+                                first(p, "min")
+                                        .map(this::nodeValue)
+                                        .map(Integer::parseInt)
+                                        .ifPresent(source::setMinIdle);
+                                first(p, "max")
+                                        .map(this::nodeValue)
+                                        .map(Integer::parseInt)
+                                        .ifPresent(source::setMaxActive);
+                            });
+
+            dataSource = new PGRasterDataSource(source);
+        }
+
+        this.dataSource = dataSource;
+
+        Element ras =
+                first(config.getDocumentElement(), "raster")
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Config has no 'raster' element"));
+
+        this.schema = first(ras, "schema").map(this::nodeValue).orElse("public");
+        this.table =
+                first(ras, "table")
+                        .map(this::nodeValue)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "column must specify a 'table' element"));
+        this.column = first(ras, "column").map(this::nodeValue).orElse(null);
+
+        // time
+        first(config.getDocumentElement(), "time")
+                .ifPresent(
+                        el -> {
+                            first(el, "enabled")
+                                    .map(this::nodeValue)
+                                    .map(Boolean::parseBoolean)
+                                    .ifPresent(it -> time.enabled = it);
+                            first(el, "column")
+                                    .map(this::nodeValue)
+                                    .ifPresent(it -> time.column = it);
+                        });
+    }
+
+    @VisibleForTesting
+    PGRasterConfig() {}
+
+    Optional<Element> first(Element el, String name) {
+        NodeList matches = el.getElementsByTagName(name);
+        if (matches.getLength() > 0) {
+            return Optional.of((Element) matches.item(0));
+        }
+        return Optional.empty();
+    }
+
+    String nodeValue(Element el) {
+        return el.getFirstChild().getNodeValue();
+    }
+
+    public void close() {
+        if (dataSource instanceof PGRasterDataSource) {
+            try {
+                ((PGRasterDataSource) dataSource).close();
+            } catch (SQLException e) {
+                LOG.log(Level.WARNING, "Error closing data source", e);
+            }
+        }
+    }
+
+    static class TimeConfig {
+        boolean enabled = true;
+        String column;
+    }
+
+    static class PGRasterDataSource extends DBCPDataSource {
+
+        PGRasterDataSource(BasicDataSource wrapped) {
+            super(wrapped);
+        }
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterFactory.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterFactory.java
@@ -1,0 +1,40 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.awt.RenderingHints;
+import java.util.Map;
+import org.geotools.coverage.grid.io.GridFormatFactorySpi;
+
+/** Factory for {@link PGRasterFormat}. */
+public class PGRasterFactory implements GridFormatFactorySpi {
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public Map<RenderingHints.Key, ?> getImplementationHints() {
+        return null;
+    }
+
+    @Override
+    public PGRasterFormat createFormat() {
+        return new PGRasterFormat();
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterFormat.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterFormat.java
@@ -1,0 +1,137 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.coverage.grid.io.imageio.GeoToolsWriteParams;
+import org.geotools.parameter.DefaultParameterDescriptorGroup;
+import org.geotools.parameter.ParameterGroup;
+import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
+import org.opengis.coverage.grid.GridCoverageWriter;
+import org.opengis.parameter.GeneralParameterDescriptor;
+
+/**
+ * Coverage format for rasters stored in a PostGIS database as described by the <a
+ * href="https://postgis.net/docs/RT_reference.html">PostGIS Raster Reference</a>.
+ */
+public class PGRasterFormat extends AbstractGridFormat {
+
+    static final Logger LOG = Logging.getLogger(PGRasterFormat.class);
+
+    public PGRasterFormat() {
+        final HashMap<String, String> info = new HashMap<String, String>();
+        info.put("name", "PGRaster");
+        info.put("description", "PostGIS Raster Mosaic Plugin");
+        info.put("vendor", "OpenNRM");
+        info.put("docURL", "");
+        info.put("version", "1.0");
+        mInfo = info;
+
+        readParameters =
+                new ParameterGroup(
+                        new DefaultParameterDescriptorGroup(
+                                mInfo,
+                                new GeneralParameterDescriptor[] {
+                                    READ_GRIDGEOMETRY2D, TIME, OVERVIEW_POLICY
+                                }));
+
+        writeParameters = null;
+    }
+
+    @Override
+    public PGRasterReader getReader(Object source) {
+        return getReader(source, null);
+    }
+
+    @Override
+    public PGRasterReader getReader(Object source, Hints hints) {
+        try {
+            PGRasterConfig config = toConfig(source);
+            return config != null ? new PGRasterReader(config, this, hints) : null;
+        } catch (IOException ex) {
+            LOG.log(Level.SEVERE, "Error loading reader", ex);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean accepts(Object source, Hints hints) {
+        if (source instanceof DataSource) {
+            return true;
+        }
+
+        return toConfigFile(source) != null;
+    }
+
+    File toConfigFile(Object source) {
+        if (source instanceof Path) {
+            source = ((Path) source).toFile();
+        }
+
+        if (source instanceof String) {
+            source = new File(source.toString());
+        }
+
+        if (source instanceof File) {
+            File file = (File) source;
+            if (file.getName().toLowerCase().endsWith(".xml")) {
+                return file;
+            }
+        }
+        return null;
+    }
+
+    PGRasterConfig toConfig(Object source) {
+        if (source instanceof PGRasterConfig) {
+            return (PGRasterConfig) source;
+        }
+
+        File file = toConfigFile(source);
+        if (file != null) {
+            return new PGRasterConfig(file);
+        }
+
+        return null;
+    }
+
+    @Override
+    public GeoToolsWriteParams getDefaultImageIOWriteParameters() {
+        throw writeNotSupported();
+    }
+
+    @Override
+    public GridCoverageWriter getWriter(Object destination) {
+        throw writeNotSupported();
+    }
+
+    @Override
+    public GridCoverageWriter getWriter(Object destination, Hints hints) {
+        throw writeNotSupported();
+    }
+
+    private UnsupportedOperationException writeNotSupported() {
+        return new UnsupportedOperationException("Write support not implemented");
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterReader.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterReader.java
@@ -1,0 +1,539 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.AbstractIterator;
+import java.awt.Color;
+import java.awt.Rectangle;
+import java.awt.geom.Point2D;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import javax.imageio.ImageReadParam;
+import javax.media.jai.Interpolation;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridEnvelope2D;
+import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.coverage.grid.io.AbstractGridCoverage2DReader;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.coverage.grid.io.OverviewPolicy;
+import org.geotools.geometry.GeneralEnvelope;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.parameter.Parameter;
+import org.geotools.referencing.CRS;
+import org.geotools.util.Converters;
+import org.geotools.util.DateRange;
+import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.io.WKBReader;
+import org.locationtech.jts.io.WKBWriter;
+import org.opengis.coverage.grid.Format;
+import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.referencing.operation.TransformException;
+
+/** PostGIS raster reader. */
+public class PGRasterReader extends AbstractGridCoverage2DReader {
+
+    static final Logger LOG = Logging.getLogger(PGRasterReader.class);
+    static final GeometryFactory GEOMS = new GeometryFactory();
+
+    final PGRasterConfig config;
+    final PGRasterFormat format;
+    final RasterColumn raster;
+
+    ExecutorService exec;
+
+    public PGRasterReader(PGRasterConfig config, PGRasterFormat format, Hints hints)
+            throws IOException {
+        super(config, hints);
+
+        this.config = config;
+        this.format = format;
+
+        try {
+            raster = RasterColumn.lookup(config);
+        } catch (SQLException e) {
+            throw new IOException("Error looking up raster column", e);
+        }
+
+        // the (possibly mapped) coverage name
+        coverageName = config.name != null ? config.name : raster.table;
+
+        // crs and bounds
+        crs = raster.crs;
+        originalEnvelope = GeneralEnvelope.toGeneralEnvelope(raster.bounds());
+        if (raster.scale != null) {
+            originalGridRange =
+                    new GridEnvelope2D(
+                            new Rectangle(
+                                    (int) (originalEnvelope.getSpan(0) / raster.scale.x),
+                                    (int) (originalEnvelope.getSpan(1) / raster.scale.y)));
+        }
+
+        if (raster.scale != null) {
+            highestRes = new double[] {raster.scale.x, raster.scale.y};
+        }
+
+        // overviews
+        numOverviews = raster.overviews.size();
+        if (numOverviews > 0) {
+            if (raster.scale != null) {
+                overViewResolutions = new double[numOverviews][2];
+                for (int i = 0; i < numOverviews; i++) {
+                    RasterOverview ov = raster.overviews.get(i);
+                    overViewResolutions[i] =
+                            new double[] {raster.scale.x * ov.factor, raster.scale.y * ov.factor};
+                }
+            } else {
+                numOverviews = 0;
+            }
+        }
+
+        // process hints
+        if (hints != null) {
+            exec = (ExecutorService) hints.get(Hints.EXECUTOR_SERVICE);
+        }
+    }
+
+    public String name() {
+        return coverageName;
+    }
+
+    @Override
+    public Format getFormat() {
+        return format;
+    }
+
+    @Override
+    public String[] getMetadataNames() {
+        if (raster.time != null) {
+            return new String[] {
+                HAS_TIME_DOMAIN, TIME_DOMAIN, TIME_DOMAIN_MINIMUM, TIME_DOMAIN_MAXIMUM
+            };
+        }
+        return null;
+    }
+
+    @Override
+    public String getMetadataValue(String coverageName, String name) {
+        if (raster.time != null) {
+            TimeColumn t = raster.time;
+            SimpleDateFormat in = dbDataFormat();
+            SimpleDateFormat out = utcDateFormat();
+
+            try {
+                switch (name) {
+                    case HAS_TIME_DOMAIN:
+                        return String.valueOf(true);
+                    case TIME_DOMAIN:
+                        {
+                            SQL sql = new SQL().append("SELECT DISTINCT to_char(").name(t.name);
+
+                            if (t.isTimestamp()) {
+                                sql.append(" AT TIME ZONE 'UTC'");
+                            }
+
+                            sql.append(", 'YYYY-MM-DD\"T\"HH24:MI:SS.MS+00'), ").append(t.name);
+                            sql.append(" FROM ")
+                                    .table(raster)
+                                    .append(" ORDER BY ")
+                                    .name(t.name)
+                                    .append(" DESC");
+
+                            try (Connection cx = newConnection()) {
+                                try (PreparedStatement ps =
+                                        cx.prepareStatement(sql.logAndGet(LOG))) {
+                                    try (ResultSet rs = ps.executeQuery()) {
+                                        List<Date> times = new ArrayList<>();
+                                        while (rs.next()) {
+                                            String s = rs.getString(1);
+                                            if (s != null) {
+                                                times.add(in.parse(s));
+                                            }
+                                        }
+                                        return times.stream()
+                                                .map(out::format)
+                                                .collect(Collectors.joining(","));
+                                    }
+                                }
+                            }
+                        }
+                    case TIME_DOMAIN_MINIMUM:
+                    case TIME_DOMAIN_MAXIMUM:
+                        String fn = TIME_DOMAIN_MINIMUM.equals(name) ? "min" : "max";
+                        Date d = queryDateExtreme(fn, raster);
+                        if (d != null) {
+                            return out.format(d);
+                        }
+                }
+            } catch (SQLException | ParseException e) {
+                throw new RuntimeException("Error fetching metadata value: " + name, e);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public GridCoverage2D read(GeneralParameterValue[] params)
+            throws IllegalArgumentException, IOException {
+
+        ReadRequest req = new ReadRequest(this);
+
+        if (params != null) {
+            for (GeneralParameterValue p : params) {
+                Parameter<Object> param = (Parameter<Object>) p;
+
+                String code = param.getDescriptor().getName().getCode();
+                if (code.equals(AbstractGridFormat.READ_GRIDGEOMETRY2D.getName().toString())) {
+                    final GridGeometry2D gg = (GridGeometry2D) param.getValue();
+                    req.bounds = GeneralEnvelope.toGeneralEnvelope(gg.getEnvelope());
+                    req.region = gg.toCanonical().getGridRange2D().getBounds();
+                } else if (code.equals(AbstractGridFormat.TIME.getName().toString())) {
+                    req.times = (List<?>) param.getValue();
+                } else if (code.equals(AbstractGridFormat.OVERVIEW_POLICY.getName().toString())) {
+                    req.overviewPolicy = (OverviewPolicy) param.getValue();
+                } else if (code.equals(AbstractGridFormat.INTERPOLATION.getName().toString())) {
+                    req.interpolation = (Interpolation) param.getValue();
+                } else if (code.equals(AbstractGridFormat.BACKGROUND_COLOR.getName().toString())) {
+                    req.backgroundColor = (Color) param.getValue();
+                }
+            }
+        }
+
+        if (req.bounds == null) {
+            // default to entire bounds
+            req.bounds = GeneralEnvelope.toGeneralEnvelope(raster.bounds());
+        }
+        if (req.region == null && raster.size != null) {
+            req.region = new Rectangle(raster.size);
+        }
+
+        // figure out bounds in raster crs
+        ReferencedEnvelope nativeBounds;
+        if (req.bounds != null) {
+            nativeBounds = new ReferencedEnvelope(req.bounds);
+        } else {
+            nativeBounds = raster.bounds();
+        }
+
+        if (nativeBounds == null) {
+            throw new IllegalStateException(
+                    "No bounds specified in read request and unable to determine raster bounds");
+        }
+
+        // transform it if need be
+        if (!CRS.equalsIgnoreMetadata(nativeBounds.getCoordinateReferenceSystem(), raster.crs)) {
+            if (raster.crs == null) {
+                throw new IllegalStateException(
+                        "Raster crs is unknown, unable to transform from request crs");
+            }
+
+            try {
+                nativeBounds = nativeBounds.transform(raster.crs, true);
+            } catch (Exception e) {
+                throw new IOException("Error transforming requested bounds", e);
+            }
+        }
+        req.nativeBounds = nativeBounds;
+
+        if (req.region != null) {
+            req.resolution =
+                    new Point2D.Double(
+                            nativeBounds.getWidth() / req.region.width,
+                            nativeBounds.getHeight() / req.region.height);
+        }
+
+        // figure out which overview to load
+        ImageReadParam readParam = new ImageReadParam();
+        Integer level = null;
+        try {
+            level = setReadParams(req.overviewPolicy(), readParam, req.bounds, req.region);
+        } catch (TransformException e) {
+            throw new IOException("Error setting read params", e);
+        }
+        if (level == null) level = 0;
+
+        RasterColumn col = this.raster;
+        if (level > 0) {
+            col = this.raster.overviews.get(level - 1);
+        }
+        req.raster = col;
+
+        // load the tiles
+        SQL sql =
+                new SQL()
+                        .append("SELECT ST_AsBinary(ST_Envelope(")
+                        .name(col.name)
+                        .append(")) AS extent")
+                        .append(", ST_AsTiff(")
+                        .name(col.name)
+                        .append(") AS tile")
+                        .append(" FROM ")
+                        .table(col)
+                        .append(" WHERE ST_Intersects(")
+                        .name(col.name)
+                        .append(",")
+                        .append(" ST_GeomFromWKB(?,?))");
+
+        // add the time constraint
+        if (col.time != null) {
+            List<Date> times = new ArrayList<>();
+            List<DateRange> ranges = new ArrayList<>();
+
+            if (req.times != null) {
+                for (Object t : req.times) {
+                    if (t instanceof Date) {
+                        times.add((Date) t);
+                    } else if (t instanceof DateRange) {
+                        ranges.add((DateRange) t);
+                    } else {
+                        Date d = Converters.convert(t, Date.class);
+                        if (d != null) {
+                            times.add(d);
+                        } else {
+                            LOG.warning("Unable to convert value to date:" + t);
+                        }
+                    }
+                }
+            } else {
+                // no time specified, default to the latest
+                try {
+                    Date latest = queryDateExtreme("max", col);
+                    if (latest != null) {
+                        times.add(latest);
+                    }
+                } catch (SQLException | ParseException e) {
+                    throw new IOException("Error querying for date max", e);
+                }
+            }
+
+            if (!times.isEmpty()) {
+                SimpleDateFormat df = dbDataFormat();
+
+                sql.append(" AND ").name(col.time.name).append(" IN (");
+
+                times.forEach(d -> sql.append("'").append(df.format(d)).append("',"));
+                sql.trim(1);
+
+                sql.append(")");
+            } else if (!ranges.isEmpty()) {
+                SimpleDateFormat df = dbDataFormat();
+                sql.append(" AND (");
+
+                for (DateRange range : ranges) {
+                    sql.append("(")
+                            .name(col.time.name)
+                            .append(range.isMinIncluded() ? ">=" : ">")
+                            .append("'")
+                            .append(df.format(range.getMinValue()))
+                            .append("' AND ");
+
+                    sql.name(col.time.name)
+                            .append(range.isMaxIncluded() ? "<=" : "<")
+                            .append("'")
+                            .append(df.format(range.getMaxValue()))
+                            .append("'");
+
+                    sql.append(") OR ");
+                }
+                sql.trim(4);
+                sql.append(")");
+            }
+        }
+
+        try {
+            try (Connection cx = newConnection()) {
+                try (PreparedStatement ps = cx.prepareStatement(sql.logAndGet(LOG))) {
+                    ps.setBytes(1, new WKBWriter().write(toPolygon(nativeBounds)));
+                    ps.setInt(2, col.srid != null ? col.srid : -1);
+
+                    try (ResultSet rs = ps.executeQuery()) {
+                        Iterator<TileData> tiles =
+                                new AbstractIterator<TileData>() {
+                                    WKBReader wkb = new WKBReader(GEOMS);
+
+                                    @Override
+                                    protected TileData computeNext() {
+                                        try {
+                                            if (rs.next()) {
+                                                return new TileData(
+                                                        rs.getBytes(2),
+                                                        wkb.read(rs.getBytes(1))
+                                                                .getEnvelopeInternal());
+                                            }
+                                        } catch (Exception e) {
+                                            Throwables.propagateIfInstanceOf(
+                                                    e, RuntimeException.class);
+                                            throw new RuntimeException(e);
+                                        }
+
+                                        try {
+                                            rs.close();
+                                        } catch (SQLException e) {
+                                            LOG.log(Level.FINE, "Error closing result set", e);
+                                        }
+                                        try {
+                                            ps.close();
+                                        } catch (SQLException e) {
+                                            LOG.log(Level.FINE, "Error closing statement", e);
+                                        }
+
+                                        return endOfData();
+                                    }
+                                };
+
+                        if (exec == null) {
+                            return compose(tiles, req);
+                        } else {
+                            return compose(tiles, req, exec);
+                        }
+                    }
+                }
+            }
+
+        } catch (SQLException e) {
+            throw new IOException("Error reading raster", e);
+        }
+    }
+
+    GridCoverage2D compose(Iterator<TileData> tiles, ReadRequest read) throws IOException {
+        Mosaic mosaic = new Mosaic(read, coverageFactory);
+
+        while (tiles.hasNext()) {
+            TileData data = tiles.next();
+            try {
+                Tile tile = new TileDecoder(data, read).call();
+                mosaic.accept(tile);
+            } catch (Exception e) {
+                Throwables.propagateIfInstanceOf(e, IOException.class);
+                throw new IOException("Error decoding tile", e);
+            }
+        }
+
+        return mosaic.coverage();
+    }
+
+    GridCoverage2D compose(Iterator<TileData> tiles, ReadRequest read, ExecutorService exec)
+            throws IOException {
+        CompletionService<Tile> work = new ExecutorCompletionService<>(exec);
+
+        int count = 0;
+        while (tiles.hasNext()) {
+            count++;
+            work.submit(new TileDecoder(tiles.next(), read));
+        }
+
+        Mosaic mosaic = new Mosaic(read, coverageFactory);
+
+        while (count > 0) {
+            try {
+                mosaic.accept(work.take().get());
+                count--;
+            } catch (Exception e) {
+                Throwables.propagateIfInstanceOf(e, IOException.class);
+                throw new IOException(e);
+            }
+        }
+
+        return mosaic.coverage();
+    }
+
+    Polygon toPolygon(Envelope e) {
+        return GEOMS.createPolygon(
+                new Coordinate[] {
+                    new Coordinate(e.getMinX(), e.getMinY()),
+                    new Coordinate(e.getMinX(), e.getMaxY()),
+                    new Coordinate(e.getMaxX(), e.getMaxY()),
+                    new Coordinate(e.getMaxX(), e.getMinY()),
+                    new Coordinate(e.getMinX(), e.getMinY())
+                });
+    }
+
+    Date queryDateExtreme(String minOrMax, RasterColumn raster)
+            throws SQLException, ParseException {
+        SQL sql = new SQL("SELECT ");
+        raster.time.select(minOrMax, sql).append(" FROM ").table(raster);
+
+        try (Connection cx = newConnection()) {
+            try (PreparedStatement ps = cx.prepareStatement(sql.logAndGet(LOG))) {
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return dbDataFormat().parse(rs.getString(1));
+                    } else {
+                        LOG.warning("Empty table, unable to calculate " + minOrMax);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void dispose() {
+        config.close();
+        super.dispose();
+    }
+
+    Connection newConnection() throws SQLException {
+        Connection cx = config.dataSource.getConnection();
+        if (config.enableDrivers != null) {
+            try (Statement st = cx.createStatement()) {
+                st.execute(
+                        String.format(
+                                "SET postgis.gdal_enabled_drivers = '%s'", config.enableDrivers));
+            }
+        }
+
+        return cx;
+    }
+
+    /** Date format used to parse dates from the database. */
+    static SimpleDateFormat dbDataFormat() {
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+        return df;
+    }
+
+    /** Date format used to encoded dates to return to client code. */
+    static SimpleDateFormat utcDateFormat() {
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        df.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return df;
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/RasterColumn.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/RasterColumn.java
@@ -1,0 +1,423 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.awt.Dimension;
+import java.awt.geom.Point2D;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geotools.gce.pgraster.PGRasterConfig.TimeConfig;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.geotools.util.logging.Logging;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * A raster column of a table in a postgis raster database, obtained from the obtained from the
+ * <code>raster_columns</code> view.
+ */
+class RasterColumn {
+
+    static final Logger LOG = Logging.getLogger(RasterColumn.class);
+
+    static RasterColumn lookup(PGRasterConfig config) throws SQLException {
+
+        try (Connection cx = config.dataSource.getConnection()) {
+
+            // load the column
+            SQL sql =
+                    new SQL()
+                            .append(
+                                    "SELECT r_table_schema, r_table_name, r_raster_column, srid, num_bands, ")
+                            .append("ST_AsText(extent) as extent, scale_x, scale_y")
+                            .append(" FROM raster_columns")
+                            .append(" WHERE r_table_name = ?");
+
+            if (config.schema != null) {
+                sql.append(" AND r_table_schema = ?");
+            }
+            if (config.column != null) {
+                sql.append(" AND r_raster_column = ?");
+            }
+
+            RasterColumn col = null;
+            try (PreparedStatement st = cx.prepareStatement(sql.logAndGet(LOG))) {
+                st.setString(1, config.table);
+                if (config.schema != null) {
+                    st.setString(2, config.schema);
+                }
+                if (config.column != null) {
+                    st.setString(2 + (config.schema == null ? 0 : 1), config.column);
+                }
+
+                try (ResultSet rc = st.executeQuery()) {
+                    while (rc.next()) {
+                        if (col != null)
+                            throw new IllegalArgumentException(
+                                    "Multiple raster columns found for table '"
+                                            + col.tableKey()
+                                            + "', please specify one in config");
+
+                        col = new RasterColumn(rc);
+
+                        // srid
+                        int srid = rc.getInt("srid");
+                        if (srid == 0) {
+                            // grab it from the actual table
+                            srid = fetchSrid(col, cx);
+                        }
+                        if (srid != 0) {
+                            col.srid = srid;
+                            try {
+                                col.crs = CRS.decode("EPSG:" + srid);
+                            } catch (Exception e) {
+                                LOG.log(
+                                        Level.WARNING,
+                                        "Error looking up SRS for srid = " + srid,
+                                        e);
+                            }
+                        }
+                        if (col.crs == null) {
+                            // TODO: look up wkt
+                            LOG.warning("Unable to determine crs for raster column: " + col.key());
+                        }
+
+                        // extent
+                        String extent = rc.getString("extent");
+                        if (extent == null) {
+                            // grab it from the table
+                            extent = fetchExtent(col, cx);
+                        }
+                        if (extent != null) {
+                            col.extent = parseExtent(extent);
+                        }
+
+                        if (col.extent == null) {
+                            LOG.warning(
+                                    "Unable to determine extent for raster column: " + col.key());
+                        }
+
+                        // scale
+                        Point2D.Double scale =
+                                new Point2D.Double(
+                                        rc.getDouble("scale_x"), rc.getDouble("scale_y"));
+
+                        if (scale.x == 0d || scale.y == 0d) {
+                            scale = fetchScale(col, cx);
+                        }
+
+                        if (scale != null && scale.x > 0d) {
+                            col.scale = scale;
+                            col.scale.y = Math.abs(col.scale.y);
+                        }
+
+                        if (col.scale == null) {
+                            LOG.warning(
+                                    "Unable to determine scale for raster column: " + col.key());
+                        }
+
+                        if (col.extent != null && col.scale != null) {
+                            col.size =
+                                    new Dimension(
+                                            (int) (col.extent.getWidth() / col.scale.x),
+                                            (int) (col.extent.getHeight() / col.scale.y));
+                        }
+
+                        // num bands
+                        int numBands = rc.getInt("num_bands");
+                        if (numBands == 0) {
+                            numBands = fetchNumBands(col, cx);
+                        }
+                        if (numBands > 0) {
+                            col.numBands = numBands;
+                        }
+
+                        // time?
+                        if (config.time.enabled) {
+                            TimeColumn time = fetchTime(col, config.time, cx);
+                            if (time != null) {
+                                col.time = time;
+                            }
+                        }
+                    }
+                }
+
+                if (col == null) {
+                    String dump =
+                            "schema = "
+                                    + config.schema
+                                    + ", table = "
+                                    + config.table
+                                    + ", column = "
+                                    + config.column;
+                    throw new IllegalArgumentException(
+                            "No raster column found for config: " + dump);
+                }
+            }
+
+            // load it's overviews
+            sql =
+                    new SQL()
+                            .append("SELECT * FROM raster_overviews")
+                            .append(" WHERE r_table_name = ?")
+                            .append(" AND r_table_schema = ?")
+                            .append(" AND r_raster_column = ?")
+                            .append(" ORDER BY overview_factor ASC");
+
+            try (PreparedStatement ps = cx.prepareCall(sql.logAndGet(LOG))) {
+                ps.setString(1, col.table);
+                ps.setString(2, col.schema);
+                ps.setString(3, col.name);
+
+                try (ResultSet ov = ps.executeQuery()) {
+                    while (ov.next()) {
+                        RasterOverview overview = new RasterOverview(ov);
+                        overview.extent = fetchAndParseExtent(overview, cx);
+                        col.overview(overview);
+                    }
+                }
+            }
+
+            return col;
+        }
+    }
+
+    static int fetchSrid(RasterColumn col, Connection cx) throws SQLException {
+        SQL sql =
+                new SQL()
+                        .append("SELECT srid FROM (")
+                        .append("SELECT DISTINCT st_srid(")
+                        .name(col.name)
+                        .append(") as srid")
+                        .append(" FROM ")
+                        .table(col)
+                        .append(") AS a WHERE srid IS NOT NULL");
+
+        try (Statement st = cx.createStatement()) {
+            try (ResultSet rs = st.executeQuery(sql.logAndGet(LOG))) {
+                if (rs.next()) return rs.getInt(1);
+            }
+        }
+        return 0;
+    }
+
+    static String fetchExtent(RasterColumn col, Connection cx) throws SQLException {
+
+        SQL sql =
+                new SQL()
+                        .append("SELECT ST_AsText(ST_Extent(ST_Envelope(")
+                        .name(col.name)
+                        .append("::geometry))) AS extent")
+                        .append(" FROM ")
+                        .table(col);
+
+        try (Statement st = cx.createStatement()) {
+            try (ResultSet rs = st.executeQuery(sql.logAndGet(LOG))) {
+                if (rs.next()) {
+                    return rs.getString(1);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    static Envelope parseExtent(String extent) {
+        try {
+            return new WKTReader().read(extent).getEnvelopeInternal();
+        } catch (ParseException e) {
+            LOG.log(Level.WARNING, "Error parsing extent", e);
+        }
+        return null;
+    }
+
+    static Envelope fetchAndParseExtent(RasterColumn col, Connection cx) throws SQLException {
+        String e = fetchExtent(col, cx);
+        if (e != null) {
+            return parseExtent(e);
+        }
+        return null;
+    }
+
+    static TimeColumn fetchTime(RasterColumn col, TimeConfig time, Connection cx)
+            throws SQLException {
+        SQL sql =
+                new SQL()
+                        .append("SELECT column_name, data_type")
+                        .append(" FROM ")
+                        .append("information_schema.columns")
+                        .append(" WHERE table_schema = ? AND table_name = ?")
+                        .append(" AND (")
+                        .append(" data_type = 'date' OR data_type LIKE 'timestamp %'")
+                        .append(" )");
+
+        if (time.column != null) {
+            sql.append(" AND column_name = ?");
+        }
+
+        try (PreparedStatement ps = cx.prepareStatement(sql.logAndGet(LOG))) {
+            ps.setString(1, col.schema);
+            ps.setString(2, col.table);
+            if (time.column != null) {
+                ps.setString(3, time.column);
+            }
+
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    TimeColumn t = new TimeColumn(rs);
+                    if (rs.next()) {
+                        LOG.warning("Multiple time columns found for table " + col.tableKey());
+                        return null;
+                    }
+
+                    return t;
+                } else {
+                    return null;
+                }
+            }
+        }
+    }
+
+    static Point2D.Double fetchScale(RasterColumn col, Connection cx) throws SQLException {
+        SQL sql =
+                new SQL()
+                        .append("SELECT ST_ScaleX(")
+                        .name(col.name)
+                        .append(") as scale_x,")
+                        .append(" ST_ScaleY(")
+                        .name(col.name)
+                        .append(") as scale_y")
+                        .append(" FROM ")
+                        .table(col)
+                        .append(" LIMIT 1");
+
+        try (Statement st = cx.createStatement()) {
+            try (ResultSet rs = st.executeQuery(sql.logAndGet(LOG))) {
+                if (rs.next()) {
+                    return new Point2D.Double(rs.getDouble(1), rs.getDouble(2));
+                }
+            }
+        }
+
+        return null;
+    }
+
+    static int fetchNumBands(RasterColumn col, Connection cx) throws SQLException {
+        SQL sql =
+                new SQL()
+                        .append("SELECT max(ST_NumBands(")
+                        .name(col.name)
+                        .append(")) as num_bands")
+                        .append(" FROM ")
+                        .table(col)
+                        .append(" LIMIT 1");
+
+        try (Statement st = cx.createStatement()) {
+            try (ResultSet rs = st.executeQuery(sql.logAndGet(LOG))) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    final String name;
+    final String table;
+    final String schema;
+    final List<RasterOverview> overviews = new ArrayList<>();
+
+    Integer srid;
+    CoordinateReferenceSystem crs;
+    Envelope extent;
+    Point2D.Double scale;
+    Dimension size;
+    Integer numBands;
+
+    TimeColumn time;
+
+    RasterColumn(String name, String table, String schema) {
+        this.name = name;
+        this.table = table;
+        this.schema = schema;
+    }
+
+    RasterColumn(ResultSet rs) throws SQLException {
+        this(
+                rs.getString("r_raster_column"),
+                rs.getString("r_table_name"),
+                rs.getString("r_table_schema"));
+    }
+
+    String key() {
+        return schema + "." + table + "." + name;
+    }
+
+    String tableKey() {
+        return schema + "." + table;
+    }
+
+    ReferencedEnvelope bounds() {
+        return extent != null ? new ReferencedEnvelope(extent, crs) : null;
+    }
+
+    void overview(RasterOverview ov) {
+        ov.srid = srid;
+        ov.time = time;
+
+        if (ov.extent == null) {
+            ov.extent = extent;
+        }
+
+        if (scale != null) {
+            ov.scale = new Point2D.Double(scale.x * ov.factor, scale.y * ov.factor);
+            if (size != null) {
+                ov.size = new Dimension(size.width / ov.factor, size.height / ov.factor);
+            }
+        }
+
+        ov.numBands = numBands;
+        overviews.add(ov);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RasterColumn that = (RasterColumn) o;
+        return Objects.equals(name, that.name)
+                && Objects.equals(table, that.table)
+                && Objects.equals(schema, that.schema);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, table, schema);
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/RasterOverview.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/RasterOverview.java
@@ -1,0 +1,39 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/** An overview of a raster column, obtained from the <code>raster_overviews</code> view. */
+class RasterOverview extends RasterColumn {
+
+    final Integer factor;
+
+    RasterOverview(String name, String table, String schema, Integer factor) {
+        super(name, table, schema);
+        this.factor = factor;
+    }
+
+    RasterOverview(ResultSet rs) throws SQLException {
+        this(
+                rs.getString("o_raster_column"),
+                rs.getString("o_table_name"),
+                rs.getString("o_table_schema"),
+                rs.getInt("overview_factor"));
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/ReadRequest.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/ReadRequest.java
@@ -1,0 +1,74 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.List;
+import javax.media.jai.Interpolation;
+import org.geotools.coverage.grid.io.OverviewPolicy;
+import org.geotools.geometry.GeneralEnvelope;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.parameter.GeneralParameterValue;
+
+/** All of the information in a {@link PGRasterReader#read(GeneralParameterValue[])} request. */
+class ReadRequest {
+
+    /** The reader */
+    PGRasterReader reader;
+
+    /** The raster / overview being requested */
+    RasterColumn raster;
+
+    /** Requested bounds in world coordinates */
+    GeneralEnvelope bounds;
+
+    /** Requested bounds transformed to raster native crs */
+    ReferencedEnvelope nativeBounds;
+
+    /** Requested area in raster coordinates */
+    Rectangle region;
+
+    /** Resolution (unit/pixel) of the request */
+    Point.Double resolution;
+
+    /** List of timestamps requested */
+    List<?> times;
+
+    /** Request overview policy */
+    OverviewPolicy overviewPolicy;
+
+    OverviewPolicy overviewPolicy() {
+        return overviewPolicy != null ? overviewPolicy : OverviewPolicy.getDefaultPolicy();
+    }
+
+    /** Request interpolation */
+    Interpolation interpolation;
+
+    Interpolation interpolation() {
+        return interpolation != null
+                ? interpolation
+                : Interpolation.getInstance(Interpolation.INTERP_BILINEAR);
+    }
+
+    Color backgroundColor;
+
+    ReadRequest(PGRasterReader reader) {
+        this.reader = reader;
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/SQL.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/SQL.java
@@ -1,0 +1,69 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.util.logging.Logger;
+
+/** Utility class for encoding SQL statements. */
+class SQL {
+
+    StringBuilder sql = new StringBuilder();
+
+    SQL() {}
+
+    SQL(String s) {
+        sql.append(s);
+    }
+
+    /** Appends some "raw" sql. */
+    public SQL append(String s) {
+        sql.append(s);
+        return this;
+    }
+
+    /** Appends a table or column name, which gets quoted. */
+    public SQL name(String s) {
+        sql.append("\"").append(s).append("\"");
+        return this;
+    }
+
+    /** Appends a table name, encoding the schema if present. */
+    public SQL table(RasterColumn col) {
+        if (col.schema != null) {
+            name(col.schema).append(".");
+        }
+        return name(col.table);
+    }
+
+    /** Trims the buffer by the specified amount. */
+    public SQL trim(int i) {
+        sql.setLength(sql.length() - i);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return sql.toString();
+    }
+
+    /** Logs the buffer and returns it. */
+    public String logAndGet(Logger log) {
+        String sql = toString();
+        log.fine(sql);
+        return sql;
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/Tile.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/Tile.java
@@ -1,0 +1,37 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.awt.image.BufferedImage;
+import org.locationtech.jts.geom.Envelope;
+
+/** A tile from a row in a raster table. */
+class Tile {
+
+    static final Tile NULL = new Tile(null, null);
+
+    /** The decoded tile image. */
+    final BufferedImage image;
+
+    /** The tiles world bounds. */
+    final Envelope bounds;
+
+    Tile(BufferedImage image, Envelope bounds) {
+        this.image = image;
+        this.bounds = bounds;
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/TileData.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/TileData.java
@@ -1,0 +1,34 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import org.locationtech.jts.geom.Envelope;
+
+/** Raw data for a {@link Tile}. */
+class TileData {
+
+    /** Raw bytes for the tile. */
+    final byte[] bytes;
+
+    /** World bounds of the tile. */
+    final Envelope bounds;
+
+    TileData(byte[] bytes, Envelope bounds) {
+        this.bytes = bytes;
+        this.bounds = bounds;
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/TileDecoder.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/TileDecoder.java
@@ -1,0 +1,85 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.util.concurrent.Callable;
+import javax.imageio.ImageIO;
+import org.locationtech.jts.geom.Envelope;
+
+/** A task that decodes {@link TileData}'s as they are streamed from a query. */
+public class TileDecoder implements Callable<Tile> {
+
+    final TileData data;
+    final ReadRequest read;
+
+    TileDecoder(TileData data, ReadRequest read) {
+        this.data = data;
+        this.read = read;
+    }
+
+    @Override
+    public Tile call() throws Exception {
+        Envelope bounds = data.bounds;
+
+        // throw out anything not in bounds, shouldn't happen but just in case
+        if (!read.nativeBounds.intersects(bounds)) return Tile.NULL;
+
+        // decode the image
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(data.bytes));
+
+        Tile tile;
+
+        // clip it if need be
+        if (!read.nativeBounds.contains(bounds)) {
+            Envelope clippedBounds = bounds.intersection(read.nativeBounds);
+
+            double scaleX = image.getWidth() / bounds.getWidth();
+            double scaleY = image.getHeight() / bounds.getHeight();
+
+            int x = (int) Math.round((clippedBounds.getMinX() - bounds.getMinX()) * scaleX);
+            int y = (int) Math.round((clippedBounds.getMaxY() - bounds.getMinY()) * scaleY);
+            y = image.getHeight() - y;
+
+            int w =
+                    (int)
+                            Math.round(
+                                    image.getWidth()
+                                            / bounds.getWidth()
+                                            * clippedBounds.getWidth());
+            int h =
+                    (int)
+                            Math.round(
+                                    image.getHeight()
+                                            / bounds.getHeight()
+                                            * clippedBounds.getHeight());
+
+            if (w > 0 && h > 0) {
+                image = image.getSubimage(x, y, w, h);
+                tile = new Tile(image, clippedBounds);
+            } else {
+                tile = Tile.NULL;
+            }
+        } else {
+            // good to go
+            tile = new Tile(image, bounds);
+        }
+
+        return tile;
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/TimeColumn.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/TimeColumn.java
@@ -1,0 +1,53 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.pgraster;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/** Time column of a raster table. */
+class TimeColumn {
+
+    String name;
+    String type;
+
+    TimeColumn(ResultSet rs) throws SQLException {
+        name = rs.getString("column_name");
+        type = rs.getString("data_type");
+    }
+
+    boolean isTimestamp() {
+        return type.startsWith("timestamp");
+    }
+
+    SQL select(String fn, SQL sql) {
+        sql.append("to_char(");
+        if (fn != null) {
+            sql.append(fn).append("(");
+        }
+        sql.name(name);
+        if (fn != null) {
+            sql.append(")");
+        }
+
+        // sql.append(" AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS+00')");
+        sql.append(", 'YYYY-MM-DD\"T\"HH24:MI:SS.MSOF')");
+        sql.append(" AS ").name(fn != null ? fn : name);
+
+        return sql;
+    }
+}

--- a/modules/unsupported/postgis-raster/src/main/resources/META-INF/services/org.geotools.coverage.grid.io.GridFormatFactorySpi
+++ b/modules/unsupported/postgis-raster/src/main/resources/META-INF/services/org.geotools.coverage.grid.io.GridFormatFactorySpi
@@ -1,0 +1,1 @@
+org.geotools.gce.pgraster.PGRasterFactory

--- a/modules/unsupported/postgis-raster/src/test/java/org/geotools/gce/pgraster/PGRasterTest.java
+++ b/modules/unsupported/postgis-raster/src/test/java/org/geotools/gce/pgraster/PGRasterTest.java
@@ -1,0 +1,159 @@
+package org.geotools.gce.pgraster;
+
+import static org.geotools.coverage.grid.io.GridCoverage2DReader.HAS_TIME_DOMAIN;
+import static org.geotools.coverage.grid.io.GridCoverage2DReader.TIME_DOMAIN_MAXIMUM;
+import static org.geotools.coverage.grid.io.GridCoverage2DReader.TIME_DOMAIN_MINIMUM;
+import static org.junit.Assert.assertNotEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.parameter.Parameter;
+import org.geotools.test.OnlineTestCase;
+import org.geotools.test.TestData;
+import org.opengis.parameter.GeneralParameterValue;
+
+public class PGRasterTest extends OnlineTestCase {
+
+    PGRasterConfig config;
+
+    @Override
+    protected String getFixtureId() {
+        return "postgis-raster";
+    }
+
+    @Override
+    protected Properties createExampleFixture() {
+        Properties fixture = new Properties();
+        fixture.put("driver", "org.postgresql.Driver");
+        fixture.put("host", "localhost");
+        fixture.put("database", "geotools");
+        fixture.put("schema", "public");
+        fixture.put("port", "5432");
+        fixture.put("username", System.getProperty("user.name"));
+        fixture.put("password", "");
+        return fixture;
+    }
+
+    @Override
+    protected boolean isOnline() throws Exception {
+        Class.forName(fixture.getProperty("driver"));
+        Connection cx =
+                DriverManager.getConnection(
+                        url(fixture),
+                        fixture.getProperty("username"),
+                        fixture.getProperty("password"));
+
+        String schema = fixture.getProperty("schema");
+        String table = "gray";
+
+        SQL sql = new SQL("SELECT * FROM ");
+        if (schema != null) {
+            sql.name(schema).append(".");
+        }
+        sql.name(table);
+        sql.append(" WHERE 1 = 0");
+
+        try (Statement st = cx.createStatement()) {
+            st.execute(sql.toString());
+        }
+        cx.close();
+        return true;
+    }
+
+    @Override
+    protected void connect() throws Exception {
+        BasicDataSource db = new BasicDataSource();
+        db.setDriverClassName(fixture.getProperty("driver"));
+        db.setUrl(url(fixture));
+        db.setUsername(fixture.getProperty("username"));
+        db.setPassword(fixture.getProperty("password"));
+
+        db.getConnection().close();
+
+        config = new PGRasterConfig();
+        config.enableDrivers = "ENABLE_ALL";
+        config.schema = fixture.getProperty("schema", "public");
+        config.dataSource = db;
+    }
+
+    @Override
+    protected void disconnect() throws Exception {
+        ((BasicDataSource) config.dataSource).close();
+    }
+
+    String url(Properties f) {
+        fixture.put("url", "jdbc:postgresql://localhost/mydbname");
+
+        return "jdbc:postgresql://"
+                + f.getProperty("host", "localhost")
+                + ":"
+                + f.getProperty("port", "5432")
+                + "/"
+                + f.getProperty("database");
+    }
+
+    public void testGray() throws Exception {
+        config.table = "gray";
+
+        PGRasterReader reader = new PGRasterReader(config, null, null);
+        GridCoverage2D rast = reader.read(null);
+        assertNotNull(rast);
+
+        show(rast);
+    }
+
+    public void testRGB() throws Exception {
+        config.table = "world";
+
+        PGRasterReader reader = new PGRasterReader(config, null, null);
+        GridCoverage2D rast = reader.read(null);
+        assertNotNull(rast);
+
+        show(rast);
+    }
+
+    public void testTime() throws Exception {
+        config.table = "world_with_time";
+
+        PGRasterReader reader = new PGRasterReader(config, null, null);
+
+        List<String> names = Arrays.asList(reader.getMetadataNames());
+        assertTrue(names.contains(HAS_TIME_DOMAIN));
+        assertTrue(names.contains(TIME_DOMAIN_MAXIMUM));
+        assertTrue(names.contains(TIME_DOMAIN_MINIMUM));
+
+        String max = reader.getMetadataValue(TIME_DOMAIN_MAXIMUM);
+        assertNotNull(max);
+        String min = reader.getMetadataValue(TIME_DOMAIN_MINIMUM);
+        assertNotNull(min);
+        assertNotEquals(min, max);
+
+        GridCoverage2D r1 =
+                reader.read(
+                        new GeneralParameterValue[] {
+                            new Parameter<>(AbstractGridFormat.TIME, Collections.singletonList(min))
+                        });
+        GridCoverage2D r2 =
+                reader.read(
+                        new GeneralParameterValue[] {
+                            new Parameter<>(AbstractGridFormat.TIME, Collections.singletonList(max))
+                        });
+
+        show(r1);
+        show(r2);
+    }
+
+    private void show(GridCoverage2D rast) {
+        if (TestData.isInteractiveTest()) {
+            rast.show();
+        }
+    }
+}


### PR DESCRIPTION
- A standalone reader, no dependencies on the core imagemosaic or imagemosaic-jdbc modules
- Supports time dimension, but not elevation
- Supports jndi connections or a direct connection pool, same as jdbc datastores
- Not a structured coverage reader in that it's not possible to read multiple coverages with one reader