### PR TITLE
[GEOT-6425] App-Schema WFS GetFeature includes namespaces for all workspaces on isolated workspace

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/config/AppSchemaDataAccessConfigurator.java
@@ -20,11 +20,15 @@ package org.geotools.data.complex.config;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -40,6 +44,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.geotools.appschema.filter.FilterFactoryImplReportInvalidProperty;
@@ -173,12 +178,49 @@ public class AppSchemaDataAccessConfigurator {
         this.config = config;
         this.dataStoreMap = dataStoreMap;
         namespaces = new NamespaceSupport();
+        declareNamespaces(config);
+    }
+
+    private void declareNamespaces(AppSchemaDataAccessDTO config) {
         Map nsMap = config.getNamespaces();
         for (Iterator it = nsMap.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry entry = (Entry) it.next();
             String prefix = (String) entry.getKey();
             String namespace = (String) entry.getValue();
             namespaces.declarePrefix(prefix, namespace);
+        }
+        // check included namespaces
+        final Set<String> evaluatedURLs = new HashSet<String>();
+        config.getIncludes()
+                .forEach(
+                        filename ->
+                                processNamespaces(
+                                        config.getBaseSchemasUrl(), filename, evaluatedURLs));
+    }
+
+    private void processNamespaces(String baseURL, String filename, Set<String> evaluatedURLs) {
+        try {
+            XMLConfigDigester configReader = new XMLConfigDigester();
+            URI baseUri = new URL(baseURL).toURI();
+            URL url = baseUri.resolve(filename).toURL();
+            if (evaluatedURLs.contains(url.toExternalForm())) return;
+            else evaluatedURLs.add(url.toExternalForm());
+            AppSchemaDataAccessDTO config = configReader.parse(url);
+            for (Iterator it = config.getNamespaces().entrySet().iterator(); it.hasNext(); ) {
+                Map.Entry entry = (Entry) it.next();
+                String prefix = (String) entry.getKey();
+                String namespace = (String) entry.getValue();
+                if (namespaces.getURI(prefix) == null) namespaces.declarePrefix(prefix, namespace);
+            }
+            if (!CollectionUtils.isEmpty(config.getIncludes())) {
+                for (String fname : config.getIncludes()) {
+                    processNamespaces(config.getBaseSchemasUrl(), fname, evaluatedURLs);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -303,6 +345,11 @@ public class AppSchemaDataAccessConfigurator {
 
                 // set original schema locations for encoding
                 target.getType().getUserData().put("schemaURI", schemaURIs);
+
+                // set mappings namespaces
+                target.getType()
+                        .getUserData()
+                        .put(Types.DECLARED_NAMESPACES_MAP, getNamespacesMap());
 
                 boolean isDatabaseBackend =
                         featureSource instanceof JDBCFeatureSource
@@ -1117,6 +1164,17 @@ public class AppSchemaDataAccessConfigurator {
             ((XmlFeatureSource) fSource).setNamespaces(namespaces);
         }
         return fSource;
+    }
+
+    private Map<String, String> getNamespacesMap() {
+        final Map<String, String> namespacesMap = new HashMap<>();
+        final Enumeration prefixes = namespaces.getPrefixes();
+        while (prefixes.hasMoreElements()) {
+            final String prefix = (String) prefixes.nextElement();
+            final String uri = namespaces.getURI(prefix);
+            namespacesMap.put(prefix, uri);
+        }
+        return namespacesMap;
     }
 
     /**

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/GeoSciMLTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/GeoSciMLTest.java
@@ -17,6 +17,7 @@
 
 package org.geotools.data.complex;
 
+import static org.geotools.data.util.FeatureStreams.toFeatureStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -25,10 +26,14 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 import org.geotools.data.DataAccess;
 import org.geotools.data.DataAccessFinder;
 import org.geotools.data.FeatureSource;
@@ -46,6 +51,8 @@ import org.geotools.xsd.SchemaIndex;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.feature.Feature;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.AttributeType;
 import org.opengis.feature.type.ComplexType;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.Name;
@@ -232,6 +239,45 @@ public class GeoSciMLTest extends AppSchemaTestSupport {
         FeatureCollection<FeatureType, Feature> features = source.getFeatures(query);
         assertNotNull(features);
         assertEquals(2, size(features));
+    }
+
+    /**
+     * Checks that declared namespaces are included on FeatureType's userData Map for the complex
+     * features collection.
+     */
+    @Test
+    public void testComplexFeatureNamespaces() throws Exception {
+        final Name typeName = Types.typeName(GSMLNS, "MappedFeature");
+        FeatureSource<FeatureType, Feature> source = mappingDataStore.getFeatureSource(typeName);
+        Query query = new Query();
+        query.setNamespace(new URI(typeName.getNamespaceURI()));
+        query.setTypeName(typeName.getLocalPart());
+        FeatureCollection<FeatureType, Feature> features = source.getFeatures(query);
+        assertNotNull(features);
+        try (final Stream<Feature> featureStream = toFeatureStream(features)) {
+            Optional<Feature> first = featureStream.findFirst();
+            Optional<Map<String, String>> mapOpt =
+                    first.map(Feature::getDescriptor)
+                            .map(AttributeDescriptor::getType)
+                            .map(AttributeType::getUserData)
+                            .map(m -> m.get(Types.DECLARED_NAMESPACES_MAP))
+                            .filter(v -> v instanceof Map)
+                            .map(x -> (Map<String, String>) x);
+            assertTrue(mapOpt.isPresent());
+            final Map<String, String> namespacesMap = mapOpt.get();
+            assertEquals(3, namespacesMap.keySet().size());
+            assertTrue(
+                    getExpectedNamespaces()
+                            .stream()
+                            .allMatch(ns -> namespacesMap.containsValue(ns)));
+        }
+    }
+
+    private List<String> getExpectedNamespaces() {
+        return Arrays.asList(
+                "http://www.w3.org/XML/1998/namespace",
+                "http://www.opengis.net/gml",
+                "http://www.cgi-iugs.org/xml/GeoSciML/2");
     }
 
     private int size(FeatureCollection<FeatureType, Feature> features) {

--- a/modules/library/main/src/main/java/org/geotools/feature/type/Types.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/type/Types.java
@@ -54,6 +54,12 @@ import org.xml.sax.helpers.NamespaceSupport;
 public class Types {
 
     /**
+     * Key for AppSchema declared namespaces on FeatureType user data Map. Value is a {@code
+     * Map<String, String>}
+     */
+    public static final String DECLARED_NAMESPACES_MAP = "declaredNamespacesMap";
+
+    /**
      * Ensures an attribute value is withing the restrictions of the AttributeDescriptor and
      * AttributeType.
      *


### PR DESCRIPTION
App-Schema WFS GetFeature GML 3.1 and 3.2 reponses include namespaces from all workspaces on isolated workspace (virtual service) request. This PR adds the namespaces map support for the fix to this issue tested on Geoserver.

https://osgeo-org.atlassian.net/browse/GEOT-6425