### PR TITLE
[GEOT-6304] Upgrade xerial-SQLite version to 3.27.2.1 (backport to 21.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1450,7 +1450,7 @@
       <dependency>
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
-        <version>3.23.1</version>
+        <version>3.27.2.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
Back port to upgrade sqlite-jdbc from 3.23.1 -> 3.27.2.1