### PR TITLE
[GEOT-6038] Oracle JDBC dialect doesn't support binary_double - 21.x

### DIFF
--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -175,6 +175,8 @@ public class OracleDialect extends PreparedStatementSQLDialect {
                     put("NVARCHAR2", String.class);
                     put("DATE", java.sql.Date.class);
                     put("TIMESTAMP", java.sql.Timestamp.class);
+                    put("BINARY_DOUBLE", Double.class);
+                    put("BINARY_FLOAT", Float.class);
                 }
             };
 

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleFeatureSourceOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleFeatureSourceOnlineTest.java
@@ -22,6 +22,7 @@ import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCFeatureSourceOnlineTest;
 import org.geotools.jdbc.JDBCTestSetup;
 import org.geotools.referencing.CRS;
+import org.opengis.feature.type.AttributeType;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.PropertyIsEqualTo;
 
@@ -85,5 +86,17 @@ public class OracleFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest {
         assertEquals(1l, Math.round(bounds.getMaxY()));
 
         assertTrue(areCRSEqual(CRS.decode("EPSG:4326"), bounds.getCoordinateReferenceSystem()));
+    }
+
+    public void testFeatureSourceWithBinaryDouble() throws Exception {
+        AttributeType binaryDoubleAttribute =
+                dataStore.getFeatureSource(tname("ft1")).getSchema().getType("BIN_DOUBLE_PROPERTY");
+        assertNotNull(binaryDoubleAttribute);
+        assertTrue(binaryDoubleAttribute.getBinding() == Double.class);
+
+        AttributeType binaryFloatAttribute =
+                dataStore.getFeatureSource(tname("ft1")).getSchema().getType("BIN_FLOAT_PROPERTY");
+        assertNotNull(binaryFloatAttribute);
+        assertTrue(binaryFloatAttribute.getBinding() == Float.class);
     }
 }

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleTestSetup.java
@@ -88,6 +88,7 @@ public class OracleTestSetup extends JDBCTestSetup {
                 "CREATE TABLE ft1 ("
                         + "id INT, geometry MDSYS.SDO_GEOMETRY, intProperty INT, "
                         + "doubleProperty FLOAT, stringProperty VARCHAR(255)"
+                        + ",bin_double_property BINARY_DOUBLE, bin_float_property BINARY_FLOAT"
                         + ", PRIMARY KEY(id))";
         run(sql);
         sql = "CREATE SEQUENCE ft1_pkey_seq";
@@ -104,12 +105,12 @@ public class OracleTestSetup extends JDBCTestSetup {
                         + " PARAMETERS ('SDO_INDX_DIMS=2 LAYER_GTYPE=\"POINT\"')";
         run(sql);
 
-        sql = "INSERT INTO ft1 VALUES (0," + pointSql(4326, 0, 0) + ", 0, 0.0,'zero')";
+        sql = "INSERT INTO ft1 VALUES (0," + pointSql(4326, 0, 0) + ", 0, 0.0,'zero',0.0,0.0)";
         run(sql);
-        sql = "INSERT INTO ft1 VALUES (1," + pointSql(4326, 1, 1) + ", 1, 1.1,'one')";
+        sql = "INSERT INTO ft1 VALUES (1," + pointSql(4326, 1, 1) + ", 1, 1.1,'one',1.1,1.1)";
         run(sql);
 
-        sql = "INSERT INTO ft1 VALUES (2," + pointSql(4326, 2, 2) + ", 2, 2.2,'two')";
+        sql = "INSERT INTO ft1 VALUES (2," + pointSql(4326, 2, 2) + ", 2, 2.2,'two',2.2,2.2)";
         run(sql);
     }
 


### PR DESCRIPTION
back port to stable