### PR TITLE
[21.x backport][GEOT-6502] Add Geometry.class as context in FilterFun…

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_toWKT.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/FilterFunction_toWKT.java
@@ -40,7 +40,7 @@ public class FilterFunction_toWKT extends FunctionExpressionImpl {
         Geometry arg0;
 
         try { // attempt to get value and perform conversion
-            arg0 = (Geometry) getExpression(0).evaluate(feature);
+            arg0 = getExpression(0).evaluate(feature, Geometry.class);
         } catch (Exception e) // probably a type error
         {
             throw new IllegalArgumentException(

--- a/modules/library/main/src/test/java/org/geotools/filter/function/FilterFunction_toWKTTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/FilterFunction_toWKTTest.java
@@ -1,0 +1,20 @@
+package org.geotools.filter.function;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.filter.FilterFactoryImpl;
+import org.junit.Test;
+import org.locationtech.jts.geom.*;
+import org.opengis.filter.expression.Function;
+
+public class FilterFunction_toWKTTest {
+
+    @Test
+    public void testToWKTWithTargetClass() {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Envelope envelope = new Envelope(10, 10, 20, 20);
+        Function toWKT = ff.function("toWKT", ff.property("."));
+        String result = (String) toWKT.evaluate(envelope);
+        assertEquals(result, "POLYGON ((10 20, 10 20, 10 20, 10 20, 10 20))");
+    }
+}


### PR DESCRIPTION
…ction_toWKT

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [X] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.