### PR TITLE
22.x Backport [GEOT-6399] Arithmetic operations not supported with Complex Attributes

### DIFF
--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/appschema/filter/ArithmeticFilterTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/appschema/filter/ArithmeticFilterTest.java
@@ -1,0 +1,138 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.appschema.filter;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.geotools.data.DataAccess;
+import org.geotools.data.DataAccessFinder;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.complex.feature.type.Types;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.filter.FilterFactoryImpl;
+import org.geotools.test.AppSchemaTestSupport;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opengis.feature.Feature;
+import org.opengis.feature.Property;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.Filter;
+import org.opengis.filter.expression.PropertyName;
+import org.xml.sax.helpers.NamespaceSupport;
+
+public class ArithmeticFilterTest extends AppSchemaTestSupport {
+
+    private static FilterFactoryImpl ff;
+
+    private static DataAccess<FeatureType, Feature> dataAccess;
+
+    private static FeatureSource<FeatureType, Feature> fSource;
+
+    @BeforeClass
+    public static void onetimeSetUp() throws Exception {
+
+        final String GSML_URI = "urn:cgi:xmlns:CGI:GeoSciML:2.0";
+        /** Set up filter factory */
+        NamespaceSupport namespaces = new NamespaceSupport();
+        namespaces.declarePrefix("gsml", GSML_URI);
+        namespaces.declarePrefix("gml", "http://www.opengis.net/gml");
+        ff = new FilterFactoryImplNamespaceAware(namespaces);
+
+        /** Load data access */
+        final Name FEATURE_TYPE = Types.typeName(GSML_URI, "MappedFeature");
+        final String schemaBase = "/test-data/";
+        Map<String, Serializable> dsParams = new HashMap<String, Serializable>();
+        dsParams.put("dbtype", "app-schema");
+        URL url = BBoxTest.class.getResource(schemaBase + "MappedFeatureAsOccurrence.xml");
+        assertNotNull(url);
+        dsParams.put("url", url.toExternalForm());
+        dataAccess = DataAccessFinder.getDataStore(dsParams);
+
+        fSource = (FeatureSource<FeatureType, Feature>) dataAccess.getFeatureSource(FEATURE_TYPE);
+    }
+
+    @Test
+    public void testWithArithmeticOperator() throws IOException {
+
+        // evaluating first feature with Location accuracy value = 200
+
+        // 200 x 2 = 400
+        Filter arithmeticMultiplyFilter =
+                ff.equals(
+                        ff.multiply(
+                                ff.property(
+                                        "gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue"),
+                                ff.literal(2)),
+                        ff.literal(400));
+
+        // 200 / 2 = 100
+        Filter arithmeticDivideFilter =
+                ff.equals(
+                        ff.divide(
+                                ff.property(
+                                        "gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue"),
+                                ff.literal(2)),
+                        ff.literal(100));
+
+        // 200 + 100 = 300
+        Filter arithmeticAdditionFilter =
+                ff.equals(
+                        ff.add(
+                                ff.property(
+                                        "gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue"),
+                                ff.literal(100)),
+                        ff.literal(300));
+
+        // 200 - 100 = 100
+        Filter arithmeticSubtractionFilter =
+                ff.equals(
+                        ff.subtract(
+                                ff.property(
+                                        "gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue"),
+                                ff.literal(100)),
+                        ff.literal(100));
+
+        FeatureCollection<FeatureType, Feature> features = fSource.getFeatures();
+
+        PropertyName positionalAccuracy =
+                ff.property("gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue");
+
+        FeatureIterator<Feature> iterator = features.features();
+        try {
+
+            Feature f = iterator.next();
+            Property val = (Property) positionalAccuracy.evaluate(f);
+            System.out.println(val.getValue());
+            // try all filters
+            assertTrue(arithmeticMultiplyFilter.evaluate(f));
+            assertTrue(arithmeticDivideFilter.evaluate(f));
+            assertTrue(arithmeticAdditionFilter.evaluate(f));
+            assertTrue(arithmeticSubtractionFilter.evaluate(f));
+
+        } finally {
+            iterator.close();
+        }
+    }
+}

--- a/modules/extension/app-schema/app-schema/src/test/resources/test-data/MappedFeatureAsOccurrence.xml
+++ b/modules/extension/app-schema/app-schema/src/test/resources/test-data/MappedFeatureAsOccurrence.xml
@@ -65,6 +65,12 @@
 						<OCQL>SHAPE</OCQL>
 					</sourceExpression>
 				</AttributeMapping>
+				<AttributeMapping>
+					<targetAttribute>/gsml:positionalAccuracy/gsml:CGI_NumericValue/gsml:principalValue</targetAttribute>
+					<sourceExpression>
+						<OCQL>LOC_ACC</OCQL>
+					</sourceExpression>
+				</AttributeMapping>
 			</attributeMappings>
 		</FeatureTypeMapping>
 	</typeMappings>

--- a/modules/library/main/src/main/java/org/geotools/filter/expression/AddImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/AddImpl.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.filter.expression;
 
+import java.util.Collection;
 import org.geotools.filter.Filters;
 import org.geotools.filter.MathExpressionImpl;
 import org.geotools.util.Utilities;
@@ -36,11 +37,16 @@ public class AddImpl extends MathExpressionImpl implements Add {
 
     public Object evaluate(Object feature) throws IllegalArgumentException {
         ensureOperandsSet();
+        Object eval1 = getExpression1().evaluate(feature);
+        Object eval2 = getExpression2().evaluate(feature);
+        if (eval1 instanceof Collection || eval2 instanceof Collection) {
+            return handleCollection(eval1, eval2);
+        } else {
+            double leftDouble = Filters.number(getExpression1().evaluate(feature, Number.class));
+            double rightDouble = Filters.number(getExpression2().evaluate(feature, Number.class));
 
-        double leftDouble = Filters.number(getExpression1().evaluate(feature));
-        double rightDouble = Filters.number(getExpression2().evaluate(feature));
-
-        return number(leftDouble + rightDouble);
+            return doArithmeticOperation(leftDouble, rightDouble);
+        }
     }
 
     public Object accept(ExpressionVisitor visitor, Object extraData) {
@@ -79,5 +85,10 @@ public class AddImpl extends MathExpressionImpl implements Add {
 
     public String toString() {
         return "(" + getExpression1().toString() + "+" + getExpression2().toString() + ")";
+    }
+
+    @Override
+    protected Object doArithmeticOperation(Double operand1, Double operand2) {
+        return number(operand1 + operand2);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/expression/DivideImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/DivideImpl.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.filter.expression;
 
+import java.util.Collection;
 import org.geotools.filter.Filters;
 import org.geotools.filter.MathExpressionImpl;
 import org.geotools.util.Utilities;
@@ -37,10 +38,16 @@ public class DivideImpl extends MathExpressionImpl implements Divide {
     public Object evaluate(Object feature) throws IllegalArgumentException {
         ensureOperandsSet();
 
-        double leftDouble = Filters.number(getExpression1().evaluate(feature));
-        double rightDouble = Filters.number(getExpression2().evaluate(feature));
+        Object eval1 = getExpression1().evaluate(feature);
+        Object eval2 = getExpression2().evaluate(feature);
+        if (eval1 instanceof Collection || eval2 instanceof Collection) {
+            return handleCollection(eval1, eval2);
+        } else {
+            double leftDouble = Filters.number(getExpression1().evaluate(feature, Number.class));
+            double rightDouble = Filters.number(getExpression2().evaluate(feature, Number.class));
 
-        return number(leftDouble / rightDouble);
+            return doArithmeticOperation(leftDouble, rightDouble);
+        }
     }
 
     public Object accept(ExpressionVisitor visitor, Object extraData) {
@@ -80,5 +87,10 @@ public class DivideImpl extends MathExpressionImpl implements Divide {
 
     public String toString() {
         return "(" + getExpression1().toString() + "/" + getExpression2().toString() + ")";
+    }
+
+    @Override
+    protected Object doArithmeticOperation(Double operand1, Double operand2) {
+        return number(operand1 / operand2);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/expression/MultiplyImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/MultiplyImpl.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.filter.expression;
 
+import java.util.Collection;
 import org.geotools.filter.Filters;
 import org.geotools.filter.MathExpressionImpl;
 import org.geotools.util.Utilities;
@@ -36,11 +37,16 @@ public class MultiplyImpl extends MathExpressionImpl implements Multiply {
 
     public Object evaluate(Object feature) throws IllegalArgumentException {
         ensureOperandsSet();
+        Object eval1 = getExpression1().evaluate(feature);
+        Object eval2 = getExpression2().evaluate(feature);
+        if (eval1 instanceof Collection || eval2 instanceof Collection) {
+            return handleCollection(eval1, eval2);
+        } else {
+            double leftDouble = Filters.number(getExpression1().evaluate(feature, Number.class));
+            double rightDouble = Filters.number(getExpression2().evaluate(feature, Number.class));
 
-        double leftDouble = Filters.number(getExpression1().evaluate(feature));
-        double rightDouble = Filters.number(getExpression2().evaluate(feature));
-
-        return number(leftDouble * rightDouble);
+            return doArithmeticOperation(leftDouble, rightDouble);
+        }
     }
 
     public Object accept(ExpressionVisitor visitor, Object extraData) {
@@ -79,5 +85,10 @@ public class MultiplyImpl extends MathExpressionImpl implements Multiply {
 
     public String toString() {
         return "(" + getExpression1().toString() + "*" + getExpression2().toString() + ")";
+    }
+
+    @Override
+    protected Object doArithmeticOperation(Double operand1, Double operand2) {
+        return number(operand1 * operand2);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/expression/SubtractImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/SubtractImpl.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.filter.expression;
 
+import java.util.Collection;
 import org.geotools.filter.Filters;
 import org.geotools.filter.MathExpressionImpl;
 import org.geotools.util.Utilities;
@@ -37,10 +38,16 @@ public class SubtractImpl extends MathExpressionImpl implements Subtract {
     public Object evaluate(Object feature) throws IllegalArgumentException {
         ensureOperandsSet();
 
-        double leftDouble = Filters.number(getExpression1().evaluate(feature));
-        double rightDouble = Filters.number(getExpression2().evaluate(feature));
+        Object eval1 = getExpression1().evaluate(feature);
+        Object eval2 = getExpression2().evaluate(feature);
+        if (eval1 instanceof Collection || eval2 instanceof Collection) {
+            return handleCollection(eval1, eval2);
+        } else {
+            double leftDouble = Filters.number(getExpression1().evaluate(feature, Number.class));
+            double rightDouble = Filters.number(getExpression2().evaluate(feature, Number.class));
 
-        return number(leftDouble - rightDouble);
+            return doArithmeticOperation(leftDouble, rightDouble);
+        }
     }
 
     public Object accept(ExpressionVisitor visitor, Object extraData) {
@@ -79,5 +86,10 @@ public class SubtractImpl extends MathExpressionImpl implements Subtract {
 
     public String toString() {
         return "(" + getExpression1().toString() + "-" + getExpression2().toString() + ")";
+    }
+
+    @Override
+    protected Object doArithmeticOperation(Double operand1, Double operand2) {
+        return number(operand1 - operand2);
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/ExpressionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/ExpressionTest.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.filter;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.logging.Logger;
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -120,6 +123,8 @@ public class ExpressionTest extends TestCase {
         ftb.add("testDouble", Double.class);
         ftb.add("testString", String.class);
         ftb.add("testZeroDouble", Double.class);
+        ftb.add("testList", Collection.class);
+        ftb.add("testList2", Collection.class);
         ftb.setName("testSchema");
         testSchema = ftb.buildFeatureType();
 
@@ -146,6 +151,8 @@ public class ExpressionTest extends TestCase {
         // Creates the feature itself
         // FlatFeatureFactory factory = new FlatFeatureFactory(testSchema);
         testFeature = SimpleFeatureBuilder.build(testSchema, attributes, null);
+        // support for properties with lists
+        testFeature.setAttribute("testList", Arrays.asList(1, 2, 3, 4));
         LOGGER.finer("...feature created");
     }
 
@@ -432,5 +439,31 @@ public class ExpressionTest extends TestCase {
         mathTest.setExpression2(testAttribute2);
 
         assertEquals(Double.valueOf(2), mathTest.evaluate(testObject));
+    }
+
+    public void testMathObjectwithLists() throws IllegalFilterException {
+        FilterFactory2 ff = new FilterFactoryImpl();
+        // Multiply Test
+        // list x 2
+        MathExpressionImpl mathExpression =
+                new MultiplyImpl(ff.property("testList"), ff.literal(Integer.valueOf(2)));
+        List scaledList = (List) mathExpression.evaluate(testFeature);
+        // verify multiplication
+        assertEquals(Double.valueOf(2), scaledList.get(0));
+
+        // list - 1
+        mathExpression = new SubtractImpl(ff.property("testList"), ff.literal(Integer.valueOf(1)));
+        List subtractedList = (List) mathExpression.evaluate(testFeature);
+        assertEquals(Double.valueOf(0), subtractedList.get(0));
+
+        // list + 1
+        mathExpression = new AddImpl(ff.literal(Integer.valueOf(1)), ff.property("testList"));
+        List addedList = (List) mathExpression.evaluate(testFeature);
+        assertEquals(Double.valueOf(2), addedList.get(0));
+
+        // list / 2
+        mathExpression = new DivideImpl(ff.literal(Integer.valueOf(2)), ff.property("testList"));
+        List dividedList = (List) mathExpression.evaluate(testFeature);
+        assertEquals(Double.valueOf(0.5), dividedList.get(0));
     }
 }


### PR DESCRIPTION
-backport 22.x
-added support for xpath numerical attributes for arithmetic operators
-integration tests added in app_schema

backport of https://github.com/geotools/geotools/pull/2602