### PR TITLE
[Backport 21.x][GEOT-6345] MongoDB OR filters are not executed on native search engine

### DIFF
--- a/docs/user/library/data/mongodb.rst
+++ b/docs/user/library/data/mongodb.rst
@@ -174,9 +174,8 @@ Implementation Notes
   indexed GeoJSON data stored in a MongoDB document collection is assumed to be 
   referenced with the WGS84 coordinate reference system.
 
-* MongoDB versions tested through 2.4.9 do not support more than one operation 
-  on a spatial index nested in an $or operation (so splitting a query into two 
-  across the dateline will not work).
+* Native $or operator execution is automatically enabled when MongoDB detected version >= 2.6.0; 
+  if you run a lower version, native $or operator execution is automatically disabled.
 
 * Within, Intersects and BBOX filters are implemented with $geoWithin and 
   $geoIntersects operations. These operations are limited when effected by 

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
@@ -33,6 +33,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.Document;
 import org.geotools.data.FeatureWriter;
 import org.geotools.data.Transaction;
 import org.geotools.data.store.ContentDataStore;
@@ -73,6 +76,8 @@ public class MongoDataStore extends ContentDataStore {
     final MongoClient dataStoreClient;
     final DB dataStoreDB;
 
+    final boolean deactivateOrNativeFilter;
+
     @SuppressWarnings("deprecation")
     FilterCapabilities filterCapabilities;
 
@@ -109,6 +114,8 @@ public class MongoDataStore extends ContentDataStore {
                     "Unknown mongodb database, \"" + dataStoreClientURI.getDatabase() + "\"");
         }
 
+        this.deactivateOrNativeFilter = isMongoVersionLessThan2_6(dataStoreClientURI);
+
         schemaStore = createSchemaStore(schemaStoreURI);
         if (schemaStore == null) {
             dataStoreClient.close(); // This smells bad too...
@@ -120,6 +127,28 @@ public class MongoDataStore extends ContentDataStore {
 
         if (schemaInitParams != null) this.schemaInitParams = schemaInitParams;
         else this.schemaInitParams = MongoSchemaInitParams.builder().build();
+    }
+
+    /**
+     * Checks if MongoDB version is less than 2.6.0.
+     *
+     * @return true if version less than 2.6.0 is found, otherwise false.
+     */
+    private boolean isMongoVersionLessThan2_6(MongoClientURI dataStoreClientURI) {
+        boolean deactivateOrAux = false;
+        // check server version
+        Document result =
+                dataStoreClient
+                        .getDatabase(dataStoreClientURI.getDatabase())
+                        .runCommand(new BsonDocument("buildinfo", new BsonString("")));
+        if (result.containsKey("versionArray")) {
+            List<Integer> versionArray = (List<Integer>) result.get("versionArray");
+            // if MongoDB server version < 2.6.0 disable native $or operator
+            if (versionArray.get(0) < 2 || (versionArray.get(0) == 2 && versionArray.get(1) < 6)) {
+                deactivateOrAux = true;
+            }
+        }
+        return deactivateOrAux;
     }
 
     final MongoClientURI createMongoClientURI(String dataStoreURI) {
@@ -207,13 +236,18 @@ public class MongoDataStore extends ContentDataStore {
     final FilterCapabilities createFilterCapabilties() {
         FilterCapabilities capabilities = new FilterCapabilities();
 
-        /* disable FilterCapabilities.LOGICAL_OPENGIS since it contains
-            Or.class (in addtions to And.class and Not.class.  MongodB 2.4
-            doesn't supprt '$or' with spatial operations.
-        */
-        //        capabilities.addAll(FilterCapabilities.LOGICAL_OPENGIS);
-        capabilities.addType(And.class);
-        capabilities.addType(Not.class);
+        if (deactivateOrNativeFilter) {
+            /*
+             * disable FilterCapabilities.LOGICAL_OPENGIS since it contains Or.class (in
+             * additions to And.class and Not.class. MongodB 2.4 doesn't support '$or' with
+             * spatial operations.
+             */
+            capabilities.addType(And.class);
+            capabilities.addType(Not.class);
+        } else {
+            // default behavior, '$or' is fully supported from MongoDB 2.6.0 version
+            capabilities.addAll(FilterCapabilities.LOGICAL_OPENGIS);
+        }
 
         capabilities.addAll(FilterCapabilities.SIMPLE_COMPARISONS_OPENGIS);
         capabilities.addType(PropertyIsNull.class);

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStoreFactory.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStoreFactory.java
@@ -76,7 +76,7 @@ public class MongoDataStoreFactory extends AbstractDataStoreFactory {
             DATASTORE_URI,
             SCHEMASTORE_URI,
             MAX_OBJECTS_FOR_SCHEMA,
-            OBJECTS_IDS_FOR_SCHEMA
+            OBJECTS_IDS_FOR_SCHEMA,
         };
     }
 

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
@@ -38,6 +38,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.opengis.filter.And;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsGreaterThan;
@@ -281,6 +282,18 @@ public class FilterToMongoTest extends TestCase {
         BasicDBList andFilter = (BasicDBList) obj.get("$and");
         assertNotNull(andFilter);
         assertEquals(andFilter.size(), 2);
+    }
+
+    public void testOrComparison() {
+        PropertyIsGreaterThan greaterThan = ff.greater(ff.property("property"), ff.literal(0));
+        PropertyIsLessThan lessThan = ff.less(ff.property("property"), ff.literal(10));
+        Or or = ff.or(greaterThan, lessThan);
+        BasicDBObject obj = (BasicDBObject) or.accept(filterToMongo, null);
+        assertNotNull(obj);
+
+        BasicDBList orFilter = (BasicDBList) obj.get("$or");
+        assertNotNull(orFilter);
+        assertEquals(orFilter.size(), 2);
     }
 
     public void testEqualToInteger() throws Exception {

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -25,7 +25,12 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.filter.And;
+import org.opengis.filter.BinaryLogicOperator;
+import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.IncludeFilter;
+import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsGreaterThan;
@@ -288,5 +293,38 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
         SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
         Query q = new Query("ft1", isNull);
         assertEquals(2, source.getCount(q));
+    }
+
+    public void testOrPostFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyIsLike f1 =
+                ff.like(ff.property("properties.stringProperty"), "on%", "%", "_", "\\");
+        PropertyIsLike f2 =
+                ff.like(ff.property("properties.stringProperty"), "no%", "%", "_", "\\");
+        Or or = ff.or(f1, f2);
+        checkBinaryLogicOperatorFilterSplitting(or);
+    }
+
+    public void testAndPostFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyIsLike f1 =
+                ff.like(ff.property("properties.stringProperty"), "on%", "%", "_", "\\");
+        PropertyIsLike f2 =
+                ff.like(ff.property("properties.stringProperty"), "no%", "%", "_", "\\");
+        And and = ff.and(f1, f2);
+        checkBinaryLogicOperatorFilterSplitting(and);
+    }
+
+    private void checkBinaryLogicOperatorFilterSplitting(BinaryLogicOperator filter)
+            throws Exception {
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        assertTrue(source instanceof MongoFeatureStore);
+        MongoFeatureStore mongoStore = (MongoFeatureStore) source;
+        MongoFeatureSource mongoSource = mongoStore.delegate;
+        Filter[] filters = mongoSource.splitFilter(filter);
+        Filter preFilter = filters[0];
+        assertTrue(preFilter instanceof BinaryLogicOperator);
+        Filter postFilter = filters[1];
+        assertTrue(postFilter instanceof IncludeFilter);
     }
 }


### PR DESCRIPTION
MongoDB store does not register OR operation into filter capabilities and due to this OR operations are not executes on native search engine leading to wrong queries results with or involved.

This seems related to older MongoDB versions unable to mix $or operations with spatial indexes, but it is already supported since 2.6.0 version.

This PR add native OR support by default and adds a store parameter for deactivate it if needed for older MongoDB versions.

See:
https://github.com/geotools/geotools/blob/master/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java#L214-L218

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6345