### PR TITLE
Fix typos, remove incomplete docstring

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
@@ -1044,14 +1044,7 @@ public class SimpleFeatureTypeBuilder {
         return b.buildFeatureType();
     }
 
-    /**
-     * Configure expected
-     *
-     * @param origional
-     * @param query
-     * @return
-     */
-    public static SimpleFeatureType retype(SimpleFeatureType origional, Query query) {
+    public static SimpleFeatureType retype(SimpleFeatureType original, Query query) {
         CoordinateReferenceSystem crs = null;
         if (query.getCoordinateSystem() != null) {
             crs = query.getCoordinateSystem();
@@ -1059,17 +1052,17 @@ public class SimpleFeatureTypeBuilder {
         if (query.getCoordinateSystemReproject() != null) {
             crs = query.getCoordinateSystemReproject();
         }
-        return retype(origional, query.getPropertyNames(), crs);
+        return retype(original, query.getPropertyNames(), crs);
     }
 
     private static SimpleFeatureType retype(
-            SimpleFeatureType origional, String[] propertyNames, CoordinateReferenceSystem crs) {
+            SimpleFeatureType original, String[] propertyNames, CoordinateReferenceSystem crs) {
         // TODO Auto-generated method stub
         return null;
     }
 
     /**
-     * Copys a feature type.
+     * Copies a feature type.
      *
      * <p>This method does a deep copy in that all individual attributes are copied as well.
      */


### PR DESCRIPTION
I figured no docstring is better than an incomplete one. I'm not comfortable explaining the function, so if someone wants to contribute a docstring, that would be great!

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.