### PR TITLE
[GEOT-6352] FilterToSQL#escapeName does not escape escape character

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/PreparedFilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/PreparedFilterToSQL.java
@@ -173,7 +173,7 @@ public class PreparedFilterToSQL extends FilterToSQL {
                 out.write("(");
 
                 for (int j = 0; j < attValues.size(); j++) {
-                    out.write(escapeName(columns.get(j).getName()));
+                    out.write(escapeIdentifier(columns.get(j).getName()));
                     out.write(" = ");
                     out.write('?');
 

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/util/SqlUtil.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/util/SqlUtil.java
@@ -243,4 +243,50 @@ public class SqlUtil {
     public static PreparedStatementBuilder prepare(PreparedStatement st) throws SQLException {
         return new PreparedStatementBuilder(st);
     }
+
+    /**
+     * Quotes a SQL identifier.
+     *
+     * <p>An identifier is quoted by enclosing it in double quotes. If the identifier contains a
+     * double quote itself, the double quote is replaced by two consecutive double quotes, e.g. a"b
+     * is quoted as "a""b".
+     *
+     * @param id The identifier to quote. Must not be null.
+     * @return Returns the quoted identifier.
+     */
+    public static String quoteIdentifier(String id) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('"');
+        for (int i = 0; i < id.length(); ++i) {
+            char c = id.charAt(i);
+            if (c != '"') {
+                sb.append(c);
+            } else {
+                sb.append("\"\"");
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    /**
+     * Quotes a series of identifiers separating them with dots.
+     *
+     * <p>Each identifier is quoted as described in {@link #quoteIdentifier(String)} and then a dot
+     * is placed between all identifiers, e.g. if the identifiers a and b were passed, the result
+     * would be "a"."b".
+     *
+     * @param iid The initial identifier.
+     * @param fids Any number of further identifiers.
+     * @return Returns the quoted series of identifiers.
+     */
+    public static String quoteIdentifiers(String iid, String... fids) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(quoteIdentifier(iid));
+        for (String fid : fids) {
+            sb.append('.');
+            sb.append(quoteIdentifier(fid));
+        }
+        return sb.toString();
+    }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEscapingOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEscapingOnlineTest.java
@@ -1,0 +1,49 @@
+package org.geotools.jdbc;
+
+import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Transaction;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.store.ContentFeatureCollection;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+public abstract class JDBCEscapingOnlineTest extends JDBCTestSupport {
+
+    protected SimpleFeatureType escapingSchema;
+    protected static final String ESCAPING = "esca\"ping";
+    protected static final String ID = "i\"d";
+    protected static final String NAME = "na\"me";
+
+    protected abstract JDBCEscapingTestSetup createTestSetup();
+
+    @Override
+    protected void connect() throws Exception {
+        super.connect();
+        escapingSchema =
+                DataUtilities.createType(
+                        dataStore.getNamespaceURI() + "." + ESCAPING,
+                        ID + ":0," + NAME + ":String");
+    }
+
+    public void testEscaping() throws Exception {
+        dataStore.createSchema(escapingSchema);
+        assertFeatureTypesEqual(escapingSchema, dataStore.getSchema(tname(ESCAPING)));
+
+        try (FeatureWriter<SimpleFeatureType, SimpleFeature> fw =
+                dataStore.getFeatureWriterAppend(tname(ESCAPING), Transaction.AUTO_COMMIT)) {
+            SimpleFeature f = (SimpleFeature) fw.next();
+            f.setAttribute(aname(ID), 1);
+            f.setAttribute(aname(NAME), "abc");
+            fw.write();
+        }
+
+        ContentFeatureCollection fc = dataStore.getFeatureSource(tname(ESCAPING)).getFeatures();
+        assertEquals(1, fc.size());
+        try (SimpleFeatureIterator fr = fc.features()) {
+            assertTrue(fr.hasNext());
+            fr.next();
+            assertFalse(fr.hasNext());
+        }
+    }
+}

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEscapingTestSetup.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEscapingTestSetup.java
@@ -1,0 +1,21 @@
+package org.geotools.jdbc;
+
+import java.sql.SQLException;
+
+public abstract class JDBCEscapingTestSetup extends JDBCDelegatingTestSetup {
+
+    protected JDBCEscapingTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    protected final void setUpData() throws Exception {
+        try {
+            dropEscapingTable();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /** Drops the "esca\"ping" created in the test. */
+    protected abstract void dropEscapingTable() throws Exception;
+}

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceOnlineTest.java
@@ -585,7 +585,7 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
         if (dialect instanceof BasicSQLDialect) {
             FilterToSQL filterToSQL = ((BasicSQLDialect) dialect).createFilterToSQL();
             String sql = filterToSQL.encodeToString(filters[0]);
-            String escapedProperty = filterToSQL.escapeName(property);
+            String escapedProperty = filterToSQL.escapeIdentifier(property);
             assertEquals(
                     "WHERE ("
                             + escapedProperty
@@ -597,7 +597,7 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
             PreparedFilterToSQL filterToSQL =
                     ((PreparedStatementSQLDialect) dialect).createPreparedFilterToSQL();
             String sql = filterToSQL.encodeToString(filters[0]);
-            String escapedProperty = filterToSQL.escapeName(property);
+            String escapedProperty = filterToSQL.escapeIdentifier(property);
             assertEquals(
                     "WHERE ("
                             + escapedProperty
@@ -640,9 +640,9 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
         if (dialect instanceof BasicSQLDialect) {
             FilterToSQL filterToSQL = ((BasicSQLDialect) dialect).createFilterToSQL();
             String sql = filterToSQL.encodeToString(filters[0]);
-            String spe = filterToSQL.escapeName(sp);
-            String ipe = filterToSQL.escapeName(ip);
-            String dpe = filterToSQL.escapeName(dp);
+            String spe = filterToSQL.escapeIdentifier(sp);
+            String ipe = filterToSQL.escapeIdentifier(ip);
+            String dpe = filterToSQL.escapeIdentifier(dp);
             assertEquals(
                     "WHERE (("
                             + spe
@@ -664,9 +664,9 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
             PreparedFilterToSQL filterToSQL =
                     ((PreparedStatementSQLDialect) dialect).createPreparedFilterToSQL();
             String sql = filterToSQL.encodeToString(filters[0]);
-            String spe = filterToSQL.escapeName(sp);
-            String ipe = filterToSQL.escapeName(ip);
-            String dpe = filterToSQL.escapeName(dp);
+            String spe = filterToSQL.escapeIdentifier(sp);
+            String ipe = filterToSQL.escapeIdentifier(ip);
+            String dpe = filterToSQL.escapeIdentifier(dp);
             assertEquals(
                     "WHERE (("
                             + spe

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/util/SqlUtilTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/util/SqlUtilTest.java
@@ -1,0 +1,17 @@
+package org.geotools.jdbc.util;
+
+import junit.framework.TestCase;
+
+public class SqlUtilTest extends TestCase {
+
+    public void testQuoteIdentifier() {
+        assertEquals("\"abc\"", SqlUtil.quoteIdentifier("abc"));
+        assertEquals("\"a\"\"b\"", SqlUtil.quoteIdentifier("a\"b"));
+    }
+
+    public void testQuoteIdentifiers() {
+        assertEquals("\"abc\"", SqlUtil.quoteIdentifiers("abc"));
+        assertEquals("\"abc\".\"def\"", SqlUtil.quoteIdentifiers("abc", "def"));
+        assertEquals("\"abc\".\"def\".\"ghi\"", SqlUtil.quoteIdentifiers("abc", "def", "ghi"));
+    }
+}

--- a/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2DialectBasic.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2DialectBasic.java
@@ -68,6 +68,11 @@ public class H2DialectBasic extends BasicSQLDialect {
     }
 
     @Override
+    public String escapeIdentifier(String identifer) {
+        return delegate.escapeIdentifier(identifer);
+    }
+
+    @Override
     public void registerSqlTypeToClassMappings(Map<Integer, Class<?>> mappings) {
         delegate.registerSqlTypeToClassMappings(mappings);
     }

--- a/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2DialectPrepared.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/main/java/org/geotools/data/h2/H2DialectPrepared.java
@@ -67,6 +67,11 @@ public class H2DialectPrepared extends PreparedStatementSQLDialect {
     }
 
     @Override
+    public String escapeIdentifier(String identifer) {
+        return delegate.escapeIdentifier(identifer);
+    }
+
+    @Override
     public void registerSqlTypeToClassMappings(Map<Integer, Class<?>> mappings) {
         delegate.registerSqlTypeToClassMappings(mappings);
     }

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectBasic.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectBasic.java
@@ -79,6 +79,11 @@ public class MySQLDialectBasic extends BasicSQLDialect {
     }
 
     @Override
+    public String escapeIdentifier(String identifer) {
+        return delegate.escapeIdentifier(identifer);
+    }
+
+    @Override
     public String getGeometryTypeName(Integer type) {
         return delegate.getGeometryTypeName(type);
     }

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectPrepared.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectPrepared.java
@@ -77,6 +77,11 @@ public class MySQLDialectPrepared extends PreparedStatementSQLDialect {
     }
 
     @Override
+    public String escapeIdentifier(String identifer) {
+        return delegate.escapeIdentifier(identifer);
+    }
+
+    @Override
     public String getGeometryTypeName(Integer type) {
         return delegate.getGeometryTypeName(type);
     }

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -491,6 +491,11 @@ public class OracleDialect extends PreparedStatementSQLDialect {
     }
 
     @Override
+    public String escapeIdentifier(String identifier) {
+        return identifier;
+    }
+
+    @Override
     public void encodeColumnName(String prefix, String raw, StringBuffer sql) {
         if (prefix != null && !prefix.isEmpty()) {
             prefix = prefix.toUpperCase();

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
@@ -87,7 +87,7 @@ public class PostgisFilterToSQL extends FilterToSQL {
                 // if we don't know at all, use the srid of the geometry we're comparing against
                 // (much slower since that has to be extracted record by record as opposed to
                 // being a constant)
-                out.write("', ST_SRID(\"" + currentGeometry.getLocalName() + "\"))");
+                out.write("', ST_SRID(" + escapeIdentifier(currentGeometry.getLocalName()) + "))");
             } else {
                 out.write("', " + currentSRID + ")");
             }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisNGDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisNGDataStoreFactory.java
@@ -30,6 +30,7 @@ import org.geotools.data.Parameter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
+import org.geotools.jdbc.util.SqlUtil;
 import org.geotools.util.KVP;
 import org.postgresql.jdbc.SslMode;
 
@@ -285,9 +286,9 @@ public class PostgisNGDataStoreFactory extends JDBCDataStoreFactory {
 
                     String createParams = (String) CREATE_PARAMS.lookUp(params);
                     String sql =
-                            "CREATE DATABASE \""
-                                    + db
-                                    + "\" "
+                            "CREATE DATABASE "
+                                    + SqlUtil.quoteIdentifier(db)
+                                    + " "
                                     + (createParams == null ? "" : createParams);
                     st = cx.createStatement();
                     st.execute(sql);
@@ -365,7 +366,7 @@ public class PostgisNGDataStoreFactory extends JDBCDataStoreFactory {
             cx = getConnection(user, password, url);
 
             // drop the database
-            String sql = "DROP DATABASE \"" + db + "\"";
+            String sql = "DROP DATABASE " + SqlUtil.quoteIdentifier(db);
             st = cx.createStatement();
             st.execute(sql);
         } catch (SQLException e) {

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisEscapingOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisEscapingOnlineTest.java
@@ -1,0 +1,12 @@
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCEscapingOnlineTest;
+import org.geotools.jdbc.JDBCEscapingTestSetup;
+
+public class PostgisEscapingOnlineTest extends JDBCEscapingOnlineTest {
+
+    @Override
+    protected JDBCEscapingTestSetup createTestSetup() {
+        return new PostgisEscapingTestSetup(new PostGISTestSetup());
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisEscapingTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisEscapingTestSetup.java
@@ -1,0 +1,16 @@
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCEscapingTestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class PostgisEscapingTestSetup extends JDBCEscapingTestSetup {
+
+    public PostgisEscapingTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void dropEscapingTable() throws Exception {
+        run("DROP TABLE \"esca\"\"ping\"");
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
@@ -131,7 +131,7 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         filterToSql.encode(bbox3d);
         String sql = writer.toString().toLowerCase();
         assertEquals(
-                "where testgeometry &&& st_makeline(st_makepoint(2.0,1.0,0.0), st_makepoint(3.0,2.0,1.0))",
+                "where \"testgeometry\" &&& st_makeline(st_makepoint(2.0,1.0,0.0), st_makepoint(3.0,2.0,1.0))",
                 sql);
     }
 

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
@@ -849,15 +849,14 @@ public class SQLServerDialect extends BasicSQLDialect {
             Connection cx, SimpleFeatureType schema, String databaseSchema, String indexName)
             throws SQLException {
         StringBuffer sql = new StringBuffer();
-        String escape = getNameEscape();
         sql.append("DROP INDEX ");
-        sql.append(escape).append(indexName).append(escape);
+        sql.append(escapeIdentifier(indexName));
         sql.append(" ON ");
         if (databaseSchema != null) {
             encodeSchemaName(databaseSchema, sql);
             sql.append(".");
         }
-        sql.append(escape).append(schema.getTypeName()).append(escape);
+        sql.append(escapeIdentifier(schema.getTypeName()));
 
         Statement st = null;
         try {

--- a/modules/plugin/jdbc/jdbc-teradata/src/main/java/org/geotools/data/teradata/TeradataFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-teradata/src/main/java/org/geotools/data/teradata/TeradataFilterToSQL.java
@@ -275,10 +275,10 @@ public class TeradataFilterToSQL extends PreparedFilterToSQL {
 
         out.write(" FROM ");
         if (tinfo.getSchemaName() != null) {
-            out.write(escapeName(tinfo.getSchemaName()));
+            out.write(escapeIdentifier(tinfo.getSchemaName()));
             out.write(".");
         }
-        out.write(escapeName(tinfo.getIndexTableName()));
+        out.write(escapeIdentifier(tinfo.getIndexTableName()));
         out.write(" t, TABLE (SYSSPATIAL.tessellate_search(1,");
 
         out.write(

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
@@ -30,6 +30,7 @@ import org.geotools.data.hana.wkb.HanaWKBWriterException;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.PreparedFilterToSQL;
 import org.geotools.jdbc.PreparedStatementSQLDialect;
+import org.geotools.jdbc.util.SqlUtil;
 import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.*;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -851,7 +852,7 @@ public class HanaDialect extends PreparedStatementSQLDialect {
             } else {
                 sb.append('.');
             }
-            sb.append(HanaUtil.encodeIdentifier(ids[i]));
+            sb.append(SqlUtil.quoteIdentifier(ids[i]));
         }
     }
 

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
@@ -46,6 +46,7 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.PreparedFilterToSQL;
 import org.geotools.jdbc.PreparedStatementSQLDialect;
 import org.geotools.jdbc.SQLDialect;
+import org.geotools.jdbc.util.SqlUtil;
 import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -87,7 +88,6 @@ import org.opengis.referencing.crs.GeographicCRS;
  *
  * @author Stefan Uhrig, SAP SE
  */
-@SuppressWarnings("deprecation")
 public class HanaFilterToSQL extends PreparedFilterToSQL {
 
     private static final Map<String, Double> UNITS_MAP = new HashMap<String, Double>();
@@ -420,7 +420,7 @@ public class HanaFilterToSQL extends PreparedFilterToSQL {
         out.write(encodeAsHex(wkb));
         if ((currentSRID == null) && (currentGeometry != null)) {
             out.write(", ");
-            out.write(HanaUtil.encodeIdentifier(currentGeometry.getLocalName()));
+            out.write(SqlUtil.quoteIdentifier(currentGeometry.getLocalName()));
             out.write(".ST_SRID())");
         } else {
             out.write("', " + currentSRID + ")");

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/HanaUtil.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/HanaUtil.java
@@ -24,27 +24,6 @@ package org.geotools.data.hana;
 public final class HanaUtil {
 
     /**
-     * Encodes an identifier.
-     *
-     * @param id The identifier to encode. Must not be null.
-     * @return Returns the encoded identifier.
-     */
-    public static String encodeIdentifier(String id) {
-        StringBuilder sb = new StringBuilder();
-        sb.append('"');
-        for (int i = 0; i < id.length(); ++i) {
-            char c = id.charAt(i);
-            if (c != '"') {
-                sb.append(c);
-            } else {
-                sb.append("\"\"");
-            }
-        }
-        sb.append('"');
-        return sb.toString();
-    }
-
-    /**
      * Converts a string to a SQL string literal by quoting it with single quotes.
      *
      * @param s The string to convert.

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/metadata/MetadataDdl.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/main/java/org/geotools/data/hana/metadata/MetadataDdl.java
@@ -17,6 +17,7 @@
 package org.geotools.data.hana.metadata;
 
 import org.geotools.data.hana.HanaUtil;
+import org.geotools.jdbc.util.SqlUtil;
 
 /**
  * Helper class to create DDL statements for creating unit-of-measures and spatial reference
@@ -29,7 +30,7 @@ public final class MetadataDdl {
     public static String getUomDdl(Uom uom) {
         StringBuilder sql = new StringBuilder();
         sql.append("CREATE SPATIAL UNIT OF MEASURE ");
-        sql.append(HanaUtil.encodeIdentifier(uom.getName()));
+        sql.append(SqlUtil.quoteIdentifier(uom.getName()));
         sql.append(" TYPE ");
         switch (uom.getType()) {
             case LINEAR:
@@ -47,11 +48,11 @@ public final class MetadataDdl {
     public static String getSrsDdl(Srs srs) {
         StringBuilder sql = new StringBuilder();
         sql.append("CREATE SPATIAL REFERENCE SYSTEM ");
-        sql.append(HanaUtil.encodeIdentifier(srs.getName()));
+        sql.append(SqlUtil.quoteIdentifier(srs.getName()));
         sql.append(" IDENTIFIED BY ");
         sql.append(Integer.toString(srs.getSrid()));
         sql.append(" ORGANIZATION ");
-        sql.append(HanaUtil.encodeIdentifier(srs.getOrganization()));
+        sql.append(SqlUtil.quoteIdentifier(srs.getOrganization()));
         sql.append(" IDENTIFIED BY ");
         sql.append(srs.getOrganizationId());
         String wkt = srs.getWkt();
@@ -65,11 +66,11 @@ public final class MetadataDdl {
             sql.append(HanaUtil.toStringLiteral(proj4));
         }
         sql.append(" LINEAR UNIT OF MEASURE ");
-        sql.append(HanaUtil.encodeIdentifier(srs.getLinearUom()));
+        sql.append(SqlUtil.quoteIdentifier(srs.getLinearUom()));
         String angularUom = srs.getAngularUom();
         if (angularUom != null) {
             sql.append(" ANGULAR UNIT OF MEASURE ");
-            sql.append(HanaUtil.encodeIdentifier(angularUom));
+            sql.append(SqlUtil.quoteIdentifier(angularUom));
         }
         sql.append(" TYPE ");
         switch (srs.getType()) {

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaEscapingOnlineTest.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaEscapingOnlineTest.java
@@ -1,0 +1,12 @@
+package org.geotools.data.hana;
+
+import org.geotools.jdbc.JDBCEscapingOnlineTest;
+import org.geotools.jdbc.JDBCEscapingTestSetup;
+
+public class HanaEscapingOnlineTest extends JDBCEscapingOnlineTest {
+
+    @Override
+    protected JDBCEscapingTestSetup createTestSetup() {
+        return new HanaEscapingTestSetup(new HanaTestSetup());
+    }
+}

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaEscapingTestSetup.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaEscapingTestSetup.java
@@ -1,0 +1,22 @@
+package org.geotools.data.hana;
+
+import java.sql.Connection;
+import org.geotools.jdbc.JDBCEscapingTestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class HanaEscapingTestSetup extends JDBCEscapingTestSetup {
+
+    private static final String TABLE = "esca\"ping";
+
+    public HanaEscapingTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void dropEscapingTable() throws Exception {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn);
+            htu.dropTestTableCascade(TABLE);
+        }
+    }
+}

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
@@ -37,7 +37,6 @@ public class HanaGeographyOnlineTest extends JDBCGeographyOnlineTest {
         // Currently, HANA only supports point-point distances
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void testVirtualTable() throws Exception {
         // We have to override to use the proper schema in the select-statement.

--- a/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaTestUtil.java
+++ b/modules/unsupported/jdbc-ng/jdbc-hana/src/test/java/org/geotools/data/hana/HanaTestUtil.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.geotools.data.hana.metadata.MetadataDdl;
 import org.geotools.data.hana.metadata.Srs;
+import org.geotools.jdbc.util.SqlUtil;
 
 /** @author Stefan Uhrig, SAP SE */
 public class HanaTestUtil {
@@ -62,9 +63,7 @@ public class HanaTestUtil {
             } else {
                 sb.append('.');
             }
-            sb.append('"');
-            sb.append(ids[i]);
-            sb.append('"');
+            sb.append(SqlUtil.quoteIdentifier(ids[i]));
         }
         return sb;
     }


### PR DESCRIPTION
SQL identifiers (column names, table names, schema names) are usually
quoted using double quotes. Furthermore, identifiers can contain double
quotes themselves. These are usually escaped using two double quotes,
e.g. a"b is quoted as "a""b".

Identifiers with double quotes are not properly escaped by
FilterToSQL#escapeName, e.g. a"b would become "a"b" resulting in an
invalid SQL statement.

Additionally, there are dozens of locations in the JDBC-plugins
themselves where the identifier quoting is done manually with patterns
like

String sql = "ALTER TABLE \"" + schemaName + "\".\"" + tableName + "\""...

This change introduces new methods for escaping identifiers and fixes
locations in which identifiers were not escaped properly.