### PR TITLE
[GEOT-5729] Schema cache autoconfiguration fails for empty GeoServer data directory

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaCache.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaCache.java
@@ -60,13 +60,6 @@ public class SchemaCache {
     private static final boolean DEFAULT_KEEP_QUERY = true;
 
     /**
-     * Filenames used to recognise a GeoServer data directory if automatic configuration is enabled.
-     */
-    private static final String[] GEOSERVER_DATA_DIRECTORY_FILENAMES = {
-        "global.xml", "wcs.xml", "wfs.xml", "wms.xml"
-    };
-
-    /**
      * Subdirectories used to recognise a GeoServer data directory if automatic configuration is
      * enabled.
      */
@@ -382,6 +375,9 @@ public class SchemaCache {
         File file = URLs.urlToFile(url);
         while (true) {
             if (file == null) {
+                LOGGER.warning(
+                        "Automatic app-schema-cache directory build failed, "
+                                + "Geoserver root folder or app-schema-cache folder not found");
                 return null;
             }
             if (isSuitableDirectoryToContainCache(file)) {
@@ -464,18 +460,16 @@ public class SchemaCache {
         if ((new File(directory, CACHE_DIRECTORY_NAME)).isDirectory()) {
             return true;
         }
-        for (String filename : GEOSERVER_DATA_DIRECTORY_FILENAMES) {
-            File file = new File(directory, filename);
-            if (!file.isFile()) {
-                return false;
-            }
-        }
         for (String subdirectory : GEOSERVER_DATA_DIRECTORY_SUBDIRECTORIES) {
             File dir = new File(directory, subdirectory);
             if (!dir.isDirectory()) {
                 return false;
             }
         }
+        // so there is a workspaces directory, lets check default.xml file
+        File workspacesDir = new File(directory, "workspaces");
+        File defaultXmlFile = new File(workspacesDir, "default.xml");
+        if (!defaultXmlFile.exists()) return false;
         return true;
     }
 }

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
@@ -17,12 +17,16 @@
 
 package org.geotools.xml.resolver;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.PrintWriter;
 import java.net.URI;
 import org.geotools.util.URLs;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Tests for {@link SchemaCache}.
@@ -30,6 +34,8 @@ import org.junit.Test;
  * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
  */
 public class SchemaCacheTest {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
 
     /**
      * Test the {@link SchemaCache#delete(File) method.
@@ -77,5 +83,19 @@ public class SchemaCacheTest {
                         .getCanonicalFile()
                         .toURI()
                         .toString());
+    }
+
+    /**
+     * Tests if current data directory have workspace and styles directories and workspace directory
+     * has default.xml file inside.
+     */
+    @Test
+    public void testIsSuitableDirectoryToContainCache() throws Exception {
+        File dataFolder = folder.newFolder("data");
+        File workspaceFolder = folder.newFolder("data", "workspaces");
+        folder.newFolder("data", "styles");
+        File defaultXmlFile = new File(workspaceFolder, "default.xml");
+        defaultXmlFile.createNewFile();
+        assertTrue(SchemaCache.isSuitableDirectoryToContainCache(dataFolder));
     }
 }


### PR DESCRIPTION
This PR fixes the Schema cache autoconfiguration bug relaxing the directory schema checking in a simpler approach, ensuring mainly the workspaces directory and its default.xml file for detecting the geoserver root folder and creating the app-schema-cache folder.

Also a warning logging line was added on not found valid directory event.

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-5729