### PR TITLE
[GEOT-6179] Delegate filter execution matching multiple same-xpath feature chained attribute names to database (21.x backport)

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/NestedFilterToSQL.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/NestedFilterToSQL.java
@@ -190,63 +190,21 @@ public class NestedFilterToSQL extends FilterToSQL {
 
     protected Object visitNestedFilter(Filter filter, Object extraData, String xpath) {
         try {
-
             FeatureChainedAttributeVisitor nestedMappingsExtractor =
                     new FeatureChainedAttributeVisitor(rootMapping);
             nestedMappingsExtractor.visit(ff.property(xpath), null);
             List<FeatureChainedAttributeDescriptor> attributes =
                     nestedMappingsExtractor.getFeatureChainedAttributes();
-            // encoding of filters on multiple nested attributes is not (yet) supported
-            if (attributes.size() == 1) {
-                FeatureChainedAttributeDescriptor nestedAttrDescr = attributes.get(0);
-
-                int numMappings = nestedAttrDescr.chainSize();
-                if (numMappings > 0 && nestedAttrDescr.isJoiningEnabled()) {
-                    out.write("EXISTS (");
-
-                    FeatureChainLink lastMappingStep = nestedAttrDescr.getLastLink();
-                    StringBuffer sql = encodeSelectKeyFrom(lastMappingStep);
-                    JDBCDataStore store =
-                            (JDBCDataStore)
-                                    lastMappingStep
-                                            .getFeatureTypeMapping()
-                                            .getSource()
-                                            .getDataStore();
-                    encodeMultipleValueJoin(nestedAttrDescr, store, sql);
-
-                    for (int i = numMappings - 2; i > 0; i--) {
-                        FeatureChainLink mappingStep = nestedAttrDescr.getLink(i);
-                        if (mappingStep.hasNestedFeature()) {
-                            FeatureTypeMapping parentFeature = mappingStep.getFeatureTypeMapping();
-                            store = (JDBCDataStore) parentFeature.getSource().getDataStore();
-                            String parentTableName =
-                                    parentFeature.getSource().getSchema().getName().getLocalPart();
-
-                            sql.append(" INNER JOIN ");
-                            store.encodeTableName(parentTableName, sql, null);
-                            sql.append(" ");
-                            store.dialect.encodeTableName(mappingStep.getAlias(), sql);
-                            sql.append(" ON ");
-                            encodeJoinCondition(nestedAttrDescr, i, sql);
-                        }
-                    }
-
-                    if (nestedAttrDescr.getAttributePath() != null) {
-                        createWhereClause(filter, xpath, nestedAttrDescr, sql);
-
-                        sql.append(" AND ");
-                    } else {
-                        sql.append(" WHERE ");
-                    }
-
-                    // join with root table
-                    encodeJoinCondition(nestedAttrDescr, 0, sql);
-
-                    out.write(sql.toString());
-                    out.write(")");
+            if (attributes.size() >= 1) {
+                out.write("(");
+                boolean first = true;
+                for (FeatureChainedAttributeDescriptor nestedAttrDescr : attributes) {
+                    if (first) first = false;
+                    else out.write(" OR ");
+                    encodeChainedAttribute(filter, xpath, nestedAttrDescr);
                 }
+                out.write(")");
             }
-
             return extraData;
 
         } catch (java.io.IOException ioe) {
@@ -255,6 +213,53 @@ public class NestedFilterToSQL extends FilterToSQL {
             throw new RuntimeException("Problem writing filter: ", e);
         } catch (FilterToSQLException e) {
             throw new RuntimeException("Problem writing filter: ", e);
+        }
+    }
+
+    private void encodeChainedAttribute(
+            Filter filter, String xpath, FeatureChainedAttributeDescriptor nestedAttrDescr)
+            throws IOException, SQLException, FilterToSQLException {
+        int numMappings = nestedAttrDescr.chainSize();
+        if (numMappings > 0 && nestedAttrDescr.isJoiningEnabled()) {
+            out.write("EXISTS (");
+
+            FeatureChainLink lastMappingStep = nestedAttrDescr.getLastLink();
+            StringBuffer sql = encodeSelectKeyFrom(lastMappingStep);
+            JDBCDataStore store =
+                    (JDBCDataStore)
+                            lastMappingStep.getFeatureTypeMapping().getSource().getDataStore();
+            encodeMultipleValueJoin(nestedAttrDescr, store, sql);
+
+            for (int i = numMappings - 2; i > 0; i--) {
+                FeatureChainLink mappingStep = nestedAttrDescr.getLink(i);
+                if (mappingStep.hasNestedFeature()) {
+                    FeatureTypeMapping parentFeature = mappingStep.getFeatureTypeMapping();
+                    store = (JDBCDataStore) parentFeature.getSource().getDataStore();
+                    String parentTableName =
+                            parentFeature.getSource().getSchema().getName().getLocalPart();
+
+                    sql.append(" INNER JOIN ");
+                    store.encodeTableName(parentTableName, sql, null);
+                    sql.append(" ");
+                    store.dialect.encodeTableName(mappingStep.getAlias(), sql);
+                    sql.append(" ON ");
+                    encodeJoinCondition(nestedAttrDescr, i, sql);
+                }
+            }
+
+            if (nestedAttrDescr.getAttributePath() != null) {
+                createWhereClause(filter, xpath, nestedAttrDescr, sql);
+
+                sql.append(" AND ");
+            } else {
+                sql.append(" WHERE ");
+            }
+
+            // join with root table
+            encodeJoinCondition(nestedAttrDescr, 0, sql);
+
+            out.write(sql.toString());
+            out.write(")");
         }
     }
 

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/NestedFilterToSQL.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/NestedFilterToSQL.java
@@ -196,14 +196,14 @@ public class NestedFilterToSQL extends FilterToSQL {
             List<FeatureChainedAttributeDescriptor> attributes =
                     nestedMappingsExtractor.getFeatureChainedAttributes();
             if (attributes.size() >= 1) {
-                out.write("(");
+                if (attributes.size() > 1) out.write("(");
                 boolean first = true;
                 for (FeatureChainedAttributeDescriptor nestedAttrDescr : attributes) {
                     if (first) first = false;
                     else out.write(" OR ");
                     encodeChainedAttribute(filter, xpath, nestedAttrDescr);
                 }
-                out.write(")");
+                if (attributes.size() > 1) out.write(")");
             }
             return extraData;
 

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
@@ -316,7 +316,7 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
             checkAttributeFound(
                     expression, exprSteps, nestedAttrExtractor, existsAttrExtractor, fcAttrs);
             // encoding of filters on multiple nested attributes is not (yet) supported
-            if (fcAttrs.size() == 1) {
+            if (fcAttrs.size() >= 1) {
                 FeatureChainedAttributeDescriptor nestedAttrDescr = fcAttrs.get(0);
                 if (nestedAttrDescr.chainSize() > 1 && nestedAttrDescr.isJoiningEnabled()) {
                     FeatureTypeMapping featureMapping =

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/ComplexFilterSplitter.java
@@ -316,7 +316,8 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
             checkAttributeFound(
                     expression, exprSteps, nestedAttrExtractor, existsAttrExtractor, fcAttrs);
             // encoding of filters on multiple nested attributes is not (yet) supported
-            if (fcAttrs.size() >= 1) {
+            if (fcAttrs.size() == 1
+                    || (fcAttrs.size() >= 1 && validateNoClientProperties(fcAttrs))) {
                 FeatureChainedAttributeDescriptor nestedAttrDescr = fcAttrs.get(0);
                 if (nestedAttrDescr.chainSize() > 1 && nestedAttrDescr.isJoiningEnabled()) {
                     FeatureTypeMapping featureMapping =
@@ -400,6 +401,19 @@ public class ComplexFilterSplitter extends PostPreProcessFilterSplittingVisitor 
         }
 
         return super.visit(expression, notUsed);
+    }
+
+    private boolean validateNoClientProperties(List<FeatureChainedAttributeDescriptor> fcAttrs) {
+        for (FeatureChainedAttributeDescriptor ad : fcAttrs) {
+            if (ad.getFeatureChain() == null) continue;
+            for (FeatureChainLink clink : ad.getFeatureChain()) {
+                if (clink.getNestedFeatureAttribute() == null) continue;
+                if (clink.getNestedFeatureAttribute().getClientProperties() != null
+                        && !clink.getNestedFeatureAttribute().getClientProperties().isEmpty())
+                    return false;
+            }
+        }
+        return true;
     }
 
     /** Attribute error check */


### PR DESCRIPTION
Currently app-schema plugin detect two posible attributes with same xpath and delegate filter execution to JVM runtime. This fix delegates filter execution to database using all available join-fields.

https://osgeo-org.atlassian.net/browse/GEOT-6179