### PR TITLE
[GEOT-4931] Fix comparison of attribute bindings in DataUtilities

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -469,7 +469,8 @@ public class DataUtilities {
             return true;
         }
 
-        if (a.getLocalName().equals(b.getLocalName()) && a.getClass().equals(b.getClass())) {
+        if (a.getLocalName().equals(b.getLocalName())
+                && a.getType().getBinding().equals(b.getType().getBinding())) {
             return true;
         }
 

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -350,6 +350,11 @@ public class DataUtilitiesTest extends DataTestCase {
         SimpleFeatureType road3 =
                 DataUtilities.createType("test.road", "id:0,geom:LineString,name:String,uuid:UUID");
         assertEquals(0, DataUtilities.compare(road3, roadType));
+
+        // different attribute bindings
+        SimpleFeatureType road4 =
+                DataUtilities.createType("road", "id:0,geom:LineString,name:String,uuid:String");
+        assertEquals(-1, DataUtilities.compare(road4, roadType));
     }
 
     public void testIsMatch() {}


### PR DESCRIPTION
* Current DataUtilities isMatch implementation compares the class of the
attribute descriptor, not the type binding

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>