### PR TITLE
[GEOT-6396] Avoid preloading GML schema on GML object construction

### DIFF
--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/v3_2/GML.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/v3_2/GML.java
@@ -54,15 +54,7 @@ public final class GML extends XSD {
     }
 
     /** private constructor */
-    private GML() {
-        // Trigger immediate construction of full GML schema before dependencies are constructed, to
-        // handle cyclic dependencies. See GEOT-3327.
-        try {
-            getSchema();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private GML() {}
 
     protected void addDependencies(Set dependencies) {
         dependencies.add(XLINK.getInstance());


### PR DESCRIPTION
@nmco can you have a look?

Removing this eager loading speeds up single test runs in the IDE by over a second (reference, GetMapIntegrationTest, since WMS unfortunately depends on WFS which in turn loads this), and I could not get a single test to fail, not even in app-schema integration. 

So... maybe the original motivation for this code is just outdated?