### PR TITLE
[GEOT-6088] - Subsampling enabled irrespective of OverViews for grids

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverage2DReader.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverage2DReader.java
@@ -360,10 +360,19 @@ public abstract class AbstractGridCoverage2DReader implements GridCoverage2DRead
 
         // //
         //
-        // default values for subsampling
+        // Resolution requested. I am here computing the resolution required by
+        // the user.
         //
-        // //
-        readP.setSourceSubsampling(1, 1, 0, 0);
+        double[] requestedRes =
+                getResolution(
+                        requestedEnvelope,
+                        requestedDim,
+                        getCoordinateReferenceSystem(coverageName));
+
+        // Decimation on reading (done here because it alters the read params allowing subsampling)
+        decimationOnReadingControl(coverageName, imageChoice, readP, requestedRes);
+
+        if (requestedRes == null) return imageChoice;
 
         // //
         //
@@ -383,29 +392,20 @@ public abstract class AbstractGridCoverage2DReader implements GridCoverage2DRead
 
         // //
         //
-        // Resolution requested. I am here computing the resolution required by
-        // the user.
-        //
-        // //
-        double[] requestedRes =
-                getResolution(
-                        requestedEnvelope,
-                        requestedDim,
-                        getCoordinateReferenceSystem(coverageName));
-        if (requestedRes == null) return imageChoice;
-
-        // //
-        //
         // overviews or decimation
         //
         // //
-        if (useOverviews)
-            imageChoice = pickOverviewLevel(coverageName, overviewPolicy, requestedRes);
+        if (useOverviews) {
+            int newImageChoice = pickOverviewLevel(coverageName, overviewPolicy, requestedRes);
 
-        // /////////////////////////////////////////////////////////////////////
-        // DECIMATION ON READING
-        // /////////////////////////////////////////////////////////////////////
-        decimationOnReadingControl(coverageName, imageChoice, readP, requestedRes);
+            // if image choice has changed due to using overviews, recalculate subsamping factors
+            if (imageChoice != newImageChoice) {
+                imageChoice = newImageChoice; // update
+                // recalculate subsampling factors if overview number has changed
+                decimationOnReadingControl(coverageName, imageChoice, readP, requestedRes);
+            }
+        }
+
         return imageChoice;
     }
 
@@ -656,6 +656,16 @@ public abstract class AbstractGridCoverage2DReader implements GridCoverage2DRead
                 subSamplingFactorY = subSamplingFactorY == 0 ? 1 : subSamplingFactorY;
 
                 readP.setSourceSubsampling(subSamplingFactorX, subSamplingFactorY, 0, 0);
+
+                if (LOGGER.isLoggable(Level.FINE))
+                    LOGGER.log(
+                            Level.FINE,
+                            String.format(
+                                    "coverageName:%s,imageChoice:%d,subSamplingFactorX:%d,subSamplingFactorY:%d",
+                                    coverageName,
+                                    imageChoice.intValue(),
+                                    subSamplingFactorX,
+                                    subSamplingFactorY));
             }
         }
     }

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTest.java
@@ -18,11 +18,15 @@ package org.geotools.coverage.grid;
 
 import static org.junit.Assert.*;
 
+import java.awt.Rectangle;
 import java.io.IOException;
 import java.net.InetAddress;
+import javax.imageio.ImageReadParam;
+import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.*;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.TransformException;
 
 /**
  * Tests the {@link GridCoverage2D} implementation.
@@ -71,5 +75,41 @@ public final class GridCoverageTest extends GridCoverageTestBase {
             assertEquals(GridCoverage2D.class, serial.getClass());
             assertRasterEquals(coverage, serial);
         }
+    }
+
+    @Test
+    public void testSubSampling() throws IllegalArgumentException, IOException, TransformException {
+
+        GridCoverage2D coverage = EXAMPLES.get(2);
+
+        MockAbstractGridCoverage2DReader reader = new MockAbstractGridCoverage2DReader();
+
+        reader.setOetOriginalGridRange(new GridEnvelope2D(new Rectangle(700, 400)));
+        reader.setHighestResolution(0.5, 0.5);
+        reader.setCRS(coverage.getCoordinateReferenceSystem());
+        ImageReadParam readP = new ImageReadParam();
+        Rectangle requestedDim = new Rectangle(700, 400);
+
+        // TEST WHEN NO SUBSAMPLING IS REQUIRED
+        GeneralEnvelope requestedEnvelope = coverage.gridGeometry.envelope;
+        // requestedEnvelope.setEnvelope(-517.2704081632651, -353.2270408163266, 697.7295918367349,
+        // 350.3571428571428);
+        reader.setReadParams("geotools_coverage", null, readP, requestedEnvelope, requestedDim);
+        assertNotNull(readP);
+        // 1 means no subsampling and no pixel skipping
+        assertTrue(readP.getSourceXSubsampling() == 1);
+        assertTrue(readP.getSourceYSubsampling() == 1);
+
+        // MOCK ZOOMOUT TO FORCE SUBSAMPLING
+        GeneralEnvelope requestedEnvelopeZoomOut = coverage.gridGeometry.envelope.clone();
+        // select much larger geographical area for same screen size
+        requestedEnvelopeZoomOut.setEnvelope(
+                -517.2704081632651, -353.2270408163266, 697.7295918367349, 350.3571428571428);
+        reader.setReadParams(
+                "geotools_coverage", null, readP, requestedEnvelopeZoomOut, requestedDim);
+        assertNotNull(readP);
+        // above 1 means do sub-sampling
+        assertTrue(readP.getSourceXSubsampling() > 1);
+        assertTrue(readP.getSourceYSubsampling() > 1);
     }
 }

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/MockAbstractGridCoverage2DReader.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/MockAbstractGridCoverage2DReader.java
@@ -1,0 +1,117 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geotools.coverage.grid;
+
+import java.awt.Rectangle;
+import java.io.IOException;
+import javax.imageio.ImageReadParam;
+import org.geotools.coverage.grid.io.AbstractGridCoverage2DReader;
+import org.geotools.coverage.grid.io.OverviewPolicy;
+import org.geotools.geometry.GeneralEnvelope;
+import org.opengis.coverage.grid.Format;
+import org.opengis.coverage.grid.GridEnvelope;
+import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.parameter.ParameterValueGroup;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.TransformException;
+
+/**
+ * A Mock Class to access methods for AbstractGridCoverage2DReader class Intially intended for
+ * GEOT-6088
+ *
+ * @author Imran Rajjad
+ */
+public class MockAbstractGridCoverage2DReader extends AbstractGridCoverage2DReader {
+
+    public void setOetOriginalGridRange(GridEnvelope mockOriginalGridRange) {
+        super.originalGridRange = mockOriginalGridRange;
+    }
+
+    public void setHighestResolution(double resolutionX, double resolutionY) {
+        super.highestRes = new double[2];
+        super.highestRes[0] = resolutionX;
+        super.highestRes[1] = resolutionY;
+    }
+
+    public void setCRS(CoordinateReferenceSystem mockCRC) {
+        super.crs = mockCRC;
+    }
+
+    @Override
+    public Format getFormat() {
+
+        return new Format() {
+
+            @Override
+            public ParameterValueGroup getWriteParameters() {
+
+                return null;
+            }
+
+            @Override
+            public String getVersion() {
+
+                return null;
+            }
+
+            @Override
+            public String getVendor() {
+
+                return null;
+            }
+
+            @Override
+            public ParameterValueGroup getReadParameters() {
+
+                return null;
+            }
+
+            @Override
+            public String getName() {
+
+                return "mock";
+            }
+
+            @Override
+            public String getDocURL() {
+
+                return null;
+            }
+
+            @Override
+            public String getDescription() {
+                return "mock format used in Junit";
+            }
+        };
+    }
+
+    @Override
+    public GridCoverage2D read(GeneralParameterValue[] parameters)
+            throws IllegalArgumentException, IOException {
+        return new GridCoverageBuilder().getGridCoverage2D();
+    }
+
+    @Override
+    protected Integer setReadParams(
+            OverviewPolicy overviewPolicy,
+            ImageReadParam readP,
+            GeneralEnvelope requestedEnvelope,
+            Rectangle requestedDim)
+            throws IOException, TransformException {
+        return super.setReadParams(overviewPolicy, readP, requestedEnvelope, requestedDim);
+    }
+
+    @Override
+    protected Integer setReadParams(
+            String coverageName,
+            OverviewPolicy overviewPolicy,
+            ImageReadParam readP,
+            GeneralEnvelope requestedEnvelope,
+            Rectangle requestedDim)
+            throws IOException, TransformException {
+        return super.setReadParams(
+                coverageName, overviewPolicy, readP, requestedEnvelope, requestedDim);
+    }
+}


### PR DESCRIPTION
Resuming @imranrajjad work on the topic, but this time with a GeoServer fix that allows committing it.
See also: https://github.com/geoserver/geoserver/pull/3455