### PR TITLE
[GEOT-6370] Repeated value omiting on AppSchema anonymous unbounded sequences

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/DataAccessMappingFeatureIterator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/DataAccessMappingFeatureIterator.java
@@ -814,6 +814,7 @@ public class DataAccessMappingFeatureIterator extends AbstractMappingFeatureIter
                 }
                 values = ((Attribute) values).getValue();
             }
+
             instance =
                     setAttributeContent(
                             target,
@@ -824,13 +825,21 @@ public class DataAccessMappingFeatureIterator extends AbstractMappingFeatureIter
                             false,
                             sourceExpression,
                             source,
-                            clientPropsMappings,
+                            cleanFromAnonymousAttribute(clientPropsMappings),
                             ignoreXlinkHref);
         }
         if (instance != null && attMapping.encodeIfEmpty()) {
             instance.getDescriptor().getUserData().put("encodeIfEmpty", attMapping.encodeIfEmpty());
         }
         return instance;
+    }
+
+    private Map<Name, Expression> cleanFromAnonymousAttribute(Map<Name, Expression> clientProps) {
+        return clientProps
+                .entrySet()
+                .stream()
+                .filter(e -> !(e.getKey() instanceof ComplexNameImpl))
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
     }
 
     private void generateInnerElementMultiValue(

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/XPath.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/filter/XPath.java
@@ -459,7 +459,7 @@ public class XPath extends XPathUtil {
 
         Attribute leafAttribute = null;
         final Name attributeName = descriptor.getName();
-        if (!isXlinkRef) {
+        if (!isXlinkRef && !isUnboundedMultivalue(parent)) {
             // skip this process if the attribute would only contain xlink:ref
             // that is chained, because it won't contain any values, and we
             // want to create a new empty leaf attribute
@@ -468,8 +468,7 @@ public class XPath extends XPathUtil {
                 if (currStepValue instanceof Collection) {
                     List<Attribute> values = new ArrayList((Collection) currStepValue);
                     if (!values.isEmpty()) {
-                        if ((!(isUnboundedMultivalue(parent)) || !descriptor.isNillable())
-                                && isEmpty(convertedValue)) {
+                        if (isEmpty(convertedValue)) {
                             // when attribute is empty, it is probably just a parent of a leaf
                             // attribute
                             // it could already exist from another attribute mapping for a different


### PR DESCRIPTION
Repeated values causes omitting elements on AppSchema anonymous unbounded sequences, this PR fix them and testing added on Geoserver app-schema online tests.