### PR TITLE
[GEOT-6329] MongoDB schema inferrer only uses first item on inner arrays (21.x backport)

### DIFF
--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexUtilities.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/complex/MongoComplexUtilities.java
@@ -372,7 +372,9 @@ public final class MongoComplexUtilities {
                 if (value instanceof List) {
                     List list = (List) value;
                     if (!list.isEmpty()) {
-                        findMappingsHelper(list.get(0), path, mappings);
+                        for (Object eo : list) {
+                            findMappingsHelper(eo, path, mappings);
+                        }
                     }
                 } else if (value instanceof DBObject) {
                     findMappingsHelper(value, path, mappings);

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
@@ -176,6 +176,10 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
             assertNotNull(schema.getDescriptor("properties.optionalProperty"));
             assertNotNull(schema.getDescriptor("properties.optionalProperty2"));
             assertNotNull(schema.getDescriptor("properties.optionalProperty3"));
+            // check inside array value (not first element)
+            assertNotNull(
+                    "Inside array value check (not first element) failed.",
+                    schema.getDescriptor("properties.listProperty.insideArrayValue"));
         } finally {
             dataStore.setSchemaInitParams(null);
             clearSchemaStore(dataStore);

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -105,7 +105,8 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                                 "listProperty",
                                 list(
                                         new BasicDBObject("value", 2.1),
-                                        new BasicDBObject("value", 2.2)))
+                                        new BasicDBObject("value", 2.2),
+                                        new BasicDBObject("insideArrayValue", 7.7)))
                         .add("dateProperty", getDateProperty(2))
                         .pop()
                         .get());


### PR DESCRIPTION
This PR allows MongoDB schema inferrer to use all inner arrays items.

21.x backport.

Requires:
https://github.com/geotools/geotools/pull/2485

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6329