### PR TITLE
[GEOT-6394] Mongodb datastore HTTP(s) schema: Fix name extractor from URL

### DIFF
--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoUtil.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoUtil.java
@@ -198,8 +198,10 @@ public class MongoUtil {
     }
 
     public static String extractFilesNameFromUrl(String url) throws MalformedURLException {
-        URL urlObject = new URL(url);
-        return urlObject.getPath().replaceAll("/", "");
+        final URL urlObject = new URL(url);
+        String path = urlObject.getPath();
+        int lastSeparatorIndex = path.lastIndexOf("/");
+        return path.substring(lastSeparatorIndex > -1 ? lastSeparatorIndex + 1 : 0, path.length());
     }
 
     public static boolean isZipFile(File file) throws IOException {

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoUtilTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoUtilTest.java
@@ -65,5 +65,7 @@ public class MongoUtilTest {
         assertTrue(MongoUtil.extractFilesNameFromUrl(url3).equalsIgnoreCase("filename.json"));
         String url4 = "https://mock.url.com/filename.json";
         assertTrue(MongoUtil.extractFilesNameFromUrl(url4).equalsIgnoreCase("filename.json"));
+        String url5 = "https://mock.url.com/path1/path2/filename.json";
+        assertTrue(MongoUtil.extractFilesNameFromUrl(url5).equalsIgnoreCase("filename.json"));
     }
 }


### PR DESCRIPTION
Fixes an issue with filename extract from path method for MongoDB HTTP(S) schema support.