### PR TITLE
21.x GEOT-3825 Fetch size defaults to 0 in JDBCDataStore

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
@@ -312,7 +312,7 @@ public abstract class JDBCDataStoreFactory implements DataStoreFactorySpi {
         // fetch size
         Integer fetchSize = (Integer) FETCHSIZE.lookUp(params);
         if (fetchSize != null && fetchSize > 0) dataStore.setFetchSize(fetchSize);
-        else dataStore.setFetchSize((Integer)FETCHSIZE.sample);
+        else dataStore.setFetchSize((Integer) FETCHSIZE.sample);
 
         Integer batchInsertSize = (Integer) BATCH_INSERT_SIZE.lookUp(params);
         if (batchInsertSize != null && batchInsertSize > 0) {

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
@@ -312,6 +312,7 @@ public abstract class JDBCDataStoreFactory implements DataStoreFactorySpi {
         // fetch size
         Integer fetchSize = (Integer) FETCHSIZE.lookUp(params);
         if (fetchSize != null && fetchSize > 0) dataStore.setFetchSize(fetchSize);
+        else dataStore.setFetchSize((Integer)FETCHSIZE.sample);
 
         Integer batchInsertSize = (Integer) BATCH_INSERT_SIZE.lookUp(params);
         if (batchInsertSize != null && batchInsertSize > 0) {

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DataStoreFactoryTest.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DataStoreFactoryTest.java
@@ -138,7 +138,7 @@ public class H2DataStoreFactoryTest {
     public void testDefaultFetchSizeDataStore() throws Exception {
         JDBCDataStore ds = null;
         try {
-        	assertNull(params.get(H2DataStoreFactory.FETCHSIZE));
+            assertNull(params.get(H2DataStoreFactory.FETCHSIZE));
             ds = factory.createDataStore(params);
             assertNotNull(ds);
             assertTrue(ds.getFetchSize() == 1000);

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DataStoreFactoryTest.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DataStoreFactoryTest.java
@@ -18,6 +18,7 @@ package org.geotools.data.h2;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -130,6 +131,21 @@ public class H2DataStoreFactoryTest {
             }
         } finally {
             server.shutdown();
+        }
+    }
+
+    @Test
+    public void testDefaultFetchSizeDataStore() throws Exception {
+        JDBCDataStore ds = null;
+        try {
+        	assertNull(params.get(H2DataStoreFactory.FETCHSIZE));
+            ds = factory.createDataStore(params);
+            assertNotNull(ds);
+            assertTrue(ds.getFetchSize() == 1000);
+        } finally {
+            if (ds != null) {
+                ds.dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
21.x backport for GEOT-3825 Fetch size defaults to 0 in JDBCDataStore