### PR TITLE
[GEOT-6267] Memory leak in DefaultRenderingExecutor

### DIFF
--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/DefaultRenderingExecutor.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/DefaultRenderingExecutor.java
@@ -288,8 +288,8 @@ public class DefaultRenderingExecutor implements RenderingExecutor {
                 if (!result) {
                     info.listener.onRenderingFailed(event);
                 } else {
+                    currentTasks.remove(info);
                     if (tasksLatch.getCount() == 0) {
-                        currentTasks.remove(info);
                         info.listener.onRenderingCompleted(event);
                         break;
                     }


### PR DESCRIPTION
The “currentTask.remove(info)” line needs to be moved up BEFORE the check of the countdown latch.