### PR TITLE
[GEOT-6222] Avoid unnecessary base64 encoding when fetching geometry from PostGIS

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStoreFactory.java
@@ -297,7 +297,7 @@ public abstract class JDBCDataStoreFactory implements DataStoreFactorySpi {
         JDBCDataStore dataStore = new JDBCDataStore();
 
         // dialect
-        final SQLDialect dialect = createSQLDialect(dataStore);
+        final SQLDialect dialect = createSQLDialect(dataStore, params);
         dataStore.setSQLDialect(dialect);
 
         // datasource
@@ -516,6 +516,16 @@ public abstract class JDBCDataStoreFactory implements DataStoreFactorySpi {
      * <p>For example: org.postgresql.Driver
      */
     protected abstract String getDriverClassName();
+
+    /**
+     * Creates the dialect that the datastore uses for communication with the underlying database.
+     *
+     * @param dataStore The datastore.
+     * @param params The connection parameters
+     */
+    protected SQLDialect createSQLDialect(JDBCDataStore dataStore, Map params) {
+        return createSQLDialect(dataStore);
+    }
 
     /**
      * Creates the dialect that the datastore uses for communication with the underlying database.

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
@@ -1,0 +1,156 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.util.Version;
+import org.opengis.feature.type.GeometryDescriptor;
+
+public class GeometryColumnEncoder {
+
+    private final boolean atLeast2_2_0;
+    private final boolean stSimplifyEnabled;
+    private final boolean encodeBase64;
+    private final PostGISDialect dialect;
+
+    GeometryColumnEncoder(
+            Version version,
+            boolean stSimplifyEnabled,
+            boolean encodeBase64,
+            PostGISDialect dialect) {
+        // version should not be null in normal usage, as it's set when SQLDialect
+        // initializeConnection is called, however, let's cover all the bases and consider
+        // possible usage outside JDBCDataStore (or unforeseens usages inside of it)
+        this.atLeast2_2_0 = version != null && version.compareTo(PostGISDialect.V_2_2_0) >= 0;
+        this.stSimplifyEnabled = stSimplifyEnabled;
+        this.encodeBase64 = encodeBase64;
+        this.dialect = dialect;
+    }
+
+    public void encode(
+            GeometryDescriptor gatt,
+            String prefix,
+            StringBuffer sql,
+            boolean force2D,
+            Double distance) {
+
+        if (encodeBase64) {
+            sql.append("encode(");
+        }
+
+        if (distance == null) {
+            encodeNotSimplified(gatt, prefix, sql, force2D);
+        } else {
+            encodeSimplified(gatt, prefix, sql, force2D, distance);
+        }
+
+        if (encodeBase64) {
+            sql.append(", 'base64')");
+        }
+    }
+
+    private void encodeNotSimplified(
+            GeometryDescriptor gatt, String prefix, StringBuffer sql, boolean force2D) {
+
+        boolean geography =
+                "geography".equals(gatt.getUserData().get(JDBCDataStore.JDBC_NATIVE_TYPENAME));
+        if (geography) {
+            encodeGeography(gatt, prefix, sql);
+        } else {
+            if (force2D) {
+                sql.append("ST_AsBinary(");
+                dialect.encodeColumnName(prefix, gatt.getLocalName(), sql);
+                sql.append(")");
+            } else {
+                sql.append("ST_AsEWKB(");
+                dialect.encodeColumnName(prefix, gatt.getLocalName(), sql);
+                sql.append(")");
+            }
+        }
+    }
+
+    private void encodeGeography(GeometryDescriptor gatt, String prefix, StringBuffer sql) {
+        sql.append("ST_AsBinary(");
+        dialect.encodeColumnName(prefix, gatt.getLocalName(), sql);
+        sql.append(")");
+    }
+
+    private void encodeSimplified(
+            GeometryDescriptor gatt,
+            String prefix,
+            StringBuffer sql,
+            boolean force2D,
+            double distance) {
+        boolean geography =
+                "geography".equals(gatt.getUserData().get(JDBCDataStore.JDBC_NATIVE_TYPENAME));
+
+        if (geography) {
+            encodeGeography(gatt, prefix, sql);
+            return;
+        }
+
+        if (dialect.isStraightSegmentsGeometry(gatt)) {
+            if (atLeast2_2_0) {
+                sql.append("ST_AsTWKB(");
+                encode2DGeometry(gatt, prefix, sql, stSimplifyEnabled ? distance : null);
+                sql.append("," + getTWKBDigits(distance) + ")");
+            } else {
+                sql.append("ST_AsBinary(");
+                encode2DGeometry(gatt, prefix, sql, stSimplifyEnabled ? distance : null);
+                sql.append(")");
+            }
+        } else {
+            // may have curves mixed in, cannot use TWKB and need to guard ST_Simplify
+            sql.append("ST_AsBinary(");
+            sql.append("CASE WHEN ST_HasArc(");
+            dialect.encodeColumnName(prefix, gatt.getLocalName(), sql);
+            sql.append(") THEN ");
+            dialect.encodeColumnName(prefix, gatt.getLocalName(), sql);
+            sql.append(" ELSE ");
+            encode2DGeometry(gatt, prefix, sql, distance);
+            sql.append(" END)");
+        }
+    }
+
+    private void encode2DGeometry(
+            GeometryDescriptor gatt, String prefix, StringBuffer sql, Double distance) {
+        if (distance != null) {
+            sql.append("ST_Simplify(");
+        }
+
+        sql.append(dialect.getForce2DFunction() + "(");
+        dialect.encodeColumnName(prefix, gatt.getLocalName(), sql);
+        sql.append(")");
+
+        if (distance != null) {
+            String preserveCollapsed = atLeast2_2_0 ? ", true" : "";
+            sql.append(", " + distance + preserveCollapsed + ")");
+        }
+    }
+
+    /**
+     * Computes the number of digits preserved by TWKB based on the magnitude of the simplification
+     * distance
+     *
+     * @param distance
+     * @return
+     */
+    private int getTWKBDigits(Double distance) {
+        int result = -(int) Math.floor(Math.log10(distance));
+        return result;
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Map;
+import java.util.Set;
 import org.geotools.jdbc.ColumnMetadata;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.PreparedFilterToSQL;
@@ -44,6 +45,13 @@ public class PostGISPSDialect extends PreparedStatementSQLDialect {
     public PostGISPSDialect(JDBCDataStore store, PostGISDialect delegate) {
         super(store);
         this.delegate = delegate;
+        // prepared statements enable native binary transfer, no need to base64 encode
+        this.delegate.base64EncodingEnabled = false;
+    }
+
+    @Override
+    protected void addSupportedHints(Set<Hints.Key> hints) {
+        delegate.addSupportedHints(hints);
     }
 
     @Override
@@ -71,7 +79,7 @@ public class PostGISPSDialect extends PreparedStatementSQLDialect {
             Connection cx,
             Hints hints)
             throws IOException, SQLException {
-        return delegate.decodeGeometryValue(descriptor, rs, column, factory, cx, new Hints());
+        return delegate.decodeGeometryValue(descriptor, rs, column, factory, cx, hints);
     }
 
     public Geometry decodeGeometryValue(
@@ -281,5 +289,26 @@ public class PostGISPSDialect extends PreparedStatementSQLDialect {
     public void encodeGeometryValue(Geometry value, int dimension, int srid, StringBuffer sql)
             throws IOException {
         delegate.encodeGeometryValue(value, dimension, srid, sql);
+    }
+
+    @Override
+    public void encodeGeometryColumnSimplified(
+            GeometryDescriptor gatt, String prefix, int srid, StringBuffer sql, Double distance) {
+        delegate.encodeGeometryColumnSimplified(gatt, prefix, srid, sql, distance);
+    }
+
+    @Override
+    public void encodeGeometryColumnGeneralized(
+            GeometryDescriptor gatt, String prefix, int srid, StringBuffer sql, Double distance) {
+        delegate.encodeGeometryColumnGeneralized(gatt, prefix, srid, sql, distance);
+    }
+
+    PostGISDialect getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public void initializeConnection(Connection cx) throws SQLException {
+        delegate.initializeConnection(cx);
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/WKBAttributeIO.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/WKBAttributeIO.java
@@ -39,6 +39,7 @@ public class WKBAttributeIO {
     WKBReader wkbr;
     ByteArrayInStream inStream = new ByteArrayInStream(new byte[0]);
     GeometryFactory gf;
+    boolean base64EncodingEnabled = true;
 
     public WKBAttributeIO() {
         this(new GeometryFactory());
@@ -54,6 +55,14 @@ public class WKBAttributeIO {
             this.gf = gf;
             wkbr = new WKBReader(gf);
         }
+    }
+
+    public boolean isBase64EncodingEnabled() {
+        return base64EncodingEnabled;
+    }
+
+    public void setBase64EncodingEnabled(boolean base64EncodingEnabled) {
+        this.base64EncodingEnabled = base64EncodingEnabled;
     }
 
     /**
@@ -85,7 +94,10 @@ public class WKBAttributeIO {
             byte bytes[] = rs.getBytes(columnName);
             if (bytes == null) // ie. its a null column -> return a null geometry!
             return null;
-            return wkb2Geometry(Base64.decode(bytes));
+            if (base64EncodingEnabled) {
+                bytes = Base64.decode(bytes);
+            }
+            return wkb2Geometry(bytes);
         } catch (SQLException e) {
             throw new DataSourceException("SQL exception occurred while reading the geometry.", e);
         }
@@ -97,7 +109,10 @@ public class WKBAttributeIO {
             byte bytes[] = rs.getBytes(columnIndex);
             if (bytes == null) // ie. its a null column -> return a null geometry!
             return null;
-            return wkb2Geometry(Base64.decode(bytes));
+            if (base64EncodingEnabled) {
+                bytes = Base64.decode(bytes);
+            }
+            return wkb2Geometry(bytes);
         } catch (SQLException e) {
             throw new DataSourceException("SQL exception occurred while reading the geometry.", e);
         }


### PR DESCRIPTION
This also involves proper delegation setup for the prepared statement dialect, which was faulty and did not end up enabling TWKB. (the prepared statement path is the only one that can enjoy true binary transfer, as that kicks in only after a statement got prepared).