### PR TITLE
[GEOT-6377]: added new filter function arrayAnyMatch and a PostGIS encoding using its ANY function (Backport to 21.x)

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/data/jdbc/SQLFilterTestSupport.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/data/jdbc/SQLFilterTestSupport.java
@@ -82,6 +82,7 @@ public abstract class SQLFilterTestSupport extends TestCase {
         ftb.add("testDouble", Double.class);
         ftb.add("testString", String.class);
         ftb.add("testZeroDouble", Double.class);
+        ftb.add("testArray", Object[].class);
         ftb.setName("testSchema");
         testSchema = ftb.buildFeatureType();
 

--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_arrayAnyMatch.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_arrayAnyMatch.java
@@ -1,0 +1,64 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+import java.util.Arrays;
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+
+public class FilterFunction_arrayAnyMatch extends FunctionExpressionImpl {
+    public static FunctionName NAME =
+            new FunctionNameImpl(
+                    "arrayAnyMatch",
+                    parameter(
+                            "arrayAnyMatch",
+                            Boolean.class,
+                            "Any",
+                            "Returns true if any array value matches candidate."),
+                    parameter("array", Object[].class, "Array", "array of values"),
+                    parameter("candidate", Object.class, "Candidate", "value to match with array"));
+
+    public FilterFunction_arrayAnyMatch() {
+        super(NAME);
+    }
+
+    public Object evaluate(Object feature) {
+        Object[] array;
+        Object candidate;
+
+        try { // attempt to get array and perform conversion
+            array = (Object[]) getExpression(0).evaluate(feature);
+        } catch (Exception e) // probably a type error
+        {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function between argument #0 - expected type Object[]");
+        }
+
+        try { // attempt to get candidate and perform conversion
+            candidate = (Object) getExpression(1).evaluate(feature);
+        } catch (Exception e) // probably a type error
+        {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function between argument #1 - expected type Object");
+        }
+
+        return Boolean.valueOf(Arrays.asList(array).contains(candidate));
+    }
+}

--- a/modules/library/main/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/modules/library/main/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -19,6 +19,7 @@ org.geotools.filter.function.Collection_SumFunction
 org.geotools.filter.function.Collection_UniqueFunction
 org.geotools.filter.function.EnvFunction
 org.geotools.filter.function.StringTemplateFunction
+org.geotools.filter.function.FilterFunction_arrayAnyMatch
 org.geotools.filter.function.FilterFunction_contains
 org.geotools.filter.function.FilterFunction_isEmpty
 org.geotools.filter.function.FilterFunction_parseDouble

--- a/modules/library/main/src/test/java/org/geotools/filter/function/FilterFunction_arrayAnyMatchTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/FilterFunction_arrayAnyMatchTest.java
@@ -1,0 +1,70 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2019, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.geotools.filter.FilterFactoryImpl;
+import org.junit.Test;
+import org.opengis.filter.expression.Function;
+
+public class FilterFunction_arrayAnyMatchTest {
+    @Test
+    public void testMatchIntegers() throws Exception {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function func =
+                ff.function(
+                        "arrayAnyMatch",
+                        ff.literal(new Integer[] {1, 2, 3, 4, 5, 6, 7, 8, 9}),
+                        ff.literal(9));
+        assertTrue((Boolean) func.evaluate(new Object()));
+    }
+
+    @Test
+    public void testMatchStrings() throws Exception {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function func =
+                ff.function(
+                        "arrayAnyMatch",
+                        ff.literal(new String[] {"a", "b", "c", "d"}),
+                        ff.literal("b"));
+        assertTrue((Boolean) func.evaluate(new Object()));
+    }
+
+    @Test
+    public void testDoesNotMatchIntegers() throws Exception {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function func =
+                ff.function(
+                        "arrayAnyMatch",
+                        ff.literal(new Integer[] {1, 2, 3, 4, 5, 6, 7, 8, 9}),
+                        ff.literal(10));
+        assertFalse((Boolean) func.evaluate(new Object()));
+    }
+
+    @Test
+    public void testDoesNotMatchStrings() throws Exception {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function func =
+                ff.function(
+                        "arrayAnyMatch",
+                        ff.literal(new String[] {"a", "b", "c", "d"}),
+                        ff.literal("g"));
+        assertFalse((Boolean) func.evaluate(new Object()));
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
@@ -33,6 +33,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.function.DateDifferenceFunction;
 import org.geotools.filter.function.FilterFunction_area;
+import org.geotools.filter.function.FilterFunction_arrayAnyMatch;
 import org.geotools.filter.function.FilterFunction_strConcat;
 import org.geotools.filter.function.FilterFunction_strEndsWith;
 import org.geotools.filter.function.FilterFunction_strEqualsIgnoreCase;
@@ -178,6 +179,9 @@ class FilterToSqlHelper {
 
             // n nearest function
             caps.addType(FilterFunction_pgNearest.class);
+
+            // array functions
+            caps.addType(FilterFunction_arrayAnyMatch.class);
         }
 
         // native filter support
@@ -928,6 +932,20 @@ class FilterToSqlHelper {
         return sb.toString();
     }
 
+    public Object visit(FilterFunction_arrayAnyMatch filter, Object extraData) {
+        Expression array = getParameter(filter, 0, true);
+        Expression candidate = getParameter(filter, 1, true);
+        try {
+            candidate.accept(delegate, extraData);
+            out.write("=any(");
+            array.accept(delegate, extraData);
+            out.write(")");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return extraData;
+    }
+
     public Object visit(
             FilterFunction_pgNearest filter, Object extraData, NearestHelperContext ctx) {
         SQLDialect pgDialect = ctx.getPgDialect();
@@ -1003,6 +1021,25 @@ class FilterToSqlHelper {
 
         public void setEncodeGeometryValue(BiConsumer<Geometry, StringBuffer> encodeGeometryValue) {
             this.encodeGeometryValue = encodeGeometryValue;
+        }
+    }
+
+    /**
+     * Detects and return a FilterFunction_arrayAnyMatch if found, otherwise null
+     *
+     * @param filter filter to evaluate
+     * @return FilterFunction_any if found
+     */
+    public FilterFunction_arrayAnyMatch getArrayAnyMatch(PropertyIsEqualTo filter) {
+        Expression expr1 = filter.getExpression1();
+        Expression expr2 = filter.getExpression2();
+        if (expr2 instanceof FilterFunction_arrayAnyMatch) {
+            return (FilterFunction_arrayAnyMatch) expr2;
+        }
+        if (expr1 instanceof FilterFunction_arrayAnyMatch) {
+            return (FilterFunction_arrayAnyMatch) expr1;
+        } else {
+            return null;
         }
     }
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.data.postgis.filter.FilterFunction_pgNearest;
 import org.geotools.filter.FilterCapabilities;
+import org.geotools.filter.function.FilterFunction_arrayAnyMatch;
 import org.geotools.jdbc.JDBCDataStore;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LinearRing;
@@ -219,6 +220,7 @@ public class PostgisFilterToSQL extends FilterToSQL {
     public Object visit(PropertyIsEqualTo filter, Object extraData) {
         helper.out = out;
         FilterFunction_pgNearest nearest = helper.getNearestFilter(filter);
+        FilterFunction_arrayAnyMatch any = helper.getArrayAnyMatch(filter);
         if (nearest != null) {
             return helper.visit(
                     nearest,
@@ -236,6 +238,8 @@ public class PostgisFilterToSQL extends FilterToSQL {
                                     throw new RuntimeException(e);
                                 }
                             }));
+        } else if (any != null) {
+            return helper.visit(any, extraData);
         } else {
             return super.visit(filter, extraData);
         }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisPSFilterToSql.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisPSFilterToSql.java
@@ -19,6 +19,7 @@ package org.geotools.data.postgis;
 import java.io.IOException;
 import org.geotools.data.postgis.filter.FilterFunction_pgNearest;
 import org.geotools.filter.FilterCapabilities;
+import org.geotools.filter.function.FilterFunction_arrayAnyMatch;
 import org.geotools.jdbc.PreparedFilterToSQL;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.filter.BinaryComparisonOperator;
@@ -169,6 +170,7 @@ public class PostgisPSFilterToSql extends PreparedFilterToSQL {
     public Object visit(PropertyIsEqualTo filter, Object extraData) {
         helper.out = out;
         FilterFunction_pgNearest nearest = helper.getNearestFilter(filter);
+        FilterFunction_arrayAnyMatch any = helper.getArrayAnyMatch(filter);
         if (nearest != null) {
             return helper.visit(
                     nearest,
@@ -187,6 +189,8 @@ public class PostgisPSFilterToSql extends PreparedFilterToSQL {
                                     throw new RuntimeException(e);
                                 }
                             }));
+        } else if (any != null) {
+            return helper.visit(any, extraData);
         } else {
             return super.visit(filter, extraData);
         }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
@@ -32,6 +32,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.spatial.BBOX3D;
 import org.opengis.filter.spatial.Intersects;
@@ -169,5 +170,38 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         filterToSql.encode(like);
         String sql = writer.toString().toLowerCase().trim();
         assertEquals("where lower(teststring) like 'a_literal'", sql);
+    }
+
+    @Test
+    public void testEncodeArrayAnyMatchCapabilities() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        PropertyIsEqualTo expr =
+                ff.equals(
+                        ff.function("arrayAnyMatch", ff.property("testArray"), ff.literal(5)),
+                        ff.literal(true));
+
+        FilterCapabilities caps = filterToSql.getCapabilities();
+        PostPreProcessFilterSplittingVisitor splitter =
+                new PostPreProcessFilterSplittingVisitor(caps, testSchema, null);
+        expr.accept(splitter, null);
+
+        Filter[] split = new Filter[2];
+        split[0] = splitter.getFilterPre();
+        split[1] = splitter.getFilterPost();
+
+        assertEquals(expr, split[0]);
+        assertEquals(Filter.INCLUDE, split[1]);
+    }
+
+    @Test
+    public void testEncodeArrayAnyMatch() throws Exception {
+        PropertyIsEqualTo expr =
+                ff.equals(
+                        ff.function("arrayAnyMatch", ff.property("testArray"), ff.literal(5)),
+                        ff.literal(true));
+
+        filterToSql.encode(expr);
+        String sql = writer.toString().toLowerCase();
+        assertEquals("where 5=any(testarray)", sql);
     }
 }


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.