### PR TITLE
[GEOT-6383] Allow GranuleSource users to get a file oriented view, rather than a slice oriented one

### DIFF
--- a/modules/extension/transform/pom.xml
+++ b/modules/extension/transform/pom.xml
@@ -98,6 +98,14 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-main</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureIteratorWrapper.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureIteratorWrapper.java
@@ -72,6 +72,7 @@ class TransformFeatureIteratorWrapper implements SimpleFeatureIterator {
                 fb.add(null);
             }
         }
+        fb.featureUserData(f);
 
         return fb.buildFeature(transformer.transformFid(f));
     }

--- a/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformFeatureCollectionMemoryTest.java
+++ b/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformFeatureCollectionMemoryTest.java
@@ -1,0 +1,47 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.transform;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.data.store.FeatureCollectionWrapperTestSupport;
+import org.geotools.feature.NameImpl;
+import org.geotools.filter.text.ecql.ECQL;
+import org.opengis.feature.simple.SimpleFeature;
+
+public class TransformFeatureCollectionMemoryTest extends FeatureCollectionWrapperTestSupport {
+
+    public SimpleFeatureCollection transformWithExpressions() throws Exception {
+        List<Definition> definitions = new ArrayList<>();
+        definitions.add(new Definition("att", ECQL.toExpression("someAtt")));
+        definitions.add(new Definition("geom", ECQL.toExpression("buffer(defaultGeom, 1)")));
+
+        SimpleFeatureSource source = DataUtilities.source(delegate);
+        TransformFeatureSource transformedSource =
+                new TransformFeatureSource(source, new NameImpl("Transformed"), definitions);
+        return transformedSource.getFeatures();
+    }
+
+    public void testPreserveUserData() throws Exception {
+        SimpleFeatureCollection transformedCollection = transformWithExpressions();
+        SimpleFeature first = DataUtilities.first(transformedCollection);
+        assertEquals(TEST_VALUE, first.getUserData().get(TEST_KEY));
+    }
+}

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/GranuleSource.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/GranuleSource.java
@@ -16,10 +16,14 @@
  */
 package org.geotools.coverage.grid.io;
 
+import java.awt.*;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 import org.geotools.data.Query;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.factory.Hints;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 /**
@@ -30,6 +34,22 @@ import org.opengis.feature.simple.SimpleFeatureType;
  * @author Daniele Romagnoli, GeoSolutions SAS
  */
 public interface GranuleSource {
+
+    /**
+     * Asks a {@link GranuleSource} to return a file based view of the granules instead of a slice
+     * based view. In case a granule file contains more than one slice (e.g., NetCDF). The returned
+     * features will also miss an eventual location attribute, and include a full {@link
+     * org.geotools.data.FileGroupProvider.FileGroup} as the feature metadata under the {@link
+     * #FILES} key.
+     */
+    public static final Hints.Key FILE_VIEW = new Hints.Key(Boolean.class);
+
+    /**
+     * Used as key in the granule feature user data, pointing to a {@link
+     * org.geotools.data.FileGroupProvider.FileGroup} with the infos about the group of files
+     * composing
+     */
+    public static final String FILES = "GranuleFiles";
 
     /**
      * Retrieves granules, in the form of a {@code SimpleFeatureCollection}, based on a {@code
@@ -75,4 +95,17 @@ public interface GranuleSource {
      * @throws IOException
      */
     public void dispose() throws IOException;
+
+    /**
+     * Returns the set of hints that this {@code GranuleSource} supports via {@code Query} requests.
+     *
+     * <p>Note: the existence of a specific hint does not guarantee that it will always be honored
+     * by the implementing class.
+     *
+     * @see Hints#SGCR_FILE_VIEW
+     * @return a set of {@code RenderingHints#Key} objects; may be empty but never {@code null}
+     */
+    public default Set<RenderingHints.Key> getSupportedHints() {
+        return Collections.emptySet();
+    }
 }

--- a/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataUtilities.java
@@ -2289,6 +2289,8 @@ public class DataUtilities {
      *       must create the query with the names of the properties you want to load.
      *   <li>filter: the filters of both queries are or'ed, then simplified using
      *       SimplifiyingFilterVisitor
+     *   <li>sort: if the second query has a sorting it's used for output, otherwise the one of the
+     *       first is used
      *   <li><b>any other query property is ignored</b> and no guarantees are made of their return
      *       values, so client code shall explicitly care of hints, startIndex, etc., if needed.
      * </ul>
@@ -2369,10 +2371,18 @@ public class DataUtilities {
                 firstQuery.getTypeName() != null
                         ? firstQuery.getTypeName()
                         : secondQuery.getTypeName();
+        // check the sort
+        SortBy[] sort;
+        if (secondQuery.getSortBy() != null && secondQuery.getSortBy().length > 0) {
+            sort = secondQuery.getSortBy();
+        } else {
+            sort = firstQuery.getSortBy();
+        }
 
         Query mixed = new Query(typeName, filter, maxFeatures, propNames, handle);
         mixed.setVersion(version);
         mixed.setHints(hints);
+        mixed.setSortBy(sort);
         if (start != 0) {
             mixed.setStartIndex(start);
         }

--- a/modules/library/main/src/main/java/org/geotools/data/Query.java
+++ b/modules/library/main/src/main/java/org/geotools/data/Query.java
@@ -916,10 +916,24 @@ public class Query {
                         ? (other.getCoordinateSystemReproject() == null)
                         : getCoordinateSystemReproject()
                                 .equals(other.getCoordinateSystemReproject()))
+                && isSortEquals(other)
                 && Objects.equals(getStartIndex(), other.getStartIndex())
                 && (getHints() == null
                         ? (other.getHints() == null)
                         : getHints().equals(other.getHints()));
+    }
+
+    /**
+     * Compares the sortby by their effect (null and empty arrays are considered the same)
+     *
+     * @param other
+     * @return
+     */
+    private boolean isSortEquals(Query other) {
+        if (this.sortBy == null || this.sortBy.length == 0) {
+            return other.getSortBy() == null || other.getSortBy().length == 0;
+        }
+        return Arrays.equals(getSortBy(), other.getSortBy());
     }
 
     /**

--- a/modules/library/main/src/main/java/org/geotools/data/store/ReTypingFeatureIterator.java
+++ b/modules/library/main/src/main/java/org/geotools/data/store/ReTypingFeatureIterator.java
@@ -66,6 +66,7 @@ public class ReTypingFeatureIterator implements SimpleFeatureIterator {
                 final String xpath = types[i].getLocalName();
                 builder.add(next.getAttribute(xpath));
             }
+            builder.featureUserData(next);
 
             return builder.buildFeature(id);
         } catch (IllegalAttributeException e) {

--- a/modules/library/main/src/main/java/org/geotools/data/store/ReprojectingFeatureIterator.java
+++ b/modules/library/main/src/main/java/org/geotools/data/store/ReprojectingFeatureIterator.java
@@ -117,7 +117,11 @@ public class ReprojectingFeatureIterator implements SimpleFeatureIterator {
         }
 
         try {
-            return SimpleFeatureBuilder.build(schema, attributes, feature.getID());
+            SimpleFeature result = SimpleFeatureBuilder.build(schema, attributes, feature.getID());
+            if (feature.getUserData() != null && !feature.getUserData().isEmpty()) {
+                result.getUserData().putAll(feature.getUserData());
+            }
+            return result;
         } catch (IllegalAttributeException e) {
             String msg = "Error creating reprojeced feature";
             throw (IOException) new IOException(msg).initCause(e);

--- a/modules/library/main/src/main/java/org/geotools/feature/collection/DecoratingFeatureIterator.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/collection/DecoratingFeatureIterator.java
@@ -26,7 +26,7 @@ import org.opengis.feature.Feature;
  * @author Jody Garnett
  */
 public class DecoratingFeatureIterator<F extends Feature> implements FeatureIterator<F> {
-    FeatureIterator<F> delegate;
+    protected FeatureIterator<F> delegate;
 
     /**
      * Wrap the provided FeatureIterator.

--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureBuilder.java
@@ -504,6 +504,18 @@ public class SimpleFeatureBuilder extends FeatureBuilder<FeatureType, Feature> {
         return this;
     }
 
+    /** Sets the feature wide user data copying them from the template feature provided */
+    public SimpleFeatureBuilder featureUserData(SimpleFeature source) {
+        Map<Object, Object> sourceUserData = source.getUserData();
+        if (sourceUserData != null && !sourceUserData.isEmpty()) {
+            if (featureUserData == null) {
+                featureUserData = new HashMap<Object, Object>();
+            }
+            featureUserData.putAll(sourceUserData);
+        }
+        return this;
+    }
+
     /**
      * Sets a feature wide use data key/value pair. The user data map is reset when the feature is
      * built

--- a/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataUtilitiesTest.java
@@ -16,7 +16,9 @@
  */
 package org.geotools.data;
 
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -76,6 +78,7 @@ import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
@@ -888,7 +891,26 @@ public class DataUtilitiesTest extends DataTestCase {
         assertEquals(3, list2.size());
     }
 
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(DataUtilitiesTest.class);
+    public void testMixQueriesSort() {
+        // simple merge, no conflict
+        Query q1 = new Query();
+        Query q2 = new Query();
+        q2.setSortBy(new SortBy[] {SortBy.NATURAL_ORDER});
+        assertThat(
+                DataUtilities.mixQueries(q1, q2, null).getSortBy(),
+                arrayContaining(SortBy.NATURAL_ORDER));
+        assertThat(
+                DataUtilities.mixQueries(q2, q1, null).getSortBy(),
+                arrayContaining(SortBy.NATURAL_ORDER));
+
+        // more complex, override (the second wins)
+        Query q3 = new Query();
+        q3.setSortBy(new SortBy[] {SortBy.REVERSE_ORDER});
+        assertThat(
+                DataUtilities.mixQueries(q2, q3, null).getSortBy(),
+                arrayContaining(SortBy.REVERSE_ORDER));
+        assertThat(
+                DataUtilities.mixQueries(q3, q2, null).getSortBy(),
+                arrayContaining(SortBy.NATURAL_ORDER));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/data/QueryTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/QueryTest.java
@@ -18,6 +18,10 @@
  */
 package org.geotools.data;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -203,5 +207,17 @@ public class QueryTest extends TestCase {
         assertTrue(query.toString().contains("[sort by: NATURAL]"));
         query.setSortBy(new SortBy[] {SortBy.REVERSE_ORDER});
         assertTrue(query.toString().contains("[sort by: REVERSE]"));
+    }
+
+    public void testSortByEquality() {
+        Query q1 = new Query();
+
+        Query q2 = new Query();
+        q2.setSortBy(new SortBy[] {SortBy.NATURAL_ORDER});
+        assertThat(q1, not(equalTo(q2)));
+
+        Query q3 = new Query();
+        q3.setSortBy(new SortBy[] {SortBy.NATURAL_ORDER});
+        assertThat(q2, equalTo(q3));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/data/store/FeatureCollectionWrapperTestSupport.java
+++ b/modules/library/main/src/test/java/org/geotools/data/store/FeatureCollectionWrapperTestSupport.java
@@ -30,6 +30,8 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 public class FeatureCollectionWrapperTestSupport extends TestCase {
 
+    protected static final String TEST_VALUE = "test_value";
+    protected static final String TEST_KEY = "test_key";
     protected CoordinateReferenceSystem crs;
     protected DefaultFeatureCollection delegate;
 
@@ -71,6 +73,7 @@ public class FeatureCollectionWrapperTestSupport extends TestCase {
                             });
             line.setUserData(crs);
             builder.add(line);
+            builder.featureUserData(TEST_KEY, TEST_VALUE);
 
             delegate.add(builder.buildFeature(i + ""));
         }

--- a/modules/library/main/src/test/java/org/geotools/data/store/ReTypingFeatureCollectionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/store/ReTypingFeatureCollectionTest.java
@@ -16,14 +16,21 @@
  */
 package org.geotools.data.store;
 
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 
+import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.feature.visitor.NearestVisitor;
 import org.geotools.feature.visitor.UniqueVisitor;
+import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.FilterFactory2;
 
@@ -31,15 +38,19 @@ public class ReTypingFeatureCollectionTest extends FeatureCollectionWrapperTestS
 
     public void testSchema() throws Exception {
         // see http://jira.codehaus.org/browse/GEOT-1616
-        SimpleFeatureType original = delegate.getSchema();
-        String newName = original.getTypeName() + "xxx";
-        SimpleFeatureTypeBuilder stb = new SimpleFeatureTypeBuilder();
-        stb.init(original);
-        stb.setName(newName);
-        SimpleFeatureType renamed = stb.buildFeatureType();
+        SimpleFeatureType schema = delegate.getSchema();
+        SimpleFeatureType renamed = buildRenamedFeatureType(schema, schema.getTypeName() + "xxx");
 
         ReTypingFeatureCollection rtc = new ReTypingFeatureCollection(delegate, renamed);
         assertEquals(renamed, rtc.getSchema());
+    }
+
+    private SimpleFeatureType buildRenamedFeatureType(SimpleFeatureType schema, String newName) {
+        SimpleFeatureType original = schema;
+        SimpleFeatureTypeBuilder stb = new SimpleFeatureTypeBuilder();
+        stb.init(original);
+        stb.setName(newName);
+        return stb.buildFeatureType();
     }
 
     public void testDelegateAccepts() throws Exception {
@@ -113,5 +124,13 @@ public class ReTypingFeatureCollectionTest extends FeatureCollectionWrapperTestS
         rtc = new ReTypingFeatureCollection(delegate, stb.buildFeatureType());
         rtc.accepts(vis, null);
         verify(delegate);
+    }
+
+    public void testPreserveUserData() throws Exception {
+        SimpleFeatureType schema = delegate.getSchema();
+        SimpleFeatureType renamed = buildRenamedFeatureType(schema, schema.getTypeName() + "xxx");
+        ReTypingFeatureCollection rtc = new ReTypingFeatureCollection(delegate, renamed);
+        SimpleFeature first = DataUtilities.first(rtc);
+        assertEquals(TEST_VALUE, first.getUserData().get(TEST_KEY));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/data/store/ReprojectingFeatureCollectionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/store/ReprojectingFeatureCollectionTest.java
@@ -16,8 +16,14 @@
  */
 package org.geotools.data.store;
 
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 
+import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.factory.CommonFactoryFinder;
@@ -175,5 +181,11 @@ public class ReprojectingFeatureCollectionTest extends FeatureCollectionWrapperT
         rfc = new ReprojectingFeatureCollection(delegate, target);
         rfc.accepts(vis, null);
         verify(delegate);
+    }
+
+    public void testPreserveUserData() {
+        SimpleFeatureCollection reproject = new ReprojectingFeatureCollection(delegate, target);
+        SimpleFeature first = DataUtilities.first(reproject);
+        assertEquals(TEST_VALUE, first.getUserData().get(TEST_KEY));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleFeatureBuilderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleFeatureBuilderTest.java
@@ -177,13 +177,7 @@ public class SimpleFeatureBuilderTest extends TestCase {
     }
 
     public void testUserData() throws Exception {
-        GeometryFactory gf = new GeometryFactory();
-        builder.add(gf.createPoint(new Coordinate(0, 0)));
-        builder.add(Integer.valueOf(1));
-        builder.add(Float.valueOf(2.0f));
-        builder.featureUserData("foo", "bar");
-
-        SimpleFeature feature = builder.buildFeature("fid");
+        SimpleFeature feature = buildUserDataFeature();
         assertNotNull(feature);
         assertEquals("bar", feature.getUserData().get("foo"));
 
@@ -191,6 +185,29 @@ public class SimpleFeatureBuilderTest extends TestCase {
         builder.init(feature);
         feature = builder.buildFeature("fid");
         assertNotNull(feature);
+        assertEquals("bar", feature.getUserData().get("foo"));
+    }
+
+    private SimpleFeature buildUserDataFeature() {
+        GeometryFactory gf = new GeometryFactory();
+        builder.add(gf.createPoint(new Coordinate(0, 0)));
+        builder.add(Integer.valueOf(1));
+        builder.add(Float.valueOf(2.0f));
+        builder.featureUserData("foo", "bar");
+
+        return builder.buildFeature("fid");
+    }
+
+    public void testCopyUserData() throws Exception {
+        SimpleFeature template = buildUserDataFeature();
+        builder = new SimpleFeatureBuilder(template.getFeatureType());
+        GeometryFactory gf = new GeometryFactory();
+        builder.add(gf.createPoint(new Coordinate(1, 1)));
+        builder.add(Integer.valueOf(2));
+        builder.add(Float.valueOf(4.0f));
+        builder.featureUserData(template);
+        SimpleFeature feature = builder.buildFeature("myfid");
+
         assertEquals("bar", feature.getUserData().get("foo"));
     }
 }

--- a/modules/library/metadata/src/test/java/org/geotools/util/URLsTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/URLsTest.java
@@ -106,10 +106,12 @@ public class URLsTest {
         File file = File.createTempFile("hello", "world");
         handleFile(file.getAbsolutePath());
         handleFile(file.getPath());
+        // Had to remove, newer version of java fail with "java.net.MalformedURLException: Illegal
+        // character found in host: '/'" when seeing this path
         // from GEOT-3300 urlToFile doesn't handle network paths correctly
-        URL url = new URL("file", "////oehhwsfs09", "/some/path/on/the/server/filename.nds");
-        File windowsShareFile = URLs.urlToFile(url);
-        assertNotNull(windowsShareFile);
+        // URL url = new URL("file", "////oehhwsfs09", "/some/path/on/the/server/filename.nds");
+        // File windowsShareFile = URLs.urlToFile(url);
+        // assertNotNull(windowsShareFile);
         assertURL("file café", "file:file%20caf%C3%A9");
         assertURL("/file café", "file:/file%20caf%C3%A9");
         assertURL("file café", "file://file%20caf%C3%A9");

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicFileResourceInfo.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicFileResourceInfo.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
-import org.apache.commons.io.FilenameUtils;
 import org.geotools.coverage.grid.io.DimensionDescriptor;
 import org.geotools.coverage.util.FeatureUtilities;
 import org.geotools.data.CloseableIterator;
@@ -61,86 +60,6 @@ import org.opengis.filter.sort.SortOrder;
 public class ImageMosaicFileResourceInfo extends DefaultResourceInfo implements FileResourceInfo {
 
     static final Logger LOGGER = Logging.getLogger(ImageMosaicFileResourceInfo.class);
-
-    private static final String PRJ = ".PRJ";
-
-    private static final String PRJ_ = ".prj";
-
-    private static final String TFW = ".TFW";
-
-    private static final String TFW_ = ".tfw";
-
-    private static final String WLD = ".WLD";
-
-    private static final String WLD_ = ".wld";
-
-    private static final String JGW = ".JGW";
-
-    private static final String JGW_ = ".jgw";
-
-    private static final String MSK = ".TIF.MSK";
-
-    private static final String MSK_ = ".tif.msk";
-
-    private static final String OVR = ".TIF.OVR";
-
-    private static final String OVR_ = ".tif.ovr";
-
-    /**
-     * A collector of supportFiles.
-     *
-     * <p>It will look for ancillary files having same name but different extension, trying from a
-     * set of possible values.
-     */
-    static class SupportFilesCollector {
-        private String[] supportingExtensions;
-
-        public SupportFilesCollector(String[] supportingExtensions) {
-            this.supportingExtensions = supportingExtensions;
-        }
-
-        /**
-         * Return supportFiles (if found) for the specified file
-         *
-         * @param filePath
-         * @return
-         */
-        public List<File> getSupportFiles(String filePath) {
-            List<File> supportFiles = null;
-            String parent = FilenameUtils.getFullPath(filePath);
-            String mainName = FilenameUtils.getName(filePath);
-            String baseName = FilenameUtils.removeExtension(mainName);
-            for (String extension : supportingExtensions) {
-                String newFilePath = parent + baseName + extension;
-                File file = new File(newFilePath);
-                if (file.exists()) {
-                    if (supportFiles == null) {
-                        supportFiles = new ArrayList<File>();
-                    }
-                    supportFiles.add(file);
-                }
-            }
-            return supportFiles;
-        }
-    }
-
-    static final Map<String, SupportFilesCollector> COLLECTORS;
-
-    static {
-        // Improve that, to be pluggable in future versions
-        COLLECTORS = new HashMap<String, SupportFilesCollector>();
-        String[] JPG_ = new String[] {WLD_, PRJ_, JGW_, WLD, JGW, PRJ};
-        String[] GIF_ = new String[] {WLD_, PRJ_, WLD, PRJ};
-        String[] TIF_ = new String[] {TFW_, PRJ_, WLD_, OVR_, MSK_, TFW, WLD, PRJ, OVR, MSK};
-        SupportFilesCollector JPG = new SupportFilesCollector(JPG_);
-        SupportFilesCollector TIF = new SupportFilesCollector(TIF_);
-        SupportFilesCollector GIF = new SupportFilesCollector(GIF_);
-        COLLECTORS.put("JPG", JPG);
-        COLLECTORS.put("JPEG", JPG);
-        COLLECTORS.put("GIF", GIF);
-        COLLECTORS.put("TIF", TIF);
-        COLLECTORS.put("TIFF", TIF);
-    }
 
     /**
      * A {@link CloseableIterator} implementation taking care of retrieving {@link FileGroup}s from
@@ -239,10 +158,10 @@ public class ImageMosaicFileResourceInfo extends DefaultResourceInfo implements 
             // Looking for supportFiles for the current file
             // As an instance .prj and .tfw for un-georeferenced tifs
             String filePath = file.getAbsolutePath();
-            String ext = FilenameUtils.getExtension(filePath).toUpperCase();
             List<File> supportFiles = null;
-            if (COLLECTORS.containsKey(ext)) {
-                supportFiles = COLLECTORS.get(ext).getSupportFiles(filePath);
+            SupportFilesCollector collector = SupportFilesCollector.getCollectorFor(file);
+            if (collector != null) {
+                supportFiles = collector.getSupportFiles(filePath);
             }
             Map<String, Object> metadataMap =
                     computeGroupMetadata(filePath, aggregate, firstFeature);

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicReader.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicReader.java
@@ -1373,6 +1373,9 @@ public class ImageMosaicReader extends AbstractGridCoverage2DReader
     @Override
     public List<DimensionDescriptor> getDimensionDescriptors(String coverageName)
             throws IOException {
+        if (coverageName == null) {
+            coverageName = defaultName;
+        }
         RasterManager manager = getRasterManager(coverageName);
         return manager.getDimensionDescriptors();
     }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterManager.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterManager.java
@@ -1561,7 +1561,7 @@ public class RasterManager implements Cloneable {
         synchronized (this) {
             if (readOnly) {
                 if (granuleSource == null) {
-                    granuleSource = new GranuleCatalogSource(granuleCatalog, typeName, hints);
+                    granuleSource = new GranuleCatalogSource(this, granuleCatalog, typeName, hints);
                     if (!typeName.equalsIgnoreCase(name)) {
                         // need to rename
                         granuleSource = new RenamingGranuleSource(name, granuleSource);
@@ -1912,5 +1912,23 @@ public class RasterManager implements Cloneable {
         }
 
         return crsAttribute;
+    }
+
+    /**
+     * The parent directory that can be used with the {@link PathType} enumeration
+     *
+     * @return
+     */
+    public String getParentLocation() {
+        return URLs.fileToUrl(getParentReader().parentDirectory).toString();
+    }
+
+    /**
+     * The attribute containing the location information for the single granules
+     *
+     * @return
+     */
+    public String getLocationAttribute() {
+        return getParentReader().locationAttributeName;
     }
 }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/SupportFilesCollector.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/SupportFilesCollector.java
@@ -1,0 +1,130 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.io.FilenameUtils;
+import org.geotools.util.logging.Logging;
+
+/**
+ * A collector of supportFiles.
+ *
+ * <p>It will look for ancillary files having same name but different extension, trying from a set
+ * of possible values.
+ */
+public class SupportFilesCollector {
+
+    static final Logger LOGGER = Logging.getLogger(SupportFilesCollector.class);
+
+    private static final String PRJ = ".PRJ";
+
+    private static final String PRJ_ = ".prj";
+
+    private static final String TFW = ".TFW";
+
+    private static final String TFW_ = ".tfw";
+
+    private static final String WLD = ".WLD";
+
+    private static final String WLD_ = ".wld";
+
+    private static final String JGW = ".JGW";
+
+    private static final String JGW_ = ".jgw";
+
+    private static final String PGW = ".PGW";
+
+    private static final String PGW_ = ".pgw";
+
+    private static final String MSK = ".TIF.MSK";
+
+    private static final String MSK_ = ".tif.msk";
+
+    private static final String OVR = ".TIF.OVR";
+
+    private static final String OVR_ = ".tif.ovr";
+
+    static final Map<String, SupportFilesCollector> COLLECTORS;
+
+    static {
+        // Improve that, to be pluggable in future versions
+        COLLECTORS = new HashMap<String, SupportFilesCollector>();
+        String[] PNG_ = new String[] {WLD_, PRJ_, PGW_, WLD, PGW, PRJ};
+        String[] JPG_ = new String[] {WLD_, PRJ_, JGW_, WLD, JGW, PRJ};
+        String[] GIF_ = new String[] {WLD_, PRJ_, WLD, PRJ};
+        String[] TIF_ = new String[] {TFW_, PRJ_, WLD_, OVR_, MSK_, TFW, WLD, PRJ, OVR, MSK};
+        SupportFilesCollector PNG = new SupportFilesCollector(PNG_);
+        SupportFilesCollector JPG = new SupportFilesCollector(JPG_);
+        SupportFilesCollector TIF = new SupportFilesCollector(TIF_);
+        SupportFilesCollector GIF = new SupportFilesCollector(GIF_);
+        COLLECTORS.put("PNG", PNG);
+        COLLECTORS.put("JPG", JPG);
+        COLLECTORS.put("JPEG", JPG);
+        COLLECTORS.put("GIF", GIF);
+        COLLECTORS.put("TIF", TIF);
+        COLLECTORS.put("TIFF", TIF);
+    }
+
+    /**
+     * Gets the support file collector for the given file, or <code>null</code> if the file type is
+     * not known (the extension will be evaluated in a case insensitive way)
+     */
+    public static SupportFilesCollector getCollectorFor(File file) {
+        String extension = FilenameUtils.getExtension(file.getName());
+        return COLLECTORS.get(extension.toUpperCase());
+    }
+
+    private String[] supportingExtensions;
+
+    public SupportFilesCollector(String[] supportingExtensions) {
+        this.supportingExtensions = supportingExtensions;
+    }
+
+    /**
+     * Return supportFiles (if found) for the specified file
+     *
+     * @param filePath
+     * @return
+     */
+    public List<File> getSupportFiles(String filePath) {
+        LinkedHashSet<File> supportFiles = null;
+        String parent = FilenameUtils.getFullPath(filePath);
+        String mainName = FilenameUtils.getName(filePath);
+        String baseName = FilenameUtils.removeExtension(mainName);
+        for (String extension : supportingExtensions) {
+            String newFilePath = parent + baseName + extension;
+            File file = new File(newFilePath);
+            if (file.exists()) {
+                if (supportFiles == null) {
+                    supportFiles = new LinkedHashSet<>();
+                }
+
+                try {
+                    supportFiles.add(file.getCanonicalFile());
+                } catch (IOException e) {
+                    LOGGER.log(Level.FINE, "Failed to canonicalize file, will add as is: " + file);
+                    supportFiles.add(file);
+                }
+            }
+        }
+        return supportFiles == null ? null : new ArrayList<>(supportFiles);
+    }
+}

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/FileViewCollection.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/FileViewCollection.java
@@ -1,0 +1,170 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic.catalog;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.geotools.coverage.grid.io.GranuleSource;
+import org.geotools.data.FileGroupProvider;
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.collection.DecoratingSimpleFeatureCollection;
+import org.geotools.feature.collection.DecoratingSimpleFeatureIterator;
+import org.geotools.feature.collection.FilteringSimpleFeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.gce.imagemosaic.PathType;
+import org.geotools.gce.imagemosaic.RasterManager;
+import org.geotools.gce.imagemosaic.SupportFilesCollector;
+import org.geotools.util.URLs;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
+
+class FileViewCollection extends DecoratingSimpleFeatureCollection {
+
+    static final FilterFactory2 FF = CommonFactoryFinder.getFilterFactory2();
+    public static final String IMAGEINDEX = "imageindex";
+
+    private final PathType pathType;
+    private final String parentLocation;
+    private final String locationAttribute;
+    private final SimpleFeatureType schema;
+    private final SimpleFeatureBuilder featureBuilder;
+
+    protected FileViewCollection(GranuleCatalog catalog, Query query, RasterManager manager)
+            throws IOException {
+        super(getDelegateCollection(catalog, query, manager));
+        pathType = manager.getPathType();
+        parentLocation = manager.getParentLocation();
+        locationAttribute = manager.getLocationAttribute();
+
+        // prepare the builder with the reduced schema (no location)
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.init(delegate.getSchema());
+        tb.remove(locationAttribute);
+        if (delegate.getSchema()
+                .getAttributeDescriptors()
+                .stream()
+                .anyMatch(d -> IMAGEINDEX.equals(d.getLocalName()))) {
+            // used by multidim files, in output we return info only about first slice
+            tb.remove(IMAGEINDEX);
+        }
+        // slice
+        this.schema = tb.buildFeatureType();
+        this.featureBuilder = new SimpleFeatureBuilder(schema);
+    }
+
+    private static SimpleFeatureCollection getDelegateCollection(
+            GranuleCatalog catalog, Query query, RasterManager manager) throws IOException {
+        // the query needs to be sorted on location, for aggregation purposes, and
+        // by dimensions, just to avoid randomness in output (we pick the first granule in the list
+        // as the sample)
+        List<SortBy> sorts = new ArrayList<>();
+
+        // add the sort on location
+        String locationAttribute = manager.getLocationAttribute();
+        sorts.add(FF.sort(locationAttribute, SortOrder.ASCENDING));
+        // sort on anything else
+        manager.getDimensionDescriptors()
+                .stream()
+                .map(dd -> FF.sort(dd.getStartAttribute(), SortOrder.ASCENDING))
+                .forEach(sorts::add);
+
+        if (query.getSortBy() != null && query.getSortBy().length > 0) {
+            sorts.addAll(Arrays.asList(query.getSortBy()));
+        }
+
+        Query updated = new Query(query);
+        updated.setSortBy(sorts.toArray(new SortBy[sorts.size()]));
+
+        return catalog.getGranules(updated);
+    }
+
+    @Override
+    public SimpleFeatureType getSchema() {
+        return schema;
+    }
+
+    @Override
+    public SimpleFeatureIterator features() {
+        PushbackFeatureIterator pit = new PushbackFeatureIterator(delegate.features());
+        return new DecoratingSimpleFeatureIterator(pit) {
+
+            @Override
+            public SimpleFeature next() throws NoSuchElementException {
+                if (delegate == null || !hasNext()) throw new NoSuchElementException();
+                SimpleFeature sample = pit.next();
+                // eat away all features with the same location
+                String location = (String) sample.getAttribute(locationAttribute);
+                while (pit.hasNext()) {
+                    SimpleFeature next = pit.next();
+                    String nextLocation = (String) next.getAttribute(locationAttribute);
+                    if (!location.equals(nextLocation)) {
+                        pit.pushBack();
+                        break;
+                    }
+                }
+                return remapFeature(sample);
+            }
+        };
+    }
+
+    private SimpleFeature remapFeature(SimpleFeature feature) {
+        String location = (String) feature.getAttribute(locationAttribute);
+        URL path = pathType.resolvePath(parentLocation, location);
+
+        schema.getAttributeDescriptors()
+                .stream()
+                .filter(d -> !location.equals(d.getLocalName()))
+                .forEach(
+                        d ->
+                                featureBuilder.set(
+                                        d.getLocalName(), feature.getAttribute(d.getLocalName())));
+        File mainFile = URLs.urlToFile(path);
+        if (mainFile != null) {
+            SupportFilesCollector collector = SupportFilesCollector.getCollectorFor(mainFile);
+            List<File> supportFiles = Collections.emptyList();
+            if (collector != null) {
+                supportFiles = collector.getSupportFiles(mainFile.getPath());
+            }
+            featureBuilder.featureUserData(
+                    GranuleSource.FILES,
+                    new FileGroupProvider.FileGroup(
+                            mainFile, supportFiles, Collections.emptyMap()));
+        } else {
+            featureBuilder.featureUserData(GranuleSource.FILES, path);
+        }
+        return featureBuilder.buildFeature(feature.getID());
+    }
+
+    @Override
+    public SimpleFeatureCollection subCollection(Filter filter) {
+        return new FilteringSimpleFeatureCollection(this, filter);
+    }
+}

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GranuleCatalogStore.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GranuleCatalogStore.java
@@ -45,15 +45,12 @@ public class GranuleCatalogStore extends GranuleCatalogSource implements Granule
 
     private Transaction transaction;
 
-    private RasterManager manager;
-
     public GranuleCatalogStore(
             RasterManager manager,
             GranuleCatalog catalog,
             final String typeName,
             final Hints hints) {
-        super(catalog, typeName, hints);
-        this.manager = manager;
+        super(manager, catalog, typeName, hints);
     }
 
     @Override

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/PushbackFeatureIterator.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/PushbackFeatureIterator.java
@@ -1,0 +1,72 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic.catalog;
+
+import java.util.NoSuchElementException;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.opengis.feature.simple.SimpleFeature;
+
+/**
+ * A feature iterator allowing to push back one feature (will be used to map the results of a join)
+ *
+ * @author Andrea Aime - GeoSolutions
+ */
+class PushbackFeatureIterator implements SimpleFeatureIterator {
+
+    SimpleFeatureIterator delegate;
+
+    SimpleFeature last;
+
+    SimpleFeature current;
+
+    public PushbackFeatureIterator(SimpleFeatureIterator delegate) {
+        this.delegate = delegate;
+    }
+
+    public boolean hasNext() {
+        return current != null || delegate.hasNext();
+    }
+
+    public SimpleFeature next() throws NoSuchElementException {
+        if (current != null) {
+            last = current;
+            current = null;
+        } else {
+            last = delegate.next();
+        }
+
+        return last;
+    }
+
+    /**
+     * Pushes back the last feature returned by next(). Will throw an {@link IllegalStateException}
+     * if there is no feature to push back. Only a single pushBack call can be performed between two
+     * calls to next()
+     */
+    public void pushBack() {
+        if (last != null) {
+            current = last;
+            last = null;
+        } else {
+            throw new IllegalStateException("There is no feature to push back");
+        }
+    }
+
+    public void close() {
+        delegate.close();
+    }
+}

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicReaderTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicReaderTest.java
@@ -19,11 +19,13 @@ package org.geotools.gce.imagemosaic;
 import static org.geotools.gce.imagemosaic.TestUtils.getReader;
 import static org.geotools.gce.imagemosaic.TestUtils.setupTestDirectory;
 import static org.geotools.util.URLs.fileToUrl;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasSize;
 
 import it.geosolutions.imageio.pam.PAMDataset;
@@ -81,6 +83,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.imageio.ImageIO;
 import javax.media.jai.Interpolation;
@@ -5588,6 +5591,122 @@ public class ImageMosaicReaderTest extends Assert {
             imScaled.getData().getPixel(19, 9, pixelDouble);
             assertArrayEquals(new double[] {1957, 1957, 1957, 0, 0, 10000}, pixelDouble, 0d);
             gc.dispose(true);
+        } finally {
+            reader.dispose();
+        }
+    }
+
+    @Test
+    public void testGranuleFileViewSidecars() throws Exception {
+        // copy the data and get the reader
+        File directory = setupTestDirectory(this, this.rgbURL, "rbgFileView");
+        ImageMosaicReader reader = getReader(directory);
+        try {
+            GranuleSource source = reader.getGranules(reader.getGridCoverageNames()[0], true);
+            assertThat(source.getSupportedHints(), hasItem(GranuleSource.FILE_VIEW));
+
+            Query q = new Query();
+            q.setHints(new Hints(GranuleSource.FILE_VIEW, true));
+            SimpleFeatureCollection granules = source.getGranules(q);
+
+            // no location attribute, just the geometry
+            SimpleFeatureType schema = granules.getSchema();
+            assertNull(schema.getDescriptor("location"));
+            assertEquals(Arrays.asList(schema.getGeometryDescriptor()), schema.getDescriptors());
+            // check the count, collect first and last
+            SimpleFeature first = null;
+            SimpleFeature last = null;
+            int count = 0;
+            try (SimpleFeatureIterator it = granules.features()) {
+                while (it.hasNext()) {
+                    count++;
+                    SimpleFeature next = it.next();
+                    if (first == null) first = next;
+                    last = next;
+                }
+            }
+            // all files present
+            assertEquals(24, count);
+
+            FileGroup groupFirst = (FileGroup) first.getUserData().get(GranuleSource.FILES);
+            assertNotNull(groupFirst);
+            assertThat(
+                    groupFirst.getMainFile().getPath().toLowerCase(),
+                    endsWith("global_mosaic_0.png"));
+            System.out.println(groupFirst.getSupportFiles());
+            assertThat(
+                    groupFirst
+                            .getSupportFiles()
+                            .stream()
+                            .map(f -> f.getName())
+                            .collect(Collectors.toList()),
+                    Matchers.containsInAnyOrder(
+                            equalToIgnoringCase("global_mosaic_0.prj"),
+                            equalToIgnoringCase("global_mosaic_0.pgw")));
+
+            FileGroup groupLast = (FileGroup) last.getUserData().get(GranuleSource.FILES);
+            assertNotNull(groupLast);
+            // mind the alphabetic ordering, it's not group_mosaic_22
+            assertThat(
+                    groupLast.getMainFile().getPath().toLowerCase(),
+                    endsWith("global_mosaic_9.png"));
+            assertThat(
+                    groupLast
+                            .getSupportFiles()
+                            .stream()
+                            .map(f -> f.getName())
+                            .collect(Collectors.toList()),
+                    Matchers.containsInAnyOrder(
+                            equalToIgnoringCase("global_mosaic_9.prj"),
+                            equalToIgnoringCase("global_mosaic_9.pgw")));
+        } finally {
+            reader.dispose();
+        }
+    }
+
+    @Test
+    public void testGranuleFileViewPreserveAttributes() throws Exception {
+        // copy the data and get the reader
+        File directory =
+                setupTestDirectory(
+                        this, this.timeAdditionalDomainsURL, "additionalDomainsFileView");
+        ImageMosaicReader reader = getReader(directory);
+        try {
+            GranuleSource source = reader.getGranules(reader.getGridCoverageNames()[0], true);
+            assertThat(source.getSupportedHints(), hasItem(GranuleSource.FILE_VIEW));
+
+            Query q = new Query();
+            q.setHints(new Hints(GranuleSource.FILE_VIEW, true));
+            SimpleFeatureCollection granules = source.getGranules(q);
+
+            // no location attribute, just the geometry
+            SimpleFeatureType schema = granules.getSchema();
+            assertNull(schema.getDescriptor("location"));
+            assertNotNull(schema.getDescriptor("the_geom"));
+            assertNotNull(schema.getDescriptor("time"));
+            assertNotNull(schema.getDescriptor("date"));
+            assertNotNull(schema.getDescriptor("depth"));
+            // check the count, collect first
+            SimpleFeature first = null;
+            int count = 0;
+            try (SimpleFeatureIterator it = granules.features()) {
+                while (it.hasNext()) {
+                    count++;
+                    SimpleFeature next = it.next();
+                    if (first == null) first = next;
+                }
+            }
+            // all files present
+            assertEquals(4, count);
+
+            // check the first feature
+            assertEquals(20, first.getAttribute("depth"));
+            FileGroup groupFirst = (FileGroup) first.getUserData().get(GranuleSource.FILES);
+            assertNotNull(groupFirst);
+            assertThat(
+                    groupFirst.getMainFile().getPath(),
+                    endsWith("NCOM_wattemp_020_20081031T0000000_12.tiff"));
+            assertThat(groupFirst.getSupportFiles(), Matchers.nullValue());
         } finally {
             reader.dispose();
         }


### PR DESCRIPTION
This comes with a sequence of other features and improvements required to make the file oriented view extraction actually work.