### PR TITLE
[GEOT-6421] AttributeExpressionImpl.evaluate() performance degradatation under concurrency

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/AttributeExpressionImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/AttributeExpressionImpl.java
@@ -17,7 +17,6 @@
 package org.geotools.filter;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -216,12 +215,12 @@ public class AttributeExpressionImpl extends DefaultExpression implements Proper
                     PropertyAccessors.findPropertyAccessors(obj, attPath, target, hints);
             List<Exception> exceptions = null;
             if (accessors != null) {
-                Iterator<PropertyAccessor> it = accessors.iterator();
-                while (!success && it.hasNext()) {
-                    accessor = it.next();
+                for (int i = 0; i < accessors.size(); i++) {
+                    accessor = accessors.get(i);
                     try {
                         value = accessor.get(obj, attPath, target);
                         success = true;
+                        break;
                     } catch (Exception e) {
                         // fine, we'll try another accessor
                         if (exceptions == null) {

--- a/modules/library/main/src/main/java/org/geotools/filter/AttributeExpressionImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/AttributeExpressionImpl.java
@@ -66,6 +66,9 @@ public class AttributeExpressionImpl extends DefaultExpression implements Proper
      */
     private Hints hints;
 
+    // accessor caching, scanning the registry every time is really very expensive
+    private volatile PropertyAccessor lastAccessor;
+
     /**
      * Constructor with the schema for this attribute.
      *
@@ -191,7 +194,7 @@ public class AttributeExpressionImpl extends DefaultExpression implements Proper
      */
     @SuppressWarnings("unchecked")
     public <T> T evaluate(Object obj, Class<T> target) {
-        PropertyAccessor accessor = getLastPropertyAccessor();
+        PropertyAccessor accessor = lastAccessor;
 
         Object value = false;
         boolean success = false;
@@ -245,7 +248,7 @@ public class AttributeExpressionImpl extends DefaultExpression implements Proper
                     throw exception;
                 }
             } else {
-                setLastPropertyAccessor(accessor);
+                lastAccessor = accessor;
             }
         }
 
@@ -254,17 +257,6 @@ public class AttributeExpressionImpl extends DefaultExpression implements Proper
         }
 
         return Converters.convert(value, target);
-    }
-
-    // accessor caching, scanning the registry every time is really very expensive
-    private PropertyAccessor lastAccessor;
-
-    private synchronized PropertyAccessor getLastPropertyAccessor() {
-        return lastAccessor;
-    }
-
-    private synchronized void setLastPropertyAccessor(PropertyAccessor accessor) {
-        lastAccessor = accessor;
     }
 
     /**


### PR DESCRIPTION
Improve the concurrency performance of `AttributeExpressionImpl.evaluate()` by replacing `synchronized` getter and setter by a `volatile` modifier on the `lastAccessor` instance variable.

A synthetic JMH benchmark has been used to assess the performance of the method under different concurrency pressure, with the following results:

### Throughput (million ops/s)
| Threads | Baseline | dc80b58e | 3a8386cd|
| -----------: | -----------: | -------------: | -------------: |
|   1 | 8.31 | 8.41 | 8.65 |
|   4 | 1.38 | 24.06 | 34.05 |
|  16 | 2.71 | 96.08 | 114.42 |
|  64 | 2.72 | 86.80 | 90.97 |
| 256 | 2.41 | 64.20 | 63.89 |

![image](https://user-images.githubusercontent.com/207423/69116019-89534100-0a69-11ea-8f28-f280e792d2f6.png)

Note the peak performance is, expectedly, provided at 16 concurrent threads, which is the number of cores in the machine where the tests were performed.
