### PR TITLE
[GEOT-6366] WFSDataStore uses the wrong parameters for DescribeFeatur…

### DIFF
--- a/docs/src/main/java/org/geotools/main/FilterExamples.java
+++ b/docs/src/main/java/org/geotools/main/FilterExamples.java
@@ -527,3 +527,4 @@ public class FilterExamples {
         functionListPretty();
     }
 }
+

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
@@ -414,17 +414,22 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
         kvp.put("SERVICE", "WFS");
         kvp.put("VERSION", getServiceVersion().toString());
         kvp.put("REQUEST", "DescribeFeatureType");
+        // ommit output format by now, server should just return xml shcema
+        // kvp.put("OUTPUTFORMAT", outputFormat);
+
+        return buildDescribeFeatureTypeParametersForGET(kvp, typeName);
+    }
+
+    protected Map<String, String> buildDescribeFeatureTypeParametersForGET(
+            Map<String, String> kvp, QName typeName) {
         String prefixedTypeName = getPrefixedTypeName(typeName);
+
         kvp.put("TYPENAME", prefixedTypeName);
 
         if (!XMLConstants.DEFAULT_NS_PREFIX.equals(typeName.getPrefix())) {
             String nsUri = typeName.getNamespaceURI();
             kvp.put("NAMESPACE", "xmlns(" + typeName.getPrefix() + "=" + nsUri + ")");
         }
-
-        // ommit output format by now, server should just return xml shcema
-        // kvp.put("OUTPUTFORMAT", outputFormat);
-
         return kvp;
     }
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import net.opengis.fes20.AbstractQueryExpressionType;
 import net.opengis.ows11.DCPType;
@@ -269,6 +270,20 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
             }
         }
 
+        return kvp;
+    }
+
+    @Override
+    protected Map<String, String> buildDescribeFeatureTypeParametersForGET(
+            Map<String, String> kvp, QName typeName) {
+        String prefixedTypeName = getPrefixedTypeName(typeName);
+
+        kvp.put("TYPENAMES", prefixedTypeName);
+
+        if (!XMLConstants.DEFAULT_NS_PREFIX.equals(typeName.getPrefix())) {
+            String nsUri = typeName.getNamespaceURI();
+            kvp.put("NAMESPACES", "xmlns(" + typeName.getPrefix() + "," + nsUri + ")");
+        }
         return kvp;
     }
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v2_0/Strategy2_0Test.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v2_0/Strategy2_0Test.java
@@ -1,0 +1,64 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.wfs.internal.v2_0;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import javax.xml.namespace.QName;
+import org.geotools.data.ows.HTTPClient;
+import org.geotools.data.ows.SimpleHttpClient;
+import org.geotools.data.wfs.WFSTestData;
+import org.geotools.data.wfs.internal.WFSClient;
+import org.geotools.data.wfs.internal.WFSConfig;
+import org.geotools.data.wfs.internal.WFSRequest;
+import org.geotools.ows.ServiceException;
+import org.junit.Test;
+
+public class Strategy2_0Test {
+
+    private WFSClient newClient(String resource) throws IOException, ServiceException {
+        URL capabilitiesURL = WFSTestData.url(resource);
+        HTTPClient httpClient = new SimpleHttpClient();
+
+        WFSClient client = new WFSClient(capabilitiesURL, httpClient, new WFSConfig());
+        return client;
+    }
+
+    @Test
+    public void testNamespaceParamKeyValue() throws ServiceException, IOException {
+        WFSClient wfsClient = newClient("GeoServer_2.2.x/1.0.0/GetCapabilities.xml");
+        WFSRequest wfsReq = wfsClient.createDescribeFeatureTypeRequest();
+        wfsReq.setTypeName(new QName("http://www.openplans.org/topp", "states", "prefix"));
+        String url = wfsReq.getStrategy().buildUrlGET(wfsReq).toString();
+        assertTrue(
+                URLDecoder.decode(url, StandardCharsets.UTF_8.toString())
+                        .contains("NAMESPACE=xmlns(prefix="));
+        assertTrue(url.contains("TYPENAME"));
+        WFSClient clientV2 = newClient("GeoServer_2.2.x/2.0.0/GetCapabilities.xml");
+        WFSRequest wfsReqV2 = clientV2.createDescribeFeatureTypeRequest();
+        wfsReqV2.setTypeName(new QName("http://www.openplans.org/topp", "states", "prefix"));
+        String urlV2 = wfsReqV2.getStrategy().buildUrlGET(wfsReqV2).toString();
+        assertTrue(
+                URLDecoder.decode(urlV2, StandardCharsets.UTF_8.toString())
+                        .contains("NAMESPACES=xmlns(prefix,"));
+        assertTrue(urlV2.contains("TYPENAMES"));
+    }
+}


### PR DESCRIPTION
…eType operation when using WFS 2.0 strategy (#2558)

(cherry picked from commit 628a2d3ef166cc47bffc7a1ff824b9d820def1b6)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.