### PR TITLE
Add to developer manual a modified google-java-format version plugin option.

### DIFF
--- a/docs/developer/conventions/code/style.rst
+++ b/docs/developer/conventions/code/style.rst
@@ -111,3 +111,6 @@ the coding conventions. Please always build before committing!.
 
 The `google-java-format <https://github.com/google/google-java-format>`_ project also offers plugins for various IDEs,
 if your IDE is not supported, please just build once on the command line before committing.
+
+Also you could use a `modified version <https://github.com/fernandor777/google-java-format/releases/download/1.7-gsgt/google-java-format-eclipse-plugin-1.6.0.jar>`__ 
+with 4 spaces indent by default, putting the jar file on Eclipse dropins folder.


### PR DESCRIPTION
Add modified google-java-format version jar download with 4 spaces indent on developer documentation.