### PR TITLE
MBStyle, use alpha also from RGBA color spec

### DIFF
--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/function/MBFunctionFactory.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/function/MBFunctionFactory.java
@@ -64,6 +64,10 @@ public class MBFunctionFactory implements FunctionFactory {
         functionList.add(ToColorFunction.NAME);
         functionList.add(MapBoxAnchorFunction.NAME);
         functionList.add(FontAlternativesFunction.NAME);
+        functionList.add(MapBoxFontBaseNameFunction.NAME);
+        functionList.add(MapBoxFontStyleFunction.NAME);
+        functionList.add(MapBoxFontWeightFunction.NAME);
+        functionList.add(MapBoxAlphaFunction.NAME);
         return Collections.unmodifiableList(functionList);
     }
 
@@ -135,6 +139,10 @@ public class MBFunctionFactory implements FunctionFactory {
             f = new MapBoxFontStyleFunction();
         } else if (MapBoxFontWeightFunction.NAME.getFunctionName().equals(name)) {
             f = new MapBoxFontWeightFunction();
+        } else if (MapBoxAlphaFunction.NAME.getFunctionName().equals(name)) {
+            f = new MapBoxAlphaFunction();
+        } else if (MapBoxRGBAFunction.NAME.getFunctionName().equals(name)) {
+            f = new MapBoxRGBAFunction();
         }
 
         if (f instanceof FunctionImpl) {

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/function/MapBoxAlphaFunction.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/function/MapBoxAlphaFunction.java
@@ -1,0 +1,49 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.mbstyle.function;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+import org.geotools.filter.FunctionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+
+import java.awt.*;
+
+/** Returns a font base name */
+public class MapBoxAlphaFunction extends FunctionImpl {
+
+    public static FunctionName NAME =
+            new FunctionNameImpl(
+                    "mbAlpha",
+                    parameter("alpha", Double.class),
+                    parameter("color", Color.class));
+
+    public MapBoxAlphaFunction() {
+        this.functionName = NAME;
+    }
+
+    @Override
+    public Object evaluate(Object object) {
+        Color color = getParameters().get(0).evaluate(object, Color.class);
+        if (color == null) {
+            return 1;
+        }
+
+        return color.getAlpha() / 255d;
+    }
+}

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/function/MapBoxRGBAFunction.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/function/MapBoxRGBAFunction.java
@@ -1,0 +1,68 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.mbstyle.function;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+import org.geotools.filter.FunctionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+
+import java.awt.*;
+
+/** Returns a font base name */
+public class MapBoxRGBAFunction extends FunctionImpl {
+
+    public static FunctionName NAME =
+            new FunctionNameImpl(
+                    "mbRGBA",
+                    parameter("alpha", Double.class),
+                    parameter("red", Integer.class),
+                    parameter("green", Integer.class),
+                    parameter("blue", Integer.class),
+                    parameter("alpha", Integer.class));
+
+    public MapBoxRGBAFunction() {
+        this.functionName = NAME;
+    }
+
+    @Override
+    public Object evaluate(Object object) {
+        Integer red = getParameters().get(0).evaluate(object, Integer.class);
+        if (red == null) {
+            throw new IllegalArgumentException(
+                    "Could not convert red component to an integer value.");
+        }
+        Integer green = getParameters().get(1).evaluate(object, Integer.class);
+        if (green == null) {
+            throw new IllegalArgumentException(
+                    "Could not convert green component to an integer value.");
+        }
+        Integer blue = getParameters().get(2).evaluate(object, Integer.class);
+        if (blue == null) {
+            throw new IllegalArgumentException(
+                    "Could not convert blue component to an integer value.");
+        }
+        Double alpha = getParameters().get(3).evaluate(object, Double.class);
+        if (alpha == null) {
+            throw new IllegalArgumentException(
+                    "Could not convert alpha component to an floating point value.");
+        }
+
+        return new Color(red, green, blue, (int) Math.round(255 * alpha));
+    }
+}

--- a/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/unsupported/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -16,12 +16,6 @@
  */
 package org.geotools.mbstyle.parse;
 
-import java.awt.Color;
-import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.geotools.data.util.ColorConverterFactory;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.mbstyle.expression.MBExpression;
@@ -37,6 +31,13 @@ import org.json.simple.parser.ParseException;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
+
+import java.awt.*;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Helper class used to perform JSON traversal of {@link JSONObject} and perform Expression and
@@ -1235,14 +1236,24 @@ public class MBObjectParser {
      *
      * This method uses {@link Hints#COLOR_DEFINITION} "CSS" to support the use of web colors names.
      *
-     * @param color name of color (CSS or "web" colors)
+     * @param colorSpec name of color (CSS or "web" colors)
      * @return appropriate java color, or null if not available.
      */
-    public Literal color(String color) {
-        if (color == null) {
+    public Expression color(String colorSpec) {
+        if (colorSpec == null) {
             return null;
         }
-        return ff.literal(convertToColor(color));
+        Color color = convertToColor(colorSpec);
+        if (color.getAlpha() != 255) {
+            return ff.function(
+                    "mbRGBA",
+                    ff.literal(color.getRed()),
+                    ff.literal(color.getGreen()),
+                    ff.literal(color.getBlue()),
+                    ff.literal(color.getAlpha() / 255d));
+        } else {
+            return ff.literal(color);
+        }
     }
 
     /**


### PR DESCRIPTION
Work in progress, needs test and check in the rendering subsystem that the alpha and opacity are both used in fill and stroke and mark.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.