### PR TITLE
GEOT-5859: Remove httpclient dependency.

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/pom.xml
+++ b/modules/plugin/coverage-multidim/netcdf/pom.xml
@@ -111,13 +111,6 @@
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>
-    <!-- required to read files remotely over HTTP -->
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-      <scope>runtime</scope>
-    </dependency> 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/reference/httpservices.html indicated this was replaced with httpcomponent 4.x. inside the UCAR libraries as of 4.3 

The dependency:tree results are consistent with that.

