### PR TITLE
Backport [GEOT-5857] to 21.x StreamingRenderer MergeLayerRequest does not merge if imag…

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -3612,15 +3612,21 @@ public class StreamingRenderer implements GTRenderer {
                 // straight, so we don't need to compose it back in.
                 final Graphics2D ftsGraphics = currentLayer.graphics;
                 if (ftsGraphics instanceof DelayedBackbufferGraphic && !(ftsGraphics == graphics)) {
-                    final BufferedImage image = ((DelayedBackbufferGraphic) ftsGraphics).image;
-                    // we may have not found anything to paint, in that case the delegate
-                    // has not been initialized
-                    if (image != null) {
-                        if (currentLayer.composite == null) {
-                            graphics.setComposite(AlphaComposite.SrcOver);
-                        } else {
-                            graphics.setComposite(currentLayer.composite);
+                    BufferedImage image = ((DelayedBackbufferGraphic) ftsGraphics).image;
+                    if (currentLayer.composite == null) {
+                        graphics.setComposite(AlphaComposite.SrcOver);
+                    } else {
+                        // we may have not found anything to paint, in that case the delegate
+                        // has not been initialized
+                        if (image == null) {
+                            Rectangle size = ((DelayedBackbufferGraphic) ftsGraphics).screenSize;
+                            image =
+                                    new BufferedImage(
+                                            size.width, size.height, BufferedImage.TYPE_4BYTE_ABGR);
                         }
+                        graphics.setComposite(currentLayer.composite);
+                    }
+                    if (image != null) {
                         graphics.drawImage(image, 0, 0, null);
                         ftsGraphics.dispose();
                     }


### PR DESCRIPTION
...e is null, sometimes this is not correct (e.g. DstIn composite)