### PR TITLE
[GEOT-6264] JDBC FeatureWriter-implementation returns null values in getAttributes()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ nb-configuration.xml
 workspace
 *.db
 .metadata
+.gradle

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureReader.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureReader.java
@@ -647,6 +647,9 @@ public class JDBCFeatureReader implements FeatureReader<SimpleFeatureType, Simpl
 
             // TODO: factory fid prefixing out
             init(featureType.getTypeName() + "." + dataStore.encodeFID(key, rs, offset));
+
+            for (int k = 0; k < values.length; k++) // ensure initialized values GEOT-6264
+            getAttribute(k);
         }
 
         public SimpleFeatureType getFeatureType() {

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureReader.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureReader.java
@@ -436,7 +436,7 @@ public class JDBCFeatureReader implements FeatureReader<SimpleFeatureType, Simpl
             throw new RuntimeException(e);
         }
     }
-    
+
     protected void ensureNext() {
         if (next == null) {
             throw new IllegalStateException("Must call hasNext before calling next");

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureReader.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureReader.java
@@ -436,7 +436,7 @@ public class JDBCFeatureReader implements FeatureReader<SimpleFeatureType, Simpl
             throw new RuntimeException(e);
         }
     }
-
+    
     protected void ensureNext() {
         if (next == null) {
             throw new IllegalStateException("Must call hasNext before calling next");
@@ -647,9 +647,6 @@ public class JDBCFeatureReader implements FeatureReader<SimpleFeatureType, Simpl
 
             // TODO: factory fid prefixing out
             init(featureType.getTypeName() + "." + dataStore.encodeFID(key, rs, offset));
-
-            for (int k = 0; k < values.length; k++) // ensure initialized values GEOT-6264
-            getAttribute(k);
         }
 
         public SimpleFeatureType getFeatureType() {
@@ -793,6 +790,8 @@ public class JDBCFeatureReader implements FeatureReader<SimpleFeatureType, Simpl
         }
 
         public List<Object> getAttributes() {
+            // ensure initialized values GEOT-6264
+            for (int k = 0; k < values.length; k++) getAttribute(k);
             return Arrays.asList(values);
         }
 

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
@@ -45,7 +45,7 @@ public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
             assertTrue(writer.hasNext());
             final SimpleFeature feature = (SimpleFeature) writer.next();
             final List<Object> attributes = feature.getAttributes();
-            for (int k = 0; k < 4; k++) {
+            for (int k = 0; k < attributes.size(); k++) {
                 assertTrue(attributes.get(k) != null);
             }
         }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.jdbc;
 
+import java.util.List;
 import org.geotools.data.FeatureWriter;
 import org.geotools.data.Transaction;
 import org.opengis.feature.simple.SimpleFeature;
@@ -43,10 +44,10 @@ public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
                 dataStore.getFeatureWriter(tname("ft1"), Transaction.AUTO_COMMIT)) {
             assertTrue(writer.hasNext());
             final SimpleFeature feature = (SimpleFeature) writer.next();
-            assertTrue(feature.getAttribute(0).toString().equals("POINT (0 0)"));
-            assertTrue((Integer) feature.getAttribute(1) == 0);
-            assertTrue((Double) feature.getAttribute(2) == 0.0);
-            assertTrue(((String) feature.getAttribute(3)).equals("zero"));
+            final List<Object> attributes = feature.getAttributes();
+            for (int k = 0; k < 4; k++) {
+                assertTrue(attributes.get(k) != null);
+            }
         }
     }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
@@ -1,0 +1,52 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.jdbc;
+
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Transaction;
+import org.opengis.feature.simple.SimpleFeature;
+
+/**
+ * JDBC {@link FeatureWriter}-implementation tampers with input-data.
+ *
+ * @author Burkhard Strauss
+ * @see GEOT-6264
+ */
+public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
+
+    public void testNext() throws Exception {
+
+        try (FeatureWriter writer =
+                dataStore.getFeatureWriter(tname("ft1"), Transaction.AUTO_COMMIT)) {
+            assertTrue(writer.hasNext());
+            final SimpleFeature feature = (SimpleFeature) writer.next();
+            assertTrue(feature.getAttribute(0).toString().equals("POINT (0 0)"));
+            assertTrue((Integer) feature.getAttribute(1) == 0);
+            assertTrue((Double) feature.getAttribute(2) == 0.0);
+            assertTrue(((String) feature.getAttribute(3)).equals("zero"));
+        }
+        try (FeatureWriter writer =
+                dataStore.getFeatureWriter(tname("ft1"), Transaction.AUTO_COMMIT)) {
+            assertTrue(writer.hasNext());
+            final SimpleFeature feature = (SimpleFeature) writer.next();
+            assertTrue(feature.getAttribute(0).toString().equals("POINT (0 0)"));
+            assertTrue((Integer) feature.getAttribute(1) == 0);
+            assertTrue((Double) feature.getAttribute(2) == 0.0);
+            assertTrue(((String) feature.getAttribute(3)).equals("zero"));
+        }
+    }
+}

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLFeatureWriterOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLFeatureWriterOnlineTest.java
@@ -1,0 +1,29 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mysql;
+
+import org.geotools.jdbc.JDBCFeatureWriterOnlineTest;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/** @author Burkhard Strauss */
+public class MySQLFeatureWriterOnlineTest extends JDBCFeatureWriterOnlineTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new MySQLTestSetup();
+    }
+}


### PR DESCRIPTION
@aaime

Here my next try. I switched off code-formatting etc. Changes now reduce to two lines in one file (plus two new unit-test files). Following contribution guidelines, "Talk first policy" does not apply to "easy bugfix with test".

See Jira GEOT-6264 for the Version of JDBCFeatureWriterOnlineTest.java which demonstrates the bug. The JDBC FeatureWriter implementation returns features whose attributes are fine in case obtained via getAttribute(int) but which are null in case obtained via getAttributes().

Please note also: I added .gradle to .gitignore.