### PR TITLE
Docstring and typos

### DIFF
--- a/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/ECQL.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/ECQL.java
@@ -60,11 +60,11 @@ import org.opengis.filter.expression.Expression;
  *
  *       Filter filter = ECQL.toFilter(<b>"IN ('river.1', 'river.2')"</b>);
  *
- *       Filter filter = ECQL.toFilter(<b>"LENGHT IN (4100001,4100002, 4100003 )"</b>);
+ *       Filter filter = ECQL.toFilter(<b>"LENGTH IN (4100001,4100002, 4100003 )"</b>);
  *
- *       List &lt;Filter&gt; list = ECQL.toFilterList(<b>"LENGHT = 100; NAME like '%omer%'"</b>);
+ *       List &lt;Filter&gt; list = ECQL.toFilterList(<b>"LENGTH = 100; NAME like '%omer%'"</b>);
  *
- *       Expression expression = ECQL.toExpression(<b>"LENGHT + 100"</b>);
+ *       Expression expression = ECQL.toExpression(<b>"LENGTH + 100"</b>);
  *
  * </code>
  * </pre>

--- a/modules/library/main/src/main/java/org/geotools/data/store/ContentFeatureStore.java
+++ b/modules/library/main/src/main/java/org/geotools/data/store/ContentFeatureStore.java
@@ -304,7 +304,7 @@ public abstract class ContentFeatureStore extends ContentFeatureSource
         }
 
         // Need to save a link to the original feature in order to be able to set the ID once it
-        // is actuall saved (see JDBCInsertFeatureWriter)
+        // is actually saved (see JDBCInsertFeatureWriter)
         toWrite.getUserData().put(ORIGINAL_FEATURE_KEY, feature);
 
         // perform the write

--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureBuilder.java
@@ -481,7 +481,7 @@ public class SimpleFeatureBuilder extends FeatureBuilder<FeatureType, Feature> {
     }
 
     /**
-     * Adds some user data to the next attributed added to the feature.
+     * Adds some user data to the next attribute added to the feature.
      *
      * <p>This value is reset when the next attribute is added.
      *
@@ -492,6 +492,12 @@ public class SimpleFeatureBuilder extends FeatureBuilder<FeatureType, Feature> {
         return setUserData(next, key, value);
     }
 
+    /**
+     * Set user data for a specific attribute.
+     * @param index The index of the attribute.
+     * @param key The key of the user data.
+     * @param value The value of the user data.
+     */
     @SuppressWarnings("unchecked")
     public SimpleFeatureBuilder setUserData(int index, Object key, Object value) {
         if (userData == null) {


### PR DESCRIPTION
The `@param`s might be overkill, but I think the main description would be helpful. Reading the docs, I defaulted to assuming `setUserData` could mean "set feature data".

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.