### PR TITLE
[backport 21.x][GEOT-6367] Url encoding issue for GetFeature operatio…

### DIFF
--- a/docs/src/main/java/org/geotools/main/FilterExamples.java
+++ b/docs/src/main/java/org/geotools/main/FilterExamples.java
@@ -129,6 +129,7 @@ public class FilterExamples {
     }
 
     // grabSelectedNames end
+
     /**
      * What features on in this bounding Box?
      *

--- a/modules/unsupported/wfs-ng/pom.xml
+++ b/modules/unsupported/wfs-ng/pom.xml
@@ -220,6 +220,7 @@
             <!-- The following tests are skipped because they do not extend OnlineTestCase -->
             <exclude>**/*OnlineTest.java</exclude>
           </excludes>
+          <argLine>-Dfile.encoding=UTF-8</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/URIs.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/URIs.java
@@ -106,7 +106,7 @@ public class URIs {
         try {
             // TODO: URLEncoder also encodes ( and ) which are considered safe chars,
             // see also http://www.w3.org/International/O-URL-code.html
-            return URLEncoder.encode(value, "ISO-8859-1");
+            return URLEncoder.encode(new String(value.getBytes(), "UTF-8"), "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("This is unexpected", e);
         }
@@ -116,7 +116,7 @@ public class URIs {
         try {
             // TODO: URLEncoder also encodes ( and ) which are considered safe chars,
             // see also http://www.w3.org/International/O-URL-code.html
-            return URLDecoder.decode(value, "ISO-8859-1");
+            return URLDecoder.decode(new String(value.getBytes(), "UTF-8"), "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("This is unexpected", e);
         }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/BuildURLTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/BuildURLTest.java
@@ -51,4 +51,12 @@ public class BuildURLTest {
 
         return ret;
     }
+
+    @Test
+    public void testParamUrlEncodingAndDecoding() {
+        String decoded = "ænd,øst,nøj";
+        String encoded = "%C3%A6nd%2C%C3%B8st%2Cn%C3%B8j";
+        assertEquals(encoded, URIs.urlEncode(decoded));
+        assertEquals(decoded, URIs.urlDecode(encoded));
+    }
 }


### PR DESCRIPTION
…n having special chars in PropertyName (#2563)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.