### PR TITLE
Upgraded sqlite-jdbc from 3.23.1 -> 3.27.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1564,7 +1564,7 @@
       <dependency>
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
-        <version>3.23.1</version>
+        <version>3.27.2.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
I was able to upgrade sqlite from 3.23.1 to 3.27.2.1 and successfully do a full build of geotools. 
I was uncertain how to do a full build of geowebcache and geoserver using this build to confirm no regressions or where to start on the interactive tests. 
Upgrading to the latest version provides access to performance upgrades and a plethora of other important fixes. 