### PR TITLE
[GEOT-6336] GML 2 temporal data is not being format like GML 3 encoding.

### DIFF
--- a/docs/user/library/metadata/geotools.rst
+++ b/docs/user/library/metadata/geotools.rst
@@ -26,6 +26,7 @@ CRS_AUTHORITY_EXTRA_DIRECTORY     org.geotools.referencing.crs-directory
 EPSG_DATA_SOURCE                  org.geotools.referencing.epsg-datasource
 FORCE_LONGITUDE_FIRST_AXIS_ORDER  org.geotools.referencing.forceXY
 LOCAL_DATE_TIME_HANDLING          org.geotools.localDateTimeHandling
+DATE_TIME_FORMAT_HANDLING         org.geotools.dateTimeFormatHandling
 RESAMPLE_TOLERANCE                org.geotools.referencing.resampleTolerance
 ENTITY_RESOLVER                   org.xml.sax.EntityResolver
 ================================= ===============================================

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
@@ -244,6 +244,23 @@ public final class GeoTools {
 
     /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
+     * assigned to the {@link Hints#DATE_TIME_FORMAT_HANDLING} hint.
+     *
+     * <p>This setting specifies if GML 2 temporal data shall be formatted using same approach as
+     * GML 3+.
+     *
+     * @see Hints#DATE_TIME_FORMAT_HANDLING
+     * @see #getDefaultHints
+     * @since 21.0
+     */
+    public static final String DATE_TIME_FORMAT_HANDLING = "org.geotools.dateTimeFormatHandling";
+
+    static {
+        bind(DATE_TIME_FORMAT_HANDLING, Hints.DATE_TIME_FORMAT_HANDLING);
+    }
+
+    /**
+     * The {@linkplain System#getProperty(String) system property} key for the default value to be
      * assigned to the {@link Hints#ENCODE_EWKT} hint.
      *
      * <p>This setting specifies if geometries with {@link

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
@@ -988,6 +988,23 @@ public class Hints extends RenderingHints {
     public static final Key ENCODE_EWKT = new Key(Boolean.class);
 
     /**
+     * Controls date time formatting output for GML 2.
+     *
+     * <p>To set on the command line:
+     *
+     * <blockquote>
+     *
+     * <pre>
+     * -D{@value GeoTools#DATE_TIME_FORMAT_HANDLING}=<var>true</var>
+     * </pre>
+     *
+     * </blockquote>
+     *
+     * @since 21.0
+     */
+    public static final Key DATE_TIME_FORMAT_HANDLING = new Key(Boolean.class);
+
+    /**
      * Constructs an initially empty set of hints.
      *
      * @since 2.5

--- a/modules/library/xml/src/main/java/org/geotools/gml/producer/FeatureTransformer.java
+++ b/modules/library/xml/src/main/java/org/geotools/gml/producer/FeatureTransformer.java
@@ -17,11 +17,13 @@
 package org.geotools.gml.producer;
 
 import java.io.IOException;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.logging.Logger;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureReader;
@@ -33,7 +35,9 @@ import org.geotools.feature.type.DateUtil;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.gml.producer.GeometryTransformer.GeometryTranslator;
 import org.geotools.referencing.CRS;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.XMLUtils;
+import org.geotools.xml.impl.DatatypeConverterImpl;
 import org.geotools.xml.transform.TransformerBase;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -848,12 +852,7 @@ public class FeatureTransformer extends TransformerBase {
                             }
                             geometryTranslator.encode((Geometry) value, srsName);
                         } else if (value instanceof Date) {
-                            String text = null;
-                            if (value instanceof java.sql.Date)
-                                text = DateUtil.serializeSqlDate((java.sql.Date) value);
-                            else if (value instanceof java.sql.Time)
-                                text = DateUtil.serializeSqlTime((java.sql.Time) value);
-                            else text = DateUtil.serializeDateTime((Date) value);
+                            String text = getDateString(value);
                             contentHandler.characters(text.toCharArray(), 0, text.length());
                         } else {
                             String text = XMLUtils.removeXMLInvalidChars(value.toString());
@@ -870,6 +869,53 @@ public class FeatureTransformer extends TransformerBase {
             } catch (Exception e) {
                 throw new IllegalStateException(
                         "Could not transform " + descriptor.getName() + ":" + e, e);
+            }
+        }
+
+        private String getDateString(Object value) {
+            String text = null;
+            if (value instanceof java.sql.Date)
+                text = DateUtil.serializeSqlDate((java.sql.Date) value);
+            else if (value instanceof java.sql.Time) {
+                // is date time formatting activated?
+                if (isDateTimeFormattingEnabled()) {
+                    final Date dateValue = (Date) value;
+                    text = DatatypeConverterImpl.getInstance().printTime(dateToCalendar(dateValue));
+                } else {
+                    text = DateUtil.serializeSqlTime((java.sql.Time) value);
+                }
+            } else {
+                // is date time formatting activated?
+                if (isDateTimeFormattingEnabled()) {
+                    final Date dateValue = (Date) value;
+                    text =
+                            DatatypeConverterImpl.getInstance()
+                                    .printDateTime(dateToCalendar(dateValue));
+                } else {
+                    text = DateUtil.serializeDateTime((Date) value);
+                }
+            }
+            return text;
+        }
+
+        private boolean isDateTimeFormattingEnabled() {
+            Object hint = Hints.getSystemDefault(Hints.DATE_TIME_FORMAT_HANDLING);
+            return !Boolean.FALSE.equals(hint);
+        }
+
+        private Calendar dateToCalendar(Date value) {
+            Calendar calendar = getConfiguredCalendar();
+            calendar.clear();
+            calendar.setTimeInMillis(value.getTime());
+            return calendar;
+        }
+
+        private Calendar getConfiguredCalendar() {
+            Object hint = Hints.getSystemDefault(Hints.LOCAL_DATE_TIME_HANDLING);
+            if (Boolean.TRUE.equals(hint)) {
+                return Calendar.getInstance();
+            } else {
+                return Calendar.getInstance(TimeZone.getTimeZone("GMT"));
             }
         }
 

--- a/modules/library/xml/src/test/java/org/geotools/gml/producer/FeatureTransformerTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/gml/producer/FeatureTransformerTest.java
@@ -3,14 +3,18 @@ package org.geotools.gml.producer;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.util.factory.Hints;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.io.WKTReader;
@@ -72,5 +76,83 @@ public class FeatureTransformerTest {
         Document dom = XMLUnit.buildControlDocument(result);
         assertXpathEvaluatesTo("1", "count(//wfs:FeatureCollection)", dom);
         assertXpathEvaluatesTo("One  test", "//gt:data", dom);
+    }
+
+    /**
+     * Checks FeatureTransformer DateTime formatting handling with
+     * 'org.geotools.dateTimeFormatHandling' system property on true.
+     */
+    @Test
+    public void testDateTimeFormatEnabled() throws Exception {
+        System.setProperty("org.geotools.dateTimeFormatHandling", "true");
+        Hints.scanSystemProperties();
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+            SimpleFeatureType ft =
+                    DataUtilities.createType("invalidChars", "the_geom:Point,dia:Date");
+            Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+            cal.clear();
+            cal.set(1982, 11, 3);
+            Date dateValue = cal.getTime();
+            SimpleFeature feature =
+                    SimpleFeatureBuilder.build(
+                            ft,
+                            new Object[] {new WKTReader().read("POINT(0 0)"), dateValue},
+                            "123");
+            SimpleFeatureCollection fc = DataUtilities.collection(feature);
+
+            FeatureTransformer tx = new FeatureTransformer();
+            tx.setIndentation(2);
+            tx.getFeatureTypeNamespaces().declareNamespace(ft, "gt", "http://www.geotools.org");
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            tx.transform(fc, bos);
+            String result = bos.toString();
+            Document dom = XMLUnit.buildControlDocument(result);
+            assertXpathEvaluatesTo("1", "count(//wfs:FeatureCollection)", dom);
+            assertXpathEvaluatesTo("1982-12-03T00:00:00Z", "//gt:dia", dom);
+        } finally {
+            System.getProperties().remove("org.geotools.dateTimeFormatHandling");
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    /**
+     * Checks FeatureTransformer DateTime formatting handling with
+     * 'org.geotools.dateTimeFormatHandling' system property on false.
+     */
+    @Test
+    public void testDateTimeFormatDisabled() throws Exception {
+        System.setProperty("org.geotools.dateTimeFormatHandling", "false");
+        Hints.scanSystemProperties();
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+            SimpleFeatureType ft =
+                    DataUtilities.createType("invalidChars", "the_geom:Point,dia:Date");
+            Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+            cal.clear();
+            cal.set(1982, 11, 3);
+            Date dateValue = cal.getTime();
+            SimpleFeature feature =
+                    SimpleFeatureBuilder.build(
+                            ft,
+                            new Object[] {new WKTReader().read("POINT(0 0)"), dateValue},
+                            "123");
+            SimpleFeatureCollection fc = DataUtilities.collection(feature);
+
+            FeatureTransformer tx = new FeatureTransformer();
+            tx.setIndentation(2);
+            tx.getFeatureTypeNamespaces().declareNamespace(ft, "gt", "http://www.geotools.org");
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            tx.transform(fc, bos);
+            String result = bos.toString();
+            Document dom = XMLUnit.buildControlDocument(result);
+            assertXpathEvaluatesTo("1", "count(//wfs:FeatureCollection)", dom);
+            assertXpathEvaluatesTo("1982-12-03T00:00:00", "//gt:dia", dom);
+        } finally {
+            System.getProperties().remove("org.geotools.dateTimeFormatHandling");
+            TimeZone.setDefault(defaultTimeZone);
+        }
     }
 }


### PR DESCRIPTION
This PR enables temporal data formatting on GML 2 encoder, using same strategy as GML 3.

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6336