### PR TITLE
[GEOT-6316] Fix MongoDB store isNull filter processing.

### DIFF
--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
@@ -372,14 +372,12 @@ public class FilterToMongo implements FilterVisitor, ExpressionVisitor {
         return output;
     }
 
-    // There is no "NULL" in MongoDB, but I assume that TODO add null support
-    // the non-existence of a column is the same...
     @Override
     public Object visit(PropertyIsNull filter, Object extraData) {
         BasicDBObject output = asDBObject(extraData);
-
-        String prop = convert(filter.accept(this, null), String.class);
-        output.put(prop, new BasicDBObject("$exists", false));
+        String prop = convert(filter.getExpression().evaluate(null), String.class);
+        // mongodb filter { item: null } supports both: null value and nonexistent attribute
+        output.put(prop, null);
         return output;
     }
 

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
@@ -48,6 +48,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.BinaryComparisonOperator;
 import org.opengis.filter.Filter;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
@@ -370,6 +371,12 @@ public class MongoFeatureSource extends ContentFeatureSource {
                         }
 
                         preStack.pop(); // value
+                        preStack.push(filter);
+                        return null;
+                    }
+
+                    @Override
+                    public Object visit(PropertyIsNull filter, Object notUsed) {
                         preStack.push(filter);
                         return null;
                     }

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -31,6 +31,7 @@ import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsGreaterThan;
 import org.opengis.filter.PropertyIsLessThan;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.spatial.BBOX;
 
 public abstract class MongoFeatureSourceTest extends MongoTestSupport {
@@ -279,5 +280,13 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
         // no feature should match
         assertEquals(0, source.getCount(q));
+    }
+
+    public void testIsNullFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyIsNull isNull = ff.isNull(ff.literal("properties.nullableAttribute"));
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", isNull);
+        assertEquals(2, source.getCount(q));
     }
 }

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -33,6 +33,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                 parseDate("2015-01-01T16:30:00.000Z"),
                 parseDate("2015-01-01T21:30:00.000Z")
             };
+    static final String NULLABLE_ATTRIBUTE = "nullableAttribute";
 
     @Override
     protected void setUpDataStore(MongoDataStore dataStore) {}
@@ -53,6 +54,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                         .add("intProperty", 0)
                         .add("doubleProperty", 0.0)
                         .add("stringProperty", "zero")
+                        .add(NULLABLE_ATTRIBUTE, "A value")
                         .add(
                                 "listProperty",
                                 list(
@@ -72,6 +74,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                         .add("intProperty", 1)
                         .add("doubleProperty", 1.1)
                         .add("stringProperty", "one")
+                        .add(NULLABLE_ATTRIBUTE, null)
                         .add(
                                 "listProperty",
                                 list(


### PR DESCRIPTION
This PR fixes IsNull filter processing on MongoDB datastore, executing null attribute (or nonexistent attribute) on database search engine using the Null equality filter.

See:
https://docs.mongodb.com/manual/tutorial/query-for-null-fields/

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6316