### PR TITLE
[GEOT-6409]: TimeParser refactoring and improvement

### DIFF
--- a/docs/user/library/coverage/mosaic.rst
+++ b/docs/user/library/coverage/mosaic.rst
@@ -9,7 +9,10 @@ list the filename of the "images" to display and the location in which they shou
 * `ImageMosaicFormat <http://docs.geotools.org/latest/javadocs/org/geotools/gce/imagemosaic/ImageMosaicFormat.html>`_ (javadoc)
 * `ImageMosaicJDBCReader <http://docs.geotools.org/latest/javadocs/org/geotools/gce/imagemosaic/jdbc/ImageMosaicJDBCReader.html>`_ (javadoc)
 * :doc:`pyramid`
-* `Using the ImageMosaic plugin <http://docs.geoserver.org/stable/en/user/tutorials/image_mosaic_plugin/imagemosaic.html>`_
+* `ImageMosaic plugin <https://docs.geoserver.org/stable/en/user/data/raster/imagemosaic/index.html>`_
+* `Using the ImageMosaic plugin for raster time-series data <https://docs.geoserver.org/stable/en/user/tutorials/imagemosaic_timeseries/imagemosaic_timeseries.html>`_
+* `Using the ImageMosaic plugin for raster with time and elevation data <https://docs.geoserver.org/stable/en/user/tutorials/imagemosaic_timeseries/imagemosaic_time-elevationseries.html>`_
+* `Using the ImageMosaic plugin with footprint management <https://docs.geoserver.org/stable/en/user/tutorials/imagemosaic_footprint/imagemosaic_footprint.html>`_
 
 **Maven**::
    

--- a/modules/library/metadata/src/main/java/org/geotools/util/DateTimeParser.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/DateTimeParser.java
@@ -1,0 +1,636 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.util;
+
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.TreeSet;
+import java.util.logging.Logger;
+import org.geotools.util.logging.Logging;
+
+/**
+ * Parses the {@code time} parameter of the request. The date, time and period are expected to be
+ * formatted according ISO-8601 standard.
+ *
+ * @author Cedric Briancon
+ * @author Martin Desruisseaux
+ * @author Simone Giannecchini, GeoSolutions SAS
+ * @author Jonathan Meyer, Applied Information Sciences, jon@gisjedi.com
+ * @author Daniele Romagnoli, GeoSolutions SAS
+ * @version $Id$
+ */
+public class DateTimeParser {
+    static final Logger LOGGER = Logging.getLogger(DateTimeParser.class);
+
+    private final Integer maxTimes;
+
+    private final int flags;
+
+    /** FLAG to return current time when the String to be parsed is "present" */
+    public static final int FLAG_GET_TIME_ON_PRESENT = 1;
+
+    /** FLAG to return current time when the String to be parsed is "now" */
+    public static final int FLAG_GET_TIME_ON_NOW = 2;
+
+    /** FLAG to return current time when the String to be parsed is "current" */
+    public static final int FLAG_GET_TIME_ON_CURRENT = 4;
+
+    /**
+     * FLAG allowing Lenient ISO8601 format alternatives, for example, YYYYMMdd in addition to
+     * YYYY-MM-dd). See the LENIENT_FORMATS_XXX Constants for a list of supported values
+     */
+    public static final int FLAG_IS_LENIENT = 256;
+
+    /** FLAG to return a validity date range for dates with reduced precision */
+    public static final int FLAG_SINGLE_DATE_AS_DATERANGE = 65536;
+
+    private static final Set<String> CURRENT_TIME_NAMES =
+            new HashSet<String>(Arrays.asList("current", "now", "present"));
+
+    private static final String SIMPLIFIED_FORMAT_MILLISECOND = "yyyyMMdd'T'HHmmssSSS";
+
+    private static final String SIMPLIFIED_FORMAT_SECOND = "yyyyMMdd'T'HHmmss";
+
+    private static final String SIMPLIFIED_FORMAT_MINUTE = "yyyyMMdd'T'HHmm";
+
+    private static final String SIMPLIFIED_FORMAT_HOUR = "yyyyMMdd'T'HH";
+
+    private static final String SIMPLIFIED_FORMAT_DAY = "yyyyMMdd";
+
+    private static final String SIMPLIFIED_FORMAT_MONTH = "yyyyMM";
+
+    private static final String SIMPLIFIED_FORMAT_YEAR = "yyyy";
+
+    public static final String[] LENIENT_FORMATS_MILLISECOND =
+            new String[] {
+                "yyyyMMdd'T'HHmmssSSS'Z'",
+                "yyyy-MM-dd'T'HHmmssSSS'Z'",
+                "yyyy-MM-dd'T'HHmmssSSS",
+                "yyyy-MM-dd'T'HH:mm:ss.SSS",
+                "yyyyMMdd'T'HH:mm:ss.SSS'Z'",
+                "yyyyMMdd'T'HH:mm:ss.SSS",
+                SIMPLIFIED_FORMAT_MILLISECOND
+            };
+
+    public static final String[] LENIENT_FORMATS_SECOND =
+            new String[] {
+                "yyyy-MM-dd'T'HH:mm:ss",
+                "yyyy-MM-dd'T'HHmmss'Z'",
+                "yyyyMMdd'T'HH:mm:ss'Z'",
+                "yyyyMMdd'T'HHmmss'Z'",
+                "yyyyMMdd'T'HH:mm:ss",
+                "yyyy-MM-dd'T'HHmmss",
+                SIMPLIFIED_FORMAT_SECOND
+            };
+
+    public static final String[] LENIENT_FORMATS_MINUTE =
+            new String[] {
+                "yyyy-MM-dd'T'HH:mm",
+                "yyyy-MM-dd'T'HHmm'Z'",
+                "yyyyMMdd'T'HH:mm'Z'",
+                "yyyyMMdd'T'HHmm'Z'",
+                "yyyy-MM-dd'T'HHmm",
+                "yyyyMMdd'T'HH:mm",
+                SIMPLIFIED_FORMAT_MINUTE
+            };
+
+    public static final String[] LENIENT_FORMATS_HOUR =
+            new String[] {"yyyyMMdd'T'HH'Z'", "yyyy-MM-dd'T'HH", SIMPLIFIED_FORMAT_HOUR};
+
+    public static final String[] LENIENT_FORMATS_DAY = new String[] {SIMPLIFIED_FORMAT_DAY};
+
+    public static final String[] LENIENT_FORMATS_MONTH = new String[] {SIMPLIFIED_FORMAT_MONTH};
+
+    public static final String[] LENIENT_FORMATS_YEAR = new String[] {}; // Intentionally empty
+
+    private static final String ISO8601_CHARS_REGEX =
+            "([^(yyyy)|^(MM)|^(dd)|^(HH)|^(mm)|^(ss)|^(SSS)|^('T')])|('Z')";
+
+    public static enum FormatAndPrecision {
+        MILLISECOND(
+                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Calendar.MILLISECOND, LENIENT_FORMATS_MILLISECOND),
+        SECOND("yyyy-MM-dd'T'HH:mm:ss'Z'", Calendar.SECOND, LENIENT_FORMATS_SECOND),
+        MINUTE("yyyy-MM-dd'T'HH:mm'Z'", Calendar.MINUTE, LENIENT_FORMATS_MINUTE),
+        HOUR("yyyy-MM-dd'T'HH'Z'", Calendar.HOUR_OF_DAY, LENIENT_FORMATS_HOUR),
+        DAY("yyyy-MM-dd", Calendar.DAY_OF_MONTH, LENIENT_FORMATS_DAY),
+        MONTH("yyyy-MM", Calendar.MONTH, LENIENT_FORMATS_MONTH),
+        YEAR(SIMPLIFIED_FORMAT_YEAR, Calendar.YEAR, LENIENT_FORMATS_YEAR);
+
+        public final String format;
+        public final int precision;
+        public final String[] lenientFormats;
+
+        FormatAndPrecision(final String format, int precision, final String[] lenientFormats) {
+            this.format = format;
+            this.precision = precision;
+            this.lenientFormats = lenientFormats;
+        }
+
+        public SimpleDateFormat getFormat() {
+            SimpleDateFormat sdf = new SimpleDateFormat(format);
+            sdf.setTimeZone(UTC_TZ);
+            return sdf;
+        }
+
+        public String[] getLenientFormats() {
+            return lenientFormats;
+        }
+
+        public DateRange expand(Date d) {
+            return expandToPrecision(d, this.precision);
+        }
+
+        public static DateRange expandFromCustomFormat(Date d, String format) {
+            int precision = findPrecision(format);
+            return expandToPrecision(d, precision);
+        }
+
+        private static DateRange expandToPrecision(Date d, int precision) {
+            Calendar c = new GregorianCalendar(UTC_TZ);
+            c.setTime(d);
+            c.add(precision, 1);
+            c.add(Calendar.MILLISECOND, -1);
+            return new DateRange(d, c.getTime());
+        }
+
+        private static int findPrecision(String format) {
+            // Converting the custom format to a simplified ISO8601
+            String simplifiedFormat = format.replaceAll(ISO8601_CHARS_REGEX, "");
+            if (SIMPLIFIED_FORMAT_MILLISECOND.equalsIgnoreCase(simplifiedFormat))
+                return Calendar.MILLISECOND;
+            else if (SIMPLIFIED_FORMAT_SECOND.equalsIgnoreCase(simplifiedFormat))
+                return Calendar.SECOND;
+            else if (SIMPLIFIED_FORMAT_MINUTE.equalsIgnoreCase(simplifiedFormat))
+                return Calendar.MINUTE;
+            else if (SIMPLIFIED_FORMAT_HOUR.equalsIgnoreCase(simplifiedFormat))
+                return Calendar.HOUR;
+            else if (SIMPLIFIED_FORMAT_DAY.equalsIgnoreCase(simplifiedFormat))
+                return Calendar.DAY_OF_MONTH;
+            else if (SIMPLIFIED_FORMAT_MONTH.equalsIgnoreCase(simplifiedFormat))
+                return Calendar.MONTH;
+            else if (SIMPLIFIED_FORMAT_YEAR.equalsIgnoreCase(simplifiedFormat))
+                return Calendar.YEAR;
+            // No ISO8601 strict variant has been identified.
+            // Try finding the precision through the ending part of the format
+            else if (simplifiedFormat.endsWith("SSS")) return Calendar.MILLISECOND;
+            else if (simplifiedFormat.endsWith("ss")) return Calendar.SECOND;
+            else if (simplifiedFormat.endsWith("mm")) return Calendar.MINUTE;
+            else if (simplifiedFormat.endsWith("HH")) return Calendar.HOUR;
+            else if (simplifiedFormat.endsWith("dd")) return Calendar.DAY_OF_MONTH;
+            else if (simplifiedFormat.endsWith("mm")) return Calendar.MONTH;
+            else if (simplifiedFormat.endsWith("yyyy")) return Calendar.YEAR;
+            throw new IllegalArgumentException(
+                    "Unable to identify an ISO8601 format corresponding to the provided format:"
+                            + format);
+        }
+    }
+
+    /** UTC timezone to serve as reference */
+    public static final TimeZone UTC_TZ = TimeZone.getTimeZone("UTC");
+
+    /** Amount of milliseconds in a day. */
+    public static final long MILLIS_IN_DAY = 24 * 60 * 60 * 1000;
+
+    /** Builds a default TimeParser with no provided maximum number of times */
+    public DateTimeParser() {
+        this(-1); // No limits on max results
+    }
+
+    /**
+     * Parses times throwing an exception if the final list exceeds maxTimes
+     *
+     * @param maxTimes Maximum number of times to parse, or a non positive number to have no limit
+     */
+    public DateTimeParser(int maxTimes) {
+        this(maxTimes, 0);
+    }
+
+    /**
+     * Parses times throwing an exception if the final list exceeds maxTimes
+     *
+     * @param maxTimes Maximum number of times to parse, or a non positive number to have no limit
+     * @param flags a combination (bitwise OR) of FLAG_XXX to customize the parsing.
+     */
+    public DateTimeParser(int maxTimes, int flags) {
+        this.maxTimes = maxTimes;
+        this.flags = flags;
+    }
+
+    private boolean isFlagSet(final int referenceFlag) {
+        return ((flags & referenceFlag) == referenceFlag);
+    }
+
+    /**
+     * Parses the date given in parameter. The date format should comply to ISO-8601 standard. The
+     * string may contains either a single date, or a start time, end time and a period. In the
+     * first case, this method returns a singleton containing only the parsed date. In the second
+     * case, this method returns a list including all dates from start time up to the end time with
+     * the interval specified in the {@code value} string.
+     *
+     * @param value The date, time and period to parse.
+     * @return A list of dates, or an empty list of the {@code value} string is null or empty.
+     * @throws ParseException if the string can not be parsed.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Collection parse(String value) throws ParseException {
+        if (value == null) {
+            return Collections.emptyList();
+        }
+        value = value.trim();
+        if (value.length() == 0) {
+            return Collections.emptyList();
+        }
+
+        final Set result =
+                new TreeSet(
+                        new Comparator() {
+
+                            public int compare(Object o1, Object o2) {
+                                final boolean o1Date = o1 instanceof Date;
+                                final boolean o2Date = o2 instanceof Date;
+
+                                if (o1 == o2) {
+                                    return 0;
+                                }
+
+                                // o1 date
+                                if (o1Date) {
+                                    final Date dateLeft = (Date) o1;
+                                    if (o2Date) {
+                                        // o2 date
+                                        return dateLeft.compareTo((Date) o2);
+                                    }
+                                    // o2 daterange
+                                    return dateLeft.compareTo(((DateRange) o2).getMinValue());
+                                }
+
+                                // o1 date range
+                                final DateRange left = (DateRange) o1;
+                                if (o2Date) {
+                                    // o2 date
+                                    return left.getMinValue().compareTo(((Date) o2));
+                                }
+                                // o2 daterange
+                                return left.getMinValue().compareTo(((DateRange) o2).getMinValue());
+                            }
+                        });
+        String[] listDates = value.split(",");
+        int maxValues = maxTimes;
+        for (String date : listDates) {
+            // is it a date or a period?
+            if (date.indexOf("/") <= 0) {
+                Object o = getFuzzyDate(date);
+                if (o instanceof Date) {
+                    addDate(result, (Date) o);
+                } else {
+                    addPeriod(result, (DateRange) o);
+                }
+            } else {
+                // period
+                String[] period = date.split("/");
+
+                //
+                // Period like one of the following:
+                // yyyy-MM-ddTHH:mm:ssZ/yyyy-MM-ddTHH:mm:ssZ/P1D
+                // May be one of the following possible ISO 8601 Time Interval formats with trailing
+                // period for
+                // breaking the interval by given period:
+                // TIME/TIME/PERIOD
+                // DURATION/TIME/PERIOD
+                // TIME/DURATION/PERIOD
+                //
+                if (period.length == 3) {
+                    Date[] range = parseTimeDuration(period);
+
+                    final long millisIncrement = parsePeriod(period[2]);
+                    final long startTime = range[0].getTime();
+                    final long endTime = range[1].getTime();
+                    long time;
+                    int j = 0;
+                    while ((time = j * millisIncrement + startTime) <= endTime) {
+                        final Calendar calendar = new GregorianCalendar(UTC_TZ);
+                        calendar.setTimeInMillis(time);
+                        addDate(result, calendar.getTime());
+                        j++;
+                        checkMaxTimes(result, maxValues);
+                    }
+                }
+                // Period like : yyyy-MM-ddTHH:mm:ssZ/yyyy-MM-ddTHH:mm:ssZ, it is an extension
+                // of WMS that works with continuos period [Tb, Te].
+                // May be one of the following possible ISO 8601 Time Interval formats, as in ECQL
+                // Time Period:
+                // TIME/DURATION
+                // DURATION/TIME
+                // TIME/TIME
+                else if (period.length == 2) {
+                    Date[] range = parseTimeDuration(period);
+                    addPeriod(result, new DateRange(range[0], range[1]));
+                } else {
+                    throw new ParseException("Invalid time period: " + Arrays.toString(period), 0);
+                }
+            }
+            checkMaxTimes(result, maxValues);
+        }
+
+        return new ArrayList(result);
+    }
+
+    public void checkMaxTimes(Set result, int maxValues) {
+        // limiting number of elements we can create
+        if (maxValues > 0 && result.size() > maxValues) {
+            throw new RuntimeException(
+                    "More than " + maxValues + " times specified in the request, bailing out.");
+        }
+    }
+
+    private Date[] parseTimeDuration(final String[] period) throws ParseException {
+        Date[] range = null;
+
+        if (period.length == 2 || period.length == 3) {
+            Date begin = null;
+            Date end = null;
+
+            // Check first to see if we have any duration value within TIME parameter
+            if (period[0].toUpperCase().startsWith("P")
+                    || period[1].toUpperCase().startsWith("P")) {
+                long durationOffset = Long.MIN_VALUE;
+
+                // Attempt to parse a time or duration from the first portion of the
+                if (period[0].toUpperCase().startsWith("P")) {
+                    durationOffset = parsePeriod(period[0]);
+                } else {
+                    begin = beginning(getFuzzyDate(period[0]));
+                }
+
+                if (period[1].toUpperCase().startsWith("P")
+                        && !period[1].toUpperCase().startsWith("PRESENT")) {
+                    // Invalid time period of the format:
+                    // DURATION/DURATION[/PERIOD]
+                    if (durationOffset != Long.MIN_VALUE) {
+                        throw new ParseException(
+                                "Invalid time period containing duration with no paired time value: "
+                                        + Arrays.toString(period),
+                                0);
+                    }
+                    // Time period of the format:
+                    // DURATION/TIME[/PERIOD]
+                    else {
+                        durationOffset = parsePeriod(period[1]);
+                        final Calendar calendar = new GregorianCalendar();
+                        calendar.setTimeInMillis(begin.getTime() + durationOffset);
+                        end = calendar.getTime();
+                    }
+                }
+                // Time period of the format:
+                // TIME/DURATION[/PERIOD]
+                else {
+                    end = end(getFuzzyDate(period[1]));
+                    final Calendar calendar = new GregorianCalendar();
+                    calendar.setTimeInMillis(end.getTime() - durationOffset);
+                    begin = calendar.getTime();
+                }
+            }
+            // Time period of the format:
+            // TIME/TIME[/PERIOD]
+            else {
+                begin = beginning(getFuzzyDate(period[0]));
+                end = end(getFuzzyDate(period[1]));
+            }
+
+            range = new Date[2];
+            range[0] = begin;
+            range[1] = end;
+        }
+
+        return range;
+    }
+
+    private static Date beginning(Object dateOrDateRange) {
+        if (dateOrDateRange instanceof DateRange) {
+            return ((DateRange) dateOrDateRange).getMinValue();
+        } else {
+            return (Date) dateOrDateRange;
+        }
+    }
+
+    private static Date end(Object dateOrDateRange) {
+        if (dateOrDateRange instanceof DateRange) {
+            return ((DateRange) dateOrDateRange).getMaxValue();
+        } else {
+            return (Date) dateOrDateRange;
+        }
+    }
+
+    /**
+     * Tries to avoid insertion of multiple time values.
+     *
+     * @param result
+     * @param newRange
+     */
+    private static void addPeriod(Collection result, DateRange newRange) {
+        for (Iterator it = result.iterator(); it.hasNext(); ) {
+            final Object element = it.next();
+            if (element instanceof Date) {
+                // convert
+                final Date local = (Date) element;
+                if (newRange.contains(local)) {
+                    it.remove();
+                }
+            } else {
+                // convert
+                final DateRange local = (DateRange) element;
+                if (local.contains(newRange)) return;
+                if (newRange.contains(local)) it.remove();
+            }
+        }
+        result.add(newRange);
+    }
+
+    private static void addDate(Collection result, Date newDate) {
+        for (Iterator<?> it = result.iterator(); it.hasNext(); ) {
+            final Object element = it.next();
+            if (element instanceof Date) {
+                if (newDate.equals(element)) return;
+            } else if (((DateRange) element).contains(newDate)) {
+                return;
+            }
+        }
+        result.add(newDate);
+    }
+
+    /**
+     * Parses date given in parameter according the ISO-8601 standard. This parameter should follow
+     * a syntax defined in the #FormatAndPrecision array to be validated. Lenient version are
+     * allowed too if the Lenient flag has been set
+     *
+     * @param value The date to parse.
+     * @return A date found in the request.
+     * @throws ParseException if the string can not be parsed.
+     */
+    private Object getFuzzyDate(final String value) throws ParseException {
+        String computedValue = value;
+
+        // special handling for 'current', 'now' and 'present' keyword (we accept both wms and wcs
+        // ways)
+        if (CURRENT_TIME_NAMES.contains(computedValue.toLowerCase())) {
+            if ((computedValue.equalsIgnoreCase("current") && isFlagSet(FLAG_GET_TIME_ON_CURRENT))
+                    || (computedValue.equalsIgnoreCase("now") && isFlagSet(FLAG_GET_TIME_ON_NOW))
+                    || (computedValue.equalsIgnoreCase("present")
+                            && isFlagSet(FLAG_GET_TIME_ON_PRESENT))) {
+                Calendar now = Calendar.getInstance();
+                now.set(Calendar.MILLISECOND, 0);
+                computedValue = FormatAndPrecision.MILLISECOND.getFormat().format(now.getTime());
+            } else {
+                return null;
+            }
+        }
+
+        for (FormatAndPrecision f : FormatAndPrecision.values()) {
+            Object parsedTime = parseTime(f, computedValue);
+            if (parsedTime != null) {
+                return parsedTime;
+            }
+        }
+
+        throw new ParseException("Invalid date: " + value, 0);
+    }
+
+    /**
+     * Parses the increment part of a period and returns it in milliseconds.
+     *
+     * @param period A string representation of the time increment according the ISO-8601:1988(E)
+     *     standard. For example: {@code "P1D"} = one day.
+     * @return The increment value converted in milliseconds.
+     * @throws ParseException if the string can not be parsed.
+     */
+    public static long parsePeriod(final String period) throws ParseException {
+        final int length = period.length();
+        if (length != 0 && Character.toUpperCase(period.charAt(0)) != 'P') {
+            throw new ParseException("Invalid period increment given: " + period, 0);
+        }
+        long millis = 0;
+        boolean time = false;
+        int lower = 0;
+        while (++lower < length) {
+            char letter = Character.toUpperCase(period.charAt(lower));
+            if (letter == 'T') {
+                time = true;
+                if (++lower >= length) {
+                    break;
+                }
+            }
+            int upper = lower;
+            letter = period.charAt(upper);
+            while (!Character.isLetter(letter) || letter == 'e' || letter == 'E') {
+                if (++upper >= length) {
+                    throw new ParseException("Missing symbol in \"" + period + "\".", lower);
+                }
+                letter = period.charAt(upper);
+            }
+            letter = Character.toUpperCase(letter);
+            final double value = Double.parseDouble(period.substring(lower, upper));
+            final double factor;
+            if (time) {
+                switch (letter) {
+                    case 'S':
+                        factor = 1000;
+                        break;
+                    case 'M':
+                        factor = 60 * 1000;
+                        break;
+                    case 'H':
+                        factor = 60 * 60 * 1000;
+                        break;
+                    default:
+                        throw new ParseException("Unknown time symbol: " + letter, upper);
+                }
+            } else {
+                switch (letter) {
+                    case 'D':
+                        factor = MILLIS_IN_DAY;
+                        break;
+                    case 'W':
+                        factor = 7 * MILLIS_IN_DAY;
+                        break;
+                        // TODO: handle months in a better way than just taking the average length.
+                    case 'M':
+                        factor = 30 * MILLIS_IN_DAY;
+                        break;
+                    case 'Y':
+                        factor = 365.25 * MILLIS_IN_DAY;
+                        break;
+                    default:
+                        throw new ParseException("Unknown period symbol: " + letter, upper);
+                }
+            }
+            millis += Math.round(value * factor);
+            lower = upper;
+        }
+        return millis;
+    }
+
+    private Object parseTime(FormatAndPrecision f, String value) {
+        ParsePosition pos = new ParsePosition(0);
+        Date time = f.getFormat().parse(value, pos);
+        Object parsed = parseAsDateRangeWithFormatPrecision(time, value, pos, f);
+
+        // Let's try with the lenient alternatives in case we didn't get a result yet
+        if (parsed == null && isFlagSet(FLAG_IS_LENIENT)) {
+            for (String lenientFormat : f.getLenientFormats()) {
+                // rebuild formats at each parse since date formats are not thread safe
+                final SimpleDateFormat format = new SimpleDateFormat(lenientFormat);
+                format.setTimeZone(UTC_TZ);
+                // The lenientFormat is already somehow a lenient version of the
+                // official format. no need to have it lenient too.
+                format.setLenient(false);
+                time = format.parse(value, pos);
+                parsed = parseAsDateRangeWithFormatPrecision(time, value, pos, f);
+                if (parsed != null) {
+                    return parsed;
+                }
+            }
+        }
+        return parsed;
+    }
+
+    private Object parseAsDateRangeWithFormatPrecision(
+            Date time, String computedValue, ParsePosition pos, FormatAndPrecision f) {
+        if (time != null && pos != null && pos.getIndex() == computedValue.length()) {
+            DateRange range = f.expand(time);
+            if (range.getMinValue().equals(range.getMaxValue())
+                    || !isFlagSet(FLAG_SINGLE_DATE_AS_DATERANGE)) {
+                return range.getMinValue();
+            } else {
+                return range;
+            }
+        }
+        return null;
+    }
+}

--- a/modules/library/metadata/src/test/java/org/geotools/util/DateTimeParserTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/DateTimeParserTest.java
@@ -14,39 +14,37 @@
  *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *    Lesser General Public License for more details.
  */
-package org.geotools.gce.imagemosaic.properties.time;
+package org.geotools.util;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.TimeZone;
+import java.util.*;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * @author Simone Giannecchini, GeoSolutions SAS
- * @deprecated This test classes test that the Deprecated TimeParser is still working properly. An
- *     updated TimeParserTest has been moved to gt-metadata testing the new DateTimeParser class
- */
-@Deprecated
-public class TimeParserTest extends Assert {
+/** @author Simone Giannecchini, GeoSolutions SAS */
+public class DateTimeParserTest extends Assert {
 
-    private static final TimeParser PARSER = new TimeParser();
+    private static final DateTimeParser PARSER =
+            new DateTimeParser(
+                    -1,
+                    DateTimeParser.FLAG_IS_LENIENT
+                            | DateTimeParser.FLAG_GET_TIME_ON_CURRENT
+                            | DateTimeParser.FLAG_GET_TIME_ON_NOW);
 
     @Test
     public void testParserOnCurrentTime() throws ParseException, InterruptedException {
         long now = System.currentTimeMillis();
         Thread.sleep(1000);
         final String timeInstant = "current";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertTrue(now < time.get(0).getTime());
+        assertTrue(now < getTime(time, 0));
     }
 
     @Test
     public void testParserOnNullTime() throws ParseException {
-        List<Date> time = PARSER.parse(null);
+        Collection time = PARSER.parse(null);
         assertTrue(time.isEmpty());
     }
 
@@ -57,9 +55,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyy
         String timeInstant = "2011";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-01-01T00:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-01-01T00:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -69,9 +67,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyyMM
         String timeInstant = "201110";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-01T00:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-01T00:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -81,9 +79,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyy-MM
         String timeInstant = "2011-10";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-01T00:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-01T00:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -93,9 +91,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyyMMdd
         String timeInstant = "20111010";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T00:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T00:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -105,9 +103,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyy-MM-dd
         String timeInstant = "2011-10-10";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T00:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T00:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -117,9 +115,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyyMMdd'T'HH
         String timeInstant = "20111010T10";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -129,9 +127,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyy-MM-dd'T'HH
         String timeInstant = "2011-10-10T10";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -142,9 +140,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HH'Z'
         String timeInstant = "20111010T10Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -155,9 +153,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HH'Z'
         String timeInstant = "2011-10-10T10Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:00:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:00:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -167,9 +165,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyyMMdd'T'HHmm
         String timeInstant = "20111010T1011";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -179,9 +177,9 @@ public class TimeParserTest extends Assert {
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         // test format yyyyMMdd'T'HH:mm
         String timeInstant = "20111010T10:11";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -192,9 +190,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HHmm
         String timeInstant = "2011-10-10T1011";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -205,9 +203,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HH:mm
         String timeInstant = "2011-10-10T10:11";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -218,9 +216,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HHmm'Z'
         String timeInstant = "20111010T1011Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -231,9 +229,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HH:mm'Z'
         String timeInstant = "20111010T10:11Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -244,9 +242,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HHmm'Z'
         String timeInstant = "2011-10-10T1011Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -257,9 +255,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HH:mm'Z'
         String timeInstant = "2011-10-10T10:11Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:00.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:00.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -270,9 +268,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HHmmss
         String timeInstant = "20111010T101120";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -283,9 +281,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HH:mm:ss
         String timeInstant = "20111010T10:11:20";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -296,9 +294,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HHmmss
         String timeInstant = "2011-10-10T101120";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -309,9 +307,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HH:mm:ss
         String timeInstant = "2011-10-10T10:11:20";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -322,9 +320,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HHmmss'Z'
         String timeInstant = "20111010T101120Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -335,9 +333,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HH:mm:ss'Z'
         String timeInstant = "20111010T10:11:20Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -348,9 +346,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HHmmss'Z'
         String timeInstant = "2011-10-10T101120Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -361,9 +359,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HH:mm:ss'Z'
         String timeInstant = "2011-10-10T10:11:20Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.000Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.000Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -374,9 +372,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HHmmssSSS
         String timeInstant = "20111010T101120666";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.666Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.666Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -387,9 +385,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HH:mm:ss.SSS
         String timeInstant = "20111010T10:11:20.666";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.666Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.666Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -400,9 +398,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HHmmssSSS
         String timeInstant = "2011-10-10T101120666";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.666Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.666Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -413,9 +411,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HH:mm:ss.SSS
         String timeInstant = "2011-10-10T10:11:20.666";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.666Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.666Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -426,9 +424,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HHmmssSSS'Z'
         String timeInstant = "20111010T101120666Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.666Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.666Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -439,9 +437,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyyMMdd'T'HH:mm:ss.SSS'Z'
         String timeInstant = "20111010T10:11:20.666Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.666Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.666Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -452,9 +450,9 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HHmmssSSS'Z'
         String timeInstant = "2011-10-10T101120666Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.666Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.666Z", df.format(getTime(time, 0)));
     }
 
     @Test
@@ -465,26 +463,40 @@ public class TimeParserTest extends Assert {
 
         // test format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
         String timeInstant = "2011-10-10T10:11:20.666Z";
-        List<Date> time = PARSER.parse(timeInstant);
+        Collection time = PARSER.parse(timeInstant);
         assertEquals(1, time.size());
-        assertEquals("2011-10-10T10:11:20.666Z", df.format(time.get(0)));
+        assertEquals("2011-10-10T10:11:20.666Z", df.format(getTime(time, 0)));
     }
 
     @Test
     public void testParserOnTimePeriod() throws ParseException {
         final String timeInterval = "2011-10-10T10:11:12.000Z/2011-10-10T14:11:12.000Z/PT1H";
-        List<Date> time = PARSER.parse(timeInterval);
+        Collection time = PARSER.parse(timeInterval);
         assertEquals(5, time.size());
-        assertEquals(1318241472000l, time.get(0).getTime());
-        assertEquals(1318241472000l + (3600 * 1000 * 4), time.get(time.size() - 1).getTime());
+        assertEquals(1318241472000l, getTime(time, 0));
+        assertEquals(1318241472000l + (3600 * 1000 * 4), getTime(time, time.size() - 1));
     }
 
     @Test
     public void testParserOnDayPeriod() throws ParseException {
         final String timeInterval = "2011-10-10T10:11:12.000Z/2011-10-14T10:11:12.000Z/P2D";
-        List<Date> time = PARSER.parse(timeInterval);
+        Collection time = PARSER.parse(timeInterval);
         assertEquals(3, time.size());
-        assertEquals(1318241472000l, time.get(0).getTime());
-        assertEquals(1318241472000l + (3600 * 1000 * 48), time.get(1).getTime());
+        assertEquals(1318241472000l, getTime(time, 0));
+        assertEquals(1318241472000l + (3600 * 1000 * 48), getTime(time, 1));
+    }
+
+    private static long getTime(Collection time, int i) {
+        Object date = null;
+        if (i <= 0) {
+            date = time.stream().findFirst().get();
+        } else {
+            date = time.stream().skip(i).findFirst().get();
+        }
+
+        if (date != null && date instanceof Date) {
+            return ((Date) date).getTime();
+        }
+        throw new IllegalArgumentException("time isn't a collection of Date");
     }
 }

--- a/modules/plugin/imagemosaic/pom.xml
+++ b/modules/plugin/imagemosaic/pom.xml
@@ -86,6 +86,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-metadata</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.geotools.jdbc</groupId>
       <artifactId>gt-jdbc-h2</artifactId>
       <version>${project.version}</version>

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/time/TimeParser.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/time/TimeParser.java
@@ -17,91 +17,32 @@
 package org.geotools.gce.imagemosaic.properties.time;
 
 import java.text.ParseException;
-import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.geotools.util.DateTimeParser;
 
 /**
  * Parses the {@code time} parameter of the request. The date, time and period are expected to be
  * formatted according ISO-8601 standard.
  *
  * @author Simone Giannecchini, GeoSolutions SAS
+ * @deprecated use #org.geotools.util.DateTimeParser instead.
  */
+@Deprecated
 public class TimeParser {
-    /** All patterns that are correct regarding the ISO-8601 norm. */
-    private static final String[] PATTERNS = {
-        "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-        "yyyy-MM-dd'T'HHmmssSSS'Z'",
-        "yyyyMMdd'T'HH:mm:ss.SSS'Z'",
-        "yyyyMMdd'T'HHmmssSSS'Z'",
-        "yyyy-MM-dd'T'HH:mm:ss.SSS",
-        "yyyy-MM-dd'T'HHmmssSSS",
-        "yyyyMMdd'T'HH:mm:ss.SSS",
-        "yyyyMMdd'T'HHmmssSSS",
-        "yyyy-MM-dd'T'HH:mm:ss'Z'",
-        "yyyy-MM-dd'T'HHmmss'Z'",
-        "yyyyMMdd'T'HH:mm:ss'Z'",
-        "yyyyMMdd'T'HHmmss'Z'",
-        "yyyy-MM-dd'T'HH:mm:ss",
-        "yyyy-MM-dd'T'HHmmss",
-        "yyyyMMdd'T'HH:mm:ss",
-        "yyyyMMdd'T'HHmmss",
-        "yyyy-MM-dd'T'HH:mm'Z'",
-        "yyyy-MM-dd'T'HHmm'Z'",
-        "yyyyMMdd'T'HH:mm'Z'",
-        "yyyyMMdd'T'HHmm'Z'",
-        "yyyy-MM-dd'T'HH:mm",
-        "yyyy-MM-dd'T'HHmm",
-        "yyyyMMdd'T'HH:mm",
-        "yyyyMMdd'T'HHmm",
-        "yyyy-MM-dd'T'HH'Z'",
-        "yyyyMMdd'T'HH'Z'",
-        "yyyy-MM-dd'T'HH",
-        "yyyyMMdd'T'HH",
-        "yyyy-MM-dd",
-        "yyyyMMdd",
-        "yyyy-MM",
-        "yyyyMM",
-        "yyyy"
-    };
 
-    private static final Map<Integer, List<String>> SPLITTED_PATTERNS;
-
-    static {
-        Map<Integer, List<String>> tmpPatterns = new HashMap<Integer, List<String>>();
-
-        for (String pattern : PATTERNS) {
-            int escapeCount = 0;
-
-            for (char c : pattern.toCharArray()) {
-                if (c == '\'') escapeCount++;
-            }
-            int len = pattern.length() - escapeCount;
-            List<String> list = tmpPatterns.get(len);
-            if (list == null) {
-                list = new ArrayList<String>();
-                tmpPatterns.put(len, list);
-            }
-            list.add(pattern);
-        }
-        SPLITTED_PATTERNS = Collections.unmodifiableMap(tmpPatterns);
-    }
-
-    /** UTC timezone to serve as reference */
-    static final TimeZone UTC_TZ = TimeZone.getTimeZone("UTC");
-
-    /** Amount of milliseconds in a day. */
-    static final long MILLIS_IN_DAY = 24 * 60 * 60 * 1000;
+    private DateTimeParser parser;
 
     /** Creates the parser */
-    public TimeParser() {}
+    public TimeParser() {
+        parser =
+                new DateTimeParser(
+                        -1,
+                        DateTimeParser.FLAG_GET_TIME_ON_CURRENT
+                                | DateTimeParser.FLAG_GET_TIME_ON_NOW
+                                | DateTimeParser.FLAG_GET_TIME_ON_PRESENT
+                                | DateTimeParser.FLAG_IS_LENIENT);
+    }
 
     /**
      * Parses the date given in parameter. The date format should comply to ISO-8601 standard. The
@@ -115,152 +56,13 @@ public class TimeParser {
      * @throws ParseException if the string can not be parsed.
      */
     public List<Date> parse(String value) throws ParseException {
-        if (value == null) {
-            return Collections.emptyList();
-        }
-        value = value.trim();
-        if (value.length() == 0) {
-            return Collections.emptyList();
-        }
-        final List<Date> dates = new ArrayList<Date>();
-        if (value.indexOf(',') >= 0) {
-            String[] listDates = value.split(",");
-            for (int i = 0; i < listDates.length; i++) {
-                dates.add(getDate(listDates[i].trim()));
-            }
-            return dates;
-        }
-        String[] period = value.split("/");
-        // Only one date given.
-        if (period.length == 1) {
-            if (value.equals("current")) {
-                dates.add(Calendar.getInstance(UTC_TZ).getTime());
-            } else {
-                dates.add(getDate(value));
-            }
-            return dates;
-        }
-        // Period like : yyyy-MM-ddTHH:mm:ssZ/yyyy-MM-ddTHH:mm:ssZ/P1D
-        if (period.length == 3) {
-            final Date begin = getDate(period[0]);
-            final Date end = getDate(period[1]);
-            final long millisIncrement = parsePeriod(period[2]);
-            final long startTime = begin.getTime();
-            final long endTime = end.getTime();
-            long time;
-            int j = 0;
-            while ((time = j * millisIncrement + startTime) <= endTime) {
-                Calendar calendar = Calendar.getInstance(UTC_TZ);
-                calendar.setTimeInMillis(time);
-                dates.add(calendar.getTime());
-                j++;
-            }
-            return dates;
-        }
-        throw new ParseException("Invalid time parameter: " + value, 0);
-    }
-
-    /**
-     * Parses date given in parameter according the ISO-8601 standard. This parameter should follow
-     * a syntax defined in the {@link #PATTERNS} array to be validated.
-     *
-     * @param value The date to parse.
-     * @return A date found in the request.
-     * @throws ParseException if the string can not be parsed.
-     */
-    private static Date getDate(final String value) throws ParseException {
-        List<String> suitablePattern = SPLITTED_PATTERNS.get(value.length());
-        final int size = suitablePattern.size();
-        for (int i = 0; i < size; i++) {
-            // rebuild formats at each parse, date formats are not thread safe
-            final SimpleDateFormat format = new SimpleDateFormat(suitablePattern.get(i));
-            format.setLenient(false);
-            format.setTimeZone(TimeZone.getTimeZone("Zulu"));
-
-            /*
-             * We do not use the standard method DateFormat.parse(String), because if the parsing stops before the end of the string, the remaining
-             * characters are just ignored and no exception is thrown. So we have to ensure that the whole string is correct for the format.
-             */
-            final ParsePosition pos = new ParsePosition(0);
-            Date time = format.parse(value, pos);
-            if (pos.getIndex() == value.length()) {
-                return time;
-            }
-        }
-        throw new ParseException("Invalid date: " + value, 0);
-    }
-
-    /**
-     * Parses the increment part of a period and returns it in milliseconds.
-     *
-     * @param period A string representation of the time increment according the ISO-8601:1988(E)
-     *     standard. For example: {@code "P1D"} = one day.
-     * @return The increment value converted in milliseconds.
-     * @throws ParseException if the string can not be parsed.
-     */
-    static long parsePeriod(final String period) throws ParseException {
-        final int length = period.length();
-        if (length != 0 && Character.toUpperCase(period.charAt(0)) != 'P') {
-            throw new ParseException("Invalid period increment given: " + period, 0);
-        }
-        long millis = 0;
-        boolean time = false;
-        int lower = 0;
-        while (++lower < length) {
-            char letter = Character.toUpperCase(period.charAt(lower));
-            if (letter == 'T') {
-                time = true;
-                if (++lower >= length) {
-                    break;
-                }
-            }
-            int upper = lower;
-            letter = period.charAt(upper);
-            while (!Character.isLetter(letter) || letter == 'e' || letter == 'E') {
-                if (++upper >= length) {
-                    throw new ParseException("Missing symbol in \"" + period + "\".", lower);
-                }
-                letter = period.charAt(upper);
-            }
-            letter = Character.toUpperCase(letter);
-            final double value = Double.parseDouble(period.substring(lower, upper));
-            final double factor;
-            if (time) {
-                switch (letter) {
-                    case 'S':
-                        factor = 1000;
-                        break;
-                    case 'M':
-                        factor = 60 * 1000;
-                        break;
-                    case 'H':
-                        factor = 60 * 60 * 1000;
-                        break;
-                    default:
-                        throw new ParseException("Unknown time symbol: " + letter, upper);
-                }
-            } else {
-                switch (letter) {
-                    case 'D':
-                        factor = MILLIS_IN_DAY;
-                        break;
-                    case 'W':
-                        factor = 7 * MILLIS_IN_DAY;
-                        break;
-                        // TODO: handle months in a better way than just taking the average length.
-                    case 'M':
-                        factor = 30 * MILLIS_IN_DAY;
-                        break;
-                    case 'Y':
-                        factor = 365.25 * MILLIS_IN_DAY;
-                        break;
-                    default:
-                        throw new ParseException("Unknown period symbol: " + letter, upper);
-                }
-            }
-            millis += Math.round(value * factor);
-            lower = upper;
-        }
-        return millis;
+        Collection results = parser.parse(value);
+        List<Date> dates =
+                (List<Date>)
+                        results.stream()
+                                .filter(o -> o instanceof Date)
+                                .map(o -> (Date) o)
+                                .collect(Collectors.toList());
+        return dates;
     }
 }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/time/TimestampFileNameExtractorSPI.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/time/TimestampFileNameExtractorSPI.java
@@ -18,6 +18,8 @@ package org.geotools.gce.imagemosaic.properties.time;
 
 import java.awt.RenderingHints.Key;
 import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -37,11 +39,15 @@ public class TimestampFileNameExtractorSPI implements PropertiesCollectorSPI {
 
     public static final String FULL_PATH = "fullPath";
 
+    public static final String USE_HIGH_TIME = "useHighTime";
+
     public static final String REGEX_PREFIX = REGEX + "=";
 
     public static final String FORMAT_PREFIX = FORMAT + "=";
 
     public static final String FULL_PATH_PREFIX = FULL_PATH + "=";
+
+    public static final String USE_HIGH_TIME_PREFIX = USE_HIGH_TIME + "=";
 
     public String getName() {
         return "TimestampFileNameExtractorSPI";
@@ -59,7 +65,9 @@ public class TimestampFileNameExtractorSPI implements PropertiesCollectorSPI {
         URL source = null;
         String regex = null;
         String format = null;
+        boolean useHighTime = false;
         boolean fullPath = false;
+        Properties properties = null;
         if (o instanceof URL) {
             source = (URL) o;
         } else if (o instanceof File) {
@@ -71,38 +79,36 @@ public class TimestampFileNameExtractorSPI implements PropertiesCollectorSPI {
 
                 String value = (String) o;
 
-                // look for the regex
-                int idx = 0;
+                int minIndex = value.length();
+
+                // parameters can be in any order
+                // look for the first parameter
+                int indexesOf[] = new int[3];
+                indexesOf[0] = value.indexOf("," + FORMAT_PREFIX);
+                indexesOf[1] = value.indexOf("," + FULL_PATH_PREFIX);
+                indexesOf[2] = value.indexOf("," + USE_HIGH_TIME_PREFIX);
+                for (int indexOf : indexesOf) {
+                    minIndex = (indexOf > 0 && indexOf < minIndex) ? indexOf : minIndex;
+                }
+
                 if (value.startsWith(REGEX_PREFIX)) {
-                    String tmp = value.substring(REGEX_PREFIX.length());
-                    if (tmp.contains("," + FORMAT_PREFIX)) {
-                        idx = tmp.indexOf("," + FORMAT_PREFIX);
-                        regex = tmp.substring(0, idx);
-                        value = tmp.substring(idx + 1);
-                    } else if (tmp.contains("," + FULL_PATH_PREFIX)) {
-                        idx = tmp.indexOf("," + FULL_PATH_PREFIX);
-                        regex = tmp.substring(0, idx);
-                        value = tmp.substring(idx + 1);
-                    } else {
-                        regex = tmp;
-                    }
-                }
+                    String prop = value;
+                    regex = value.substring(REGEX_PREFIX.length(), minIndex);
+                    // Do we have more parameters?
+                    if (minIndex != value.length()) {
+                        value = value.substring(minIndex + 1);
+                        prop = value.replaceAll(",", "\n");
 
-                // look for the format
-                if (value.startsWith(FORMAT_PREFIX)) {
-                    if (value.contains("," + FULL_PATH_PREFIX)) {
-                        idx = value.indexOf("," + FULL_PATH_PREFIX);
-                        format = value.substring(0, idx);
-                        value = value.substring(idx + 1);
-                    } else {
-                        format = value;
+                        // Setup properties from String for future extraction
+                        properties = new Properties();
+                        try {
+                            properties.load(new StringReader(prop));
+                            properties.setProperty(REGEX, regex);
+                        } catch (IOException e1) {
+                            throw new IllegalArgumentException(
+                                    "Unable to parse the specified regex: " + value, e1);
+                        }
                     }
-                    format = format.substring(FORMAT_PREFIX.length());
-                }
-
-                // look for the full path param
-                if (value.startsWith(FULL_PATH_PREFIX)) {
-                    fullPath = Boolean.valueOf(value.substring(FULL_PATH_PREFIX.length()));
                 }
             }
         } else {
@@ -111,25 +117,31 @@ public class TimestampFileNameExtractorSPI implements PropertiesCollectorSPI {
 
         // it is a url
         if (source != null) {
-            final Properties properties = CoverageUtilities.loadPropertiesFromURL(source);
+            properties = CoverageUtilities.loadPropertiesFromURL(source);
+        }
+        if (properties != null) {
             regex = properties.getProperty(REGEX);
             format = properties.getProperty(FORMAT);
             String fullPathParam = properties.getProperty(FULL_PATH);
             if (fullPathParam != null && fullPathParam.trim().length() > 0) {
                 fullPath = Boolean.valueOf(fullPathParam);
             }
+            String useHighTimeParam = properties.getProperty(USE_HIGH_TIME);
+            if (useHighTimeParam != null && useHighTimeParam.trim().length() > 0) {
+                useHighTime = Boolean.valueOf(useHighTimeParam);
+            }
         }
 
-        if (regex != null) {
-            regex = regex.trim();
-        }
         if (format != null) {
             format = format.trim();
         }
 
         if (regex != null) {
-            return new TimestampFileNameExtractor(this, propertyNames, regex, format, fullPath);
+            regex = regex.trim();
+            return new TimestampFileNameExtractor(
+                    this, propertyNames, regex, format, fullPath, useHighTime);
         }
+
         return null;
     }
 }

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/time/TimestampFileNameExtractorTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/time/TimestampFileNameExtractorTest.java
@@ -94,6 +94,21 @@ public class TimestampFileNameExtractorTest {
     }
 
     @Test
+    public void testParseCustomTimestampUseHighTime() {
+        PropertiesCollectorSPI spi = getTimestampSpi();
+        PropertiesCollector collector =
+                spi.create(
+                        "regex=[0-9]{10},format=yyyyMMddHH,useHighTime=true",
+                        Arrays.asList("time"));
+        File file = new File("Temperature_2017111319.tif");
+        collector.collect(file);
+        collector.setProperties(feature);
+        Date time = (Date) feature.getAttribute("time");
+        assertNotNull(time);
+        assertEquals("2017-11-13T19:59:59.999Z", df.format(time));
+    }
+
+    @Test
     public void testParseFullPathTimestamp() {
         PropertiesCollectorSPI spi = getTimestampSpi();
         String regex = "(?:\\\\)(\\d{8})(?:\\\\)(?:file.)(T\\d{6})(?:.txt)";
@@ -105,6 +120,20 @@ public class TimestampFileNameExtractorTest {
         Date time = (Date) feature.getAttribute("time");
         assertNotNull(time);
         assertEquals("2012-06-02T12:00:00.000Z", df.format(time));
+    }
+
+    @Test
+    public void testTimestampWithHighTimeRange() {
+        PropertiesCollectorSPI spi = getTimestampSpi();
+        PropertiesCollector collector =
+                spi.create("regex=[0-9]{8},useHighTime=true", Arrays.asList("time"));
+        File file = new File("polyphemus_20130301.nc");
+        collector.collect(file);
+        collector.setProperties(feature);
+        Date time = (Date) feature.getAttribute("time");
+        assertNotNull(time);
+        // Getting the higher time value of that time range
+        assertEquals("2013-03-01T23:59:59.999Z", df.format(time));
     }
 
     @Test
@@ -121,6 +150,58 @@ public class TimestampFileNameExtractorTest {
         Date time = (Date) feature.getAttribute("time");
         assertNotNull(time);
         assertEquals("2012-06-02T12:00:00.000Z", df.format(time));
+    }
+
+    @Test
+    public void testParseFullPathTimestampWithCustomFormat2() {
+        PropertiesCollectorSPI spi = getTimestampSpi();
+        String regex = "(?:\\\\)(\\d{8})(?:\\\\)(?:file.)(t\\d{2}z)(?:.txt)";
+        PropertiesCollector collector =
+                spi.create(
+                        "regex=" + regex + ",fullPath=true,format=yyyyMMdd't'HH'z'",
+                        Arrays.asList("time"));
+        File file = new File("c:\\data\\20120602\\file.t12z.txt");
+        collector.collect(file);
+        collector.setProperties(feature);
+        Date time = (Date) feature.getAttribute("time");
+        assertNotNull(time);
+        assertEquals("2012-06-02T12:00:00.000Z", df.format(time));
+    }
+
+    @Test
+    public void testParseFullPathTimestampWithCustomFormatHighTimeRange() {
+        PropertiesCollectorSPI spi = getTimestampSpi();
+        String regex = "(?:\\\\)(\\d{8})(?:\\\\)(?:file.)(t\\d{2}z)(?:.txt)";
+        PropertiesCollector collector =
+                spi.create(
+                        "regex="
+                                + regex
+                                + ",fullPath=true,format=yyyyMMdd't'HH'z',useHighTime=true",
+                        Arrays.asList("time"));
+        File file = new File("c:\\data\\20120602\\file.t12z.txt");
+        collector.collect(file);
+        collector.setProperties(feature);
+        Date time = (Date) feature.getAttribute("time");
+        assertNotNull(time);
+        assertEquals("2012-06-02T12:59:59.999Z", df.format(time));
+    }
+
+    @Test
+    public void testParseFullPathTimestampWithCustomFormatHighTimeRange2() {
+        PropertiesCollectorSPI spi = getTimestampSpi();
+        String regex = "(?:\\\\)(\\d{8})(?:\\\\)(?:file.)(t\\d{2}z)(?:.txt)";
+        PropertiesCollector collector =
+                spi.create(
+                        "regex="
+                                + regex
+                                + ",format=yyyyMMdd't'HH'z', useHighTime=true,   fullPath=true",
+                        Arrays.asList("time"));
+        File file = new File("c:\\data\\20120602\\file.t12z.txt");
+        collector.collect(file);
+        collector.setProperties(feature);
+        Date time = (Date) feature.getAttribute("time");
+        assertNotNull(time);
+        assertEquals("2012-06-02T12:59:59.999Z", df.format(time));
     }
 
     private PropertiesCollectorSPI getTimestampSpi() {


### PR DESCRIPTION
New PR addressing all changes requested in previous https://github.com/geotools/geotools/pull/2648

- Updated GT Doc with links to new ImageMosaic documentation
- ImageMosaic TimeParser class get deprecated (old tests still run properly using deprecated class, new tests use new class on its module)
- Ticket updated with more details on the fuzzy date support
- inclusive flag has been renamed to useHighTime
