### PR TITLE
[GEOT-6330] XS DateTime encoder doesn't support Local DateTime Handling

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/XSUtils.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/XSUtils.java
@@ -1,0 +1,40 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.xs;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+import org.geotools.util.factory.Hints;
+
+/** Util class for shared static methods for XS and its bindings. */
+public final class XSUtils {
+
+    private XSUtils() {}
+
+    /**
+     * Returns a configured Calendar object in base to System properties configurations, for use
+     * with temporal types like Date, DateTime and Time.
+     */
+    public static Calendar getConfiguredCalendar() {
+        Object hint = Hints.getSystemDefault(Hints.LOCAL_DATE_TIME_HANDLING);
+        if (Boolean.TRUE.equals(hint)) {
+            return Calendar.getInstance();
+        } else {
+            return Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        }
+    }
+}

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDateBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDateBinding.java
@@ -18,11 +18,10 @@ package org.geotools.xs.bindings;
 
 import java.sql.Date;
 import java.util.Calendar;
-import java.util.TimeZone;
 import javax.xml.namespace.QName;
-import org.geotools.util.factory.Hints;
 import org.geotools.xml.impl.DatatypeConverterImpl;
 import org.geotools.xs.XS;
+import org.geotools.xs.XSUtils;
 import org.geotools.xsd.InstanceComponent;
 import org.geotools.xsd.SimpleBinding;
 
@@ -104,16 +103,9 @@ public class XSDateBinding implements SimpleBinding {
 
     public String encode(Object object, String value) throws Exception {
         final Date date = (Date) object;
-        Object hint = Hints.getSystemDefault(Hints.LOCAL_DATE_TIME_HANDLING);
-        Calendar calendar;
-        if (Boolean.TRUE.equals(hint)) {
-            calendar = Calendar.getInstance();
-        } else {
-            calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-        }
+        Calendar calendar = XSUtils.getConfiguredCalendar();
         calendar.clear();
         calendar.setTimeInMillis(date.getTime());
-
         return DatatypeConverterImpl.getInstance().printDate(calendar);
     }
 }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDateTimeBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDateTimeBinding.java
@@ -19,11 +19,11 @@ package org.geotools.xs.bindings;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.TimeZone;
 import javax.xml.namespace.QName;
 import org.geotools.util.Converters;
 import org.geotools.xml.impl.DatatypeConverterImpl;
 import org.geotools.xs.XS;
+import org.geotools.xs.XSUtils;
 import org.geotools.xsd.InstanceComponent;
 import org.geotools.xsd.SimpleBinding;
 
@@ -113,9 +113,9 @@ public class XSDateTimeBinding implements SimpleBinding {
      */
     public String encode(Object object, String value) {
         final Date timestamp = Converters.convert(object, Date.class);
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-        cal.clear();
-        cal.setTimeInMillis(timestamp.getTime());
-        return DatatypeConverterImpl.getInstance().printDateTime(cal);
+        Calendar calendar = XSUtils.getConfiguredCalendar();
+        calendar.clear();
+        calendar.setTimeInMillis(timestamp.getTime());
+        return DatatypeConverterImpl.getInstance().printDateTime(calendar);
     }
 }

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/DateConversionTimezoneTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/DateConversionTimezoneTest.java
@@ -23,6 +23,7 @@ import junit.framework.TestCase;
 import org.geotools.util.factory.Hints;
 import org.geotools.xml.XmlConverterFactory;
 import org.geotools.xs.bindings.XSDateBinding;
+import org.geotools.xs.bindings.XSDateTimeBinding;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,6 +40,7 @@ public class DateConversionTimezoneTest extends TestCase {
     private XmlConverterFactory sut1 = new XmlConverterFactory();
 
     private XSDateBinding sut2 = new XSDateBinding();
+    private XSDateTimeBinding sut3 = new XSDateTimeBinding();
 
     private TimeZone systemTimeZone;
 
@@ -55,23 +57,36 @@ public class DateConversionTimezoneTest extends TestCase {
         assertDateEquals("2015-09-02", 2015, 9, 2, 0, "UTC");
         assertDateEquals("2015-09-02", 2015, 9, 2, 1, "UTC");
         assertDateEquals("2015-09-02", 2015, 9, 2, 23, "UTC");
+        assertDateTimeEquals("2015-09-02T00:00:00Z", 2015, 9, 2, 0, "UTC");
+        assertDateTimeEquals("2015-09-02T01:00:00Z", 2015, 9, 2, 1, "UTC");
+        assertDateTimeEquals("2015-09-02T23:00:00Z", 2015, 9, 2, 23, "UTC");
         // GMT
         assertDateEquals("2015-09-02", 2015, 9, 2, 0, "GMT");
         assertDateEquals("2015-09-02", 2015, 9, 2, 1, "GMT");
         assertDateEquals("2015-09-02", 2015, 9, 2, 23, "GMT");
+        assertDateTimeEquals("2015-09-02T00:00:00Z", 2015, 9, 2, 0, "GMT");
+        assertDateTimeEquals("2015-09-02T01:00:00Z", 2015, 9, 2, 1, "GMT");
+        assertDateTimeEquals("2015-09-02T23:00:00Z", 2015, 9, 2, 23, "GMT");
         // CET
         assertDateEquals("2015-09-02", 2015, 9, 2, 0, "CET");
         assertDateEquals("2015-09-02", 2015, 9, 2, 1, "CET");
         assertDateEquals("2015-09-02", 2015, 9, 2, 2, "CET");
         assertDateEquals("2015-09-02", 2015, 9, 2, 23, "CET");
+        assertDateTimeEquals("2015-09-02T00:00:00+02:00", 2015, 9, 2, 0, "CET");
+        assertDateTimeEquals("2015-09-02T01:00:00+02:00", 2015, 9, 2, 1, "CET");
+        assertDateTimeEquals("2015-09-02T02:00:00+02:00", 2015, 9, 2, 2, "CET");
+        assertDateTimeEquals("2015-09-02T23:00:00+02:00", 2015, 9, 2, 23, "CET");
         // EST
         assertDateEquals("2015-09-02", 2015, 9, 2, 0, "EST");
         assertDateEquals("2015-09-02", 2015, 9, 2, 1, "EST");
         assertDateEquals("2015-09-02", 2015, 9, 2, 23, "EST");
+        assertDateTimeEquals("2015-09-02T00:00:00-05:00", 2015, 9, 2, 0, "EST");
+        assertDateTimeEquals("2015-09-02T01:00:00-05:00", 2015, 9, 2, 1, "EST");
+        assertDateTimeEquals("2015-09-02T23:00:00-05:00", 2015, 9, 2, 23, "EST");
     }
 
     /**
-     * Tests date encoding having {@link Hints#LOCAL_DATE_TIME_HANDLING} activated
+     * Tests date encoding having {@link Hints#LOCAL_DATE_TIME_HANDLING} deactivated
      *
      * @throws Exception
      */
@@ -81,24 +96,45 @@ public class DateConversionTimezoneTest extends TestCase {
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 0, "UTC");
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 1, "UTC");
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 23, "UTC");
+        assertDateTimeEquals("2015-09-02T00:00:00Z", 2015, 9, 2, 0, "UTC");
+        assertDateTimeEquals("2015-09-02T01:00:00Z", 2015, 9, 2, 1, "UTC");
+        assertDateTimeEquals("2015-09-02T23:00:00Z", 2015, 9, 2, 23, "UTC");
         // GMT: zone offset == 0 -> no shifting
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 0, "GMT");
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 1, "GMT");
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 23, "GMT");
+        assertDateTimeEquals("2015-09-02T00:00:00Z", 2015, 9, 2, 0, "GMT");
+        assertDateTimeEquals("2015-09-02T01:00:00Z", 2015, 9, 2, 1, "GMT");
+        assertDateTimeEquals("2015-09-02T23:00:00Z", 2015, 9, 2, 23, "GMT");
         // CET: zone offset > 0 -> shifting backwards
         assertDateEquals("2015-09-01Z", 2015, 9, 2, 0, "CET");
         assertDateEquals("2015-09-01Z", 2015, 9, 2, 1, "CET");
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 2, "CET");
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 23, "CET");
+        assertDateTimeEquals("2015-09-01T22:00:00Z", 2015, 9, 2, 0, "CET");
+        assertDateTimeEquals("2015-09-01T23:00:00Z", 2015, 9, 2, 1, "CET");
+        assertDateTimeEquals("2015-09-02T00:00:00Z", 2015, 9, 2, 2, "CET");
+        assertDateTimeEquals("2015-09-02T21:00:00Z", 2015, 9, 2, 23, "CET");
         // EST: zone offset < 0 -> shifting forward
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 0, "EST");
         assertDateEquals("2015-09-02Z", 2015, 9, 2, 1, "EST");
         assertDateEquals("2015-09-03Z", 2015, 9, 2, 23, "EST");
+        assertDateTimeEquals("2015-09-02T05:00:00Z", 2015, 9, 2, 0, "EST");
+        assertDateTimeEquals("2015-09-02T06:00:00Z", 2015, 9, 2, 1, "EST");
+        assertDateTimeEquals("2015-09-03T04:00:00Z", 2015, 9, 2, 23, "EST");
     }
 
     private void assertDateEquals(
             String expected, int year, int month, int day, int hour, String timezoneId)
             throws Exception {
+        Calendar calendar = calendarOf(year, month, day, hour, timezoneId);
+        java.util.Date utilDate = calendar.getTime();
+        Date date = new Date(utilDate.getTime());
+        assertEquals(expected, sut1Convert(date));
+        assertEquals(expected, sut2Convert(date));
+    }
+
+    private Calendar calendarOf(int year, int month, int day, int hour, String timezoneId) {
         TimeZone timeZone = TimeZone.getTimeZone(timezoneId);
         TimeZone.setDefault(timeZone);
         Calendar calendar = Calendar.getInstance();
@@ -107,10 +143,16 @@ public class DateConversionTimezoneTest extends TestCase {
         calendar.set(Calendar.DAY_OF_MONTH, day);
         calendar.set(Calendar.MONTH, month - 1);
         calendar.set(Calendar.HOUR_OF_DAY, hour);
+        return calendar;
+    }
+
+    private void assertDateTimeEquals(
+            String expected, int year, int month, int day, int hour, String timezoneId)
+            throws Exception {
+        Calendar calendar = calendarOf(year, month, day, hour, timezoneId);
         java.util.Date utilDate = calendar.getTime();
         Date date = new Date(utilDate.getTime());
-        assertEquals(expected, sut1Convert(date));
-        assertEquals(expected, sut2Convert(date));
+        assertEquals(expected, sut3Convert(date));
     }
 
     /** Save & restore system time zone, so later tests are not affected. */
@@ -131,5 +173,9 @@ public class DateConversionTimezoneTest extends TestCase {
 
     private String sut2Convert(Date date) throws Exception {
         return sut2.encode(date, null);
+    }
+
+    private String sut3Convert(Date date) throws Exception {
+        return sut3.encode(date, null);
     }
 }


### PR DESCRIPTION
This PR adds Local DateTime Handling system property support for XS DateTime data type, in the same way it is already supported on XS Date.

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6330