### PR TITLE
[GEOT-6179] Fix. Check for client properties on feature chaining.

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/NestedFilterToSQL.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/NestedFilterToSQL.java
@@ -196,14 +196,14 @@ public class NestedFilterToSQL extends FilterToSQL {
             List<FeatureChainedAttributeDescriptor> attributes =
                     nestedMappingsExtractor.getFeatureChainedAttributes();
             if (attributes.size() >= 1) {
-                out.write("(");
+                if (attributes.size() > 1) out.write("(");
                 boolean first = true;
                 for (FeatureChainedAttributeDescriptor nestedAttrDescr : attributes) {
                     if (first) first = false;
                     else out.write(" OR ");
                     encodeChainedAttribute(filter, xpath, nestedAttrDescr);
                 }
-                out.write(")");
+                if (attributes.size() > 1) out.write(")");
             }
             return extraData;
 

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
@@ -316,7 +316,8 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
             checkAttributeFound(
                     expression, exprSteps, nestedAttrExtractor, existsAttrExtractor, fcAttrs);
             // encoding of filters on multiple nested attributes is not (yet) supported
-            if (fcAttrs.size() >= 1) {
+            if (fcAttrs.size() == 1
+                    || (fcAttrs.size() >= 1 && validateNoClientProperties(fcAttrs))) {
                 FeatureChainedAttributeDescriptor nestedAttrDescr = fcAttrs.get(0);
                 if (nestedAttrDescr.chainSize() > 1 && nestedAttrDescr.isJoiningEnabled()) {
                     FeatureTypeMapping featureMapping =
@@ -400,6 +401,19 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
         }
 
         return super.visit(expression, notUsed);
+    }
+
+    private boolean validateNoClientProperties(List<FeatureChainedAttributeDescriptor> fcAttrs) {
+        for (FeatureChainedAttributeDescriptor ad : fcAttrs) {
+            if (ad.getFeatureChain() == null) continue;
+            for (FeatureChainLink clink : ad.getFeatureChain()) {
+                if (clink.getNestedFeatureAttribute() == null) continue;
+                if (clink.getNestedFeatureAttribute().getClientProperties() != null
+                        && !clink.getNestedFeatureAttribute().getClientProperties().isEmpty())
+                    return false;
+            }
+        }
+        return true;
     }
 
     /** Attribute error check */


### PR DESCRIPTION
This PR fixes some Geoserver App-Schema online tests failing after initial commit, due to:
- Parenthesis checking on generated SQL.
- Client properties chaining unsupported corner cases.

Tested on Geoserver App-Schema tests module PR:
https://github.com/geoserver/geoserver/pull/3239

https://osgeo-org.atlassian.net/browse/GEOT-6179