### PR TITLE
Backport [GEOT-5857] to 20.x: StreamingRenderer MergeLayerRequest does not merge if imag…

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -3449,15 +3449,21 @@ public class StreamingRenderer implements GTRenderer {
                 // straight, so we don't need to compose it back in.
                 final Graphics2D ftsGraphics = currentLayer.graphics;
                 if (ftsGraphics instanceof DelayedBackbufferGraphic && !(ftsGraphics == graphics)) {
-                    final BufferedImage image = ((DelayedBackbufferGraphic) ftsGraphics).image;
-                    // we may have not found anything to paint, in that case the delegate
-                    // has not been initialized
-                    if (image != null) {
-                        if (currentLayer.composite == null) {
-                            graphics.setComposite(AlphaComposite.SrcOver);
-                        } else {
-                            graphics.setComposite(currentLayer.composite);
+                    BufferedImage image = ((DelayedBackbufferGraphic) ftsGraphics).image;
+                    if (currentLayer.composite == null) {
+                        graphics.setComposite(AlphaComposite.SrcOver);
+                    } else {
+                        // we may have not found anything to paint, in that case the delegate
+                        // has not been initialized
+                        if (image == null) {
+                            Rectangle size = ((DelayedBackbufferGraphic) ftsGraphics).screenSize;
+                            image =
+                                    new BufferedImage(
+                                            size.width, size.height, BufferedImage.TYPE_4BYTE_ABGR);
                         }
+                        graphics.setComposite(currentLayer.composite);
+                    }
+                    if (image != null) {
                         graphics.drawImage(image, 0, 0, null);
                         ftsGraphics.dispose();
                     }

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/StreamingRendererTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/StreamingRendererTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.awt.AlphaComposite;
+import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
@@ -60,11 +62,13 @@ import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.LiteCoordinateSequence;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.map.DefaultMapContext;
+import org.geotools.map.DirectLayer;
 import org.geotools.map.FeatureLayer;
 import org.geotools.map.GridCoverageLayer;
 import org.geotools.map.Layer;
 import org.geotools.map.MapContent;
 import org.geotools.map.MapContext;
+import org.geotools.map.MapViewport;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.renderer.RenderListener;
@@ -112,6 +116,23 @@ public class StreamingRendererTest {
     private GeometryFactory gf = new GeometryFactory();
     protected int errors;
     protected int features;
+
+    private static final class MergeLayerRequestTester extends StreamingRenderer {
+        Graphics2D graphics;
+        List<LiteFeatureTypeStyle> styles;
+
+        public MergeLayerRequestTester(Graphics2D graphics, List<LiteFeatureTypeStyle> styles) {
+            super();
+            this.graphics = graphics;
+            this.styles = styles;
+        }
+
+        public void mergeRequest() {
+
+            MergeLayersRequest request = new MergeLayersRequest(graphics, styles);
+            request.execute();
+        }
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -742,5 +763,44 @@ public class StreamingRendererTest {
         // correctly handled no geometries were selected and so no features were rendered
         Assert.assertEquals(features, 4);
         Assert.assertEquals(errors, 0);
+    }
+
+    @Test
+    public void testMergeLayerWithNullImage() {
+        BufferedImage finalImage = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+        Graphics2D finalGraphics = (Graphics2D) finalImage.getGraphics();
+        finalGraphics.setColor(Color.RED);
+        finalGraphics.fillRect(0, 0, 100, 100);
+
+        List<LiteFeatureTypeStyle> lfts = new ArrayList<LiteFeatureTypeStyle>();
+        Layer layer =
+                new DirectLayer() {
+
+                    @Override
+                    public void draw(Graphics2D graphics, MapContent map, MapViewport viewport) {}
+
+                    @Override
+                    public ReferencedEnvelope getBounds() {
+                        return null;
+                    }
+                };
+
+        // style with empty (null) image
+        DelayedBackbufferGraphic graphics =
+                new DelayedBackbufferGraphic(finalGraphics, new Rectangle(100, 100));
+        LiteFeatureTypeStyle style1 =
+                new LiteFeatureTypeStyle(layer, graphics, new ArrayList(), new ArrayList(), null);
+        style1.composite = AlphaComposite.DstIn;
+        lfts.add(style1);
+
+        MergeLayerRequestTester renderer = new MergeLayerRequestTester(finalGraphics, lfts);
+        renderer.mergeRequest();
+        int color = finalImage.getRGB(0, 0);
+        int red = (color & 0x00ff0000) >> 16;
+        int green = (color & 0x0000ff00) >> 8;
+        int blue = color & 0x000000ff;
+        assertEquals(0, red);
+        assertEquals(0, green);
+        assertEquals(0, blue);
     }
 }


### PR DESCRIPTION
…e is null, sometimes this is not correct (e.g. DstIn composite)