### PR TITLE
(Backport 21.x) [GEOT-6317] Enhance mongodb schema generation.

### DIFF
--- a/docs/user/library/data/mongodb.rst
+++ b/docs/user/library/data/mongodb.rst
@@ -59,6 +59,14 @@ following connection parameters:
   are stored as MongoDB documents or files adhering to the JSON schema format with 
   the schema "Type Name" (typeName) as the key.
 
+* max_objs_schema: specifies the maximun integer number of JSON objects on the collection
+  to be used in the schema generation process.  
+  The default value is 1.  This parameter  is not required.
+  
+* objs_id_schema: specifies a collection of comma separated Object IDs to be used 
+  in the schema generation process.  It can be used along 
+  with ``max_objs_schema`` parameter.  Default is empty.  This parameter is not required.
+
 JSON Schema
 -----------
 

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/FeatureTypeMapping.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/FeatureTypeMapping.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.xml.namespace.QName;
 import org.geotools.appschema.util.IndexQueryUtils;
 import org.geotools.data.FeatureSource;
@@ -54,6 +55,8 @@ public class FeatureTypeMapping {
      * access instead of a data store as the source data store
      */
     private FeatureSource<? extends FeatureType, ? extends Feature> source;
+
+    private String sourceDatastoreId;
 
     // Index FeatureSource, optional
     private FeatureSource<SimpleFeatureType, SimpleFeature> indexSource;
@@ -489,5 +492,15 @@ public class FeatureTypeMapping {
             return mapp.getIndexField();
         }
         return null;
+    }
+
+    /** Returns the source datastore id from mappings configurations. */
+    public Optional<String> getSourceDatastoreId() {
+        return Optional.ofNullable(sourceDatastoreId);
+    }
+
+    /** Sets the source datastore id from mappings configurations. */
+    public void setSourceDatastoreId(String sourceDatastoreId) {
+        this.sourceDatastoreId = sourceDatastoreId;
     }
 }

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/FeatureTypeMappingFactory.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/FeatureTypeMappingFactory.java
@@ -65,4 +65,30 @@ public class FeatureTypeMappingFactory {
                         });
         return featureTypeMapping;
     }
+
+    public static FeatureTypeMapping getInstance(
+            FeatureSource source,
+            FeatureSource indexSource,
+            AttributeDescriptor target,
+            String defaultGeometryXPath,
+            List<AttributeMapping> mappings,
+            NamespaceSupport namespaces,
+            String itemXpath,
+            boolean isXmlDataStore,
+            boolean isDenormalised,
+            String sourceDatastoreId) {
+        FeatureTypeMapping featureTypeMapping =
+                getInstance(
+                        source,
+                        indexSource,
+                        target,
+                        defaultGeometryXPath,
+                        mappings,
+                        namespaces,
+                        itemXpath,
+                        isXmlDataStore,
+                        isDenormalised);
+        featureTypeMapping.setSourceDatastoreId(sourceDatastoreId);
+        return featureTypeMapping;
+    }
 }

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
@@ -338,7 +338,8 @@ public class AppSchemaDataAccessConfigurator {
                                 namespaces,
                                 dto.getItemXpath(),
                                 dto.isXmlDataStore(),
-                                dto.isDenormalised());
+                                dto.isDenormalised(),
+                                dto.getSourceDataStore());
 
                 String mappingName = dto.getMappingName();
                 if (mappingName != null) {

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStoreFactory.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStoreFactory.java
@@ -19,7 +19,10 @@ package org.geotools.data.mongodb;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.data.AbstractDataStoreFactory;
 import org.geotools.data.DataStore;
 
@@ -41,6 +44,20 @@ public class MongoDataStoreFactory extends AbstractDataStoreFactory {
                     "Schema Store URI",
                     true,
                     "file://<absolute path>");
+    public static final Param MAX_OBJECTS_FOR_SCHEMA =
+            new Param(
+                    "max_objs_schema",
+                    Integer.class,
+                    "Max objects for schema generation",
+                    false,
+                    1);
+    public static final Param OBJECTS_IDS_FOR_SCHEMA =
+            new Param(
+                    "objs_id_schema",
+                    String.class,
+                    "Objects IDs for schema generation (comma separated)",
+                    false,
+                    null);
 
     @Override
     public String getDisplayName() {
@@ -54,20 +71,55 @@ public class MongoDataStoreFactory extends AbstractDataStoreFactory {
 
     @Override
     public Param[] getParametersInfo() {
-        return new Param[] {NAMESPACE, DATASTORE_URI, SCHEMASTORE_URI};
+        return new Param[] {
+            NAMESPACE,
+            DATASTORE_URI,
+            SCHEMASTORE_URI,
+            MAX_OBJECTS_FOR_SCHEMA,
+            OBJECTS_IDS_FOR_SCHEMA
+        };
     }
 
     @Override
     public MongoDataStore createDataStore(Map<String, Serializable> params) throws IOException {
+        // retrieve schema generation parameters
+        final List<String> ids = getIds(params);
+        final Integer maxObjects = (Integer) MAX_OBJECTS_FOR_SCHEMA.lookUp(params);
+        final MongoSchemaInitParams schemaParams =
+                MongoSchemaInitParams.builder()
+                        .ids(ids.toArray(new String[] {}))
+                        .maxObjects(maxObjects != null ? maxObjects : 1)
+                        .build();
+        // instance datastore
         MongoDataStore dataStore =
                 new MongoDataStore(
                         (String) DATASTORE_URI.lookUp(params),
-                        (String) SCHEMASTORE_URI.lookUp(params));
+                        (String) SCHEMASTORE_URI.lookUp(params),
+                        true,
+                        schemaParams);
         String uri = (String) NAMESPACE.lookUp(params);
         if (uri != null) {
             dataStore.setNamespaceURI(uri);
         }
         return dataStore;
+    }
+
+    private List<String> getIds(Map<String, Serializable> params) throws IOException {
+        List<String> ids = new ArrayList<>();
+        Object ofs = OBJECTS_IDS_FOR_SCHEMA.lookUp(params);
+        // if null, there are not ids to parse
+        if (ofs == null) return ids;
+        // type checking
+        if (!(ofs instanceof String)) {
+            throw new IllegalArgumentException("Object Ids parameter should be String type.");
+        }
+        String idsStr = (String) ofs;
+        String[] parts = idsStr.split(",");
+        for (String epart : parts) {
+            String id = epart.trim();
+            if (StringUtils.isNotEmpty(id)) ids.add(id);
+        }
+        return ids;
     }
 
     @Override

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureSource.java
@@ -71,7 +71,11 @@ public class MongoFeatureSource extends ContentFeatureSource {
     final void initMapper() {
         // use schema with mapping info if it exists
         SimpleFeatureType type = entry.getState(null).getFeatureType();
-        setMapper(type != null ? new MongoSchemaMapper(type) : new MongoInferredMapper());
+        setMapper(
+                type != null
+                        ? new MongoSchemaMapper(type)
+                        : new MongoInferredMapper(
+                                getDataStore().getSchemaInitParams().orElse(null)));
     }
 
     public DBCollection getCollection() {

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoInferredMapper.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoInferredMapper.java
@@ -18,13 +18,20 @@
 package org.geotools.data.mongodb;
 
 import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
+import com.mongodb.QueryBuilder;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.bson.types.ObjectId;
 import org.geotools.data.mongodb.complex.MongoComplexUtilities;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
@@ -42,6 +49,17 @@ public class MongoInferredMapper extends AbstractCollectionMapper {
     MongoGeometryBuilder geomBuilder = new MongoGeometryBuilder();
 
     SimpleFeatureType schema;
+    /** Schema generation parameters, not null */
+    private MongoSchemaInitParams schemainitParams;
+
+    public MongoInferredMapper() {
+        this.schemainitParams = MongoSchemaInitParams.builder().build();
+    }
+
+    public MongoInferredMapper(MongoSchemaInitParams schemainitParams) {
+        if (schemainitParams != null) this.schemainitParams = schemainitParams;
+        else this.schemainitParams = MongoSchemaInitParams.builder().build();
+    }
 
     @Override
     public String getGeometryPath() {
@@ -80,7 +98,12 @@ public class MongoInferredMapper extends AbstractCollectionMapper {
         Set<String> indexedGeometries = MongoUtil.findIndexedGeometries(collection);
         Set<String> indexedFields = MongoUtil.findIndexedFields(collection);
         // Map<String, Class<?>> mappedFields = MongoUtil.findMappableFields(collection);
-        Map<String, Class> mappedFields = MongoComplexUtilities.findMappings(collection.findOne());
+        // if we have valid schemainitParams use a DB cursor for inferring schema. Else use the
+        // first object as default.
+        Map<String, Class> mappedFields =
+                schemainitParams.getIds().isEmpty() && schemainitParams.getMaxObjects() == 1
+                        ? MongoComplexUtilities.findMappings(collection.findOne())
+                        : generateMappedFields(collection);
 
         // don't need to worry about indexed properties we've found in our scan...
         indexedFields.removeAll(mappedFields.keySet());
@@ -153,5 +176,46 @@ public class MongoInferredMapper extends AbstractCollectionMapper {
         this.schema = featureType;
 
         return featureType;
+    }
+
+    private Map<String, Class> generateMappedFields(DBCollection collection) {
+        final Map<String, Class> resultMap = new HashMap<>();
+        final DBCursor idsCursor = obtainCursorByIds(collection);
+        Map<String, Class> idsMappings =
+                idsCursor != null
+                        ? MongoComplexUtilities.findMappings(idsCursor)
+                        : Collections.emptyMap();
+        int max = schemainitParams.getMaxObjects() - idsMappings.size();
+        final DBCursor maxObjectsCursor = obtainCursorByMaxObjects(collection, max);
+        if (maxObjectsCursor != null)
+            resultMap.putAll(MongoComplexUtilities.findMappings(maxObjectsCursor));
+        if (!idsMappings.isEmpty()) resultMap.putAll(idsMappings);
+        return resultMap;
+    }
+
+    private DBCursor obtainCursorByIds(DBCollection collection) {
+        List<String> ids = schemainitParams.getIds();
+        if (!ids.isEmpty()) {
+            LOG.info("Using IDs list for schema generation.");
+            // if we have a list of ids, obtain those objects
+            List<ObjectId> oidList =
+                    ids.stream().map(id -> new ObjectId(id)).collect(Collectors.toList());
+            DBObject query = QueryBuilder.start("_id").in(oidList.toArray(new ObjectId[] {})).get();
+            LOG.log(Level.INFO, "IDs query for execute: {0}", query);
+            return collection.find(query);
+        } else {
+            return null;
+        }
+    }
+
+    private DBCursor obtainCursorByMaxObjects(DBCollection collection, int maxObects) {
+        if (maxObects > 0) {
+            LOG.info("Using objects max num for schema generation.");
+            // else use max num of objects
+            LOG.log(Level.INFO, "Max objects limit: {0}", schemainitParams.getMaxObjects());
+            return collection.find().limit(maxObects);
+        } else {
+            return null;
+        }
     }
 }

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoSchemaInitParams.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoSchemaInitParams.java
@@ -1,0 +1,80 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/*
+ * Holds schema generation parameters for MongoDB datastore.
+ */
+public class MongoSchemaInitParams implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private List<String> ids;
+    private int maxObjects = 1;
+
+    private MongoSchemaInitParams(List<String> ids, Integer maxObjects) {
+        super();
+        this.ids = ids != null ? ids : Collections.emptyList();
+        this.maxObjects = maxObjects;
+    }
+
+    public List<String> getIds() {
+        return ids;
+    }
+
+    public void setIds(List<String> ids) {
+        this.ids = ids;
+    }
+
+    public int getMaxObjects() {
+        return maxObjects;
+    }
+
+    public void setMaxObjects(int maxObjects) {
+        this.maxObjects = maxObjects;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private List<String> ids;
+        private int maxObjects = 1;
+
+        private Builder() {}
+
+        public Builder ids(String... ids) {
+            this.ids = Arrays.asList(ids);
+            return this;
+        }
+
+        public Builder maxObjects(int maxObjects) {
+            this.maxObjects = maxObjects;
+            return this;
+        }
+
+        public MongoSchemaInitParams build() {
+            return new MongoSchemaInitParams(ids, maxObjects);
+        }
+    }
+}

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexUtilities.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexUtilities.java
@@ -17,6 +17,7 @@
 package org.geotools.data.mongodb.complex;
 
 import com.mongodb.BasicDBList;
+import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,13 +25,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.geotools.data.mongodb.AbstractCollectionMapper;
 import org.geotools.data.mongodb.MongoFeature;
 import org.geotools.data.mongodb.MongoGeometryBuilder;
+import org.geotools.util.logging.Logging;
 import org.opengis.feature.Feature;
 
 /** This class contains utilities methods for dealing with MongoDB complex features. */
 public final class MongoComplexUtilities {
+
+    private static final Logger LOG = Logging.getLogger(MongoComplexUtilities.class);
 
     // if this property is set to TRUE the system will expect nested collection full path to be
     // provided
@@ -332,6 +338,22 @@ public final class MongoComplexUtilities {
         return mappings;
     }
 
+    /**
+     * Compute the mappings for a mongodb cursor(iterator), this can be used to create a feature
+     * mapping. This method will close the cursor.
+     */
+    public static Map<String, Class> findMappings(DBCursor cursor) {
+        Map<String, Class> mappings = new HashMap<>();
+        try {
+            while (cursor.hasNext()) {
+                findMappingsHelper(cursor.next(), "", mappings);
+            }
+        } finally {
+            cursor.close();
+        }
+        return mappings;
+    }
+
     /** Helper method that will recursively walk a mongo db object and compute is mappings. */
     private static void findMappingsHelper(
             Object object, String parentPath, Map<String, Class> mappings) {
@@ -339,6 +361,7 @@ public final class MongoComplexUtilities {
             return;
         }
         if (object instanceof DBObject) {
+            LOG.log(Level.INFO, "Generating mappings from object: {0}", object);
             DBObject dbObject = (DBObject) object;
             for (String key : dbObject.keySet()) {
                 Object value = dbObject.get(key);
@@ -354,7 +377,7 @@ public final class MongoComplexUtilities {
                 } else if (value instanceof DBObject) {
                     findMappingsHelper(value, path, mappings);
                 } else {
-                    mappings.put(path, value.getClass());
+                    mappings.putIfAbsent(path, value.getClass());
                 }
             }
         } else {

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
@@ -17,6 +17,7 @@
  */
 package org.geotools.data.mongodb;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.geotools.data.Query;
 import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureReader;
 import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.GeometryBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -129,5 +131,50 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
 
         source = dataStore.getFeatureSource("ft2");
         assertEquals(1, source.getCount(new Query("ft2")));
+    }
+
+    public void testRebuildSchemaWithId() throws Exception {
+        try {
+            dataStore.setSchemaInitParams(
+                    MongoSchemaInitParams.builder().ids("58e5889ce4b02461ad5af082").build());
+            clearSchemaStore(dataStore);
+            dataStore.cleanEntries();
+            SimpleFeatureType schema = dataStore.getSchema("ft1");
+            assertNotNull(schema);
+
+            assertNotNull(schema.getDescriptor("properties.optionalProperty"));
+        } finally {
+            dataStore.setSchemaInitParams(null);
+            clearSchemaStore(dataStore);
+            dataStore.cleanEntries();
+        }
+    }
+
+    public void testRebuildSchemaWithMax() throws Exception {
+        try {
+            dataStore.setSchemaInitParams(MongoSchemaInitParams.builder().maxObjects(3).build());
+            clearSchemaStore(dataStore);
+            dataStore.cleanEntries();
+            SimpleFeatureType schema = dataStore.getSchema("ft1");
+            assertNotNull(schema);
+
+            assertNotNull(schema.getDescriptor("properties.optionalProperty"));
+        } finally {
+            dataStore.setSchemaInitParams(null);
+            clearSchemaStore(dataStore);
+            dataStore.cleanEntries();
+        }
+    }
+
+    private void clearSchemaStore(MongoDataStore mongoStore) {
+        List<String> typeNames = mongoStore.getSchemaStore().typeNames();
+        for (String et : typeNames) {
+            try {
+                mongoStore.getSchemaStore().deleteSchema(new NameImpl(et));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        mongoStore.cleanEntries();
     }
 }

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -22,6 +22,7 @@ import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import java.util.Date;
+import org.bson.types.ObjectId;
 import org.geotools.data.mongodb.MongoDataStore;
 import org.geotools.data.mongodb.MongoTestSetup;
 
@@ -44,6 +45,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
 
         ft1.save(
                 BasicDBObjectBuilder.start()
+                        .add("_id", new ObjectId("58e5889ce4b02461ad5af080"))
                         .add("id", "ft1.0")
                         .push("geometry")
                         .add("type", "Point")
@@ -63,6 +65,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                         .get());
         ft1.save(
                 BasicDBObjectBuilder.start()
+                        .add("_id", new ObjectId("58e5889ce4b02461ad5af081"))
                         .add("id", "ft1.1")
                         .push("geometry")
                         .add("type", "Point")
@@ -82,6 +85,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                         .get());
         ft1.save(
                 BasicDBObjectBuilder.start()
+                        .add("_id", new ObjectId("58e5889ce4b02461ad5af082"))
                         .add("id", "ft1.2")
                         .push("geometry")
                         .add("type", "Point")
@@ -91,6 +95,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                         .add("intProperty", 2)
                         .add("doubleProperty", 2.2)
                         .add("stringProperty", "two")
+                        .add("optionalProperty", "optional")
                         .add(
                                 "listProperty",
                                 list(


### PR DESCRIPTION
This PR enhances MongoDB schema generation with new initialization parameters for using multiple JSON objects from collection, and adds methods for cleaning already persisted schemas so they can be regenerated with new parameters on demand.

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6317