### PR TITLE
[GEOT-6358] xsd-kml: Fix LatLonAltBox parsing for KML 2.2

### DIFF
--- a/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/v22/KMLConfiguration.java
+++ b/modules/extension/xsd/xsd-kml/src/main/java/org/geotools/kml/v22/KMLConfiguration.java
@@ -178,7 +178,9 @@ public class KMLConfiguration extends Configuration {
         container.registerComponentImplementation(KML.KmlType, KmlTypeBinding.class);
         container.registerComponentImplementation(KML.LabelStyleType, LabelStyleTypeBinding.class);
         //
-        // container.registerComponentImplementation(KML.LatLonAltBoxType,LatLonAltBoxTypeBinding.class);
+        // For 2.2, LatLonAltBoxType does not extend LatLonBoxType as in 2.1, both extend
+        // AbstractLatLonBoxType instead, so LatLonAltBoxType requires a specifig binding
+        container.registerComponentImplementation(KML.LatLonAltBoxType, LatLonBoxTypeBinding.class);
         container.registerComponentImplementation(KML.LatLonBoxType, LatLonBoxTypeBinding.class);
         container.registerComponentImplementation(KML.LinearRingType, LinearRingTypeBinding.class);
         container.registerComponentImplementation(KML.LineStringType, LineStringTypeBinding.class);

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/RegionTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/RegionTypeBindingTest.java
@@ -1,0 +1,84 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.kml.v22;
+
+import org.geotools.xsd.Binding;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LinearRing;
+
+/**
+ * Test 2.2 Region/LanLonAltBox bindings (i.e. using v22 {@link KMLConfiguration} by extending v22
+ * {@link KMLTestSupport})
+ */
+public class RegionTypeBindingTest extends KMLTestSupport {
+    public void testType() {
+        assertEquals(LinearRing.class, binding(KML.RegionType).getType());
+    }
+
+    public void testExecutionMode() {
+        assertEquals(Binding.OVERRIDE, binding(KML.RegionType).getExecutionMode());
+    }
+
+    public void testParse() throws Exception {
+        String xml =
+                "<Region>"
+                        + "<LatLonAltBox>"
+                        + "<north>1</north>"
+                        + "<south>-1</south>"
+                        + "<east>1</east>"
+                        + "<west>-1</west>"
+                        + "</LatLonAltBox>"
+                        + "</Region>";
+
+        buildDocument(xml);
+
+        LinearRing box = (LinearRing) parse();
+        Coordinate[] coordinates = box.getCoordinates();
+        assertEquals("Invalid number of coordinates", 5, coordinates.length);
+        assertEquals(coordinates[0], new Coordinate(-1, -1));
+        assertEquals(coordinates[1], new Coordinate(-1, 1));
+        assertEquals(coordinates[2], new Coordinate(1, 1));
+        assertEquals(coordinates[3], new Coordinate(1, -1));
+        assertEquals("Last and first coordinates should be equal", coordinates[0], coordinates[4]);
+    }
+
+    public void testParseWithUnparsedElements() throws Exception {
+        String xml =
+                "<Region>"
+                        + "<LatLonAltBox>"
+                        + "<north>1</north>"
+                        + "<south>-1</south>"
+                        + "<east>1</east>"
+                        + "<west>-1</west>"
+                        + "<minAltitude>-1.5</minAltitude>"
+                        + "<maxAltitude>1500</maxAltitude>"
+                        + "<altitudeMode>clampToGround</altitudeMode>"
+                        + "</LatLonAltBox>"
+                        + "</Region>";
+
+        buildDocument(xml);
+
+        LinearRing box = (LinearRing) parse();
+        Coordinate[] coordinates = box.getCoordinates();
+        assertEquals("Invalid number of coordinates", 5, coordinates.length);
+        assertEquals(coordinates[0], new Coordinate(-1, -1));
+        assertEquals(coordinates[1], new Coordinate(-1, 1));
+        assertEquals(coordinates[2], new Coordinate(1, 1));
+        assertEquals(coordinates[3], new Coordinate(1, -1));
+        assertEquals("Last and first coordinates should be equal", coordinates[0], coordinates[4]);
+    }
+}


### PR DESCRIPTION
Add explicit binding for `LatLonAltBoxType` in KML 2.2
`Configuration`. Otherwise parsing a `Region` with a
`LatLonAltBox` child element throws a `ClassCastException`
because it wasn't parsed to a JTS `Envelope`.

Reason being that in KML 2.1 `LatLonAltBoxType` is a subtype
of `LatLonBoxType`, but in KML 2.2 it is not, both being
derived from `AbstractLatLonBoxType` instead.