### PR TITLE
[GEOT-6352] FilterToSQL#escapeName does not escape escape character

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -1859,6 +1859,8 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
      *
      * <p>Typically this is the double-quote character, ", but may not be for all databases.
      *
+     * <p>If a name contains the escape string itself, the escape string is duplicated.
+     *
      * <p>For example, consider the following query:
      *
      * <p>SELECT Geom FROM Spear.ArchSites May be interpreted by the database as: SELECT GEOM FROM
@@ -1872,12 +1874,27 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
     }
 
     /**
-     * Surrounds a name with the SQL escape character.
+     * Surrounds a name with the SQL escape string.
+     *
+     * <p>If the name contains the SQL escape string, the SQL escape string is duplicated.
      *
      * @param name
      */
     public String escapeName(String name) {
-        return sqlNameEscape + name + sqlNameEscape;
+        if (sqlNameEscape.isEmpty()) return name;
+        StringBuilder sb = new StringBuilder();
+        sb.append(sqlNameEscape);
+        int offset = 0;
+        int escapeOffset;
+        while ((escapeOffset = name.indexOf(sqlNameEscape, offset)) != -1) {
+            sb.append(name.substring(offset, escapeOffset));
+            sb.append(sqlNameEscape);
+            sb.append(sqlNameEscape);
+            offset = escapeOffset + sqlNameEscape.length();
+        }
+        sb.append(name.substring(offset));
+        sb.append(sqlNameEscape);
+        return sb.toString();
     }
 
     /**

--- a/modules/library/jdbc/src/test/java/org/geotools/data/jdbc/FilterToSQLTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/data/jdbc/FilterToSQLTest.java
@@ -412,4 +412,14 @@ public class FilterToSQLTest extends TestCase {
         FilterToSQL encoder = new FilterToSQL(output);
         assertEquals("WHERE (P1 IN (1, 2) OR P2 > 3 OR P2 < 4)", encoder.encodeToString(filter));
     }
+
+    public void testEscapeName() {
+        encoder.setSqlNameEscape("\"");
+        assertEquals("\"abc\"", encoder.escapeName("abc"));
+        assertEquals("\"\"\"abc\"", encoder.escapeName("\"abc"));
+        assertEquals("\"a\"\"bc\"", encoder.escapeName("a\"bc"));
+        assertEquals("\"abc\"\"\"", encoder.escapeName("abc\""));
+        encoder.setSqlNameEscape("");
+        assertEquals("abc", encoder.escapeName("abc"));
+    }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEscapingOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEscapingOnlineTest.java
@@ -1,0 +1,49 @@
+package org.geotools.jdbc;
+
+import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Transaction;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.store.ContentFeatureCollection;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+public abstract class JDBCEscapingOnlineTest extends JDBCTestSupport {
+
+    protected SimpleFeatureType escapingSchema;
+    protected static final String ESCAPING = "esca\"ping";
+    protected static final String ID = "i\"d";
+    protected static final String NAME = "na\"me";
+
+    protected abstract JDBCEscapingTestSetup createTestSetup();
+
+    @Override
+    protected void connect() throws Exception {
+        super.connect();
+        escapingSchema =
+                DataUtilities.createType(
+                        dataStore.getNamespaceURI() + "." + ESCAPING,
+                        ID + ":0," + NAME + ":String");
+    }
+
+    public void testEscaping() throws Exception {
+        dataStore.createSchema(escapingSchema);
+        assertFeatureTypesEqual(escapingSchema, dataStore.getSchema(tname(ESCAPING)));
+
+        try (FeatureWriter<SimpleFeatureType, SimpleFeature> fw =
+                dataStore.getFeatureWriterAppend(tname(ESCAPING), Transaction.AUTO_COMMIT)) {
+            SimpleFeature f = (SimpleFeature) fw.next();
+            f.setAttribute(aname(ID), 1);
+            f.setAttribute(aname(NAME), "abc");
+            fw.write();
+        }
+
+        ContentFeatureCollection fc = dataStore.getFeatureSource(tname(ESCAPING)).getFeatures();
+        assertEquals(1, fc.size());
+        try (SimpleFeatureIterator fr = fc.features()) {
+            assertTrue(fr.hasNext());
+            fr.next();
+            assertFalse(fr.hasNext());
+        }
+    }
+}

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEscapingTestSetup.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEscapingTestSetup.java
@@ -1,0 +1,20 @@
+package org.geotools.jdbc;
+
+import java.sql.SQLException;
+
+public abstract class JDBCEscapingTestSetup extends JDBCDelegatingTestSetup {
+
+    protected JDBCEscapingTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    protected final void setUpData() throws Exception {
+        try {
+            dropEscapingTable();
+        } catch (SQLException e) {
+        }
+    }
+
+    /** Drops the "esca\"ping" table created in the test. */
+    protected abstract void dropEscapingTable() throws Exception;
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaEscapingOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaEscapingOnlineTest.java
@@ -1,0 +1,12 @@
+package org.geotools.data.hana;
+
+import org.geotools.jdbc.JDBCEscapingOnlineTest;
+import org.geotools.jdbc.JDBCEscapingTestSetup;
+
+public class HanaEscapingOnlineTest extends JDBCEscapingOnlineTest {
+
+    @Override
+    protected JDBCEscapingTestSetup createTestSetup() {
+        return new HanaEscapingTestSetup(new HanaTestSetup());
+    }
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaEscapingTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaEscapingTestSetup.java
@@ -1,0 +1,22 @@
+package org.geotools.data.hana;
+
+import java.sql.Connection;
+import org.geotools.jdbc.JDBCEscapingTestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class HanaEscapingTestSetup extends JDBCEscapingTestSetup {
+
+    private static final String TABLE = "esca\"ping";
+
+    public HanaEscapingTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void dropEscapingTable() throws Exception {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn);
+            htu.dropTestTableCascade(TABLE);
+        }
+    }
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaTestUtil.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaTestUtil.java
@@ -62,9 +62,7 @@ public class HanaTestUtil {
             } else {
                 sb.append('.');
             }
-            sb.append('"');
-            sb.append(ids[i]);
-            sb.append('"');
+            sb.append(HanaUtil.encodeIdentifier(ids[i]));
         }
         return sb;
     }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
@@ -87,7 +87,7 @@ public class PostgisFilterToSQL extends FilterToSQL {
                 // if we don't know at all, use the srid of the geometry we're comparing against
                 // (much slower since that has to be extracted record by record as opposed to
                 // being a constant)
-                out.write("', ST_SRID(\"" + currentGeometry.getLocalName() + "\"))");
+                out.write("', ST_SRID(" + escapeName(currentGeometry.getLocalName()) + "))");
             } else {
                 out.write("', " + currentSRID + ")");
             }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisEscapingOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisEscapingOnlineTest.java
@@ -1,0 +1,12 @@
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCEscapingOnlineTest;
+import org.geotools.jdbc.JDBCEscapingTestSetup;
+
+public class PostgisEscapingOnlineTest extends JDBCEscapingOnlineTest {
+
+    @Override
+    protected JDBCEscapingTestSetup createTestSetup() {
+        return new PostgisEscapingTestSetup(new PostGISTestSetup());
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisEscapingTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisEscapingTestSetup.java
@@ -1,0 +1,16 @@
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCEscapingTestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class PostgisEscapingTestSetup extends JDBCEscapingTestSetup {
+
+    public PostgisEscapingTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void dropEscapingTable() throws Exception {
+        run("DROP TABLE \"esca\"\"ping\"");
+    }
+}

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
@@ -849,15 +849,14 @@ public class SQLServerDialect extends BasicSQLDialect {
             Connection cx, SimpleFeatureType schema, String databaseSchema, String indexName)
             throws SQLException {
         StringBuffer sql = new StringBuffer();
-        String escape = getNameEscape();
         sql.append("DROP INDEX ");
-        sql.append(escape).append(indexName).append(escape);
+        sql.append(escapeName(indexName));
         sql.append(" ON ");
         if (databaseSchema != null) {
             encodeSchemaName(databaseSchema, sql);
             sql.append(".");
         }
-        sql.append(escape).append(schema.getTypeName()).append(escape);
+        sql.append(escapeName(schema.getTypeName()));
 
         Statement st = null;
         try {


### PR DESCRIPTION
SQL identifiers (column names, table names, schema names) are usually
quoted using double quotes. Furthermore, identifiers can contain double
quotes themselves. These are usually escaped using two double quotes,
e.g. a"b is quoted as "a""b".

Identifiers with double quotes are not properly escaped by
FilterToSQL#escapeName, e.g. a"b would become "a"b" resulting in an
invalid SQL statement.

Additionally, there are dozens of locations in the JDBC-plugins
themselves where the identifier quoting is done manually with patterns
like

String sql = "ALTER TABLE \"" + schemaName + "\".\"" + tableName + "\""...

This change fixes the FilterToSQL#escapeName method and adapts locations
where the escaping was done manually.