### PR TITLE
[GEOT-6088] - Subsampling enabled irrespective of Overviews/Overview Policy

### DIFF
--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTest.java
@@ -18,11 +18,15 @@ package org.geotools.coverage.grid;
 
 import static org.junit.Assert.*;
 
+import java.awt.Rectangle;
 import java.io.IOException;
 import java.net.InetAddress;
+import javax.imageio.ImageReadParam;
+import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.*;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.TransformException;
 
 /**
  * Tests the {@link GridCoverage2D} implementation.
@@ -71,5 +75,41 @@ public final class GridCoverageTest extends GridCoverageTestBase {
             assertEquals(GridCoverage2D.class, serial.getClass());
             assertRasterEquals(coverage, serial);
         }
+    }
+
+    @Test
+    public void testSubSampling() throws IllegalArgumentException, IOException, TransformException {
+
+        GridCoverage2D coverage = EXAMPLES.get(2);
+
+        MockAbstractGridCoverage2DReader reader = new MockAbstractGridCoverage2DReader();
+
+        reader.setOetOriginalGridRange(new GridEnvelope2D(new Rectangle(700, 400)));
+        reader.setHighestResolution(0.5, 0.5);
+        reader.setCRS(coverage.getCoordinateReferenceSystem());
+        ImageReadParam readP = new ImageReadParam();
+        Rectangle requestedDim = new Rectangle(700, 400);
+
+        // TEST WHEN NO SUBSAMPLING IS REQUIRED
+        GeneralEnvelope requestedEnvelope = coverage.gridGeometry.envelope;
+        // requestedEnvelope.setEnvelope(-517.2704081632651, -353.2270408163266, 697.7295918367349,
+        // 350.3571428571428);
+        reader.setReadParams("geotools_coverage", null, readP, requestedEnvelope, requestedDim);
+        assertNotNull(readP);
+        // 1 means no subsampling and no pixel skipping
+        assertTrue(readP.getSourceXSubsampling() == 1);
+        assertTrue(readP.getSourceYSubsampling() == 1);
+
+        // MOCK ZOOMOUT TO FORCE SUBSAMPLING
+        GeneralEnvelope requestedEnvelopeZoomOut = coverage.gridGeometry.envelope.clone();
+        // select much larger geographical area for same screen size
+        requestedEnvelopeZoomOut.setEnvelope(
+                -517.2704081632651, -353.2270408163266, 697.7295918367349, 350.3571428571428);
+        reader.setReadParams(
+                "geotools_coverage", null, readP, requestedEnvelopeZoomOut, requestedDim);
+        assertNotNull(readP);
+        // above 1 means do sub-sampling
+        assertTrue(readP.getSourceXSubsampling() > 1);
+        assertTrue(readP.getSourceYSubsampling() > 1);
     }
 }

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/MockAbstractGridCoverage2DReader.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/MockAbstractGridCoverage2DReader.java
@@ -1,0 +1,117 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geotools.coverage.grid;
+
+import java.awt.Rectangle;
+import java.io.IOException;
+import javax.imageio.ImageReadParam;
+import org.geotools.coverage.grid.io.AbstractGridCoverage2DReader;
+import org.geotools.coverage.grid.io.OverviewPolicy;
+import org.geotools.geometry.GeneralEnvelope;
+import org.opengis.coverage.grid.Format;
+import org.opengis.coverage.grid.GridEnvelope;
+import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.parameter.ParameterValueGroup;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.TransformException;
+
+/** 
+ * A Mock Class to access methods for AbstractGridCoverage2DReader class
+ * Intially intended for GEOT-6088
+ * 
+ * @author Imran Rajjad
+ *  */
+public class MockAbstractGridCoverage2DReader extends AbstractGridCoverage2DReader {
+
+    public void setOetOriginalGridRange(GridEnvelope mockOriginalGridRange) {
+        super.originalGridRange = mockOriginalGridRange;
+    }
+
+    public void setHighestResolution(double resolutionX, double resolutionY) {
+        super.highestRes = new double[2];
+        super.highestRes[0] = resolutionX;
+        super.highestRes[1] = resolutionY;
+    }
+
+    public void setCRS(CoordinateReferenceSystem mockCRC) {
+        super.crs = mockCRC;
+    }
+
+    @Override
+    public Format getFormat() {
+
+        return new Format() {
+
+            @Override
+            public ParameterValueGroup getWriteParameters() {
+
+                return null;
+            }
+
+            @Override
+            public String getVersion() {
+
+                return null;
+            }
+
+            @Override
+            public String getVendor() {
+
+                return null;
+            }
+
+            @Override
+            public ParameterValueGroup getReadParameters() {
+
+                return null;
+            }
+
+            @Override
+            public String getName() {
+
+                return "mock";
+            }
+
+            @Override
+            public String getDocURL() {
+
+                return null;
+            }
+
+            @Override
+            public String getDescription() {
+                return "mock format used in Junit";
+            }
+        };
+    }
+
+    @Override
+    public GridCoverage2D read(GeneralParameterValue[] parameters)
+            throws IllegalArgumentException, IOException {
+        return new GridCoverageBuilder().getGridCoverage2D();
+    }
+
+    @Override
+    protected Integer setReadParams(
+            OverviewPolicy overviewPolicy,
+            ImageReadParam readP,
+            GeneralEnvelope requestedEnvelope,
+            Rectangle requestedDim)
+            throws IOException, TransformException {
+        return super.setReadParams(overviewPolicy, readP, requestedEnvelope, requestedDim);
+    }
+
+    @Override
+    protected Integer setReadParams(
+            String coverageName,
+            OverviewPolicy overviewPolicy,
+            ImageReadParam readP,
+            GeneralEnvelope requestedEnvelope,
+            Rectangle requestedDim)
+            throws IOException, TransformException {
+        return super.setReadParams(
+                coverageName, overviewPolicy, readP, requestedEnvelope, requestedDim);
+    }
+}


### PR DESCRIPTION
Calculation of Subsampling factor only applied to grids with overviews, now they will be calculated irrespective of overview policy or presence of overviews inside a grid coverage.

https://osgeo-org.atlassian.net/browse/GEOT-6088