### PR TITLE
[GEOT-6423] Hints.ensureSystemDefaultsLoaded() incorrect use of AtomicBoolean semantics

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
@@ -1169,12 +1169,12 @@ public class Hints extends RenderingHints {
      *     otherwise.
      */
     private static boolean ensureSystemDefaultLoaded() {
-        if (needScan.get()) {
+        // update GLOBAL atomically only if needScan == true
+        if (needScan.compareAndSet(true, false)) {
             Map<RenderingHints.Key, Object> newGlobal =
                     new ConcurrentHashMap<RenderingHints.Key, Object>(GLOBAL);
             boolean modified = GeoTools.scanForSystemHints(newGlobal);
             GLOBAL = newGlobal;
-            needScan.set(false);
             return modified;
         } else {
             return false;


### PR DESCRIPTION
Make updating `Hints.GLOBAL` actually an atomic operation.

Do use `AtomicBoolean` semantics at `org.geotools.util.factory.Hints.ensureSystemDefaultLoaded()` to update the GLOBAL class variable.