### PR TITLE
Backport to 20.x [GEOT-6327] tolerate geotiff_coverage as the coverageName

### DIFF
--- a/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffReader.java
+++ b/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffReader.java
@@ -108,6 +108,7 @@ import org.geotools.resources.i18n.VocabularyKeys;
 import org.geotools.resources.image.ImageUtilities;
 import org.geotools.util.NumberRange;
 import org.geotools.util.URLs;
+import org.geotools.util.Utilities;
 import org.opengis.coverage.ColorInterpretation;
 import org.opengis.coverage.grid.Format;
 import org.opengis.coverage.grid.GridCoverage;
@@ -1029,6 +1030,17 @@ public class GeoTiffReader extends AbstractGridCoverage2DReader implements GridC
             }
         }
         return null;
+    }
+
+    @Override
+    protected boolean checkName(
+            String coverageName) { // GEOS-6327 - tolerate geotiff_coverage as coverageName
+        if ("geotiff_coverage".equalsIgnoreCase(coverageName)) {
+            return true;
+        } else {
+            Utilities.ensureNonNull("coverageName", coverageName);
+            return coverageName.equalsIgnoreCase(this.coverageName);
+        }
     }
 
     /**

--- a/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffReaderTest.java
+++ b/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffReaderTest.java
@@ -58,6 +58,7 @@ import org.geotools.coverage.processing.CoverageProcessor;
 import org.geotools.coverage.processing.operation.Scale;
 import org.geotools.data.DataSourceException;
 import org.geotools.data.PrjFileReader;
+import org.geotools.factory.GeoTools;
 import org.geotools.factory.Hints;
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.geometry.GeneralEnvelope;
@@ -421,6 +422,7 @@ public class GeoTiffReaderTest extends org.junit.Assert {
         assertNotNull(file);
         final AbstractGridFormat format = new GeoTiffFormat();
         GridCoverage2D coverage = format.getReader(file).read(null);
+
         String band1Name = coverage.getSampleDimension(0).getDescription().toString();
         String band2Name = coverage.getSampleDimension(1).getDescription().toString();
         assertEquals("Band1", band1Name);
@@ -1027,6 +1029,15 @@ public class GeoTiffReaderTest extends org.junit.Assert {
                 }
             }
         }
+    }
+
+    @Test
+    public void testCoverageName() throws Exception {
+        final File file = TestData.file(GeoTiffReaderTest.class, "wind.tiff");
+        assertNotNull(file);
+
+        GeoTiffReader reader = new GeoTiffReader(file, GeoTools.getDefaultHints());
+        assertTrue(reader.checkName("geotiff_coverage"));
     }
 
     @Test


### PR DESCRIPTION


--bot backport failed, so  manual backport