### PR TITLE
[GEOT-6347] Layer creation using REST API very slow in a PostGIS database with thousands of tables

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -238,6 +238,9 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
     /** sql type to sql type name overrides */
     protected HashMap<Integer, String> sqlTypeToSqlTypeNameOverrides;
 
+    /** cache of sqltypes found in database */
+    protected ConcurrentHashMap<Integer, String> dBsqlTypesCache;
+
     /** Feature visitor to aggregate function name */
     protected HashMap<Class<? extends FeatureVisitor>, String> aggregateFunctions;
 
@@ -624,6 +627,20 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
         }
 
         return sqlTypeToSqlTypeNameOverrides;
+    }
+
+    /**
+     * Returns a map integer constants for database types (from {@link Types}) to database type
+     * names.
+     *
+     * <p>This method will return an empty map when there are no overrides.
+     */
+    public ConcurrentHashMap<Integer, String> getDBsqlTypesCache() {
+        if (dBsqlTypesCache == null) {
+            dBsqlTypesCache = new ConcurrentHashMap<Integer, String>();
+        }
+
+        return dBsqlTypesCache;
     }
 
     /** Returns the supported aggregate functions and the visitors they map to. */
@@ -3224,80 +3241,87 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
                 }
             }
 
+            // check types previously read from DB
+            String sqlTypeDBName = getDBsqlTypesCache().get(sqlType);
+            if (sqlTypeDBName != null) {
+                sqlTypeNames[i] = sqlTypeDBName;
+            }
+
             // check the overrides
             String sqlTypeName = getSqlTypeToSqlTypeNameOverrides().get(sqlType);
             if (sqlTypeName != null) {
                 sqlTypeNames[i] = sqlTypeName;
             }
         }
-        // Geos-7533 if all sql type names have been found in dialect dont
+        // GEOT-6347 if all sql type names have been found in dialect dont
         // go to database
         boolean allTypesFound = !ArrayUtils.contains(sqlTypeNames, null);
-        if (allTypesFound) return sqlTypeNames;
+        if (allTypesFound) {
+            LOGGER.log(Level.WARNING, "Fetching fields from Database");
+            // figure out the type names that correspond to the sql types from
+            // the database metadata
+            DatabaseMetaData metaData = cx.getMetaData();
 
-        // figure out the type names that correspond to the sql types from
-        // the database metadata
-        DatabaseMetaData metaData = cx.getMetaData();
+            /*
+            *      <LI><B>TYPE_NAME</B> String => Type name
+            *        <LI><B>DATA_TYPE</B> int => SQL data type from java.sql.Types
+            *        <LI><B>PRECISION</B> int => maximum precision
+            *        <LI><B>LITERAL_PREFIX</B> String => prefix used to quote a literal
+            *      (may be <code>null</code>)
+            *        <LI><B>LITERAL_SUFFIX</B> String => suffix used to quote a literal
+                (may be <code>null</code>)
+            *        <LI><B>CREATE_PARAMS</B> String => parameters used in creating
+            *      the type (may be <code>null</code>)
+            *        <LI><B>NULLABLE</B> short => can you use NULL for this type.
+            *      <UL>
+            *      <LI> typeNoNulls - does not allow NULL values
+            *      <LI> typeNullable - allows NULL values
+            *      <LI> typeNullableUnknown - nullability unknown
+            *      </UL>
+            *        <LI><B>CASE_SENSITIVE</B> boolean=> is it case sensitive.
+            *        <LI><B>SEARCHABLE</B> short => can you use "WHERE" based on this type:
+            *      <UL>
+            *      <LI> typePredNone - No support
+            *      <LI> typePredChar - Only supported with WHERE .. LIKE
+            *      <LI> typePredBasic - Supported except for WHERE .. LIKE
+            *      <LI> typeSearchable - Supported for all WHERE ..
+            *      </UL>
+            *        <LI><B>UNSIGNED_ATTRIBUTE</B> boolean => is it unsigned.
+            *        <LI><B>FIXED_PREC_SCALE</B> boolean => can it be a money value.
+            *        <LI><B>AUTO_INCREMENT</B> boolean => can it be used for an
+            *      auto-increment value.
+            *        <LI><B>LOCAL_TYPE_NAME</B> String => localized version of type name
+            *      (may be <code>null</code>)
+            *        <LI><B>MINIMUM_SCALE</B> short => minimum scale supported
+            *        <LI><B>MAXIMUM_SCALE</B> short => maximum scale supported
+            *        <LI><B>SQL_DATA_TYPE</B> int => unused
+            *        <LI><B>SQL_DATETIME_SUB</B> int => unused
+            *        <LI><B>NUM_PREC_RADIX</B> int => usually 2 or 10
+            */
+            ResultSet types = metaData.getTypeInfo();
 
-        /*
-        *      <LI><B>TYPE_NAME</B> String => Type name
-        *        <LI><B>DATA_TYPE</B> int => SQL data type from java.sql.Types
-        *        <LI><B>PRECISION</B> int => maximum precision
-        *        <LI><B>LITERAL_PREFIX</B> String => prefix used to quote a literal
-        *      (may be <code>null</code>)
-        *        <LI><B>LITERAL_SUFFIX</B> String => suffix used to quote a literal
-            (may be <code>null</code>)
-        *        <LI><B>CREATE_PARAMS</B> String => parameters used in creating
-        *      the type (may be <code>null</code>)
-        *        <LI><B>NULLABLE</B> short => can you use NULL for this type.
-        *      <UL>
-        *      <LI> typeNoNulls - does not allow NULL values
-        *      <LI> typeNullable - allows NULL values
-        *      <LI> typeNullableUnknown - nullability unknown
-        *      </UL>
-        *        <LI><B>CASE_SENSITIVE</B> boolean=> is it case sensitive.
-        *        <LI><B>SEARCHABLE</B> short => can you use "WHERE" based on this type:
-        *      <UL>
-        *      <LI> typePredNone - No support
-        *      <LI> typePredChar - Only supported with WHERE .. LIKE
-        *      <LI> typePredBasic - Supported except for WHERE .. LIKE
-        *      <LI> typeSearchable - Supported for all WHERE ..
-        *      </UL>
-        *        <LI><B>UNSIGNED_ATTRIBUTE</B> boolean => is it unsigned.
-        *        <LI><B>FIXED_PREC_SCALE</B> boolean => can it be a money value.
-        *        <LI><B>AUTO_INCREMENT</B> boolean => can it be used for an
-        *      auto-increment value.
-        *        <LI><B>LOCAL_TYPE_NAME</B> String => localized version of type name
-        *      (may be <code>null</code>)
-        *        <LI><B>MINIMUM_SCALE</B> short => minimum scale supported
-        *        <LI><B>MAXIMUM_SCALE</B> short => maximum scale supported
-        *        <LI><B>SQL_DATA_TYPE</B> int => unused
-        *        <LI><B>SQL_DATETIME_SUB</B> int => unused
-        *        <LI><B>NUM_PREC_RADIX</B> int => usually 2 or 10
-        */
-        ResultSet types = metaData.getTypeInfo();
+            try {
+                while (types.next()) {
+                    int sqlType = types.getInt("DATA_TYPE");
+                    String sqlTypeName = types.getString("TYPE_NAME");
 
-        try {
-            while (types.next()) {
-                int sqlType = types.getInt("DATA_TYPE");
-                String sqlTypeName = types.getString("TYPE_NAME");
+                    for (int i = 0; i < sqlTypes.length; i++) {
+                        // check if we already have the type name from the dialect
+                        if (sqlTypeNames[i] != null) {
+                            continue;
+                        }
 
-                for (int i = 0; i < sqlTypes.length; i++) {
-                    // check if we already have the type name from the dialect
-                    if (sqlTypeNames[i] != null) {
-                        continue;
-                    }
-
-                    if (sqlType == sqlTypes[i]) {
-                        sqlTypeNames[i] = sqlTypeName;
-                        // Geos-7533
-                        // cache the sqlType which required going to database for sql types
-                        getSqlTypeToSqlTypeNameOverrides().put(sqlType, sqlTypeName);
+                        if (sqlType == sqlTypes[i]) {
+                            sqlTypeNames[i] = sqlTypeName;
+                            // GEOT-6347
+                            // cache the sqlType which required going to database for sql types
+                            getDBsqlTypesCache().putIfAbsent(sqlType, sqlTypeName);
+                        }
                     }
                 }
+            } finally {
+                closeSafe(types);
             }
-        } finally {
-            closeSafe(types);
         }
 
         // apply the overrides specified by the dialect

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -3229,17 +3229,16 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
             if (sqlTypeName != null) {
                 sqlTypeNames[i] = sqlTypeName;
             }
-        }        
-        //Step 2 Geos-7533 make below two lines controllable from hint or param
-        //if all sql type names have been found in dialect dont
-        //go to database GEOS-7533
-        boolean allTypesFound = !ArrayUtils.contains(sqlTypeNames, null);        
-        if(allTypesFound) return sqlTypeNames;
+        }
+        // Geos-7533 if all sql type names have been found in dialect dont
+        // go to database
+        boolean allTypesFound = !ArrayUtils.contains(sqlTypeNames, null);
+        if (allTypesFound) return sqlTypeNames;
 
         // figure out the type names that correspond to the sql types from
         // the database metadata
         DatabaseMetaData metaData = cx.getMetaData();
-        
+
         /*
         *      <LI><B>TYPE_NAME</B> String => Type name
         *        <LI><B>DATA_TYPE</B> int => SQL data type from java.sql.Types
@@ -3291,6 +3290,9 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
 
                     if (sqlType == sqlTypes[i]) {
                         sqlTypeNames[i] = sqlTypeName;
+                        // Geos-7533
+                        // cache the sqlType which required going to database for sql types
+                        getSqlTypeToSqlTypeNameOverrides().put(sqlType, sqlTypeName);
                     }
                 }
             }

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -3246,17 +3246,11 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
             if (sqlTypeDBName != null) {
                 sqlTypeNames[i] = sqlTypeDBName;
             }
-
-            // check the overrides
-            String sqlTypeName = getSqlTypeToSqlTypeNameOverrides().get(sqlType);
-            if (sqlTypeName != null) {
-                sqlTypeNames[i] = sqlTypeName;
-            }
         }
         // GEOT-6347 if all sql type names have been found in dialect dont
         // go to database
         boolean allTypesFound = !ArrayUtils.contains(sqlTypeNames, null);
-        if (allTypesFound) {
+        if (!allTypesFound) {
             LOGGER.log(Level.WARNING, "Fetching fields from Database");
             // figure out the type names that correspond to the sql types from
             // the database metadata

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import javax.sql.DataSource;
+import org.apache.commons.lang3.ArrayUtils;
 import org.geotools.data.DataStore;
 import org.geotools.data.DefaultTransaction;
 import org.geotools.data.FeatureStore;
@@ -3228,12 +3229,17 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
             if (sqlTypeName != null) {
                 sqlTypeNames[i] = sqlTypeName;
             }
-        }
+        }        
+        //Step 2 Geos-7533 make below two lines controllable from hint or param
+        //if all sql type names have been found in dialect dont
+        //go to database GEOS-7533
+        boolean allTypesFound = !ArrayUtils.contains(sqlTypeNames, null);        
+        if(allTypesFound) return sqlTypeNames;
 
         // figure out the type names that correspond to the sql types from
         // the database metadata
         DatabaseMetaData metaData = cx.getMetaData();
-
+        
         /*
         *      <LI><B>TYPE_NAME</B> String => Type name
         *        <LI><B>DATA_TYPE</B> int => SQL data type from java.sql.Types

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -71,7 +71,6 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.postgresql.core.Oid;
 
 public class PostGISDialect extends BasicSQLDialect {
 
@@ -1115,8 +1114,6 @@ public class PostGISDialect extends BasicSQLDialect {
 
     @Override
     public void registerSqlTypeToSqlTypeNameOverrides(Map<Integer, String> overrides) {
-        //Step 1 Geos-7533 put the types in dialect
-        overrides.put(4, "int4");
         overrides.put(Types.VARCHAR, "VARCHAR");
         overrides.put(Types.BOOLEAN, "BOOL");
         overrides.put(Types.BLOB, "BYTEA");
@@ -1366,7 +1363,7 @@ public class PostGISDialect extends BasicSQLDialect {
             throws SQLException {
         Statement st = cx.createStatement();
         String tableName = featureType.getTypeName();
-        
+
         try {
             // remove all the geometry_column entries
             String sql =

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -71,6 +71,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.postgresql.core.Oid;
 
 public class PostGISDialect extends BasicSQLDialect {
 
@@ -1114,6 +1115,8 @@ public class PostGISDialect extends BasicSQLDialect {
 
     @Override
     public void registerSqlTypeToSqlTypeNameOverrides(Map<Integer, String> overrides) {
+        //Step 1 Geos-7533 put the types in dialect
+        overrides.put(4, "int4");
         overrides.put(Types.VARCHAR, "VARCHAR");
         overrides.put(Types.BOOLEAN, "BOOL");
         overrides.put(Types.BLOB, "BYTEA");
@@ -1363,7 +1366,7 @@ public class PostGISDialect extends BasicSQLDialect {
             throws SQLException {
         Statement st = cx.createStatement();
         String tableName = featureType.getTypeName();
-
+        
         try {
             // remove all the geometry_column entries
             String sql =


### PR DESCRIPTION
Actual Reported Issue
https://osgeo-org.atlassian.net/browse/GEOS-7533?oldIssueView=true

Geotools JIRA
https://osgeo-org.atlassian.net/browse/GEOT-6347

I propose to put commonly used sqltypes inside overrides map and have the behavior inside JDBCDataStore controllable through some param, that if all sqlTypeName have been found through dialect, it should not bother the driver for querying for datatypes inside underlying Database.