### PR TITLE
Remove XML Entities when parsing via PullParser

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/PullParser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/PullParser.java
@@ -140,6 +140,9 @@ public class PullParser {
         XMLInputFactory factory = XMLInputFactory.newInstance();
         factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
         factory.setProperty(XMLInputFactory.IS_VALIDATING, false);
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
         try {
             return factory.createXMLStreamReader(input);
         } catch (XMLStreamException e) {

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/PullParserTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/PullParserTest.java
@@ -25,4 +25,17 @@ public class PullParserTest extends TestCase {
 
         assertNull(parser.parse());
     }
+
+    // Validate that entity references are stripped when parsing xml
+    public void testParseEntity() throws Exception {
+        PullParser parser =
+                new PullParser(
+                        new MLConfiguration(),
+                        ML.class.getResourceAsStream("mails-external-entities.xml"),
+                        new QName(ML.NAMESPACE, "mail"));
+
+        Mail m = (Mail) parser.parse();
+        assertNotNull(m);
+        assertEquals("", m.getBody());
+    }
 }


### PR DESCRIPTION
The XMLInputFactory is currently using the default configuration for handling XML entities when creating the XMLStreamReader. If there is a more private way for me to communicate with a maintainer, please let me know.
