### PR TITLE
Change log level from "warning" to "fine"

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/DefaultFeatureCollection.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/DefaultFeatureCollection.java
@@ -182,7 +182,7 @@ public class DefaultFeatureCollection
         }
         SimpleFeatureType childType = (SimpleFeatureType) getSchema();
         if (!feature.getFeatureType().equals(childType)) {
-            LOGGER.warning("Feature Collection contains a heterogeneous" + " mix of features");
+            LOGGER.fine("Feature Collection contains a heterogeneous mix of features");
         }
         // Check inheritance with FeatureType here?
         contents.put(ID, feature);


### PR DESCRIPTION
A heterogenous feature collection is a _potential_ configuration error but certainly NOT a software fault.
If this condition is to be logged at all, it maximum level should be 'FINE'.

Current level creates false warnings in application logs.