### PR TITLE
[GEOT-6363]Error in SQL conversion when function uses a like expression

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -523,8 +523,9 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
 
         // JD: hack for date values, we append some additional padding to handle
         // the matching of time/timezone/etc...
-        AttributeDescriptor ad = (AttributeDescriptor) att.evaluate(featureType);
-        if (ad != null && Date.class.isAssignableFrom(ad.getType().getBinding())) {
+        Class attributeType = getExpressionType(att);
+        // AttributeDescriptor ad = (AttributeDescriptor) att.evaluate(featureType);
+        if (Date.class.isAssignableFrom(attributeType)) {
             literal += multi;
         }
 

--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -524,7 +524,6 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
         // JD: hack for date values, we append some additional padding to handle
         // the matching of time/timezone/etc...
         Class attributeType = getExpressionType(att);
-        // AttributeDescriptor ad = (AttributeDescriptor) att.evaluate(featureType);
         if (Date.class.isAssignableFrom(attributeType)) {
             literal += multi;
         }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceOnlineTest.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.jdbc;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
@@ -46,6 +48,7 @@ import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.expression.Subtract;
 import org.opengis.filter.sort.SortBy;
@@ -689,5 +692,21 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
         } else {
             fail("Unexpected dialect, supports basic or prepared, but was a : " + dialect);
         }
+    }
+
+    /**
+     * Online tests for String functions along with Like operator
+     *
+     * @throws Exception
+     */
+    public void testStringFunction() throws Exception {
+
+        FilterFactory ff = dataStore.getFilterFactory();
+        Function function = ff.function("strToLowerCase", ff.property("stringProperty"));
+
+        // should hit the row where stringProperty starts with z (e.g zero)
+        PropertyIsLike likeWithStringFunction = ff.like(function, "z%", "%", "-", "\\", true);
+        assumeTrue(dataStore.getFilterCapabilities().fullySupports(likeWithStringFunction));
+        assertEquals(1, featureSource.getCount(new Query(null, likeWithStringFunction)));
     }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceOnlineTest.java
@@ -16,8 +16,6 @@
  */
 package org.geotools.jdbc;
 
-import static org.junit.Assume.assumeTrue;
-
 import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
@@ -31,6 +29,7 @@ import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.function.FilterFunction_strToLowerCase;
 import org.geotools.geometry.jts.LiteCoordinateSequenceFactory;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
@@ -700,13 +699,17 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
      * @throws Exception
      */
     public void testStringFunction() throws Exception {
+        // ignore if the String function is not supported
+        if (!dataStore.getFilterCapabilities().supports(FilterFunction_strToLowerCase.class)) {
+            LOGGER.info("Ignoring testStringFunction test");
+            return;
+        }
 
         FilterFactory ff = dataStore.getFilterFactory();
         Function function = ff.function("strToLowerCase", ff.property("stringProperty"));
 
         // should hit the row where stringProperty starts with z (e.g zero)
         PropertyIsLike likeWithStringFunction = ff.like(function, "z%", "%", "-", "\\", true);
-        assumeTrue(dataStore.getFilterCapabilities().fullySupports(likeWithStringFunction));
         assertEquals(1, featureSource.getCount(new Query(null, likeWithStringFunction)));
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
@@ -22,6 +22,7 @@ import org.geotools.data.jdbc.SQLFilterTestSupport;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.SchemaException;
 import org.geotools.filter.FilterCapabilities;
+import org.geotools.filter.function.FilterFunction_strToLowerCase;
 import org.geotools.filter.visitor.PostPreProcessFilterSplittingVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope3D;
 import org.geotools.referencing.CRS;
@@ -33,6 +34,7 @@ import org.opengis.feature.IllegalAttributeException;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.spatial.BBOX3D;
 import org.opengis.filter.spatial.Intersects;
 import org.opengis.geometry.MismatchedDimensionException;
@@ -199,5 +201,15 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         filterToSql.encode(expr);
         String sql = writer.toString().toLowerCase();
         assertEquals("where 5::text=any(testarray)", sql);
+    }
+    
+    @Test
+    public void testIsLike() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        PropertyIsLike like=ff.like(ff.function("strToLowerCase",ff.property("testString")), "a_literal","%", "-", "\\", true);
+        
+        filterToSql.encode(like);
+        String sql = writer.toString().toLowerCase().trim();        
+        assertEquals("where lower(teststring) like 'a_literal'", sql); 
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
@@ -22,7 +22,6 @@ import org.geotools.data.jdbc.SQLFilterTestSupport;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.SchemaException;
 import org.geotools.filter.FilterCapabilities;
-import org.geotools.filter.function.FilterFunction_strToLowerCase;
 import org.geotools.filter.visitor.PostPreProcessFilterSplittingVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope3D;
 import org.geotools.referencing.CRS;
@@ -202,14 +201,21 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         String sql = writer.toString().toLowerCase();
         assertEquals("where 5::text=any(testarray)", sql);
     }
-    
+
     @Test
-    public void testIsLike() throws Exception {
+    public void testFunctionLike() throws Exception {
         filterToSql.setFeatureType(testSchema);
-        PropertyIsLike like=ff.like(ff.function("strToLowerCase",ff.property("testString")), "a_literal","%", "-", "\\", true);
-        
+        PropertyIsLike like =
+                ff.like(
+                        ff.function("strToLowerCase", ff.property("testString")),
+                        "a_literal",
+                        "%",
+                        "-",
+                        "\\",
+                        true);
+
         filterToSql.encode(like);
-        String sql = writer.toString().toLowerCase().trim();        
-        assertEquals("where lower(teststring) like 'a_literal'", sql); 
+        String sql = writer.toString().toLowerCase().trim();
+        assertEquals("where lower(teststring) like 'a_literal'", sql);
     }
 }


### PR DESCRIPTION
JIRA:https://osgeo-org.atlassian.net/browse/GEOT-6363

Fixed issue related to using String functions on database fields through CQL filters.

E.g the below CQL filter was failing on PostGIS feature sources 

`strToLowerCase("state_name") LIKE '%texa%'`

