### PR TITLE
Revert "[GEOT-6396] Avoid preloading GML schema on GML object construction"

### DIFF
--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/v3_2/GML.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/v3_2/GML.java
@@ -54,7 +54,15 @@ public final class GML extends XSD {
     }
 
     /** private constructor */
-    private GML() {}
+    private GML() {
+        // Trigger immediate construction of full GML schema before dependencies are constructed, to
+        // handle cyclic dependencies. See GEOT-3327.
+        try {
+            getSchema();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     protected void addDependencies(Set dependencies) {
         dependencies.add(XLINK.getInstance());


### PR DESCRIPTION
Reverts geotools/geotools#2571

Seeing random build failures in a concurrent GetFeature test in GeoServer, this seems to be the most likely cause, reverting to verify.