### PR TITLE
Fix mapping of MultiLineString in DataUtilities

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -256,8 +256,8 @@ public class DataUtilities {
 
         typeEncode.put(MultiLineString.class, "MultiLineString");
         typeMap.put("MultiLineString", MultiLineString.class);
-        typeMap.put("com.vividsolutions.jts.geom.MultiPoint", MultiLineString.class);
-        typeMap.put("org.locationtech.jts.geom.MultiPoint", MultiLineString.class);
+        typeMap.put("com.vividsolutions.jts.geom.MultiLineString", MultiLineString.class);
+        typeMap.put("org.locationtech.jts.geom.MultiLineString", MultiLineString.class);
 
         typeEncode.put(MultiPolygon.class, "MultiPolygon");
         typeMap.put("MultiPolygon", MultiPolygon.class);

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -47,7 +47,13 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.util.factory.Hints;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 import org.opengis.feature.IllegalAttributeException;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -757,6 +763,37 @@ public class DataUtilitiesTest extends DataTestCase {
         // System.out.println("BEFORE:"+spec);
         // System.out.println(" AFTER:"+spec2);
         assertEquals(spec, spec2);
+    }
+
+    public void testAllGeometryTypes() throws Exception {
+        List<Class<?>> bindings =
+                Arrays.asList(
+                        Geometry.class,
+                        Point.class,
+                        LineString.class,
+                        Polygon.class,
+                        MultiPoint.class,
+                        MultiLineString.class,
+                        MultiPolygon.class,
+                        GeometryCollection.class);
+
+        StringBuilder specBuilder = new StringBuilder();
+        bindings.forEach(
+                b ->
+                        specBuilder
+                                .append(b.getSimpleName())
+                                .append("_type:")
+                                .append(b.getName())
+                                .append(','));
+
+        String spec = specBuilder.toString();
+        SimpleFeatureType ft = DataUtilities.createType("testType", spec);
+        bindings.forEach(
+                b -> {
+                    AttributeDescriptor descriptor = ft.getDescriptor(b.getSimpleName() + "_type");
+                    assertNotNull(descriptor);
+                    assertEquals(b, descriptor.getType().getBinding());
+                });
     }
 
     public void testSpecNotIdentifiable() throws Exception {


### PR DESCRIPTION
DataUtilities.createType(String name, String spec)
was mapping full qualified MultiPoint class names
to MultiLineString instead of to MultiPoint.

This is a forward port of #2200 that was not applied to master at its time