### PR TITLE
gt-imagemosaic/testHarvestHeteroUTM unit test fails

### DIFF
--- a/modules/plugin/imagemosaic/src/test/resources/org/geotools/gce/imagemosaic/test-data/hetero_utm/indexer.properties
+++ b/modules/plugin/imagemosaic/src/test/resources/org/geotools/gce/imagemosaic/test-data/hetero_utm/indexer.properties
@@ -1,3 +1,4 @@
+AbsolutePath=true
 GranuleAcceptors=org.geotools.gce.imagemosaic.acceptors.HeterogeneousCRSAcceptorFactory
 GranuleHandler=org.geotools.gce.imagemosaic.granulehandler.ReprojectingGranuleHandlerFactory
 HeterogeneousCRS=true


### PR DESCRIPTION
Set AbsolutePath property of the Indexer to true. That will help to pass unit test when the code is buld and run from D-drive.  

Default relative path behaviour does not work with different drives (Temporary directory with test data is copied to C: drive).

forum message:
https://sourceforge.net/p/geotools/mailman/message/36771990/


