### PR TITLE
[Backport 21.x][GEOT-6318] Allow setting entity expansion limit on GeoTools XML parser.

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -70,6 +71,11 @@ public class Parser {
 
     private static final String SAX_PROPERTY_PREFIX = "http://xml.org/sax/properties/";
 
+    private static final String JAXP_PROPERTY_PREFIX = "http://www.oracle.com/xml/jaxp/properties/";
+    private static final String JDK_ENTITY_EXPANSION_LIMIT =
+            JAXP_PROPERTY_PREFIX + "entityExpansionLimit";
+    private static final Integer DEFAULT_ENTITY_EXPANSION_LIMIT = 100;
+
     /** sax handler which maintains the element stack */
     private ParserHandler handler;
 
@@ -78,6 +84,9 @@ public class Parser {
 
     /** the instance document being parsed */
     private InputStream input;
+
+    /** Entity expansion limit configuration, set to null by default */
+    private Integer entityExpansionLimit;
 
     /**
      * Creates a new instance of the parser.
@@ -543,7 +552,23 @@ public class Parser {
                 schemaLocation.toString());
         // add the handler as a LexicalHandler too.
         parser.setProperty(SAX_PROPERTY_PREFIX + LEXICAL_HANDLER_PROPERTY, handler);
+        // set Entity expansion limit
+        parser.setProperty(
+                JDK_ENTITY_EXPANSION_LIMIT,
+                entityExpansionLimit != null
+                        ? entityExpansionLimit
+                        : DEFAULT_ENTITY_EXPANSION_LIMIT);
+        //
+        // return builded parser
         return parser;
+    }
+
+    public Optional<Integer> getEntityExpansionLimit() {
+        return Optional.ofNullable(entityExpansionLimit);
+    }
+
+    public void setEntityExpansionLimit(Integer entityExpansionLimit) {
+        this.entityExpansionLimit = entityExpansionLimit;
     }
 
     /**

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/ParserTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/ParserTest.java
@@ -27,10 +27,12 @@ import junit.framework.TestCase;
 import org.geotools.ml.MLConfiguration;
 import org.geotools.ml.Mail;
 import org.geotools.ml.bindings.MLSchemaLocationResolver;
+import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 import org.xml.sax.ext.EntityResolver2;
 
 public class ParserTest extends TestCase {
@@ -335,5 +337,91 @@ public class ParserTest extends TestCase {
                 MLSchemaLocationResolver.class.getResourceAsStream("mails-external-entities.xml"));
         parser.validate(
                 MLSchemaLocationResolver.class.getResourceAsStream("mails-external-entities.xml"));
+    }
+
+    /** Tests returned exception caused by entity expansion limit configuration on Parser. */
+    @Test
+    public void testEntityExpansionLimitException() throws Exception {
+        final StringBuffer sb = new StringBuffer();
+        XSD xsd =
+                new XSD() {
+                    @Override
+                    public String getSchemaLocation() {
+                        return ParserTest.class.getResource("mixed.xsd").getFile();
+                    }
+
+                    @Override
+                    public String getNamespaceURI() {
+                        return "http://geotools.org/test";
+                    }
+                };
+        Configuration cfg =
+                new Configuration(xsd) {
+                    @Override
+                    protected void registerBindings(Map bindings) {
+                        bindings.put(
+                                new QName("http://geotools.org/test", "MixedType"),
+                                new MixedTypeBinding(sb));
+                    }
+
+                    @Override
+                    protected void configureParser(Parser parser) {
+                        parser.setHandleMixedContent(true);
+                    }
+                };
+
+        Parser p = new Parser(cfg);
+        p.setEntityExpansionLimit(1);
+        SAXParseException expected = null;
+        try {
+            p.parse(getClass().getResourceAsStream("entityExpansionLimit.xml"));
+        } catch (SAXParseException ex) {
+            expected = ex;
+        }
+        assertNotNull(expected);
+        // check for the entity expansion limit error code in exception message
+        assertTrue(expected.getMessage().contains("JAXP00010001"));
+    }
+
+    /** Tests entity expansion limit configuration on Parser. */
+    @Test
+    public void testEntityExpansionLimitAllowed() throws Exception {
+        final StringBuffer sb = new StringBuffer();
+        XSD xsd =
+                new XSD() {
+                    @Override
+                    public String getSchemaLocation() {
+                        return ParserTest.class.getResource("mixed.xsd").getFile();
+                    }
+
+                    @Override
+                    public String getNamespaceURI() {
+                        return "http://geotools.org/test";
+                    }
+                };
+        Configuration cfg =
+                new Configuration(xsd) {
+                    @Override
+                    protected void registerBindings(Map bindings) {
+                        bindings.put(
+                                new QName("http://geotools.org/test", "MixedType"),
+                                new MixedTypeBinding(sb));
+                    }
+
+                    @Override
+                    protected void configureParser(Parser parser) {
+                        parser.setHandleMixedContent(true);
+                    }
+                };
+
+        Parser p = new Parser(cfg);
+        p.setEntityExpansionLimit(100);
+        SAXParseException unexpected = null;
+        try {
+            p.parse(getClass().getResourceAsStream("entityExpansionLimit.xml"));
+        } catch (SAXParseException ex) {
+            unexpected = ex;
+        }
+        assertNull(unexpected);
     }
 }

--- a/modules/extension/xsd/xsd-core/src/test/resources/org/geotools/xsd/entityExpansionLimit.xml
+++ b/modules/extension/xsd/xsd-core/src/test/resources/org/geotools/xsd/entityExpansionLimit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE convert [ <!ENTITY lol "lol"><!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;"> ]>
+<foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://geotools.org/test mixed.xsd"
+ xmlns="http://geotools.org/test">
+ Hello <bar>&lol1;</bar>
+ </foo>


### PR DESCRIPTION
Currently GeoTools XML parser (org.geotools.xsd.Parser) doesn't allow to set a custom entity expansion limit on the embedded SAX Parser. Since the default can be too big for some use cases (64000) it could be useful to can configure the limit using the Geotools Parser API, so it can be easily used, as example, by Geoserver WFS and more.

See Entity Expansion limit on documentation:
https://docs.oracle.com/javase/tutorial/jaxp/limits/using.html

This PR adds a entityExpansionLimit attribute to Geotools XML Parser.

Issue:
https://osgeo-org.atlassian.net/browse/GEOT-6318