### PR TITLE
[Backport 22.x][GEOT-6345] MongoDB OR filters are not executed on native search engine

### DIFF
--- a/docs/user/library/data/mongodb.rst
+++ b/docs/user/library/data/mongodb.rst
@@ -174,9 +174,8 @@ Implementation Notes
   indexed GeoJSON data stored in a MongoDB document collection is assumed to be 
   referenced with the WGS84 coordinate reference system.
 
-* MongoDB versions tested through 2.4.9 do not support more than one operation 
-  on a spatial index nested in an $or operation (so splitting a query into two 
-  across the dateline will not work).
+* Native $or operator execution is automatically enabled when MongoDB detected version >= 2.6.0; 
+  if you run a lower version, native $or operator execution is automatically disabled.
 
 * Within, Intersects and BBOX filters are implemented with $geoWithin and 
   $geoIntersects operations. These operations are limited when effected by 

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStoreFactory.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStoreFactory.java
@@ -76,7 +76,7 @@ public class MongoDataStoreFactory implements DataStoreFactorySpi {
             DATASTORE_URI,
             SCHEMASTORE_URI,
             MAX_OBJECTS_FOR_SCHEMA,
-            OBJECTS_IDS_FOR_SCHEMA
+            OBJECTS_IDS_FOR_SCHEMA,
         };
     }
 

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
@@ -38,6 +38,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.opengis.filter.And;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsGreaterThan;
@@ -281,6 +282,18 @@ public class FilterToMongoTest extends TestCase {
         BasicDBList andFilter = (BasicDBList) obj.get("$and");
         assertNotNull(andFilter);
         assertEquals(andFilter.size(), 2);
+    }
+
+    public void testOrComparison() {
+        PropertyIsGreaterThan greaterThan = ff.greater(ff.property("property"), ff.literal(0));
+        PropertyIsLessThan lessThan = ff.less(ff.property("property"), ff.literal(10));
+        Or or = ff.or(greaterThan, lessThan);
+        BasicDBObject obj = (BasicDBObject) or.accept(filterToMongo, null);
+        assertNotNull(obj);
+
+        BasicDBList orFilter = (BasicDBList) obj.get("$or");
+        assertNotNull(orFilter);
+        assertEquals(orFilter.size(), 2);
     }
 
     public void testEqualToInteger() throws Exception {

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -25,7 +25,12 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.And;
+import org.opengis.filter.BinaryLogicOperator;
+import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.IncludeFilter;
+import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsGreaterThan;
@@ -288,5 +293,38 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
         SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
         Query q = new Query("ft1", isNull);
         assertEquals(2, source.getCount(q));
+    }
+
+    public void testOrPostFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyIsLike f1 =
+                ff.like(ff.property("properties.stringProperty"), "on%", "%", "_", "\\");
+        PropertyIsLike f2 =
+                ff.like(ff.property("properties.stringProperty"), "no%", "%", "_", "\\");
+        Or or = ff.or(f1, f2);
+        checkBinaryLogicOperatorFilterSplitting(or);
+    }
+
+    public void testAndPostFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyIsLike f1 =
+                ff.like(ff.property("properties.stringProperty"), "on%", "%", "_", "\\");
+        PropertyIsLike f2 =
+                ff.like(ff.property("properties.stringProperty"), "no%", "%", "_", "\\");
+        And and = ff.and(f1, f2);
+        checkBinaryLogicOperatorFilterSplitting(and);
+    }
+
+    private void checkBinaryLogicOperatorFilterSplitting(BinaryLogicOperator filter)
+            throws Exception {
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        assertTrue(source instanceof MongoFeatureStore);
+        MongoFeatureStore mongoStore = (MongoFeatureStore) source;
+        MongoFeatureSource mongoSource = mongoStore.delegate;
+        Filter[] filters = mongoSource.splitFilter(filter);
+        Filter preFilter = filters[0];
+        assertTrue(preFilter instanceof BinaryLogicOperator);
+        Filter postFilter = filters[1];
+        assertTrue(postFilter instanceof IncludeFilter);
     }
 }


### PR DESCRIPTION
MongoDB store does not register OR operation into filter capabilities and due to this OR operations are not executes on native search engine leading to wrong queries results with or involved.

This seems related to older MongoDB versions unable to mix $or operations with spatial indexes, but it is already supported since 2.6.0 version.

This PR add native OR support by default and adds a store parameter for deactivate it if needed for older MongoDB versions.

See:
https://github.com/geotools/geotools/blob/master/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java#L214-L218

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6345