### PR TITLE
WFS-NG Check

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetFeatureRequest.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetFeatureRequest.java
@@ -61,17 +61,6 @@ public class GetFeatureRequest extends WFSRequest {
         resultType = ResultType.RESULTS;
     }
 
-    //
-    // public GetFeatureRequest(GetFeatureRequest query) {
-    // setFilter(query.getFilter());
-    // setMaxFeatures(query.getMaxFeatures());
-    // setOutputFormat(query.getOutputFormat());
-    // setPropertyNames(query.getPropertyNames());
-    // setResultType(query.getResultType());
-    // setSortBy(query.getSortBy());
-    // setSrsName(query.getSrsName());
-    // }
-
     public String[] getPropertyNames() {
         return propertyNames;
     }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -268,6 +268,9 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
                 String count = kvp.remove("MAXFEATURES");
                 kvp.put("COUNT", count);
             }
+            // Also crude
+            String typeName = kvp.remove("TYPENAME");
+            kvp.put("TYPENAMES", typeName);
         }
 
         return kvp;

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/GeoServerWFSOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/GeoServerWFSOnlineTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TreeSet;
 import org.geotools.data.DataStoreFinder;
 import org.geotools.data.Query;
@@ -44,8 +45,10 @@ import org.opengis.filter.FilterFactory;
 
 /** @author ian */
 public class GeoServerWFSOnlineTest extends OnlineTestSupport {
-
-    TreeSet<String> expected = new TreeSet<>();
+    /** Results expected for Version 1.x */
+    TreeSet<String> expected1 = new TreeSet<>();
+    /** Results expected for Version 2.x */
+    TreeSet<String> expected2 = new TreeSet<>();
 
     @Before
     public void setup() {
@@ -59,9 +62,23 @@ public class GeoServerWFSOnlineTest extends OnlineTestSupport {
             "states.18",
             "states.19",
             "states.21",
-            "states.22",
+            "states.22"
         };
-        expected.addAll(Arrays.asList(expectedA));
+        expected1.addAll(Arrays.asList(expectedA));
+
+        String[] expectedB = {
+            "states.1",
+            "states.13",
+            "states.14",
+            "states.17",
+            "states.18",
+            "states.19",
+            "states.21",
+            "states.22",
+            "states.23",
+            "states.24",
+        };
+        expected2.addAll(Arrays.asList(expectedB));
     }
 
     @Test
@@ -86,33 +103,41 @@ public class GeoServerWFSOnlineTest extends OnlineTestSupport {
 
     @Test
     public void testGeoServerWFSFilter_V2_get() throws IOException, NoSuchElementException {
-        geoServerTest("2.0.0", true);
+        geoServerTest("2.0.0", true, expected2);
     }
 
     @Test
     public void testGeoServerWFSFilter_V2_post() throws IOException, NoSuchElementException {
-        geoServerTest("2.0.0", false);
+        geoServerTest("2.0.0", false, expected2);
+    }
+
+    private void geoServerTest(String version, boolean get) throws IOException {
+        geoServerTest(version, get, expected1);
     }
     /**
      * @param expected
      * @param version
      * @throws IOException
      */
-    private void geoServerTest(String version, boolean get) throws IOException {
+    private void geoServerTest(String version, boolean get, Set<String> expected)
+            throws IOException {
         Properties fixture = getFixture();
-        
+
         String getCapabilities =
-                fixture.getProperty(WFSDataStoreFactory.URL.key, "http://localhost:8080/geoserver/wfs?") +
-                "REQUEST=GetCapabilities&SERVICE=WFS&VERSION=" + version;
-        
-        
+                fixture.getProperty(
+                                WFSDataStoreFactory.URL.key, "http://localhost:8080/geoserver/wfs?")
+                        + "REQUEST=GetCapabilities&SERVICE=WFS&VERSION="
+                        + version;
+
         Map<String, Object> connectionParameters = new HashMap<String, Object>();
         connectionParameters.put(WFSDataStoreFactory.URL.key, getCapabilities);
-        connectionParameters.put(WFSDataStoreFactory.LENIENT.key,
-                Boolean.valueOf(fixture.getProperty(WFSDataStoreFactory.LENIENT.key,"true")));
-        connectionParameters.put(WFSDataStoreFactory.TIMEOUT.key, Integer.valueOf(
-                fixture.getProperty(WFSDataStoreFactory.TIMEOUT.key,"30")));
-        
+        connectionParameters.put(
+                WFSDataStoreFactory.LENIENT.key,
+                Boolean.valueOf(fixture.getProperty(WFSDataStoreFactory.LENIENT.key, "true")));
+        connectionParameters.put(
+                WFSDataStoreFactory.TIMEOUT.key,
+                Integer.valueOf(fixture.getProperty(WFSDataStoreFactory.TIMEOUT.key, "30")));
+
         if (get) {
             connectionParameters.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
         }
@@ -140,8 +165,9 @@ public class GeoServerWFSOnlineTest extends OnlineTestSupport {
         try (SimpleFeatureIterator iterator = features.features()) {
             while (iterator.hasNext() && count < 10) {
                 SimpleFeature feature = iterator.next();
-
-                assertTrue(expected.contains(feature.getID()));
+                assertTrue(
+                        "unexpected feature " + feature.getID(),
+                        expected.contains(feature.getID()));
                 count++;
             }
         }
@@ -163,17 +189,15 @@ public class GeoServerWFSOnlineTest extends OnlineTestSupport {
     protected String getFixtureId() {
         return "geoserver-wfs";
     }
-    
+
     /** Create placeholder fixture, the use of localhost is hardcoded anyways */
     @Override
     protected Properties createExampleFixture() {
         Properties template = new Properties();
         template.put(WFSDataStoreFactory.URL.key, "http://localhost:8080/geoserver/wfs?");
-        template.put(WFSDataStoreFactory.LENIENT.key,"true");
-        template.put(WFSDataStoreFactory.TIMEOUT.key,"5");
-        
+        template.put(WFSDataStoreFactory.LENIENT.key, "true");
+        template.put(WFSDataStoreFactory.TIMEOUT.key, "5");
+
         return template;
     }
-
-    
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/GeoServerWFSOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/GeoServerWFSOnlineTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Properties;
 import java.util.TreeSet;
 import org.geotools.data.DataStoreFinder;
 import org.geotools.data.Query;
@@ -98,16 +99,20 @@ public class GeoServerWFSOnlineTest extends OnlineTestSupport {
      * @throws IOException
      */
     private void geoServerTest(String version, boolean get) throws IOException {
-
+        Properties fixture = getFixture();
+        
         String getCapabilities =
-                "http://localhost:8080/geoserver/wfs?request=GetCapabilities&service=WFS&version="
-                        + version;
+                fixture.getProperty(WFSDataStoreFactory.URL.key, "http://localhost:8080/geoserver/wfs?") +
+                "REQUEST=GetCapabilities&SERVICE=WFS&VERSION=" + version;
+        
+        
         Map<String, Object> connectionParameters = new HashMap<String, Object>();
         connectionParameters.put(WFSDataStoreFactory.URL.key, getCapabilities);
-        connectionParameters.put(WFSDataStoreFactory.LENIENT.key, Boolean.TRUE);
-        // connectionParameters.put(WFSDataStoreFactory.WFS_STRATEGY.key, "arcgis");
-        connectionParameters.put(WFSDataStoreFactory.TIMEOUT.key, 30);
-        //
+        connectionParameters.put(WFSDataStoreFactory.LENIENT.key,
+                Boolean.valueOf(fixture.getProperty(WFSDataStoreFactory.LENIENT.key,"true")));
+        connectionParameters.put(WFSDataStoreFactory.TIMEOUT.key, Integer.valueOf(
+                fixture.getProperty(WFSDataStoreFactory.TIMEOUT.key,"30")));
+        
         if (get) {
             connectionParameters.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
         }
@@ -158,4 +163,17 @@ public class GeoServerWFSOnlineTest extends OnlineTestSupport {
     protected String getFixtureId() {
         return "geoserver-wfs";
     }
+    
+    /** Create placeholder fixture, the use of localhost is hardcoded anyways */
+    @Override
+    protected Properties createExampleFixture() {
+        Properties template = new Properties();
+        template.put(WFSDataStoreFactory.URL.key, "http://localhost:8080/geoserver/wfs?");
+        template.put(WFSDataStoreFactory.LENIENT.key,"true");
+        template.put(WFSDataStoreFactory.TIMEOUT.key,"5");
+        
+        return template;
+    }
+
+    
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/GeoServerOnlineTest.java
@@ -17,6 +17,7 @@
 package org.geotools.data.wfs.online.v2_0;
 
 import static org.geotools.data.wfs.WFSTestData.GEOS_STATES_11;
+
 import java.util.Collections;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.online.AbstractWfsDataStoreOnlineTest;
@@ -61,8 +62,8 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
         return ff.intersects(ff.property("the_geom"), ff.literal(polygon));
     }
 
-        @Override
-        public void testDataStoreHandlesAxisFlipping() {
-            // disabled, not implemented for 2.0.0
-        }
+    @Override
+    public void testDataStoreHandlesAxisFlipping() {
+        // disabled, not implemented for 2.0.0
+    }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/GeoServerOnlineTest.java
@@ -17,7 +17,6 @@
 package org.geotools.data.wfs.online.v2_0;
 
 import static org.geotools.data.wfs.WFSTestData.GEOS_STATES_11;
-
 import java.util.Collections;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.online.AbstractWfsDataStoreOnlineTest;
@@ -33,7 +32,7 @@ import org.opengis.filter.FilterFactory2;
 public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
 
     public static final String SERVER_URL =
-            "http://localhost:9090/geoserver/wfs?service=WFS&request=GetCapabilities&version=2.0.0";
+            "http://localhost:8080/geoserver/wfs?service=WFS&request=GetCapabilities&version=2.0.0";
 
     public GeoServerOnlineTest() {
         super(
@@ -62,8 +61,8 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
         return ff.intersects(ff.property("the_geom"), ff.literal(polygon));
     }
 
-    @Override
-    public void testDataStoreHandlesAxisFlipping() {
-        // disabled, not implemented for 2.0.0
-    }
+        @Override
+        public void testDataStoreHandlesAxisFlipping() {
+            // disabled, not implemented for 2.0.0
+        }
 }


### PR DESCRIPTION
Looking at an axis order issue encountered by GeoNetwork when updating to GeoTools 21.x:

* [x] set up fixture template for GeoServer online tests
* [x] check WFSDataStore ability to reproject based on axis order change

Reference:
* https://github.com/geonetwork/core-geonetwork/pull/3886
* https://github.com/geoserver/geoserver/pull/3674