### PR TITLE
[GEOT-6284] make sure tempfile prefix is longer than 3 chars

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
@@ -50,7 +50,14 @@ public class DescribeFeatureTypeResponse extends WFSResponse {
 
         InputStream responseStream = httpResponse.getResponseStream();
         try {
-            File tmpSchemaFile = File.createTempFile(remoteTypeName.getLocalPart(), ".xsd");
+            String prefix = remoteTypeName.getLocalPart();
+            if (prefix.length() < 3) {
+                /*
+                 * CreateTempFile will throw an exception if the prefix is less that 3 chars long
+                 */
+                prefix += "zzz";
+            }
+            File tmpSchemaFile = File.createTempFile(prefix, ".xsd");
             OutputStream output = new BufferedOutputStream(new FileOutputStream(tmpSchemaFile));
             try {
                 IOUtils.copy(responseStream, output);


### PR DESCRIPTION
No test as I can't find any evidence we have ever tested DescribeFeatureTypeResponse in GeoTools, GeoServer still works after this change.