### PR TITLE
[GEOT-6350] Enable configuration of the max connection pool size

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/MultithreadedHttpClient.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/MultithreadedHttpClient.java
@@ -38,6 +38,7 @@ import org.apache.commons.httpclient.params.HttpConnectionManagerParams;
 import org.geotools.data.ows.AbstractOpenWebService;
 import org.geotools.data.ows.HTTPClient;
 import org.geotools.data.ows.HTTPResponse;
+import org.geotools.data.wfs.internal.WFSConfig;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -65,14 +66,14 @@ public class MultithreadedHttpClient implements HTTPClient {
 
     private boolean tryGzip;
 
-    public MultithreadedHttpClient() {
+    public MultithreadedHttpClient(WFSConfig config) {
         connectionManager = new MultiThreadedHttpConnectionManager();
 
         HttpConnectionManagerParams params = new HttpConnectionManagerParams();
-        params.setSoTimeout(30000);
-        params.setConnectionTimeout(30000);
-        params.setMaxTotalConnections(6);
-        params.setDefaultMaxConnectionsPerHost(6);
+        params.setSoTimeout(config.getTimeoutMillis());
+        params.setConnectionTimeout(config.getTimeoutMillis());
+        params.setMaxTotalConnections(config.getMaxConnectionPoolSize());
+        params.setDefaultMaxConnectionsPerHost(config.getMaxConnectionPoolSize());
 
         connectionManager.setParams(params);
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSDataStoreFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSDataStoreFactory.java
@@ -135,7 +135,7 @@ public class WFSDataStoreFactory extends WFSDataAccessFactory implements DataSto
         final URL capabilitiesURL = (URL) URL.lookUp(params);
         final WFSConfig config = WFSConfig.fromParams(params);
         return config.isUseHttpConnectionPooling() && isHttp(capabilitiesURL)
-                ? new MultithreadedHttpClient()
+                ? new MultithreadedHttpClient(config)
                 : new SimpleHttpClient();
     }
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
@@ -574,8 +574,9 @@ public class WFSDataAccessFactory implements DataAccessFactory {
                         new WFSFactoryParam<Boolean>(name, Boolean.class, title, description, true);
     }
 
-    /** Optional {@code Integer} controlling the size of the connection pool to use for http(s) requests.
-     *  Only activated when {@link #USE_HTTP_CONNECTION_POOLING} is <code>true</code>
+    /**
+     * Optional {@code Integer} controlling the size of the connection pool to use for http(s)
+     * requests. Only activated when {@link #USE_HTTP_CONNECTION_POOLING} is <code>true</code>
      */
     public static final WFSFactoryParam<Integer> MAX_CONNECTION_POOL_SIZE;
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
@@ -147,7 +147,7 @@ public class WFSDataAccessFactory implements DataAccessFactory {
     }
 
     /** Access with {@link WFSDataStoreFactory#getParametersInfo()  */
-    private static final WFSFactoryParam<?>[] parametersInfo = new WFSFactoryParam[21];
+    private static final WFSFactoryParam<?>[] parametersInfo = new WFSFactoryParam[22];
 
     private static final int GMLComplianceLevel = 2;
 
@@ -572,6 +572,20 @@ public class WFSDataAccessFactory implements DataAccessFactory {
         parametersInfo[20] =
                 USE_HTTP_CONNECTION_POOLING =
                         new WFSFactoryParam<Boolean>(name, Boolean.class, title, description, true);
+    }
+
+    /** Optional {@code Integer} controlling the size of the connection pool to use for http(s) requests.
+     *  Only activated when {@link #USE_HTTP_CONNECTION_POOLING} is <code>true</code>
+     */
+    public static final WFSFactoryParam<Integer> MAX_CONNECTION_POOL_SIZE;
+
+    static {
+        String name = "WFSDataStoreFactory:MAX_CONNECTION_POOL_SIZE";
+        String title = "Set the default connection pool size";
+        String description = "Sets the default connection pool size for http(s) requests";
+        parametersInfo[21] =
+                MAX_CONNECTION_POOL_SIZE =
+                        new WFSFactoryParam<>(name, Integer.class, title, description, 6);
     }
 
     /**

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSConfig.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSConfig.java
@@ -262,7 +262,10 @@ public class WFSConfig {
         return useHttpConnectionPooling;
     }
 
-    /** @return the size of the connection pool, if {@link #isUseHttpConnectionPooling()} is <code>true</code> */
+    /**
+     * @return the size of the connection pool, if {@link #isUseHttpConnectionPooling()} is <code>
+     *     true</code>
+     */
     public int getMaxConnectionPoolSize() {
         return maxConnectionPoolSize;
     }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSConfig.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSConfig.java
@@ -34,6 +34,7 @@ import static org.geotools.data.wfs.WFSDataStoreFactory.TRY_GZIP;
 import static org.geotools.data.wfs.WFSDataStoreFactory.USERNAME;
 import static org.geotools.data.wfs.WFSDataStoreFactory.USE_HTTP_CONNECTION_POOLING;
 import static org.geotools.data.wfs.WFSDataStoreFactory.WFS_STRATEGY;
+import static org.geotools.data.wfs.impl.WFSDataAccessFactory.MAX_CONNECTION_POOL_SIZE;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -85,6 +86,8 @@ public class WFSConfig {
 
     protected boolean useHttpConnectionPooling;
 
+    protected int maxConnectionPoolSize;
+
     protected EntityResolver entityResolver;
 
     public static enum PreferredHttpMethod {
@@ -111,6 +114,7 @@ public class WFSConfig {
         gmlCompatibleTypenames = (Boolean) GML_COMPATIBLE_TYPENAMES.getDefaultValue();
         entityResolver = (EntityResolver) ENTITY_RESOLVER.getDefaultValue();
         useHttpConnectionPooling = (Boolean) USE_HTTP_CONNECTION_POOLING.getDefaultValue();
+        maxConnectionPoolSize = (Integer) MAX_CONNECTION_POOL_SIZE.getDefaultValue();
     }
 
     public static WFSConfig fromParams(Map<?, ?> params) throws IOException {
@@ -155,6 +159,7 @@ public class WFSConfig {
                         : GML_COMPATIBLE_TYPENAMES.lookUp(params);
         config.entityResolver = ENTITY_RESOLVER.lookUp(params);
         config.useHttpConnectionPooling = USE_HTTP_CONNECTION_POOLING.lookUp(params);
+        config.maxConnectionPoolSize = MAX_CONNECTION_POOL_SIZE.lookUp(params);
         return config;
     }
 
@@ -255,6 +260,11 @@ public class WFSConfig {
     /** @return if http connection pooling should be used */
     public boolean isUseHttpConnectionPooling() {
         return useHttpConnectionPooling;
+    }
+
+    /** @return the size of the connection pool, if {@link #isUseHttpConnectionPooling()} is <code>true</code> */
+    public int getMaxConnectionPoolSize() {
+        return maxConnectionPoolSize;
     }
 
     /**

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/WFSConfigTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/WFSConfigTest.java
@@ -1,0 +1,21 @@
+package org.geotools.data.wfs.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.geotools.data.wfs.impl.WFSDataAccessFactory;
+import org.junit.Test;
+
+public class WFSConfigTest {
+
+    @Test
+    public void testConfiguresConnectionPoolSize() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(WFSDataAccessFactory.MAX_CONNECTION_POOL_SIZE.getName(), "10");
+        WFSConfig config = WFSConfig.fromParams(params);
+
+        assertEquals(10, config.getMaxConnectionPoolSize());
+    }
+
+}

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/WFSConfigTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/WFSConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2008-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
 package org.geotools.data.wfs.internal;
 
 import static org.junit.Assert.assertEquals;

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/WFSConfigTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/WFSConfigTest.java
@@ -33,5 +33,4 @@ public class WFSConfigTest {
 
         assertEquals(10, config.getMaxConnectionPoolSize());
     }
-
 }


### PR DESCRIPTION
This enables you to configure the max connection pool size by configuring
the `WFSDataStoreFactory:MAX_CONNECTION_POOL_SIZE` parameter. The
default values were far too small to scale effectively.