### PR TITLE
[GEOT-6328] Allow MongoDB data store schema builder to user all DB collection items (21.x backport)

### DIFF
--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
@@ -166,6 +166,23 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
         }
     }
 
+    public void testRebuildSchemaWithAllItems() throws Exception {
+        try {
+            dataStore.setSchemaInitParams(MongoSchemaInitParams.builder().maxObjects(-1).build());
+            clearSchemaStore(dataStore);
+            dataStore.cleanEntries();
+            SimpleFeatureType schema = dataStore.getSchema("ft1");
+            assertNotNull(schema);
+            assertNotNull(schema.getDescriptor("properties.optionalProperty"));
+            assertNotNull(schema.getDescriptor("properties.optionalProperty2"));
+            assertNotNull(schema.getDescriptor("properties.optionalProperty3"));
+        } finally {
+            dataStore.setSchemaInitParams(null);
+            clearSchemaStore(dataStore);
+            dataStore.cleanEntries();
+        }
+    }
+
     private void clearSchemaStore(MongoDataStore mongoStore) {
         List<String> typeNames = mongoStore.getSchemaStore().typeNames();
         for (String et : typeNames) {

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -56,6 +56,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                         .add("intProperty", 0)
                         .add("doubleProperty", 0.0)
                         .add("stringProperty", "zero")
+                        .add("optionalProperty3", "optional")
                         .add(NULLABLE_ATTRIBUTE, "A value")
                         .add(
                                 "listProperty",
@@ -76,6 +77,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                         .push("properties")
                         .add("intProperty", 1)
                         .add("doubleProperty", 1.1)
+                        .add("optionalProperty2", "optional")
                         .add("stringProperty", "one")
                         .add(NULLABLE_ATTRIBUTE, null)
                         .add(


### PR DESCRIPTION
This PR allows mongoDB store to use -1 value in "max_objs_schema" parameter for using all collection items in schema build process. Also improves some schema build process logging.

21.x backport.

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6328