### PR TITLE
Revert "GEOT-6238 shapefile dump with custom filename"

### DIFF
--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDumperTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDumperTest.java
@@ -97,15 +97,6 @@ public class ShapefileDumperTest {
     }
 
     @Test
-    public void testBasicPolygonsOtherName() throws Exception {
-        SimpleFeatureCollection fc = getFeaturesFromProperties(BASIC_POLYGONS);
-        ShapefileDumper dumper = new ShapefileDumper(dumperFolder);
-        dumper.dump("DaBasicPolygons", fc);
-
-        testBasicPolygonCollection(3, "DaBasicPolygons");
-    }
-
-    @Test
     public void testLongNames() throws Exception {
         SimpleFeatureCollection fc = getFeaturesFromProperties(LONGNAMES);
         ShapefileDumper dumper = new ShapefileDumper(dumperFolder);
@@ -164,7 +155,7 @@ public class ShapefileDumperTest {
         assertEquals(expectedSize, fc.size());
         assertFieldsNotEmpty(fc);
         checkTypeStructure(fc.getSchema(), MultiPolygon.class, "ID");
-        assertCst(typeName, "ISO-8859-1");
+        assertCst(BASIC_POLYGONS, "ISO-8859-1");
         return fc;
     }
 


### PR DESCRIPTION
Reverts geotools/geotools#2261 as it breaks the GeoServer build. Sorry about that, did not notice during review.

Ah, @NielsCharlier , in case you're interested or can share information, I've also started a thread on the deve list to see if we can add a build check for this (e.g., to run a geoserver build off the geotools changes and get a firm result before merging a GeoTools PR)