### PR TITLE
gt-jdbc-hana: Support connections to cloud instances

### DIFF
--- a/docs/user/library/jdbc/hana.rst
+++ b/docs/user/library/jdbc/hana.rst
@@ -5,10 +5,11 @@ Supports direct access to a HANA database.
 
 A free version of HANA (HANA Express Edition) can be downloaded at the link below.
 
-You need HANA's JDBC driver ``ngdbc.jar`` to connect to HANA. Its license does not allow redistribution, so you have to download it separately. It is part of HANA Express Edition.
+You need HANA's JDBC driver ``ngdbc.jar`` to connect to HANA. Its license does not allow redistribution, so you have to download it separately. It can be downloaded from SAP's Development Tools site and is also part of HANA Express Edition.
 
 **References**
 
+* https://tools.hana.ondemand.com/#hanatools
 * https://www.sap.com/cmp/ft/crm-xu16-dat-hddedft/index.html
 
 **Maven**
@@ -31,11 +32,13 @@ Parameter      Description
 ============== ============================================
 "dbtype"       Must be the string "hana"
 "host"         Machine name or IP address to connect to
-"instance"     Instance of the database
-"database"     Database to connect to. Leave empty in case of single-container databases. Set to ``SYSTEMDB`` to connect to the system database of a multi-container database.
+"port"         Port to connect to. If set and different from 0, parameters "instance" and "database" are ignored. If not set or 0, the "instance" parameter must be set.
+"instance"     Instance of the database. Ignored if a port is set.
+"database"     Database to connect to. Leave empty in case of single-container databases. Set to ``SYSTEMDB`` to connect to the system database of a multi-container database. Ignored if a port is set.
 "schema"       The database schema to access
 "user"         User name
 "passwd"       Password
+"use ssl"      Use SSL to connect
 ============== ============================================
 
 Creating
@@ -74,10 +77,18 @@ On Windows::
 
   java -cp <path to gt-jdbc-hana.jar>;<path to ngdbc.jar> \
     org.geotools.data.hana.metadata.MetadataImport \
-    <username> <host> <instance> [<dbname>]
+    <username> <host> <instance> [<dbname>] [--ssl]
+
+  java -cp <path to gt-jdbc-hana.jar>;<path to ngdbc.jar> \
+    org.geotools.data.hana.metadata.MetadataImport \
+    <username> <host>:<port> [--ssl]
 
 On Linux and Mac::
 
   java -cp <path to gt-jdbc-hana.jar>:<path to ngdbc.jar> \
     org.geotools.data.hana.metadata.MetadataImport \
-    <username> <host> <instance> [<dbname>]
+    <username> <host> <instance> [<dbname>] [--ssl]
+
+  java -cp <path to gt-jdbc-hana.jar>:<path to ngdbc.jar> \
+    org.geotools.data.hana.metadata.MetadataImport \
+    <username> <host>:<port> [--ssl]

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaJNDIDataSourceOnlineTest.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaJNDIDataSourceOnlineTest.java
@@ -46,6 +46,7 @@ public class HanaJNDIDataSourceOnlineTest extends JDBCJNDIDataSourceOnlineTest {
         standardParams.remove(JDBCDataStoreFactory.VALIDATECONN.key);
         standardParams.remove(JDBCDataStoreFactory.MAX_OPEN_PREPARED_STATEMENTS.key);
         standardParams.remove(HanaDataStoreFactory.INSTANCE.key);
+        standardParams.remove(HanaDataStoreFactory.USE_SSL.key);
         standardParams.removeAll(baseParams);
         List<String> baseJndiParams = getBaseJNDIParams();
         List<String> jndiParams = getParamKeys(getJNDIStoreFactory());

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/metadata/CommandLineArgumentsTest.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/metadata/CommandLineArgumentsTest.java
@@ -18,32 +18,81 @@ package org.geotools.data.hana.metadata;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Map;
 import junit.framework.TestCase;
 import org.geotools.data.hana.HanaConnectionParameters;
 
 /** @author Stefan Uhrig, SAP SE */
 public class CommandLineArgumentsTest extends TestCase {
 
-    public void testValidArgs() {
+    public void testValidArgsUsePort() {
+        String[] args = {"user", "host:1234"};
+        CommandLineArguments cla = CommandLineArguments.parse(args);
+        assertNotNull(cla);
+        assertEquals("user", cla.getUser());
+        HanaConnectionParameters hcp = cla.getConnectionParameters();
+        assertEquals("host", hcp.getHost());
+        assertEquals(1234, hcp.getPort().intValue());
+    }
+
+    public void testValidArgsUsePortSsl() {
+        String[] args = {"user", "host:1234", "--ssl"};
+        CommandLineArguments cla = CommandLineArguments.parse(args);
+        assertNotNull(cla);
+        assertEquals("user", cla.getUser());
+        HanaConnectionParameters hcp = cla.getConnectionParameters();
+        assertEquals("host", hcp.getHost());
+        assertEquals(1234, hcp.getPort().intValue());
+        Map<String, String> options = hcp.getAdditionalOptions();
+        assertEquals("true", options.get("encrypt"));
+    }
+
+    public void testValidArgsSingleContainer() {
         String[] args = {"user", "host", "0"};
         CommandLineArguments cla = CommandLineArguments.parse(args);
         assertNotNull(cla);
         assertEquals("user", cla.getUser());
         HanaConnectionParameters hcp = cla.getConnectionParameters();
         assertEquals("host", hcp.getHost());
-        assertEquals(0, hcp.getInstance());
-        assertNull(hcp.getDatabase());
+        Map<String, String> options = hcp.getAdditionalOptions();
+        assertEquals("0", options.get("instanceNumber"));
     }
 
-    public void testValidArgsWithDatabase() {
+    public void testValidArgsSingleContainerSsl() {
+        String[] args = {"user", "host", "0", "--ssl"};
+        CommandLineArguments cla = CommandLineArguments.parse(args);
+        assertNotNull(cla);
+        assertEquals("user", cla.getUser());
+        HanaConnectionParameters hcp = cla.getConnectionParameters();
+        assertEquals("host", hcp.getHost());
+        Map<String, String> options = hcp.getAdditionalOptions();
+        assertEquals("0", options.get("instanceNumber"));
+        assertEquals("true", options.get("encrypt"));
+    }
+
+    public void testValidArgsMultiContainer() {
         String[] args = {"user", "host", "0", "DTB"};
         CommandLineArguments cla = CommandLineArguments.parse(args);
         assertNotNull(cla);
         assertEquals("user", cla.getUser());
         HanaConnectionParameters hcp = cla.getConnectionParameters();
         assertEquals("host", hcp.getHost());
-        assertEquals(0, hcp.getInstance());
-        assertEquals("DTB", hcp.getDatabase());
+        Map<String, String> options = hcp.getAdditionalOptions();
+        assertEquals("0", options.get("instanceNumber"));
+        assertEquals("DTB", options.get("databaseName"));
+    }
+
+    public void testValidArgsMultiContainerSsl() {
+        String[] args = {"user", "host", "0", "DTB", "--ssl"};
+        CommandLineArguments cla = CommandLineArguments.parse(args);
+        assertNotNull(cla);
+        assertEquals("user", cla.getUser());
+        HanaConnectionParameters hcp = cla.getConnectionParameters();
+        assertEquals("host", hcp.getHost());
+        Map<String, String> options = hcp.getAdditionalOptions();
+        assertEquals("0", options.get("instanceNumber"));
+        assertEquals("DTB", options.get("databaseName"));
+        assertEquals("true", options.get("encrypt"));
     }
 
     public void testInvalidArgs() {


### PR DESCRIPTION
HANA connection parameters have been extended by port number and a
switch to enable encryption to support connections to HANA cloud
instances.