### PR TITLE
[GEOT-5830] Fids can become corrupted in ShapeFileReader when deletion occurs

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/IndexManager.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/IndexManager.java
@@ -206,8 +206,8 @@ class IndexManager {
             throw new IllegalStateException(
                     "This method only applies if the files are local and the file can be created");
 
-        URL indexURL = shpFiles.acquireRead(indexType, writer);
         URL shpURL = shpFiles.acquireRead(SHP, writer);
+        URL indexURL = shpFiles.acquireRead(indexType, writer);
         try {
 
             if (indexURL == null) {

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
@@ -133,13 +133,13 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
     }
 
     Name getTypeName() {
-      String typeName="Null";
-      if(shpFiles!=null) {
-        typeName = shpFiles.getTypeName();
-      } else {
-        typeName = "Null";
-      }
-      return new NameImpl(namespaceURI, typeName);
+        String typeName = "Null";
+        if (shpFiles != null) {
+            typeName = shpFiles.getTypeName();
+        } else {
+            typeName = "Null";
+        }
+        return new NameImpl(namespaceURI, typeName);
     }
 
     @Override

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
@@ -133,7 +133,13 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
     }
 
     Name getTypeName() {
-        return new NameImpl(namespaceURI, shpFiles.getTypeName());
+      String typeName="Null";
+      if(shpFiles!=null) {
+        typeName = shpFiles.getTypeName();
+      } else {
+        typeName = "Null";
+      }
+      return new NameImpl(namespaceURI, typeName);
     }
 
     @Override

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
@@ -136,8 +136,8 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
         String typeName = "Null";
         if (shpFiles != null) {
             typeName = shpFiles.getTypeName();
-        } else {
-            typeName = "Null";
+            /*} else {
+            typeName = "Null";*/
         }
         return new NameImpl(namespaceURI, typeName);
     }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
@@ -136,8 +136,6 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
         String typeName = "Null";
         if (shpFiles != null) {
             typeName = shpFiles.getTypeName();
-            /*} else {
-            typeName = "Null";*/
         }
         return new NameImpl(namespaceURI, typeName);
     }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -363,7 +363,7 @@ class ShapefileFeatureSource extends ContentFeatureSource {
         // get the .fix file reader, if we have a .fix file
         IndexedFidReader fidReader = null;
         if (getDataStore().isFidIndexed()
-                && filter instanceof Id
+                /* && filter instanceof Id*/
                 && indexManager.hasFidIndex(false)) {
             fidReader = new IndexedFidReader(shpFiles);
         }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -42,6 +42,7 @@ import org.geotools.data.shapefile.dbf.DbaseFileHeader;
 import org.geotools.data.shapefile.dbf.DbaseFileReader;
 import org.geotools.data.shapefile.fid.IndexedFidReader;
 import org.geotools.data.shapefile.files.FileReader;
+import org.geotools.data.shapefile.files.ShpFileType;
 import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.shapefile.index.Data;
 import org.geotools.data.shapefile.index.TreeException;
@@ -328,6 +329,9 @@ class ShapefileFeatureSource extends ContentFeatureSource {
                 && filter instanceof Id
                 && indexManager.hasFidIndex(false)) {
             Id fidFilter = (Id) filter;
+            if(indexManager.isIndexStale(ShpFileType.FIX)) {
+              indexManager.createFidIndex();
+            }
             List<Data> records = indexManager.queryFidIndex(fidFilter);
             if (records != null) {
                 goodRecs = new CloseableIteratorWrapper<Data>(records.iterator());

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -362,9 +362,7 @@ class ShapefileFeatureSource extends ContentFeatureSource {
 
         // get the .fix file reader, if we have a .fix file
         IndexedFidReader fidReader = null;
-        if (getDataStore().isFidIndexed()
-                /* && filter instanceof Id*/
-                && indexManager.hasFidIndex(false)) {
+        if (getDataStore().isFidIndexed() && indexManager.hasFidIndex(false)) {
             fidReader = new IndexedFidReader(shpFiles);
         }
 

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -329,8 +329,8 @@ class ShapefileFeatureSource extends ContentFeatureSource {
                 && filter instanceof Id
                 && indexManager.hasFidIndex(false)) {
             Id fidFilter = (Id) filter;
-            if(indexManager.isIndexStale(ShpFileType.FIX)) {
-              indexManager.createFidIndex();
+            if (indexManager.isIndexStale(ShpFileType.FIX)) {
+                indexManager.createFidIndex();
             }
             List<Data> records = indexManager.queryFidIndex(fidFilter);
             if (records != null) {

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
@@ -25,6 +25,7 @@ import org.geotools.data.Query;
 import org.geotools.data.QueryCapabilities;
 import org.geotools.data.ResourceInfo;
 import org.geotools.data.Transaction;
+import org.geotools.data.shapefile.files.ShpFileType;
 import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureStore;
@@ -70,6 +71,9 @@ class ShapefileFeatureStore extends ContentFeatureStore {
                     new IndexedShapefileFeatureWriter(
                             ds.indexManager, reader, ds.getCharset(), ds.getTimeZone());
         } else {
+            if(ds.indexManager.isIndexStale(ShpFileType.FIX)) {
+              ds.indexManager.createFidIndex();
+            }
             writer =
                     new ShapefileFeatureWriter(
                             delegate.shpFiles, reader, ds.getCharset(), ds.getTimeZone());

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
@@ -71,8 +71,8 @@ class ShapefileFeatureStore extends ContentFeatureStore {
                     new IndexedShapefileFeatureWriter(
                             ds.indexManager, reader, ds.getCharset(), ds.getTimeZone());
         } else {
-            if(ds.indexManager.isIndexStale(ShpFileType.FIX)) {
-              ds.indexManager.createFidIndex();
+            if (ds.indexManager.isIndexStale(ShpFileType.FIX)) {
+                ds.indexManager.createFidIndex();
             }
             writer =
                     new ShapefileFeatureWriter(

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureStore.java
@@ -25,7 +25,6 @@ import org.geotools.data.Query;
 import org.geotools.data.QueryCapabilities;
 import org.geotools.data.ResourceInfo;
 import org.geotools.data.Transaction;
-import org.geotools.data.shapefile.files.ShpFileType;
 import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureStore;
@@ -71,9 +70,6 @@ class ShapefileFeatureStore extends ContentFeatureStore {
                     new IndexedShapefileFeatureWriter(
                             ds.indexManager, reader, ds.getCharset(), ds.getTimeZone());
         } else {
-            if (ds.indexManager.isIndexStale(ShpFileType.FIX)) {
-                ds.indexManager.createFidIndex();
-            }
             writer =
                     new ShapefileFeatureWriter(
                             delegate.shpFiles, reader, ds.getCharset(), ds.getTimeZone());

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidWriter.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidWriter.java
@@ -203,17 +203,33 @@ public class IndexedFidWriter implements FileWriter {
     }
 
     /**
-     * Increments the fidIndex by 1. Indicates that a feature was removed from the location. This is
-     * intended to ensure that FIDs stay constant over time. Consider the following case of 5
-     * features. feature 1 has fid typename.0 feature 2 has fid typename.1 feature 3 has fid
-     * typename.2 feature 4 has fid typename.3 feature 5 has fid typename.4
+     * Increments the fidIndex by 1.
+     *
+     * <p>Indicates that a feature was removed from the location. This is intended to ensure that
+     * FIDs stay constant over time. Consider the following case of 5 features.
+     *
+     * <ul>
+     *   <li>feature 1 has fid typename.0
+     *   <li>feature 2 has fid typename.1
+     *   <li>feature 3 has fid typename.2
+     *   <li>feature 4 has fid typename.3
+     *   <li>feature 5 has fid typename.4
+     * </ul>
      *
      * <p>when feature 3 is removed/deleted the following usage of the write should take place:
-     * next(); (move to feature 1) next(); (move to feature 2) next(); (move to feature 3)
-     * remove();(delete feature 3) next(); (move to feature 4) // optional write(); (write feature
-     * 4) next(); (move to feature 5) write(); (write(feature 5)
      *
-     * @throws IOException
+     * <ul>
+     *   <li>next(); (move to feature 1)
+     *   <li>next(); (move to feature 2)
+     *   <li>next(); (move to feature 3)
+     *   <li>remove();(delete feature 3)
+     *   <li>next(); (move to feature 4)
+     *   <li>// optional write(); (write feature 4)
+     *   <li>next(); (move to feature 5)
+     *   <li>write(); (write(feature 5)
+     * </ul>
+     *
+     * @throws IOException if current fid index is null
      */
     public void remove() throws IOException {
         if (current == -1)
@@ -221,8 +237,6 @@ public class IndexedFidWriter implements FileWriter {
         if (hasNext()) {
             removes++;
             current = -1;
-
-            // reader.next();
         }
     }
 

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidWriter.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidWriter.java
@@ -204,23 +204,14 @@ public class IndexedFidWriter implements FileWriter {
 
     /**
      * Increments the fidIndex by 1. Indicates that a feature was removed from the location. This is
-     * intended to ensure that FIDs stay constant over time. 
-     * Consider the following case of 5 features. 
-     * feature 1 has fid typename.0 
-     * feature 2 has fid typename.1 
-     * feature 3 has fid typename.2 
-     * feature 4 has fid typename.3 
-     * feature 5 has fid typename.4 
-     * 
-     * when feature 3 is removed/deleted the following usage of the write should take place: 
-     * next(); (move to feature 1)
-     * next(); (move to feature 2)
-     * next(); (move to feature 3) 
-     * remove();(delete feature 3)
-     * next(); (move to feature 4) 
-     * // optional write(); (write feature 4) 
-     * next(); (move to feature 5) 
-     * write(); (write(feature 5)
+     * intended to ensure that FIDs stay constant over time. Consider the following case of 5
+     * features. feature 1 has fid typename.0 feature 2 has fid typename.1 feature 3 has fid
+     * typename.2 feature 4 has fid typename.3 feature 5 has fid typename.4
+     *
+     * <p>when feature 3 is removed/deleted the following usage of the write should take place:
+     * next(); (move to feature 1) next(); (move to feature 2) next(); (move to feature 3)
+     * remove();(delete feature 3) next(); (move to feature 4) // optional write(); (write feature
+     * 4) next(); (move to feature 5) write(); (write(feature 5)
      *
      * @throws IOException
      */

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidWriter.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidWriter.java
@@ -204,13 +204,23 @@ public class IndexedFidWriter implements FileWriter {
 
     /**
      * Increments the fidIndex by 1. Indicates that a feature was removed from the location. This is
-     * intended to ensure that FIDs stay constant over time. Consider the following case of 5
-     * features. feature 1 has fid typename.0 feature 2 has fid typename.1 feature 3 has fid
-     * typename.2 feature 4 has fid typename.3 feature 5 has fid typename.4 when feature 3 is
-     * removed/deleted the following usage of the write should take place: next(); (move to feature
-     * 1) next(); (move to feature 2) next(); (move to feature 3) remove();(delete feature 3)
-     * next(); (move to feature 4) // optional write(); (write feature 4) next(); (move to feature
-     * 5) write(); (write(feature 5)
+     * intended to ensure that FIDs stay constant over time. 
+     * Consider the following case of 5 features. 
+     * feature 1 has fid typename.0 
+     * feature 2 has fid typename.1 
+     * feature 3 has fid typename.2 
+     * feature 4 has fid typename.3 
+     * feature 5 has fid typename.4 
+     * 
+     * when feature 3 is removed/deleted the following usage of the write should take place: 
+     * next(); (move to feature 1)
+     * next(); (move to feature 2)
+     * next(); (move to feature 3) 
+     * remove();(delete feature 3)
+     * next(); (move to feature 4) 
+     * // optional write(); (write feature 4) 
+     * next(); (move to feature 5) 
+     * write(); (write(feature 5)
      *
      * @throws IOException
      */

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/fid/FidQueryTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/fid/FidQueryTest.java
@@ -16,8 +16,9 @@
  */
 package org.geotools.data.shapefile.fid;
 
-import static junit.framework.Assert.*;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import org.geotools.data.Query;
 import org.geotools.data.shapefile.ShapefileDataStore;
+import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.factory.CommonFactoryFinder;
@@ -46,167 +48,218 @@ import org.opengis.filter.identity.FeatureId;
 
 public class FidQueryTest extends FIDTestCase {
 
-    private ShapefileDataStore ds;
+  private ShapefileDataStore ds;
 
-    private static final FilterFactory2 fac = CommonFactoryFinder.getFilterFactory2(null);
+  private static final FilterFactory2 fac = CommonFactoryFinder.getFilterFactory2(null);
 
-    Map<String, SimpleFeature> fids = new HashMap<String, SimpleFeature>();
+  Map<String, SimpleFeature> fids = new HashMap<String, SimpleFeature>();
 
-    SimpleFeatureStore featureStore;
+  SimpleFeatureStore featureStore;
 
-    private int numFeatures;
+  private int numFeatures;
 
-    @Before
-    public void setUpFixQueryTest() throws Exception {
-        URL url = backshp.toURI().toURL();
-        ds = new ShapefileDataStore(url);
-        numFeatures = 0;
-        featureStore = (SimpleFeatureStore) ds.getFeatureSource();
-        {
-            SimpleFeatureIterator features = featureStore.getFeatures().features();
-            try {
-                while (features.hasNext()) {
-                    numFeatures++;
-                    SimpleFeature feature = features.next();
-                    fids.put(feature.getID(), feature);
-                }
-            } finally {
-                if (features != null) features.close();
-            }
-            assertEquals(numFeatures, fids.size());
+  @Before
+  public void setUpFixQueryTest() throws Exception {
+    URL url = backshp.toURI().toURL();
+    ds = new ShapefileDataStore(url);
+    numFeatures = 0;
+    featureStore = (SimpleFeatureStore) ds.getFeatureSource();
+    {
+      SimpleFeatureIterator features = featureStore.getFeatures().features();
+      try {
+        while (features.hasNext()) {
+          numFeatures++;
+          SimpleFeature feature = features.next();
+          fids.put(feature.getID(), feature);
         }
+      } finally {
+        if (features != null) features.close();
+      }
+      assertEquals(numFeatures, fids.size());
+    }
+  }
+
+  @After
+  public void dispose() throws Exception {
+    ds.dispose();
+  }
+
+  @Test
+  public void testGetByFID() throws Exception {
+    assertFidsMatch();
+  }
+
+  @Test
+  public void testAddFeature() throws Exception {
+    SimpleFeature feature = fids.values().iterator().next();
+    SimpleFeatureType schema = ds.getSchema();
+
+    SimpleFeatureBuilder build = new SimpleFeatureBuilder(schema);
+    GeometryFactory gf = new GeometryFactory();
+    build.add(gf.createPoint((new Coordinate(0, 0))));
+    build.add(Long.valueOf(0));
+    build.add(Long.valueOf(0));
+    build.add("Hey");
+    SimpleFeature newFeature = build.buildFeature(null);
+    DefaultFeatureCollection collection = new DefaultFeatureCollection();
+    collection.add(newFeature);
+
+    List<FeatureId> newFids = featureStore.addFeatures(collection);
+    assertEquals(1, newFids.size());
+    // this.assertFidsMatch();
+
+    Query query = new Query(schema.getTypeName());
+    FeatureId id = newFids.iterator().next();
+    String fid = id.getID();
+
+    Filter filter = fac.id(Collections.singleton(id));
+    query.setFilter(filter);
+    SimpleFeatureIterator features = featureStore.getFeatures(query).features();
+    try {
+      feature = features.next();
+      for (int i = 0; i < schema.getAttributeCount(); i++) {
+        Object value = feature.getAttribute(i);
+        Object newValue = newFeature.getAttribute(i);
+        assertEquals(newValue, value);
+      }
+      assertFalse(features.hasNext());
+    } finally {
+      if (features != null) features.close();
+    }
+  }
+
+  @Test
+  public void testModifyFeature() throws Exception {
+    SimpleFeature feature = this.fids.values().iterator().next();
+    int newId = 237594123;
+
+    FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+
+    Id createFidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
+
+    SimpleFeatureType schema = feature.getFeatureType();
+    featureStore.modifyFeatures(
+        schema.getDescriptor("ID"), Integer.valueOf(newId), createFidFilter);
+
+    SimpleFeatureIterator features = featureStore.getFeatures(createFidFilter).features();
+    try {
+      assertFalse(feature.equals(features.next()));
+    } finally {
+      if (features != null) {
+        features.close();
+      }
+    }
+    feature.setAttribute("ID", Integer.valueOf(newId));
+    this.assertFidsMatch();
+  }
+
+  @Test
+  public void testDeleteFeature() throws Exception {
+    SimpleFeatureIterator features = featureStore.getFeatures().features();
+    SimpleFeature feature;
+    try {
+      feature = features.next();
+    } finally {
+      if (features != null) {
+        features.close();
+      }
+    }
+    FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+    Id fidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
+
+    featureStore.removeFeatures(fidFilter);
+    fids.remove(feature.getID());
+
+    assertEquals(fids.size(), featureStore.getCount(Query.ALL));
+
+    features = featureStore.getFeatures(fidFilter).features();
+    try {
+      assertFalse(features.hasNext());
+    } finally {
+      if (features != null) {
+        features.close();
+      }
     }
 
-    @After
-    public void dispose() throws Exception {
-        ds.dispose();
+    this.assertFidsMatch();
+  }
+
+  /**
+   * Attempt to test GEOT-5830 User reports that deleting a feature, re-requesting the data gives a
+   * duplicate FID and the subsequent attempt to delete fails due to corrupt FIX
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testDeleteCloseAndRerequestFID() throws Exception {
+    SimpleFeature feature;
+    SimpleFeatureCollection allfeatures = featureStore.getFeatures();
+    int size = allfeatures.size();
+    try (SimpleFeatureIterator features = allfeatures.features()) {
+      feature = features.next();
     }
+    FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+    Id fidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
 
-    @Test
-    public void testGetByFID() throws Exception {
-        assertFidsMatch();
+    featureStore.removeFeatures(fidFilter);
+    fids.remove(feature.getID());
+    assertEquals((size-1), featureStore.getCount(Query.ALL));
+    assertEquals(fids.size(), featureStore.getCount(Query.ALL));
+
+    featureStore.getDataStore().dispose();
+    URL url = backshp.toURI().toURL();
+    ds = new ShapefileDataStore(url);
+    numFeatures = 0;
+    featureStore = (SimpleFeatureStore) ds.getFeatureSource();
+    assertEquals((size-1), featureStore.getCount(Query.ALL));
+    
+    SimpleFeatureCollection features2 = featureStore.getFeatures(fidFilter);
+    assertEquals("wrong number of features", 0, features2.size());
+    try (SimpleFeatureIterator features = features2.features()) {
+      assertFalse("found fid", features.hasNext());
     }
+    
+    // when we fetch the features again the first feature is archsites.1 again!
+    // yet the IndexedShapeReader tries very hard to avoid this!
+    try (SimpleFeatureIterator features = allfeatures.features()) {
 
-    @Test
-    public void testAddFeature() throws Exception {
-        SimpleFeature feature = fids.values().iterator().next();
-        SimpleFeatureType schema = ds.getSchema();
+      SimpleFeature f = (SimpleFeature) features.next();
+      assertFalse(fidFilter.evaluate(f));
+    }
+    // but not if we use the fid filter
+    features2 = featureStore.getFeatures(fidFilter);
+    assertEquals("wrong number of features", 0, features2.size());
+    try (SimpleFeatureIterator features = features2.features()) {
+      assertFalse("found fid", features.hasNext());
+    }
+    this.assertFidsMatch();
+  }
 
-        SimpleFeatureBuilder build = new SimpleFeatureBuilder(schema);
-        GeometryFactory gf = new GeometryFactory();
-        build.add(gf.createPoint((new Coordinate(0, 0))));
-        build.add(Long.valueOf(0));
-        build.add(Long.valueOf(0));
-        build.add("Hey");
-        SimpleFeature newFeature = build.buildFeature(null);
-        DefaultFeatureCollection collection = new DefaultFeatureCollection();
-        collection.add(newFeature);
+  private void assertFidsMatch() throws IOException {
+    // long start = System.currentTimeMillis();
+    Query query = new Query(featureStore.getSchema().getTypeName());
 
-        List<FeatureId> newFids = featureStore.addFeatures(collection);
-        assertEquals(1, newFids.size());
-        // this.assertFidsMatch();
+    int i = 0;
 
-        Query query = new Query(schema.getTypeName());
-        FeatureId id = newFids.iterator().next();
-        String fid = id.getID();
-
-        Filter filter = fac.id(Collections.singleton(id));
-        query.setFilter(filter);
-        SimpleFeatureIterator features = featureStore.getFeatures(query).features();
-        try {
-            feature = features.next();
-            for (int i = 0; i < schema.getAttributeCount(); i++) {
-                Object value = feature.getAttribute(i);
-                Object newValue = newFeature.getAttribute(i);
-                assertEquals(newValue, value);
-            }
-            assertFalse(features.hasNext());
-        } finally {
-            if (features != null) features.close();
+    for (Iterator iter = fids.entrySet().iterator(); iter.hasNext(); ) {
+      i++;
+      Map.Entry entry = (Map.Entry) iter.next();
+      String fid = (String) entry.getKey();
+      FeatureId id = fac.featureId(fid);
+      Filter filter = fac.id(Collections.singleton(id));
+      query.setFilter(filter);
+      SimpleFeatureIterator features = null;
+      try {
+        features = featureStore.getFeatures(query).features();
+        assertTrue("Missing feature for fid " + fid, features.hasNext());
+        SimpleFeature feature = features.next();
+        assertFalse("More than one feature with fid " + fid, features.hasNext());
+        assertEquals(i + "th feature", entry.getValue(), feature);
+      } finally {
+        if (features != null) {
+          features.close();
         }
+      }
     }
-
-    @Test
-    public void testModifyFeature() throws Exception {
-        SimpleFeature feature = this.fids.values().iterator().next();
-        int newId = 237594123;
-
-        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
-
-        Id createFidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
-
-        SimpleFeatureType schema = feature.getFeatureType();
-        featureStore.modifyFeatures(
-                schema.getDescriptor("ID"), Integer.valueOf(newId), createFidFilter);
-
-        SimpleFeatureIterator features = featureStore.getFeatures(createFidFilter).features();
-        try {
-            assertFalse(feature.equals(features.next()));
-        } finally {
-            if (features != null) {
-                features.close();
-            }
-        }
-        feature.setAttribute("ID", Integer.valueOf(newId));
-        this.assertFidsMatch();
-    }
-
-    @Test
-    public void testDeleteFeature() throws Exception {
-        SimpleFeatureIterator features = featureStore.getFeatures().features();
-        SimpleFeature feature;
-        try {
-            feature = features.next();
-        } finally {
-            if (features != null) {
-                features.close();
-            }
-        }
-        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
-        Id fidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
-
-        featureStore.removeFeatures(fidFilter);
-        fids.remove(feature.getID());
-
-        assertEquals(fids.size(), featureStore.getCount(Query.ALL));
-
-        features = featureStore.getFeatures(fidFilter).features();
-        try {
-            assertFalse(features.hasNext());
-        } finally {
-            if (features != null) {
-                features.close();
-            }
-        }
-
-        this.assertFidsMatch();
-    }
-
-    private void assertFidsMatch() throws IOException {
-        // long start = System.currentTimeMillis();
-        Query query = new Query(featureStore.getSchema().getTypeName());
-
-        int i = 0;
-
-        for (Iterator iter = fids.entrySet().iterator(); iter.hasNext(); ) {
-            i++;
-            Map.Entry entry = (Map.Entry) iter.next();
-            String fid = (String) entry.getKey();
-            FeatureId id = fac.featureId(fid);
-            Filter filter = fac.id(Collections.singleton(id));
-            query.setFilter(filter);
-            SimpleFeatureIterator features = null;
-            try {
-                features = featureStore.getFeatures(query).features();
-                assertTrue("Missing feature for fid " + fid, features.hasNext());
-                SimpleFeature feature = features.next();
-                assertFalse("More than one feature with fid " + fid, features.hasNext());
-                assertEquals(i + "th feature", entry.getValue(), feature);
-            } finally {
-                if (features != null) {
-                    features.close();
-                }
-            }
-        }
-    }
+  }
 }

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/fid/FidQueryTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/fid/FidQueryTest.java
@@ -219,7 +219,7 @@ public class FidQueryTest extends FIDTestCase {
         try (SimpleFeatureIterator features = features2.features()) {
             assertFalse("found fid", features.hasNext());
         }
-
+        // refresh the features using the new datastore
         allfeatures = featureStore.getFeatures();
         try (SimpleFeatureIterator features = allfeatures.features()) {
 

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/fid/FidQueryTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/fid/FidQueryTest.java
@@ -19,6 +19,7 @@ package org.geotools.data.shapefile.fid;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
@@ -48,218 +49,218 @@ import org.opengis.filter.identity.FeatureId;
 
 public class FidQueryTest extends FIDTestCase {
 
-  private ShapefileDataStore ds;
+    private ShapefileDataStore ds;
 
-  private static final FilterFactory2 fac = CommonFactoryFinder.getFilterFactory2(null);
+    private static final FilterFactory2 fac = CommonFactoryFinder.getFilterFactory2(null);
 
-  Map<String, SimpleFeature> fids = new HashMap<String, SimpleFeature>();
+    Map<String, SimpleFeature> fids = new HashMap<String, SimpleFeature>();
 
-  SimpleFeatureStore featureStore;
+    SimpleFeatureStore featureStore;
 
-  private int numFeatures;
+    private int numFeatures;
 
-  @Before
-  public void setUpFixQueryTest() throws Exception {
-    URL url = backshp.toURI().toURL();
-    ds = new ShapefileDataStore(url);
-    numFeatures = 0;
-    featureStore = (SimpleFeatureStore) ds.getFeatureSource();
-    {
-      SimpleFeatureIterator features = featureStore.getFeatures().features();
-      try {
-        while (features.hasNext()) {
-          numFeatures++;
-          SimpleFeature feature = features.next();
-          fids.put(feature.getID(), feature);
+    @Before
+    public void setUpFixQueryTest() throws Exception {
+        URL url = backshp.toURI().toURL();
+        ds = new ShapefileDataStore(url);
+        numFeatures = 0;
+        featureStore = (SimpleFeatureStore) ds.getFeatureSource();
+        {
+            SimpleFeatureIterator features = featureStore.getFeatures().features();
+            try {
+                while (features.hasNext()) {
+                    numFeatures++;
+                    SimpleFeature feature = features.next();
+                    fids.put(feature.getID(), feature);
+                }
+            } finally {
+                if (features != null) features.close();
+            }
+            assertEquals(numFeatures, fids.size());
         }
-      } finally {
-        if (features != null) features.close();
-      }
-      assertEquals(numFeatures, fids.size());
-    }
-  }
-
-  @After
-  public void dispose() throws Exception {
-    ds.dispose();
-  }
-
-  @Test
-  public void testGetByFID() throws Exception {
-    assertFidsMatch();
-  }
-
-  @Test
-  public void testAddFeature() throws Exception {
-    SimpleFeature feature = fids.values().iterator().next();
-    SimpleFeatureType schema = ds.getSchema();
-
-    SimpleFeatureBuilder build = new SimpleFeatureBuilder(schema);
-    GeometryFactory gf = new GeometryFactory();
-    build.add(gf.createPoint((new Coordinate(0, 0))));
-    build.add(Long.valueOf(0));
-    build.add(Long.valueOf(0));
-    build.add("Hey");
-    SimpleFeature newFeature = build.buildFeature(null);
-    DefaultFeatureCollection collection = new DefaultFeatureCollection();
-    collection.add(newFeature);
-
-    List<FeatureId> newFids = featureStore.addFeatures(collection);
-    assertEquals(1, newFids.size());
-    // this.assertFidsMatch();
-
-    Query query = new Query(schema.getTypeName());
-    FeatureId id = newFids.iterator().next();
-    String fid = id.getID();
-
-    Filter filter = fac.id(Collections.singleton(id));
-    query.setFilter(filter);
-    SimpleFeatureIterator features = featureStore.getFeatures(query).features();
-    try {
-      feature = features.next();
-      for (int i = 0; i < schema.getAttributeCount(); i++) {
-        Object value = feature.getAttribute(i);
-        Object newValue = newFeature.getAttribute(i);
-        assertEquals(newValue, value);
-      }
-      assertFalse(features.hasNext());
-    } finally {
-      if (features != null) features.close();
-    }
-  }
-
-  @Test
-  public void testModifyFeature() throws Exception {
-    SimpleFeature feature = this.fids.values().iterator().next();
-    int newId = 237594123;
-
-    FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
-
-    Id createFidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
-
-    SimpleFeatureType schema = feature.getFeatureType();
-    featureStore.modifyFeatures(
-        schema.getDescriptor("ID"), Integer.valueOf(newId), createFidFilter);
-
-    SimpleFeatureIterator features = featureStore.getFeatures(createFidFilter).features();
-    try {
-      assertFalse(feature.equals(features.next()));
-    } finally {
-      if (features != null) {
-        features.close();
-      }
-    }
-    feature.setAttribute("ID", Integer.valueOf(newId));
-    this.assertFidsMatch();
-  }
-
-  @Test
-  public void testDeleteFeature() throws Exception {
-    SimpleFeatureIterator features = featureStore.getFeatures().features();
-    SimpleFeature feature;
-    try {
-      feature = features.next();
-    } finally {
-      if (features != null) {
-        features.close();
-      }
-    }
-    FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
-    Id fidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
-
-    featureStore.removeFeatures(fidFilter);
-    fids.remove(feature.getID());
-
-    assertEquals(fids.size(), featureStore.getCount(Query.ALL));
-
-    features = featureStore.getFeatures(fidFilter).features();
-    try {
-      assertFalse(features.hasNext());
-    } finally {
-      if (features != null) {
-        features.close();
-      }
     }
 
-    this.assertFidsMatch();
-  }
-
-  /**
-   * Attempt to test GEOT-5830 User reports that deleting a feature, re-requesting the data gives a
-   * duplicate FID and the subsequent attempt to delete fails due to corrupt FIX
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testDeleteCloseAndRerequestFID() throws Exception {
-    SimpleFeature feature;
-    SimpleFeatureCollection allfeatures = featureStore.getFeatures();
-    int size = allfeatures.size();
-    try (SimpleFeatureIterator features = allfeatures.features()) {
-      feature = features.next();
+    @After
+    public void dispose() throws Exception {
+        ds.dispose();
     }
-    FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
-    Id fidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
 
-    featureStore.removeFeatures(fidFilter);
-    fids.remove(feature.getID());
-    assertEquals((size-1), featureStore.getCount(Query.ALL));
-    assertEquals(fids.size(), featureStore.getCount(Query.ALL));
-
-    featureStore.getDataStore().dispose();
-    URL url = backshp.toURI().toURL();
-    ds = new ShapefileDataStore(url);
-    numFeatures = 0;
-    featureStore = (SimpleFeatureStore) ds.getFeatureSource();
-    assertEquals((size-1), featureStore.getCount(Query.ALL));
-    
-    SimpleFeatureCollection features2 = featureStore.getFeatures(fidFilter);
-    assertEquals("wrong number of features", 0, features2.size());
-    try (SimpleFeatureIterator features = features2.features()) {
-      assertFalse("found fid", features.hasNext());
+    @Test
+    public void testGetByFID() throws Exception {
+        assertFidsMatch();
     }
-    
-    // when we fetch the features again the first feature is archsites.1 again!
-    // yet the IndexedShapeReader tries very hard to avoid this!
-    try (SimpleFeatureIterator features = allfeatures.features()) {
 
-      SimpleFeature f = (SimpleFeature) features.next();
-      assertFalse(fidFilter.evaluate(f));
-    }
-    // but not if we use the fid filter
-    features2 = featureStore.getFeatures(fidFilter);
-    assertEquals("wrong number of features", 0, features2.size());
-    try (SimpleFeatureIterator features = features2.features()) {
-      assertFalse("found fid", features.hasNext());
-    }
-    this.assertFidsMatch();
-  }
+    @Test
+    public void testAddFeature() throws Exception {
+        SimpleFeature feature = fids.values().iterator().next();
+        SimpleFeatureType schema = ds.getSchema();
 
-  private void assertFidsMatch() throws IOException {
-    // long start = System.currentTimeMillis();
-    Query query = new Query(featureStore.getSchema().getTypeName());
+        SimpleFeatureBuilder build = new SimpleFeatureBuilder(schema);
+        GeometryFactory gf = new GeometryFactory();
+        build.add(gf.createPoint((new Coordinate(0, 0))));
+        build.add(Long.valueOf(0));
+        build.add(Long.valueOf(0));
+        build.add("Hey");
+        SimpleFeature newFeature = build.buildFeature(null);
+        DefaultFeatureCollection collection = new DefaultFeatureCollection();
+        collection.add(newFeature);
 
-    int i = 0;
+        List<FeatureId> newFids = featureStore.addFeatures(collection);
+        assertEquals(1, newFids.size());
+        // this.assertFidsMatch();
 
-    for (Iterator iter = fids.entrySet().iterator(); iter.hasNext(); ) {
-      i++;
-      Map.Entry entry = (Map.Entry) iter.next();
-      String fid = (String) entry.getKey();
-      FeatureId id = fac.featureId(fid);
-      Filter filter = fac.id(Collections.singleton(id));
-      query.setFilter(filter);
-      SimpleFeatureIterator features = null;
-      try {
-        features = featureStore.getFeatures(query).features();
-        assertTrue("Missing feature for fid " + fid, features.hasNext());
-        SimpleFeature feature = features.next();
-        assertFalse("More than one feature with fid " + fid, features.hasNext());
-        assertEquals(i + "th feature", entry.getValue(), feature);
-      } finally {
-        if (features != null) {
-          features.close();
+        Query query = new Query(schema.getTypeName());
+        FeatureId id = newFids.iterator().next();
+        String fid = id.getID();
+
+        Filter filter = fac.id(Collections.singleton(id));
+        query.setFilter(filter);
+        SimpleFeatureIterator features = featureStore.getFeatures(query).features();
+        try {
+            feature = features.next();
+            for (int i = 0; i < schema.getAttributeCount(); i++) {
+                Object value = feature.getAttribute(i);
+                Object newValue = newFeature.getAttribute(i);
+                assertEquals(newValue, value);
+            }
+            assertFalse(features.hasNext());
+        } finally {
+            if (features != null) features.close();
         }
-      }
     }
-  }
+
+    @Test
+    public void testModifyFeature() throws Exception {
+        SimpleFeature feature = this.fids.values().iterator().next();
+        int newId = 237594123;
+
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+
+        Id createFidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
+
+        SimpleFeatureType schema = feature.getFeatureType();
+        featureStore.modifyFeatures(
+                schema.getDescriptor("ID"), Integer.valueOf(newId), createFidFilter);
+
+        SimpleFeatureIterator features = featureStore.getFeatures(createFidFilter).features();
+        try {
+            assertFalse(feature.equals(features.next()));
+        } finally {
+            if (features != null) {
+                features.close();
+            }
+        }
+        feature.setAttribute("ID", Integer.valueOf(newId));
+        this.assertFidsMatch();
+    }
+
+    @Test
+    public void testDeleteFeature() throws Exception {
+        SimpleFeatureIterator features = featureStore.getFeatures().features();
+        SimpleFeature feature;
+        try {
+            feature = features.next();
+        } finally {
+            if (features != null) {
+                features.close();
+            }
+        }
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        Id fidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
+
+        featureStore.removeFeatures(fidFilter);
+        fids.remove(feature.getID());
+
+        assertEquals(fids.size(), featureStore.getCount(Query.ALL));
+
+        features = featureStore.getFeatures(fidFilter).features();
+        try {
+            assertFalse(features.hasNext());
+        } finally {
+            if (features != null) {
+                features.close();
+            }
+        }
+
+        this.assertFidsMatch();
+    }
+
+    /**
+     * Attempt to test GEOT-5830 User reports that deleting a feature, re-requesting the data gives
+     * a duplicate FID and the subsequent attempt to delete fails due to corrupt FIX
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDeleteCloseAndRerequestFID() throws Exception {
+        SimpleFeature feature;
+        SimpleFeatureCollection allfeatures = featureStore.getFeatures();
+        int size = allfeatures.size();
+        try (SimpleFeatureIterator features = allfeatures.features()) {
+            feature = features.next();
+        }
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        Id fidFilter = ff.id(Collections.singleton(ff.featureId(feature.getID())));
+
+        featureStore.removeFeatures(fidFilter);
+        fids.remove(feature.getID());
+        assertEquals((size - 1), featureStore.getCount(Query.ALL));
+        assertEquals(fids.size(), featureStore.getCount(Query.ALL));
+
+        featureStore.getDataStore().dispose();
+        URL url = backshp.toURI().toURL();
+        ds = new ShapefileDataStore(url);
+        numFeatures = 0;
+        featureStore = (SimpleFeatureStore) ds.getFeatureSource();
+        assertEquals((size - 1), featureStore.getCount(Query.ALL));
+
+        SimpleFeatureCollection features2 = featureStore.getFeatures(fidFilter);
+        assertEquals("wrong number of features", 0, features2.size());
+        try (SimpleFeatureIterator features = features2.features()) {
+            assertFalse("found fid", features.hasNext());
+        }
+
+        // when we fetch the features again the first feature is archsites.1 again!
+        // yet the IndexedShapeReader tries very hard to avoid this!
+        try (SimpleFeatureIterator features = allfeatures.features()) {
+
+            SimpleFeature f = (SimpleFeature) features.next();
+            assertFalse(fidFilter.evaluate(f));
+        }
+        // but not if we use the fid filter
+        features2 = featureStore.getFeatures(fidFilter);
+        assertEquals("wrong number of features", 0, features2.size());
+        try (SimpleFeatureIterator features = features2.features()) {
+            assertFalse("found fid", features.hasNext());
+        }
+        this.assertFidsMatch();
+    }
+
+    private void assertFidsMatch() throws IOException {
+        // long start = System.currentTimeMillis();
+        Query query = new Query(featureStore.getSchema().getTypeName());
+
+        int i = 0;
+
+        for (Iterator iter = fids.entrySet().iterator(); iter.hasNext(); ) {
+            i++;
+            Map.Entry entry = (Map.Entry) iter.next();
+            String fid = (String) entry.getKey();
+            FeatureId id = fac.featureId(fid);
+            Filter filter = fac.id(Collections.singleton(id));
+            query.setFilter(filter);
+            SimpleFeatureIterator features = null;
+            try {
+                features = featureStore.getFeatures(query).features();
+                assertTrue("Missing feature for fid " + fid, features.hasNext());
+                SimpleFeature feature = features.next();
+                assertFalse("More than one feature with fid " + fid, features.hasNext());
+                assertEquals(i + "th feature", entry.getValue(), feature);
+            } finally {
+                if (features != null) {
+                    features.close();
+                }
+            }
+        }
+    }
 }

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/fid/FidQueryTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/fid/FidQueryTest.java
@@ -220,14 +220,13 @@ public class FidQueryTest extends FIDTestCase {
             assertFalse("found fid", features.hasNext());
         }
 
-        // when we fetch the features again the first feature is archsites.1 again!
-        // yet the IndexedShapeReader tries very hard to avoid this!
+        allfeatures = featureStore.getFeatures();
         try (SimpleFeatureIterator features = allfeatures.features()) {
 
             SimpleFeature f = (SimpleFeature) features.next();
             assertFalse(fidFilter.evaluate(f));
         }
-        // but not if we use the fid filter
+
         features2 = featureStore.getFeatures(fidFilter);
         assertEquals("wrong number of features", 0, features2.size());
         try (SimpleFeatureIterator features = features2.features()) {


### PR DESCRIPTION
See [GEOT-5830](https://osgeo-org.atlassian.net/projects/GEOT/issues/GEOT-5830) for an explanation of the issue.