### PR TITLE
Compile error with IntelliJ after maven import - multiple active profiles

### DIFF
--- a/docs/developer/conventions/code/qa.rst
+++ b/docs/developer/conventions/code/qa.rst
@@ -79,7 +79,7 @@ Error Prone
 
 The `Error Prone <https://errorprone.info/>`_ checker runs a compiler plugin.
 
-In order to activate the Error Prone checks, use the "-Perrorprone" for JDK 11 builds, or "-Perrorprone8" for JDK 8 builds.
+In order to activate the Error Prone checks, use the "-Perrorprone". For JDK 8 the profile "errorprone-jdk8-fix" is automatically added.
 
 Any failure to comply with the "Error Prone" rules will show up as a compile error in the build output, e.g.::
 

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
     <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
     <!-- see instructions at https://errorprone.info/docs/installation -->
     <profile>
-      <id>errorprone8</id>
+      <id>errorprone-jdk8-fix</id>
       <activation>
         <jdk>1.8</jdk>
       </activation>
@@ -346,20 +346,12 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.0</version>
             <configuration>
               <fork>true</fork>
               <compilerArgs combine.children="append">
                 <!-- append decorates the compiler settings - see errorprone profile -->
                 <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
               </compilerArgs>
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>error_prone_core</artifactId>
-                  <version>2.3.2</version>
-                </path>
-              </annotationProcessorPaths>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,6 @@
         <property>
           <name>qa</name>
         </property>
-        <jdk>(1.8,)</jdk>
       </activation>
       <build>
         <plugins>
@@ -336,12 +335,10 @@
     </profile>
     
     <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
+    <!-- see instructions at https://errorprone.info/docs/installation -->
     <profile>
       <id>errorprone8</id>
       <activation>
-        <property>
-          <name>qa</name>
-        </property>
         <jdk>1.8</jdk>
       </activation>
       <build>
@@ -353,8 +350,7 @@
             <configuration>
               <fork>true</fork>
               <compilerArgs combine.children="append">
-                <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne -XepExcludedPaths:${project.build.directory}/generated-sources/.* ${errorProneFlags}</arg>
+                <!-- append decorates the compiler settings - see errorprone profile -->
                 <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
               </compilerArgs>
               <annotationProcessorPaths>


### PR DESCRIPTION
Problem found running under Windows, but it might be a general parsing issue in the errorprone library.
Using JDK 8, IntelliJ 2018.3.5

The error i got was like this:
```
Information:java: Errors occurred while compiling module 'org.w3.xlink'
Information:javac 11.0.2 was used to compile java sources
Information:20.03.2019 16.32 - Compilation completed with 1 error and 89 warnings in 12 s 714 ms
Error:java: Illegal/unsupported escape sequence near index 7
C:\dev\geotools-kartverket\modules\ogc\org.w3.xlink\target/generated-sources/.*
       ^
```

The issue is quotation of the compiler arguments.

Steps to reproduce:
mvn install -fn
Open file `/pom.xml` in IntelliJ and import as project.
Choose "Delete existing project and import"
Make sure your JDK is set to Java 8. (mine keeps bouncing back to JDK 10 after re-import)
Build -> Rebuild Project


Problem
The Java Compiler settings aren't quoted correctly.
Another issue is compiler arguments being duplicated.

![geotools-compile-intellij-error](https://user-images.githubusercontent.com/13136714/54753452-6114f900-4be1-11e9-8fc5-0800165ed3f5.png)

Quotation that works for me:
```
"-XDcompilePolicy=simple -Xplugin:ErrorProne -XepDisableAllChecks -XepExcludedPaths:C:\dev\geotools-kartverket\modules\ogc\org.w3.xlink\target/generated-sources/.* -J-Xbootclasspath/p:C:\Users\lislei\.m2\repository/com/google/errorprone/javac/9+181-r4173-1/javac-9+181-r4173-1.jar"
```


Solution
Use `compilerArgument` in sted of multiple `compilerArgs`.
Make configurations for errorprone and errorprone8 profiles mutially exclusive to prevent multiple compiler arguments. 
