### PR TITLE
[GEOT-6210] - Check for Zip Slip Vulnerability

### DIFF
--- a/modules/extension/graph/src/main/java/org/geotools/graph/util/ZipUtil.java
+++ b/modules/extension/graph/src/main/java/org/geotools/graph/util/ZipUtil.java
@@ -27,6 +27,7 @@ import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
+import org.geotools.util.Utilities;
 
 public class ZipUtil {
 
@@ -36,6 +37,8 @@ public class ZipUtil {
 
     public static void zip(String zipFilename, String[] filenames, String[] archFilenames)
             throws IOException {
+        // throws exception
+        Utilities.assertNotZipSlipVulnerable(zipFilename);
 
         ZipOutputStream zout =
                 new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(zipFilename)));
@@ -43,8 +46,8 @@ public class ZipUtil {
         byte[] data = new byte[512];
         int bc;
         for (int i = 0; i < filenames.length; i++) {
+            Utilities.assertNotZipSlipVulnerable(filenames[i]);
             InputStream fin = new BufferedInputStream(new FileInputStream(filenames[i]));
-
             ZipEntry entry = new ZipEntry(new File(archFilenames[i]).getName());
             zout.putNextEntry(entry);
 
@@ -100,6 +103,7 @@ public class ZipUtil {
 
         while (entries.hasMoreElements()) {
             ZipEntry entry = (ZipEntry) entries.nextElement();
+            Utilities.assertNotZipSlipVulnerable(entry.getName());
             byte[] buffer = new byte[1024];
             int len;
 

--- a/modules/library/metadata/src/main/java/org/geotools/util/Utilities.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/Utilities.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.util;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.AbstractQueue;
@@ -91,6 +93,9 @@ public final class Utilities {
 
     /** The singleton instance to be returned by {@link #emptyQueue}. */
     private static final Queue<?> EMPTY_QUEUE = new EmptyQueue<Object>();
+
+    /** expression to detect Zip Slip vulnerability */
+    private static final String ZIP_SLIP_EXPRESSION = String.format("..%s", File.separator);
 
     /**
      * The class for the {@link #EMPTY_QUEUE} instance. Defined as a named class rather than
@@ -754,5 +759,21 @@ public final class Utilities {
                 element -> element.getClass().getName(),
                 Function.identity(),
                 (first, second) -> second);
+    }
+
+    /**
+     * Asserting if the passed string is not prefixed with '..' to allow an attacker to traverse
+     * outside the referenced directory
+     *
+     * @param fileName to checked for zip sip vulnerability
+     * @throws IOException if passed fileName is found to be vulnerable to zlip slip, e.g fileName
+     *     should not be prefixed with '..'
+     */
+    public static void assertNotZipSlipVulnerable(String fileName) throws IOException {
+        File destinationfile = new File(fileName);
+        String canonicalDestinationFile = destinationfile.getCanonicalPath();
+        if (canonicalDestinationFile.startsWith(ZIP_SLIP_EXPRESSION)) {
+            throw new IOException("Vulnerable File Name");
+        }
     }
 }

--- a/modules/library/metadata/src/test/java/org/geotools/util/URLsTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/URLsTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -113,5 +114,19 @@ public class URLsTest {
         assertURL("file café", "file:file%20caf%C3%A9");
         assertURL("/file café", "file:/file%20caf%C3%A9");
         assertURL("file café", "file://file%20caf%C3%A9");
+    }
+
+    @Test
+    public void zipSlipTest() throws Exception {
+        String validPath = String.format(".%stest_folder", File.separator);
+        String zipSlipPath = String.format("..%s..%stest_folder", File.separator, File.separator);
+        Utilities.assertNotZipSlipVulnerable(validPath); // should not throw exception
+        try {
+            Utilities.assertNotZipSlipVulnerable(zipSlipPath); // should throw exception
+
+        } catch (IOException e) {
+            // should throw exception
+            assertTrue(true);
+        }
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
@@ -133,7 +133,11 @@ public class SchemaFactory {
                             new BufferedReader(new InputStreamReader(res.openStream(), "UTF-8"));
 
                     while (rd.ready()) {
-                        String factoryClassName = rd.readLine().trim();
+
+                        String factoryClassName = rd.readLine();
+                        // null check as per NP_IMMEDIATE_DEREFERENCE_OF_READLINE
+                        if (factoryClassName == null) break;
+                        factoryClassName = factoryClassName.trim();
 
                         try {
                             Schema s =

--- a/modules/plugin/epsg-hsql/src/main/java/org/geotools/referencing/factory/epsg/hsql/DatabaseCreationScript.java
+++ b/modules/plugin/epsg-hsql/src/main/java/org/geotools/referencing/factory/epsg/hsql/DatabaseCreationScript.java
@@ -29,6 +29,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.geotools.util.Utilities;
 import org.hsqldb.jdbc.JDBCDataSource;
 
 /** Utility used to create a HSQL zipped version of the official EPSG database */
@@ -129,6 +130,9 @@ public class DatabaseCreationScript {
         ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile));
         File[] files = new File[] {databaseFile, propertyFile, scriptFile};
         for (File file : files) {
+            // zlip slip check
+            Utilities.assertNotZipSlipVulnerable(file.getName());
+
             FileInputStream in = new FileInputStream(file);
 
             zos.putNextEntry(new ZipEntry(file.getName()));

--- a/modules/plugin/epsg-hsql/src/main/java/org/geotools/referencing/factory/epsg/hsql/ThreadedHsqlEpsgFactory.java
+++ b/modules/plugin/epsg-hsql/src/main/java/org/geotools/referencing/factory/epsg/hsql/ThreadedHsqlEpsgFactory.java
@@ -36,6 +36,7 @@ import org.geotools.metadata.i18n.LoggingKeys;
 import org.geotools.metadata.i18n.Loggings;
 import org.geotools.referencing.factory.AbstractAuthorityFactory;
 import org.geotools.referencing.factory.epsg.ThreadedEpsgFactory;
+import org.geotools.util.Utilities;
 import org.geotools.util.Version;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
@@ -276,6 +277,9 @@ public class ThreadedHsqlEpsgFactory extends ThreadedEpsgFactory {
                     byte[] buf = new byte[1024];
                     int read = 0;
                     while ((ze = zin.getNextEntry()) != null) {
+
+                        Utilities.assertNotZipSlipVulnerable(ze.getName());
+
                         FileOutputStream fout =
                                 new FileOutputStream(new File(directory, ze.getName()));
                         while ((read = zin.read(buf)) > 0) {

--- a/modules/unsupported/gtopo30/src/main/java/org/geotools/gce/gtopo30/GTopo30Writer.java
+++ b/modules/unsupported/gtopo30/src/main/java/org/geotools/gce/gtopo30/GTopo30Writer.java
@@ -71,6 +71,7 @@ import org.geotools.referencing.operation.matrix.XAffineTransform;
 import org.geotools.referencing.operation.transform.LinearTransform1D;
 import org.geotools.util.NumberRange;
 import org.geotools.util.URLs;
+import org.geotools.util.Utilities;
 import org.geotools.util.factory.Hints;
 import org.opengis.coverage.grid.Format;
 import org.opengis.coverage.grid.GridCoverage;
@@ -502,6 +503,8 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
 
         if (dest instanceof File) {
 
+            Utilities.assertNotZipSlipVulnerable(name);
+
             final PrintWriter out =
                     new PrintWriter(
                             new BufferedOutputStream(
@@ -571,6 +574,8 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
             out.flush();
             out.close();
         } else {
+            Utilities.assertNotZipSlipVulnerable(gc.getName().toString());
+
             final ZipOutputStream outZ = (ZipOutputStream) dest;
             final ZipEntry e = new ZipEntry(gc.getName().toString() + ".HDR");
             outZ.putNextEntry(e);
@@ -680,6 +685,7 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
                     new File((File) dest, new StringBuffer(name).append(".SRC").toString());
             out = ImageIOExt.createImageOutputStream(image, file);
         } else {
+            Utilities.assertNotZipSlipVulnerable(gc.getName().toString());
             final ZipOutputStream outZ = (ZipOutputStream) dest;
             final ZipEntry e = new ZipEntry(gc.getName().toString() + ".SRC");
             outZ.putNextEntry(e);
@@ -764,11 +770,15 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
 
         // get the image out stream
         if (dest instanceof File) {
+            Utilities.assertNotZipSlipVulnerable(name);
+
             // writing gif image
             final File file =
                     new File((File) dest, new StringBuffer(name).append(".GIF").toString());
             out = ImageIOExt.createImageOutputStream(image, file);
         } else {
+            Utilities.assertNotZipSlipVulnerable(gc.getName().toString());
+
             final ZipOutputStream outZ = (ZipOutputStream) dest;
             final ZipEntry e = new ZipEntry(gc.getName().toString() + ".GIF");
             outZ.putNextEntry(e);
@@ -831,6 +841,8 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
      */
     private void writePRJ(final GridCoverage2D gc, String name, Object dest) throws IOException {
         if (dest instanceof File) {
+            Utilities.assertNotZipSlipVulnerable(name);
+
             // create the file
             final BufferedWriter fileWriter =
                     new BufferedWriter(
@@ -843,6 +855,8 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
             fileWriter.write(gc.getCoordinateReferenceSystem().toWKT());
             fileWriter.close();
         } else {
+            Utilities.assertNotZipSlipVulnerable(gc.getName().toString());
+
             final ZipOutputStream out = (ZipOutputStream) dest;
             final ZipEntry e =
                     new ZipEntry(
@@ -910,6 +924,7 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
             p.print(hist.getStandardDeviation()[0]);
             p.close();
         } else {
+            Utilities.assertNotZipSlipVulnerable(name);
             final ZipOutputStream outZ = (ZipOutputStream) dest;
             final ZipEntry e = new ZipEntry(name + ".STX");
             outZ.putNextEntry(e);
@@ -980,6 +995,7 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
             out.println(yLoc);
             out.close();
         } else {
+            Utilities.assertNotZipSlipVulnerable(gc.getName().toString());
             final ZipOutputStream outZ = (ZipOutputStream) dest;
             final ZipEntry e = new ZipEntry(gc.getName().toString() + ".DMW");
             outZ.putNextEntry(e);
@@ -1013,6 +1029,9 @@ public final class GTopo30Writer extends AbstractGridCoverageWriter implements G
      */
     private void writeDEM(PlanarImage image, final String name, Object dest)
             throws FileNotFoundException, IOException {
+
+        Utilities.assertNotZipSlipVulnerable(name);
+
         ImageOutputStream out;
 
         if (dest instanceof File) {


### PR DESCRIPTION
added a generic method in `org.geotools.util.Utilities` to verify zip file names for Zip Slip vulnerability as reported at https://osgeo-org.atlassian.net/browse/GEOT-6210. Code that is inline with suggestion at https://lgtm.com/rules/1506728586782/ was not modified