### PR TITLE
[GEOT-6378] Remove jdom dependency from main and shapefile modules

### DIFF
--- a/modules/extension/app-schema/app-schema/pom.xml
+++ b/modules/extension/app-schema/app-schema/pom.xml
@@ -53,6 +53,10 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+       <dependency>
+           <groupId>org.jdom</groupId>
+           <artifactId>jdom2</artifactId>
+       </dependency>
         <dependency>
             <groupId>commons-digester</groupId>
             <artifactId>commons-digester</artifactId>

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffIIOMetadataEncoder.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffIIOMetadataEncoder.java
@@ -23,8 +23,10 @@ import it.geosolutions.imageio.plugins.tiff.TIFFTagSet;
 import java.awt.geom.AffineTransform;
 import java.util.Iterator;
 import java.util.Map;
+import javax.imageio.metadata.IIOMetadataNode;
 import org.geotools.util.KeySortedList;
-import org.jdom2.Element;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * This class is responsible for encoding the geotiff tags into suitable metadata for the ImageIO
@@ -416,12 +418,12 @@ public class GeoTiffIIOMetadataEncoder {
     }
 
     public void assignTo(Element element) {
-        if (!element.getName().equals(GeoTiffConstants.GEOTIFF_IIO_ROOT_ELEMENT_NAME)) {
+        if (!element.getLocalName().equals(GeoTiffConstants.GEOTIFF_IIO_ROOT_ELEMENT_NAME)) {
             throw new IllegalArgumentException(
                     "root not found: " + GeoTiffConstants.GEOTIFF_IIO_ROOT_ELEMENT_NAME);
         }
 
-        final Element ifd1 = element.getChild(GeoTiffConstants.GEOTIFF_IFD_TAG);
+        final Element ifd1 = getChild(element, GeoTiffConstants.GEOTIFF_IFD_TAG);
 
         if (ifd1 == null) {
             throw new IllegalArgumentException(
@@ -429,21 +431,26 @@ public class GeoTiffIIOMetadataEncoder {
         }
 
         final Element ifd2 = createIFD();
+        String attribute = ifd2.getAttribute(GeoTiffConstants.GEOTIFF_TAGSETS_ATT_NAME);
         ifd1.setAttribute(
-                GeoTiffConstants.GEOTIFF_TAGSETS_ATT_NAME,
-                ifd2.getAttributeValue(GeoTiffConstants.GEOTIFF_TAGSETS_ATT_NAME));
+                GeoTiffConstants.GEOTIFF_TAGSETS_ATT_NAME, "".equals(attribute) ? null : attribute);
 
-        final Element[] childElems = (Element[]) ifd2.getChildren().toArray(new Element[0]);
+        NodeList childNodes = ifd2.getChildNodes();
+        final Element[] childElems = new Element[childNodes.getLength()];
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            final Element child = (Element) childNodes.item(i);
+            childElems[i] = child;
+        }
         for (int i = 0; i < childElems.length; i++) {
             final Element child = childElems[i];
-            ifd2.removeContent(child);
-            ifd1.addContent(child);
+            ifd2.removeChild(child);
+            ifd1.appendChild(child);
         }
     }
 
     public Element createRootTree() {
-        final Element rootElement = new Element(GeoTiffConstants.GEOTIFF_IIO_ROOT_ELEMENT_NAME);
-        rootElement.addContent(createIFD());
+        final Element rootElement = newElement(GeoTiffConstants.GEOTIFF_IIO_ROOT_ELEMENT_NAME);
+        rootElement.appendChild(createIFD());
 
         return rootElement;
     }
@@ -576,35 +583,35 @@ public class GeoTiffIIOMetadataEncoder {
     }
 
     private Element createIFD() {
-        Element ifd = new Element(GeoTiffConstants.GEOTIFF_IFD_TAG);
+        Element ifd = newElement(GeoTiffConstants.GEOTIFF_IFD_TAG);
         ifd.setAttribute(
                 GeoTiffConstants.GEOTIFF_TAGSETS_ATT_NAME,
                 BaselineTIFFTagSet.class.getName() + "," + GeoTIFFTagSet.class.getName());
 
         if (modelPixelScale.isSet()) {
-            ifd.addContent(createModelPixelScaleElement());
+            ifd.appendChild(createModelPixelScaleElement());
         }
 
         if (isModelTiePointsSet()) {
-            ifd.addContent(createModelTiePointsElement());
+            ifd.appendChild(createModelTiePointsElement());
         } else if (isModelTransformationSet()) {
-            ifd.addContent(createModelTransformationElement());
+            ifd.appendChild(createModelTransformationElement());
         }
 
         if (getNumGeoKeyEntries() > 1) {
-            ifd.addContent(createGeoKeyDirectoryElement());
+            ifd.appendChild(createGeoKeyDirectoryElement());
         }
 
         if (numGeoTiffDoubleParams > 0) {
-            ifd.addContent(createGeoDoubleParamsElement());
+            ifd.appendChild(createGeoDoubleParamsElement());
         }
 
         if (numGeoTiffAsciiParams > 0) {
-            ifd.addContent(createGeoAsciiParamsElement());
+            ifd.appendChild(createGeoAsciiParamsElement());
         }
 
         if (isNodataSet) {
-            ifd.addContent(createNoDataElement());
+            ifd.appendChild(createNoDataElement());
         }
 
         if (isMetadataSet) {
@@ -677,16 +684,16 @@ public class GeoTiffIIOMetadataEncoder {
 
     private Element createGeoKeyDirectoryElement() {
         Element field = createFieldElement(getGeoKeyDirectoryTag());
-        Element data = new Element(GeoTiffConstants.GEOTIFF_SHORTS_TAG);
-        field.addContent(data);
+        Element data = newElement(GeoTiffConstants.GEOTIFF_SHORTS_TAG);
+        field.appendChild(data);
         int[] values;
 
         // GeoKey directory root tag
         values = getGeoKeyEntryAt(0).getValues();
-        data.addContent(createShortElement(values[0]));
-        data.addContent(createShortElement(values[1]));
-        data.addContent(createShortElement(values[3]));
-        data.addContent(createShortElement(values[2]));
+        data.appendChild(createShortElement(values[0]));
+        data.appendChild(createShortElement(values[1]));
+        data.appendChild(createShortElement(values[3]));
+        data.appendChild(createShortElement(values[2]));
 
         // GeoKeys
         for (int i = 1; i < numGeoTiffEntries; i++) {
@@ -694,7 +701,7 @@ public class GeoTiffIIOMetadataEncoder {
             int lenght = values.length;
             for (int j = 0; j < lenght; j++) {
                 Element GeoKeyRecord = createShortElement(values[j]);
-                data.addContent(GeoKeyRecord);
+                data.appendChild(GeoKeyRecord);
             }
         }
 
@@ -703,11 +710,11 @@ public class GeoTiffIIOMetadataEncoder {
 
     private Element createGeoDoubleParamsElement() {
         Element field = createFieldElement(getGeoDoubleParamsTag());
-        Element data = new Element(GeoTiffConstants.GEOTIFF_DOUBLES_TAG);
-        field.addContent(data);
+        Element data = newElement(GeoTiffConstants.GEOTIFF_DOUBLES_TAG);
+        field.appendChild(data);
         for (int i = 0; i < numGeoTiffDoubleParams; i++) {
             Element param = createDoubleElement(geoTiffDoubleParams[i]);
-            data.addContent(param);
+            data.appendChild(param);
         }
 
         return field;
@@ -715,17 +722,17 @@ public class GeoTiffIIOMetadataEncoder {
 
     private Element createGeoAsciiParamsElement() {
         Element field = createFieldElement(getGeoAsciiParamsTag());
-        Element data = new Element(GeoTiffConstants.GEOTIFF_ASCIIS_TAG);
-        field.addContent(data);
-        data.addContent(createAsciiElement(geoTiffAsciiParams.toString()));
+        Element data = newElement(GeoTiffConstants.GEOTIFF_ASCIIS_TAG);
+        field.appendChild(data);
+        data.appendChild(createAsciiElement(geoTiffAsciiParams.toString()));
 
         return field;
     }
 
     private Element createModelPixelScaleElement() {
         Element field = createFieldElement(getModelPixelScaleTag());
-        Element data = new Element(GeoTiffConstants.GEOTIFF_DOUBLES_TAG);
-        field.addContent(data);
+        Element data = newElement(GeoTiffConstants.GEOTIFF_DOUBLES_TAG);
+        field.appendChild(data);
         addDoubleElements(data, modelPixelScale.getValues());
 
         return field;
@@ -733,8 +740,8 @@ public class GeoTiffIIOMetadataEncoder {
 
     private Element createModelTransformationElement() {
         Element field = createFieldElement(getModelTransformationTag());
-        Element data = new Element(GeoTiffConstants.GEOTIFF_DOUBLES_TAG);
-        field.addContent(data);
+        Element data = newElement(GeoTiffConstants.GEOTIFF_DOUBLES_TAG);
+        field.appendChild(data);
         addDoubleElements(data, modelTransformation);
 
         return field;
@@ -742,8 +749,8 @@ public class GeoTiffIIOMetadataEncoder {
 
     private Element createModelTiePointsElement() {
         Element field = createFieldElement(getModelTiePointTag());
-        Element data = new Element(GeoTiffConstants.GEOTIFF_DOUBLES_TAG);
-        field.addContent(data);
+        Element data = newElement(GeoTiffConstants.GEOTIFF_DOUBLES_TAG);
+        field.appendChild(data);
 
         for (int i = 0; i < numModelTiePoints; i++) {
             addDoubleElements(data, modelTiePoints[i].getData());
@@ -754,9 +761,9 @@ public class GeoTiffIIOMetadataEncoder {
 
     private Element createNoDataElement() {
         Element field = createFieldElement(getNoDataTag());
-        Element data = new Element(GeoTiffConstants.GEOTIFF_ASCIIS_TAG);
-        field.addContent(data);
-        data.addContent(createAsciiElement(Double.toString(noData)));
+        Element data = newElement(GeoTiffConstants.GEOTIFF_ASCIIS_TAG);
+        field.appendChild(data);
+        data.appendChild(createAsciiElement(Double.toString(noData)));
         return field;
     }
 
@@ -776,10 +783,10 @@ public class GeoTiffIIOMetadataEncoder {
                     final TIFFTag tag = getAsciiTag(set, Integer.valueOf(keyName));
                     if (tag != null) {
                         Element field = createFieldElement(tag);
-                        Element data = new Element(GeoTiffConstants.GEOTIFF_ASCIIS_TAG);
-                        field.addContent(data);
-                        data.addContent(createAsciiElement(value));
-                        ifd.addContent(field);
+                        Element data = newElement(GeoTiffConstants.GEOTIFF_ASCIIS_TAG);
+                        field.appendChild(data);
+                        data.appendChild(createAsciiElement(value));
+                        ifd.appendChild(field);
                     }
                 }
             }
@@ -787,7 +794,7 @@ public class GeoTiffIIOMetadataEncoder {
     }
 
     private Element createFieldElement(final TIFFTag tag) {
-        Element field = new Element(GeoTiffConstants.GEOTIFF_FIELD_TAG);
+        Element field = newElement(GeoTiffConstants.GEOTIFF_FIELD_TAG);
         field.setAttribute(GeoTiffConstants.NUMBER_ATTRIBUTE, String.valueOf(tag.getNumber()));
         field.setAttribute(GeoTiffConstants.NAME_ATTRIBUTE, tag.getName());
 
@@ -795,21 +802,21 @@ public class GeoTiffIIOMetadataEncoder {
     }
 
     private Element createShortElement(final int value) {
-        Element GeoKeyRecord = new Element(GeoTiffConstants.GEOTIFF_SHORT_TAG);
+        Element GeoKeyRecord = newElement(GeoTiffConstants.GEOTIFF_SHORT_TAG);
         GeoKeyRecord.setAttribute(GeoTiffConstants.VALUE_ATTRIBUTE, String.valueOf(value));
 
         return GeoKeyRecord;
     }
 
     private Element createDoubleElement(final double value) {
-        Element param = new Element(GeoTiffConstants.GEOTIFF_DOUBLE_TAG);
+        Element param = newElement(GeoTiffConstants.GEOTIFF_DOUBLE_TAG);
         param.setAttribute(GeoTiffConstants.VALUE_ATTRIBUTE, String.valueOf(value));
 
         return param;
     }
 
     private Element createAsciiElement(final String value) {
-        Element param = new Element(GeoTiffConstants.GEOTIFF_ASCII_TAG);
+        Element param = newElement(GeoTiffConstants.GEOTIFF_ASCII_TAG);
         param.setAttribute(GeoTiffConstants.VALUE_ATTRIBUTE, String.valueOf(value));
 
         return param;
@@ -819,7 +826,7 @@ public class GeoTiffIIOMetadataEncoder {
         final int length = values.length;
         for (int j = 0; j < length; j++) {
             Element GeoKeyRecord = createDoubleElement(values[j]);
-            data.addContent(GeoKeyRecord);
+            data.appendChild(GeoKeyRecord);
         }
     }
 
@@ -836,5 +843,21 @@ public class GeoTiffIIOMetadataEncoder {
     public void setTiffTagsMetadata(Map<String, String> metadata) {
         this.tiffTagsMetadata = metadata;
         isMetadataSet = true;
+    }
+
+    private Element newElement(String name) {
+        return new IIOMetadataNode(name);
+    }
+
+    /** @return the first matching child element, or null if not found */
+    private Element getChild(Element element, String childName) {
+        NodeList childNodes = element.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Element child = (Element) childNodes.item(i);
+            if (childName.equals(child.getLocalName())) {
+                return child;
+            }
+        }
+        return null;
     }
 }

--- a/modules/library/main/pom.xml
+++ b/modules/library/main/pom.xml
@@ -227,11 +227,6 @@
       <artifactId>jts-core</artifactId>
       <!-- The version number is specified in the parent POM. -->
     </dependency>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom2</artifactId>
-      <!-- The version number is specified in the parent POM. -->
-    </dependency>
 	<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
 	<dependency>
 		<groupId>org.apache.commons</groupId>

--- a/modules/library/main/src/main/java/org/geotools/data/ows/Response.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/Response.java
@@ -19,7 +19,6 @@ package org.geotools.data.ows;
 import java.io.IOException;
 import java.io.InputStream;
 import org.geotools.ows.ServiceException;
-import org.jdom2.JDOMException;
 
 /**
  * Provides a base class for Responses from an OWS. Checks the incoming content for a
@@ -86,8 +85,6 @@ public abstract class Response {
     protected ServiceException parseException(InputStream inputStream) throws IOException {
         try {
             return ServiceExceptionParser.parse(inputStream);
-        } catch (JDOMException e) {
-            throw (IOException) new IOException().initCause(e);
         } finally {
             inputStream.close();
         }

--- a/modules/library/main/src/main/java/org/geotools/data/ows/ServiceExceptionParser.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/ServiceExceptionParser.java
@@ -16,15 +16,21 @@
  */
 package org.geotools.data.ows;
 
+import static javax.xml.stream.XMLInputFactory.IS_COALESCING;
+import static javax.xml.stream.XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES;
+import static javax.xml.stream.XMLInputFactory.SUPPORT_DTD;
+import static javax.xml.stream.XMLStreamConstants.END_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import org.geotools.ows.ServiceException;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.JDOMException;
-import org.jdom2.input.SAXBuilder;
 
 /**
  * Utility class that will parse ServiceExceptions out of an inputStream.
@@ -39,51 +45,61 @@ public class ServiceExceptionParser {
      *
      * <p>ServiceExceptions beyond the first can be accessed using ServiceException.next();
      *
-     * @param inputStream
-     * @throws JDOMException
+     * @param inputStream stream to parse the exception report from, not closed by this method
      * @throws IOException
      */
-    public static ServiceException parse(InputStream inputStream)
-            throws JDOMException, IOException {
-        SAXBuilder builder = new SAXBuilder();
-        builder.setExpandEntities(false);
-        Document document = builder.build(inputStream);
+    public static ServiceException parse(InputStream inputStream) throws IOException {
+        List<ServiceException> exceptions = new ArrayList<>();
+        try {
+            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            // disable resolving of external DTD entities (coalescing needs to be false)
+            inputFactory.setProperty(IS_COALESCING, false);
+            inputFactory.setProperty(IS_REPLACING_ENTITY_REFERENCES, false);
+            // disallow DTDs entirely
+            inputFactory.setProperty(SUPPORT_DTD, false);
 
-        Element root = document.getRootElement();
-        List<Element> serviceExceptions = root.getChildren("ServiceException");
-
+            XMLStreamReader reader = inputFactory.createXMLStreamReader(inputStream, "UTF-8");
+            int tag;
+            while ((tag = reader.next()) != END_DOCUMENT) {
+                if (tag == START_ELEMENT && reader.getLocalName().equals("ServiceException")) {
+                    String code = parseServiceExceptionCode(reader);
+                    String errorMessage = parseServiceExceptionMessage(reader);
+                    exceptions.add(new ServiceException(errorMessage, code));
+                }
+            }
+        } catch (XMLStreamException e) {
+            throw new IOException(e);
+        }
         /*
          * ServiceExceptions with codes get bumped to the top of the list.
          */
-        List<ServiceException> parsedExceptions =
-                serviceExceptions
-                        .stream()
-                        .map(ServiceExceptionParser::parseSE)
-                        .sorted(ServiceExceptionParser::compare)
-                        .collect(Collectors.toList());
+        Collections.sort(exceptions, ServiceExceptionParser::compare);
         /*
          * Now chain them.
          */
-        ServiceException firstException = null;
-        ServiceException recentException = null;
-        for (ServiceException exception : parsedExceptions) {
-            if (firstException == null) {
-                firstException = exception;
-                recentException = exception;
-            } else {
-                recentException.setNext(exception);
-                recentException = exception;
-            }
+        for (int i = 0; i < exceptions.size() - 1; i++) {
+            exceptions.get(i).setNext(exceptions.get(i + 1));
         }
-
-        return firstException;
+        return exceptions.isEmpty() ? null : exceptions.get(0);
     }
 
-    private static ServiceException parseSE(Element element) {
-        String errorMessage = element.getText();
-        String code = element.getAttributeValue("code");
+    private static String parseServiceExceptionMessage(XMLStreamReader reader)
+            throws XMLStreamException {
+        reader.require(START_ELEMENT, null, "ServiceException");
+        return reader.getElementText();
+    }
 
-        return new ServiceException(errorMessage, code);
+    private static String parseServiceExceptionCode(XMLStreamReader reader)
+            throws XMLStreamException {
+        reader.require(START_ELEMENT, null, "ServiceException");
+        String value = null;
+        for (int i = 0; i < reader.getAttributeCount(); i++) {
+            if ("code".equals(reader.getAttributeLocalName(i))) {
+                value = reader.getAttributeValue(i);
+                break;
+            }
+        }
+        return value;
     }
 
     private static int sortValue(ServiceException exception) {

--- a/modules/library/main/src/test/java/org/geotools/data/ows/ServiceExceptionParserTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/ows/ServiceExceptionParserTest.java
@@ -52,6 +52,23 @@ public class ServiceExceptionParserTest {
     }
 
     @Test
+    public void testCoalescing() throws Exception {
+        ServiceException exception =
+                ServiceExceptionParser.parse(
+                        mockStream(
+                                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                                        + "<ServiceExceptionReport>\n"
+                                        + "  <ServiceException code=\"42\"><![CDATA[coalesced]]> message</ServiceException>\n"
+                                        + "</ServiceExceptionReport>"));
+
+        Assert.assertThat(
+                exception,
+                both(hasProperty("message", equalTo("coalesced message")))
+                        .and(hasProperty("code", equalTo("42"))));
+        Assert.assertThat(exception.getNext(), nullValue());
+    }
+
+    @Test
     public void testSequence() throws Exception {
         ServiceException exception =
                 ServiceExceptionParser.parse(

--- a/modules/plugin/coverage-multidim/netcdf/pom.xml
+++ b/modules/plugin/coverage-multidim/netcdf/pom.xml
@@ -122,6 +122,10 @@
       <artifactId>log4j-over-slf4j</artifactId>
       <version>1.6.4</version>
     </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+    </dependency>
             
     <!-- Test dependencies -->
     <dependency>

--- a/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffWriter.java
+++ b/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffWriter.java
@@ -61,12 +61,6 @@ import org.geotools.referencing.operation.matrix.XAffineTransform;
 import org.geotools.util.URLs;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.JDOMException;
-import org.jdom2.Parent;
-import org.jdom2.input.DOMBuilder;
-import org.jdom2.output.DOMOutputter;
 import org.opengis.coverage.grid.Format;
 import org.opengis.coverage.grid.GridCoverage;
 import org.opengis.coverage.grid.GridCoverageWriter;
@@ -76,6 +70,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.crs.GeographicCRS;
 import org.opengis.referencing.crs.ProjectedCRS;
 import org.opengis.util.ProgressListener;
+import org.w3c.dom.Node;
 
 /**
  * {@link AbstractGridCoverageWriter} implementation for the geotiff format.
@@ -470,24 +465,13 @@ public class GeoTiffWriter extends AbstractGridCoverageWriter implements GridCov
         org.w3c.dom.Element w3cElement =
                 (org.w3c.dom.Element)
                         imageMetadata.getAsTree(GeoTiffConstants.GEOTIFF_IIO_METADATA_FORMAT_NAME);
-        final Element element = new DOMBuilder().build(w3cElement);
 
-        geoTIFFMetadata.assignTo(element);
-
-        final Parent parent = element.getParent();
-        parent.removeContent(element);
-
-        final Document document = new Document(element);
-
+        geoTIFFMetadata.assignTo(w3cElement);
         try {
-            final org.w3c.dom.Document w3cDoc = new DOMOutputter().output(document);
+            Node TIFFIFD = w3cElement.getChildNodes().item(0);
             final IIOMetadata iioMetadata =
-                    new TIFFImageMetadata(
-                            TIFFImageMetadata.parseIFD(
-                                    w3cDoc.getDocumentElement().getFirstChild()));
+                    new TIFFImageMetadata(TIFFImageMetadata.parseIFD(TIFFIFD));
             imageMetadata = iioMetadata;
-        } catch (JDOMException e) {
-            throw new IIOException("Failed to set GeoTIFFWritingUtilities specific tags.", e);
         } catch (IIOInvalidTreeException e) {
             throw new IIOException("Failed to set GeoTIFFWritingUtilities specific tags.", e);
         }

--- a/modules/plugin/shapefile/pom.xml
+++ b/modules/plugin/shapefile/pom.xml
@@ -139,11 +139,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom2</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-sample-data</artifactId>
       <version>${project.version}</version>

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/xml/ShpXmlFileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/xml/ShpXmlFileReader.java
@@ -16,23 +16,26 @@
  */
 package org.geotools.data.shapefile.shp.xml;
 
+import static javax.xml.stream.XMLInputFactory.IS_COALESCING;
+import static javax.xml.stream.XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES;
+import static javax.xml.stream.XMLInputFactory.SUPPORT_DTD;
+import static javax.xml.stream.XMLStreamConstants.END_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
 import java.io.IOException;
 import java.io.InputStream;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import org.geotools.data.shapefile.files.FileReader;
 import org.geotools.data.shapefile.files.ShpFileType;
 import org.geotools.data.shapefile.files.ShpFiles;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.JDOMException;
-import org.jdom2.JDOMFactory;
-import org.jdom2.input.SAXBuilder;
-import org.jdom2.input.sax.SAXHandlerFactory;
-import org.jdom2.input.sax.XMLReaders;
 import org.locationtech.jts.geom.Envelope;
 
 public class ShpXmlFileReader implements FileReader {
 
-    Document dom;
+    private ShpFiles shapefileFiles;
 
     /**
      * Parse metadataFile (currently for bounding box information).
@@ -40,53 +43,111 @@ public class ShpXmlFileReader implements FileReader {
      * <p>
      *
      * @param shapefileFiles
-     * @throws JDOMException
-     * @throws IOException
      */
-    public ShpXmlFileReader(ShpFiles shapefileFiles) throws JDOMException, IOException {
-        SAXBuilder builder =
-                new SAXBuilder(
-                        XMLReaders.NONVALIDATING, (SAXHandlerFactory) null, (JDOMFactory) null);
+    public ShpXmlFileReader(ShpFiles shapefileFiles) {
+        this.shapefileFiles = shapefileFiles;
+    }
 
-        InputStream inputStream = shapefileFiles.getInputStream(ShpFileType.SHP_XML, this);
-        try {
-            dom = builder.build(inputStream);
-        } finally {
-            inputStream.close();
-        }
+    private XMLStreamReader reader(InputStream in) throws XMLStreamException {
+        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+        // disable resolving of external DTD entities (coalescing needs to be false)
+        inputFactory.setProperty(IS_COALESCING, false);
+        inputFactory.setProperty(IS_REPLACING_ENTITY_REFERENCES, false);
+        // disallow DTDs entirely
+        inputFactory.setProperty(SUPPORT_DTD, false);
+
+        return inputFactory.createXMLStreamReader(in, "UTF-8");
     }
 
     public Metadata parse() {
-        return parseMetadata(dom.getRootElement());
+        try (InputStream inputStream = shapefileFiles.getInputStream(ShpFileType.SHP_XML, this)) {
+            return parseMetadata(reader(inputStream));
+        } catch (IOException | XMLStreamException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    protected Metadata parseMetadata(Element root) {
+    protected Metadata parseMetadata(XMLStreamReader reader) throws XMLStreamException {
         Metadata meta = new Metadata();
-        meta.setIdinfo(parseIdInfo(root.getChild("idinfo")));
-
+        int tag;
+        while ((tag = reader.next()) != END_DOCUMENT) {
+            if (START_ELEMENT == tag) {
+                switch (reader.getLocalName()) {
+                    case "idinfo":
+                        IdInfo idInfo = parseIdInfo(reader);
+                        meta.setIdinfo(idInfo);
+                        break; // break, no other contents being parsed atm
+                }
+            }
+        }
         return meta;
     }
 
-    protected IdInfo parseIdInfo(Element element) {
+    protected IdInfo parseIdInfo(XMLStreamReader reader) throws XMLStreamException {
+        reader.require(START_ELEMENT, null, "idinfo");
+
+        Envelope bounding = new Envelope();
+        Envelope lbounding = new Envelope();
+        if (seekElement(reader, "spdom")) {
+            int tag;
+            while ((tag = reader.nextTag()) != END_ELEMENT
+                    && !"spdom".equals(reader.getLocalName())) {
+                if (tag == START_ELEMENT) {
+                    switch (reader.getLocalName()) {
+                        case "bounding":
+                            bounding = parseBounding(reader);
+                            break;
+                        case "lbounding":
+                            lbounding = parseBounding(reader);
+                            break;
+                    }
+                }
+            }
+        }
         IdInfo idInfo = new IdInfo();
-
-        Element bounding = element.getChild("spdom").getChild("bounding");
-        idInfo.setBounding(parseBounding(bounding));
-
-        Element lbounding = element.getChild("spdom").getChild("lbounding");
-        idInfo.setLbounding(parseBounding(lbounding));
-
+        idInfo.setBounding(bounding);
+        idInfo.setLbounding(lbounding);
         return idInfo;
     }
 
-    protected Envelope parseBounding(Element bounding) {
-        if (bounding == null) return new Envelope();
+    private boolean seekElement(XMLStreamReader reader, String elementName)
+            throws XMLStreamException {
+        reader.require(START_ELEMENT, null, null);
+        final String thisElem = reader.getLocalName();
+        while (true) {
+            int tag = reader.next();
+            if (tag == START_ELEMENT && elementName.equals(reader.getLocalName())) {
+                return true;
+            }
+            if (tag == END_ELEMENT && thisElem.equals(reader.getLocalName())) {
+                return false;
+            }
+        }
+    }
 
-        double minX = Double.parseDouble(bounding.getChildText("westbc"));
-        double maxX = Double.parseDouble(bounding.getChildText("eastbc"));
-        double minY = Double.parseDouble(bounding.getChildText("southbc"));
-        double maxY = Double.parseDouble(bounding.getChildText("northbc"));
-
+    protected Envelope parseBounding(XMLStreamReader reader) throws XMLStreamException {
+        reader.require(START_ELEMENT, null, null);
+        double minX = Double.NaN;
+        double maxX = Double.NaN;
+        double minY = Double.NaN;
+        double maxY = Double.NaN;
+        final String thisElem = reader.getLocalName();
+        while (reader.nextTag() != END_ELEMENT && !thisElem.equals(reader.getLocalName())) {
+            switch (reader.getLocalName()) {
+                case "westbc":
+                    minX = Double.parseDouble(reader.getElementText());
+                    break;
+                case "eastbc":
+                    maxX = Double.parseDouble(reader.getElementText());
+                    break;
+                case "southbc":
+                    minY = Double.parseDouble(reader.getElementText());
+                    break;
+                case "northbc":
+                    maxY = Double.parseDouble(reader.getElementText());
+                    break;
+            }
+        }
         return new Envelope(minX, maxX, minY, maxY);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1149,13 +1149,6 @@
         <version>1.1.1-20090908</version>
       </dependency>
     
-      <!-- XML -->
-      <dependency>
-        <groupId>org.jdom</groupId>
-        <artifactId>jdom2</artifactId>
-        <version>2.0.6</version>
-      </dependency>
-
       <!-- Apache -->
       <dependency>
         <groupId>oro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1149,6 +1149,13 @@
         <version>1.1.1-20090908</version>
       </dependency>
     
+      <!-- XML -->
+      <dependency>
+        <groupId>org.jdom</groupId>
+        <artifactId>jdom2</artifactId>
+        <version>2.0.6</version>
+      </dependency>
+
       <!-- Apache -->
       <dependency>
         <groupId>oro</groupId>


### PR DESCRIPTION
there's a direct dependency on the jdom library
from main and shapefile, which adds nothing that
can't be done with official XML API's, hence
drawing the dependency unnnecessary.

This patch removes such dependency and replaces the
XML parsing done with it by the StAX API which is
faster and is part of the default Java library.

For instance, the following classes have been adapted:

* org.geotools.data.ows.ServiceExceptionParser
* org.geotools.data.shapefile.shp.xml.ShpXmlFileReader