### PR TITLE
FIX GEOT-6284 : IllegalArgumentException on DescribeFeatureTypeResponse

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
@@ -50,7 +50,7 @@ public class DescribeFeatureTypeResponse extends WFSResponse {
 
         InputStream responseStream = httpResponse.getResponseStream();
         try {
-            File tmpSchemaFile = File.createTempFile(remoteTypeName.getLocalPart(), ".xsd");
+            File tmpSchemaFile = File.createTempFile(remoteTypeName.getLocalPart() + System.currentTimeMillis(), ".xsd");
             OutputStream output = new BufferedOutputStream(new FileOutputStream(tmpSchemaFile));
             try {
                 IOUtils.copy(responseStream, output);

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
@@ -50,7 +50,9 @@ public class DescribeFeatureTypeResponse extends WFSResponse {
 
         InputStream responseStream = httpResponse.getResponseStream();
         try {
-            File tmpSchemaFile = File.createTempFile(remoteTypeName.getLocalPart() + System.currentTimeMillis(), ".xsd");
+            File tmpSchemaFile =
+                    File.createTempFile(
+                            remoteTypeName.getLocalPart() + System.currentTimeMillis(), ".xsd");
             OutputStream output = new BufferedOutputStream(new FileOutputStream(tmpSchemaFile));
             try {
                 IOUtils.copy(responseStream, output);


### PR DESCRIPTION
We have an IllegalArgumentException on a DescribeFeatureTypeResponse when type name size is less than 3 :

java.lang.IllegalArgumentException: Prefix string too short
at java.io.File.createTempFile(Unknown Source)
at java.io.File.createTempFile(Unknown Source)
at org.geotools.data.wfs.internal.DescribeFeatureTypeResponse.<init>(DescribeFeatureTypeResponse.java:53)
at org.geotools.data.wfs.internal.parsers.DescribeFeatureTypeResponseFactory.createResponse(DescribeFeatureTypeResponseFactory.java:70)
at org.geotools.data.wfs.internal.WFSRequest.createResponse(WFSRequest.java:215)
at org.geotools.data.wfs.internal.WFSRequest.createResponse(WFSRequest.java:36)
at org.geotools.data.ows.AbstractOpenWebService.internalIssueRequest(AbstractOpenWebService.java:441)
at org.geotools.data.wfs.internal.WFSClient.internalIssueRequest(WFSClient.java:313)
at org.geotools.data.wfs.internal.WFSClient.issueRequest(WFSClient.java:374)
at org.geotools.data.wfs.WFSDataStore.getRemoteFeatureType(WFSDataStore.java:206)
at org.geotools.data.wfs.WFSDataStore.getRemoteSimpleFeatureType(WFSDataStore.java:262)
at org.geotools.data.wfs.WFSFeatureSource.buildFeatureType(WFSFeatureSource.java:364)
at org.geotools.data.wfs.WFSFeatureStore.buildFeatureType(WFSFeatureStore.java:106)
at org.geotools.data.store.ContentFeatureSource.getAbsoluteSchema(ContentFeatureSource.java:327)
at org.geotools.data.store.ContentFeatureSource.getSchema(ContentFeatureSource.java:296)
at org.geotools.data.store.ContentDataStore.getSchema(ContentDataStore.java:291)

Extract from javadoc for function createTempFile" : "The prefix argument must be at least three characters long"