### PR TITLE
[GEOT-6293] ContentFeatureStore.getReader(Query) returns incorrect results when canTransact() returns false.

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/store/ContentFeatureSource.java
+++ b/modules/library/main/src/main/java/org/geotools/data/store/ContentFeatureSource.java
@@ -618,7 +618,7 @@ public abstract class ContentFeatureSource implements SimpleFeatureSource {
                     (DiffTransactionState) getTransaction().getState(getEntry());
             reader =
                     new DiffFeatureReader<SimpleFeatureType, SimpleFeature>(
-                            reader, state.getDiff());
+                            reader, state.getDiff(), query.getFilter());
         }
 
         // filtering

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
@@ -883,6 +883,65 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
         sds.dispose();
     }
 
+    @Test
+    public void testUpdateMultipleAttributesNoAutocommit() throws Exception {
+        // create feature type
+        SimpleFeatureType type = DataUtilities.createType("junk",
+                "the_geom:Point,b:java.lang.Integer,c:java.lang.Integer");
+        DefaultFeatureCollection features = new DefaultFeatureCollection();
+
+        SimpleFeatureBuilder build = new SimpleFeatureBuilder(type);
+        SimpleFeature feature = null;
+        for (int i = 0; i < 3; i++) {
+            build.add(new GeometryFactory().createPoint(new Coordinate(i, i)));
+            build.add(i);
+            feature = build.buildFeature(null);
+            features.add(feature);
+        }
+
+        // store features
+        File tmpFile = getTempFile();
+        tmpFile.createNewFile();
+        ShapefileDataStore s = new ShapefileDataStore(tmpFile.toURI().toURL());
+        writeFeatures(s, features);
+
+        // read them back
+        FeatureReader<SimpleFeatureType, SimpleFeature> reader = s.getFeatureReader();
+        // System.out.println(DataUtilities.list(features));
+        reader.close();
+
+        Transaction transaction = new DefaultTransaction();
+        SimpleFeatureStore store =
+                (SimpleFeatureStore) s.getFeatureSource(s.getSchema().getTypeName(), transaction);
+
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        Query query = new Query(s.getSchema().getTypeName());
+        for (int i = 0; i < 3; i++) {
+            query.setFilter(ff.equal(ff.property("b"), ff.literal(i), true));
+            store.modifyFeatures(new String[] {"b", "c"},
+                    new Object[] {new Integer(-1 * i), new Integer(i)}, query.getFilter());
+        }
+
+        transaction.commit();
+
+        reader = s.getFeatureReader();
+        Set<Object> numOfDistinctValues = new HashSet<Object>();
+        try {
+            while (reader.hasNext()) {
+                SimpleFeature f = reader.next();
+                // System.out.println(f);
+                assertEquals(f.getAttribute("b"), -1 * (Integer) f.getAttribute("c"));
+                numOfDistinctValues.add(f.getAttribute("b"));
+            }
+            // ensure that each feature has a distinct value for attribute 'b'
+            assertEquals("Wrong number of distinct values for attribute 'b'",
+                    store.getFeatures().size(), numOfDistinctValues.size());
+        } finally {
+            reader.close();
+        }
+        s.dispose();
+    }
+
     /**
      * Create a test file, then continue removing the first entry until there are no features left.
      */

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
@@ -919,7 +919,7 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
         for (int i = 0; i < 3; i++) {
             query.setFilter(ff.equal(ff.property("b"), ff.literal(i), true));
             store.modifyFeatures(new String[] {"b", "c"},
-                    new Object[] {new Integer(-1 * i), new Integer(i)}, query.getFilter());
+                    new Integer[] {-1 * i, i}, query.getFilter());
         }
 
         transaction.commit();

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
@@ -886,8 +886,9 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
     @Test
     public void testUpdateMultipleAttributesNoAutocommit() throws Exception {
         // create feature type
-        SimpleFeatureType type = DataUtilities.createType("junk",
-                "the_geom:Point,b:java.lang.Integer,c:java.lang.Integer");
+        SimpleFeatureType type =
+                DataUtilities.createType(
+                        "junk", "the_geom:Point,b:java.lang.Integer,c:java.lang.Integer");
         DefaultFeatureCollection features = new DefaultFeatureCollection();
 
         SimpleFeatureBuilder build = new SimpleFeatureBuilder(type);
@@ -918,8 +919,8 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
         Query query = new Query(s.getSchema().getTypeName());
         for (int i = 0; i < 3; i++) {
             query.setFilter(ff.equal(ff.property("b"), ff.literal(i), true));
-            store.modifyFeatures(new String[] {"b", "c"},
-                    new Integer[] {-1 * i, i}, query.getFilter());
+            store.modifyFeatures(
+                    new String[] {"b", "c"}, new Integer[] {-1 * i, i}, query.getFilter());
         }
 
         transaction.commit();
@@ -934,8 +935,10 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
                 numOfDistinctValues.add(f.getAttribute("b"));
             }
             // ensure that each feature has a distinct value for attribute 'b'
-            assertEquals("Wrong number of distinct values for attribute 'b'",
-                    store.getFeatures().size(), numOfDistinctValues.size());
+            assertEquals(
+                    "Wrong number of distinct values for attribute 'b'",
+                    store.getFeatures().size(),
+                    numOfDistinctValues.size());
         } finally {
             reader.close();
         }


### PR DESCRIPTION
fix related to https://osgeo-org.atlassian.net/projects/GEOT/issues/GEOT-6293 with a test case
 (see also https://github.com/locationtech/udig-platform/issues/348)

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>