### PR TITLE
swing: find resources when started from an OSGI bundle (GEOT-6290)

### DIFF
--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
@@ -119,6 +119,7 @@ public class PropertiesFileFinder {
                 File[] children = mydirectory.listFiles();
                 if (children != null) {
                     for (File child : mydirectory.listFiles()) {
+                        if (child == null) continue;
                         String name = child.getName();
                         if (name.endsWith(".properties")) {
                             infoList.add(parseEntry(0, name));

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
@@ -118,7 +118,7 @@ public class PropertiesFileFinder {
             if (mydirectory != null) {
                 File[] children = mydirectory.listFiles();
                 if (children != null) {
-                    for (File child : mydirectory.listFiles()) {
+                    for (File child : children) {
                         if (child == null) continue;
                         String name = child.getName();
                         if (name.endsWith(".properties")) {

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
@@ -102,6 +102,9 @@ public class PropertiesFileFinder {
             try {
                 urlFile = (URL) toFileURLMethod.invoke(null, url);
                 // try to load
+                if (urlFile == null)
+                    throw new RuntimeException(
+                            "error while converting the url " + url + " to a file");
                 mydirectory = new File(urlFile.getFile());
             } catch (IllegalAccessException
                     | IllegalArgumentException
@@ -110,13 +113,16 @@ public class PropertiesFileFinder {
                 throw new RuntimeException(
                         "error while converting the url " + url + " to a file", e);
             }
+
             // list files
-            File[] children = mydirectory.listFiles();
-            if (children != null) {
-                for (File child : mydirectory.listFiles()) {
-                    String name = child.getName();
-                    if (name.endsWith(".properties")) {
-                        infoList.add(parseEntry(0, name));
+            if (mydirectory != null) {
+                File[] children = mydirectory.listFiles();
+                if (children != null) {
+                    for (File child : mydirectory.listFiles()) {
+                        String name = child.getName();
+                        if (name.endsWith(".properties")) {
+                            infoList.add(parseEntry(0, name));
+                        }
                     }
                 }
             }

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
@@ -103,11 +103,7 @@ public class PropertiesFileFinder {
                 urlFile = (URL) toFileURLMethod.invoke(null, url);
                 // try to load
                 mydirectory = new File(urlFile.getFile());
-            } catch (IllegalAccessException
-                    | IllegalArgumentException
-                    | InvocationTargetException
-                            // | URISyntaxException
-                            e) {
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
                 e.printStackTrace();
                 throw new RuntimeException(
                         "error while converting the url " + url + " to a file", e);

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
@@ -20,6 +20,8 @@ package org.geotools.swing.locale;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,6 +74,54 @@ public class PropertiesFileFinder {
             }
             jarFile.close();
 
+        } else if (isBundle(path)) {
+            // try to load the eclipse classes which enable to solve bundle:/ urls
+            // we use reflection in order to avoid adding a dependency between geotools to eclipse
+            Class<?> classFileLocator = null;
+            Method toFileURLMethod = null;
+            try {
+                classFileLocator = Class.forName("org.eclipse.core.runtime.FileLocator");
+                toFileURLMethod = classFileLocator.getMethod("toFileURL", URL.class);
+            } catch (LinkageError | ClassNotFoundException ex) {
+                ex.printStackTrace();
+                throw new IllegalArgumentException(
+                        "trying to load a bundle resource "
+                                + resourceDir
+                                + " whilst the org.eclipse.core.runtime.FileLocator is not available",
+                        ex);
+            } catch (NoSuchMethodException | SecurityException ex) {
+                ex.printStackTrace();
+                throw new IllegalArgumentException(
+                        "did not found method toFileUTL in class the org.eclipse.core.runtime.FileLocator",
+                        ex);
+            }
+            // convert to a directory we can list
+            URL url = new URL(path);
+            URL urlFile;
+            File mydirectory;
+            try {
+                urlFile = (URL) toFileURLMethod.invoke(null, url);
+                // try to load
+                mydirectory = new File(urlFile.getFile());
+            } catch (IllegalAccessException
+                    | IllegalArgumentException
+                    | InvocationTargetException
+                            // | URISyntaxException
+                            e) {
+                e.printStackTrace();
+                throw new RuntimeException(
+                        "error while converting the url " + url + " to a file", e);
+            }
+            // list files
+            File[] children = mydirectory.listFiles();
+            if (children != null) {
+                for (File child : mydirectory.listFiles()) {
+                    String name = child.getName();
+                    if (name.endsWith(".properties")) {
+                        infoList.add(parseEntry(0, name));
+                    }
+                }
+            }
         } else { // must be running locally
             File localDir = getAsLocalDir(path);
             File[] children = localDir.listFiles();
@@ -116,6 +166,10 @@ public class PropertiesFileFinder {
      */
     private boolean isJarPath(String path) {
         return path.contains(".jar!");
+    }
+
+    private boolean isBundle(String path) {
+        return path.toLowerCase().startsWith("bundleresource:/");
     }
 
     /**

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/locale/PropertiesFileFinder.java
@@ -103,7 +103,9 @@ public class PropertiesFileFinder {
                 urlFile = (URL) toFileURLMethod.invoke(null, url);
                 // try to load
                 mydirectory = new File(urlFile.getFile());
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            } catch (IllegalAccessException
+                    | IllegalArgumentException
+                    | InvocationTargetException e) {
                 e.printStackTrace();
                 throw new RuntimeException(
                         "error while converting the url " + url + " to a file", e);


### PR DESCRIPTION
see JIRA GEOT-6290: https://osgeo-org.atlassian.net/browse/GEOT-6290

The idea is to accept to load resources from bundle:// urls, which occur when geotools are started from an osgi-packaged application.

Uses the standard methods to solved this situation. 
Uses reflection is order not to add any mandatoru dependency to eclipse nor osgi frameworks. 

Tested under Linux and Windows; is anyway not platform dependent. I don't plan to submit any test case, as building unit tests in an osgi setting would be extremely difficult.