### PR TITLE
[GEOT-6269] Allow  MapViewports to retain scale or bounds on resize

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/map/MapViewport.java
+++ b/modules/library/render/src/main/java/org/geotools/map/MapViewport.java
@@ -96,6 +96,7 @@ public class MapViewport {
     private CopyOnWriteArrayList<MapBoundsListener> boundsListeners;
     private boolean matchingAspectRatio;
     private boolean hasCenteringTransforms;
+    private boolean fixedBoundsOnResize = false;
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     /**
@@ -350,8 +351,11 @@ public class MapViewport {
         } else {
             this.screenArea = new Rectangle(screenArea);
         }
-
-        setTransforms(false);
+        if (fixedBoundsOnResize) {
+            setTransforms(true);
+        } else {
+            setTransforms(false);
+        }
     }
 
     /**
@@ -529,6 +533,16 @@ public class MapViewport {
         hasCenteringTransforms = true;
     }
 
+    /** @return the fixedBoundsOnResize */
+    public boolean isFixedBoundsOnResize() {
+        return fixedBoundsOnResize;
+    }
+
+    /** @param fixedBoundsOnResize the fixedBoundsOnResize to set */
+    public void setFixedBoundsOnResize(boolean fixedBoundsOnResize) {
+        this.fixedBoundsOnResize = fixedBoundsOnResize;
+    }
+
     /**
      * Calculates transforms suitable for no aspect ratio matching.
      *
@@ -570,7 +584,7 @@ public class MapViewport {
     }
 
     /**
-     * Helper for setter methods which checkst that this viewport is editable and issues a log
+     * Helper for setter methods which checks that this viewport is editable and issues a log
      * message if not.
      */
     private boolean checkEditable(String methodName) {

--- a/modules/library/render/src/main/java/org/geotools/map/MapViewport.java
+++ b/modules/library/render/src/main/java/org/geotools/map/MapViewport.java
@@ -96,7 +96,12 @@ public class MapViewport {
     private CopyOnWriteArrayList<MapBoundsListener> boundsListeners;
     private boolean matchingAspectRatio;
     private boolean hasCenteringTransforms;
+    /**
+     * Determine if the map retains its scale (false) or its bounds (true) when the MapPane is
+     * resized.
+     */
     private boolean fixedBoundsOnResize = false;
+
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     /**
@@ -533,12 +538,19 @@ public class MapViewport {
         hasCenteringTransforms = true;
     }
 
-    /** @return the fixedBoundsOnResize */
+    /**
+     * Determine if the map retains its scale (false) or its bounds (true) when the MapPane is
+     * resized.
+     */
     public boolean isFixedBoundsOnResize() {
         return fixedBoundsOnResize;
     }
-
-    /** @param fixedBoundsOnResize the fixedBoundsOnResize to set */
+    /**
+     * Determine if the map retains its scale (false) or its bounds (true) when the MapPane is
+     * resized.
+     *
+     * @param fixedBoundsOnResize - if true retain bounds on resize otherwise retain scale.
+     */
     public void setFixedBoundsOnResize(boolean fixedBoundsOnResize) {
         this.fixedBoundsOnResize = fixedBoundsOnResize;
     }

--- a/modules/library/render/src/test/java/org/geotools/map/MapViewportTest.java
+++ b/modules/library/render/src/test/java/org/geotools/map/MapViewportTest.java
@@ -49,7 +49,8 @@ public class MapViewportTest extends LoggerTest {
     private static final Rectangle SCREEN_2_1 = new Rectangle(200, 100);
     // Screen area with aspect ratio 1:2
     private static final Rectangle SCREEN_1_2 = new Rectangle(100, 200);
-
+    // Screen area with aspect ration 2:2 (or 1:1)
+    private static final Rectangle SCREEN_2_2 = new Rectangle(200, 200);
     private static final double TOL = 1.0e-6d;
 
     @Test
@@ -200,6 +201,29 @@ public class MapViewportTest extends LoggerTest {
                         WORLD_1_1.getCoordinateReferenceSystem());
 
         assertTrue(expectedBounds.boundsEquals2D(vp.getBounds(), TOL));
+        // Now check with Fixed bounds set - bounding box will change but will include the old bbox
+        vp.setFixedBoundsOnResize(true);
+        vp.setScreenArea(SCREEN_1_1);
+        vp.setBounds(WORLD_1_1);
+
+        vp.setScreenArea(SCREEN_2_1);
+
+        expectedBounds =
+                new ReferencedEnvelope(
+                        WORLD_1_1.getMinX() - WORLD_1_1.getWidth() / 2,
+                        WORLD_1_1.getMaxX() + WORLD_1_1.getWidth() / 2,
+                        WORLD_1_1.getMinY(),
+                        WORLD_1_1.getMaxY(),
+                        WORLD_1_1.getCoordinateReferenceSystem());
+        assertTrue(expectedBounds.boundsEquals2D(vp.getBounds(), TOL));
+        // double size of screen - no change in BBOX
+        vp.setScreenArea(SCREEN_1_1);
+        vp.setBounds(WORLD_1_1);
+        vp.setScreenArea(SCREEN_2_2);
+        assertTrue(WORLD_1_1.boundsEquals2D(vp.getBounds(), TOL));
+        // and back to small
+        vp.setScreenArea(SCREEN_1_1);
+        assertTrue(WORLD_1_1.boundsEquals2D(vp.getBounds(), TOL));
     }
 
     @Test


### PR DESCRIPTION
As discussed in [GEOT-6269](https://osgeo-org.atlassian.net/projects/GEOT/issues/GEOT-6269) this enhancement allows a resizing MapPane to keep it's bounds rather than its bounds. The behaviour defaults to the current practice of maintaining the scale and adjusting the bounds.

A call to `setFixedBoundsOnResize` with True will maintain the bounds and adjust the scale.