### PR TITLE
[Backport 21.x] [GEOT-6341] demote gt-epsg-hsql in gt-tile-client to test scope

### DIFF
--- a/modules/extension/tile-client/pom.xml
+++ b/modules/extension/tile-client/pom.xml
@@ -85,6 +85,7 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/modules/extension/wmts/pom.xml
+++ b/modules/extension/wmts/pom.xml
@@ -94,6 +94,12 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
             <artifactId>gt-sample-data</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
This should prevent `gt-tile-client` from dragging in `gt-epsg-hsql`, see [GEOT-6341](https://osgeo-org.atlassian.net/browse/GEOT-6341)

Backports #2487