### PR TITLE
[GEOT-6419] gt-jdbc-hana - Missing apostrophe in query generation

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
@@ -419,7 +419,7 @@ public class HanaFilterToSQL extends PreparedFilterToSQL {
         out.write("ST_GeomFromWKB('");
         out.write(encodeAsHex(wkb));
         if ((currentSRID == null) && (currentGeometry != null)) {
-            out.write(", ");
+            out.write("', ");
             out.write(HanaUtil.encodeIdentifier(currentGeometry.getLocalName()));
             out.write(".ST_SRID())");
         } else {

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSpatialFilterOnViewOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSpatialFilterOnViewOnlineTest.java
@@ -1,0 +1,41 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import org.geotools.data.store.ContentFeatureCollection;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.spatial.BBOX;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaSpatialFilterOnViewOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new HanaSpatialFilterOnViewTestSetup();
+    }
+
+    public void testFilterOnView() throws Exception {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        BBOX bbox = ff.bbox(aname("geom"), 0, 0, 4, 4, "EPSG:4326");
+        ContentFeatureCollection features =
+                dataStore.getFeatureSource(tname("viewoftab")).getFeatures(bbox);
+        assertEquals(1, features.size());
+    }
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSpatialFilterOnViewTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSpatialFilterOnViewTestSetup.java
@@ -1,0 +1,45 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import java.sql.Connection;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaSpatialFilterOnViewTestSetup extends HanaTestSetupBase {
+
+    private static final String TABLE = "tabforview";
+
+    private static final String VIEW = "viewoftab";
+
+    @Override
+    protected void setUpData() throws Exception {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn);
+            htu.createTestSchema();
+
+            htu.dropTestView(VIEW);
+            htu.dropTestTableCascade(TABLE);
+
+            String[][] cols = {{"id", "INT"}, {"geom", "ST_Geometry(1000004326)"}};
+            htu.createTestTable(TABLE, cols);
+
+            htu.insertIntoTestTable(TABLE, 1, htu.geometry("POINT(1 2)", 1000004326));
+            htu.insertIntoTestTable(TABLE, 2, htu.geometry("POINT(11 12)", 1000004326));
+            htu.createTestView(VIEW, TABLE);
+        }
+    }
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaTestSetup.java
@@ -17,80 +17,16 @@
 package org.geotools.data.hana;
 
 import java.sql.Connection;
-import java.util.HashMap;
-import java.util.Properties;
 import org.geotools.data.hana.metadata.Srs;
-import org.geotools.jdbc.JDBCDataStoreFactory;
-import org.geotools.jdbc.JDBCTestSetup;
 
 /** @author Stefan Uhrig, SAP SE */
-public class HanaTestSetup extends JDBCTestSetup {
+public class HanaTestSetup extends HanaTestSetupBase {
 
     private static final String TABLE1 = "ft1";
 
     private static final String TABLE2 = "ft2";
 
     private static final String TABLE3 = "ft3";
-
-    private static final String DRIVER_CLASS_NAME = "com.sap.db.jdbc.Driver";
-
-    @Override
-    protected JDBCDataStoreFactory createDataStoreFactory() {
-        return new HanaDataStoreFactory();
-    }
-
-    @Override
-    protected Properties createExampleFixture() {
-        Properties fixture = new Properties();
-        fixture.put("host", "localhost");
-        fixture.put("port", "30015");
-        fixture.put("user", "myuser");
-        fixture.put("password", "mypassword");
-        fixture.put("use ssl", "false");
-        return fixture;
-    }
-
-    @Override
-    public void setFixture(Properties fixture) {
-        fixture.setProperty("driver", DRIVER_CLASS_NAME);
-        String host = fixture.getProperty("host");
-        String sport = fixture.getProperty("port");
-        String sinstance = fixture.getProperty("instance");
-        String database = fixture.getProperty("database");
-        String useSsl = fixture.getProperty("use ssl");
-
-        HashMap<String, String> options = new HashMap<String, String>();
-        if ("true".equals(useSsl)) {
-            options.put("encrypt", "true");
-        }
-
-        int port = 0;
-        if ((sport != null) && !sport.isEmpty()) {
-            port = Integer.parseInt(sport);
-        }
-        if (port != 0) {
-            fixture.setProperty(
-                    "url", HanaConnectionParameters.forPort(host, port, options).buildUrl());
-            super.setFixture(fixture);
-            return;
-        }
-
-        int instance = Integer.parseInt(sinstance);
-        if ((database == null) || database.isEmpty()) {
-            fixture.setProperty(
-                    "url",
-                    HanaConnectionParameters.forSingleContainer(host, instance, options)
-                            .buildUrl());
-            super.setFixture(fixture);
-            return;
-        }
-
-        fixture.setProperty(
-                "url",
-                HanaConnectionParameters.forMultiContainer(host, instance, database, options)
-                        .buildUrl());
-        super.setFixture(fixture);
-    }
 
     @Override
     protected void setUpData() throws Exception {

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaTestSetupBase.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaTestSetupBase.java
@@ -1,0 +1,86 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import java.util.HashMap;
+import java.util.Properties;
+import org.geotools.jdbc.JDBCDataStoreFactory;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaTestSetupBase extends JDBCTestSetup {
+
+    private static final String DRIVER_CLASS_NAME = "com.sap.db.jdbc.Driver";
+
+    @Override
+    protected Properties createExampleFixture() {
+        Properties fixture = new Properties();
+        fixture.put("host", "localhost");
+        fixture.put("port", "30015");
+        fixture.put("user", "myuser");
+        fixture.put("password", "mypassword");
+        fixture.put("use ssl", "false");
+        return fixture;
+    }
+
+    @Override
+    public void setFixture(Properties fixture) {
+        fixture.setProperty("driver", DRIVER_CLASS_NAME);
+        String host = fixture.getProperty("host");
+        String sport = fixture.getProperty("port");
+        String sinstance = fixture.getProperty("instance");
+        String database = fixture.getProperty("database");
+        String useSsl = fixture.getProperty("use ssl");
+
+        HashMap<String, String> options = new HashMap<String, String>();
+        if ("true".equals(useSsl)) {
+            options.put("encrypt", "true");
+        }
+
+        int port = 0;
+        if ((sport != null) && !sport.isEmpty()) {
+            port = Integer.parseInt(sport);
+        }
+        if (port != 0) {
+            fixture.setProperty(
+                    "url", HanaConnectionParameters.forPort(host, port, options).buildUrl());
+            super.setFixture(fixture);
+            return;
+        }
+
+        int instance = Integer.parseInt(sinstance);
+        if ((database == null) || database.isEmpty()) {
+            fixture.setProperty(
+                    "url",
+                    HanaConnectionParameters.forSingleContainer(host, instance, options)
+                            .buildUrl());
+            super.setFixture(fixture);
+            return;
+        }
+
+        fixture.setProperty(
+                "url",
+                HanaConnectionParameters.forMultiContainer(host, instance, database, options)
+                        .buildUrl());
+        super.setFixture(fixture);
+    }
+
+    @Override
+    protected JDBCDataStoreFactory createDataStoreFactory() {
+        return new HanaDataStoreFactory();
+    }
+}


### PR DESCRIPTION
If the SRID of a column is not known (e.g. the column is part of a
view), a malformed SQL query is generated. In particular, the geometry
string literal does not have the second enclosing apostrophe.