### PR TITLE
[22.x backport][GEOT-6398] RenderListener Extension (#2600)

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/RenderListener.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/RenderListener.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.renderer;
 
+import org.geotools.map.Layer;
 import org.opengis.feature.simple.SimpleFeature;
 
 /**
@@ -41,4 +42,29 @@ public interface RenderListener {
      * @param e
      */
     public void errorOccurred(Exception e);
+
+    /** Event issued when the layer begins rendering. */
+    default void layerStart(Layer layer) {
+        // does nothing
+    }
+
+    /** Event issued when the layer completed rendering. May not be issued. */
+    default void layerEnd(Layer layer) {
+        // does nothing
+    }
+
+    /** Event issued when labelling starts. May not be issued if there are no labels to paint. */
+    default void labellingStart() {
+        // does nothing
+    }
+
+    /** Event issued when labelling ends. May not be issued. */
+    default void labellingEnd() {
+        // does nothing
+    }
+
+    /** Event issued when rendering ends. Always issued. */
+    default void renderingComplete() {
+        // does nothing
+    }
 }

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/CompositingGroup.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/CompositingGroup.java
@@ -77,6 +77,7 @@ class CompositingGroup {
                         clone.setVisible(layer.isVisible());
                         clone.setSelected(layer.isSelected());
                         clone.getUserData().putAll(layer.getUserData());
+                        clone.setTitle(layer.getTitle());
                         layers.add(clone);
                     }
                 }


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.