### PR TITLE
Make Solr store log its complete http request URL to Solr core (20.x backport)

### DIFF
--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrFeatureReader.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrFeatureReader.java
@@ -225,7 +225,13 @@ public class SolrFeatureReader implements FeatureReader<SimpleFeatureType, Simpl
                     try {
                         QueryResponse rsp = server.query(solrQuery);
                         if (this.solrDataStore.getLogger().isLoggable(Level.FINE)) {
-                            this.solrDataStore.getLogger().log(Level.FINE, solrQuery.toString());
+                            this.solrDataStore
+                                    .getLogger()
+                                    .log(
+                                            Level.FINE,
+                                            server.getBaseURL()
+                                                    + "/select?"
+                                                    + solrQuery.toString());
                         }
                         this.solrDocIterator = rsp.getResults().iterator();
                         nextCursorMark = rsp.getNextCursorMark();


### PR DESCRIPTION
Adds complete request URL sent to Solr with its parameters including now Host and action path, for copy and use it on a browser easily.

Example:
```
http://localhost:8983/solr/stations/select?omitHeader=true&fl=id&q=*:*&rows=1000000&sort=id+asc&fq=common_name:/.{1,1}*/+
```