### PR TITLE
[GEOT-6506] Unnecessary synchronization in GeoTools.scanForSystemHints()

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
@@ -130,12 +130,6 @@ public final class GeoTools {
     private static final EventListenerList LISTENERS = new EventListenerList();
 
     /**
-     * The bindings between {@linkplain System#getProperties system properties} and a hint key. This
-     * field must be declared before any call to the {@link #bind} method.
-     */
-    private static final Map<String, RenderingHints.Key> BINDINGS = new HashMap<>();
-
-    /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
      * assigned to the {@link Hints#CRS_AUTHORITY_EXTRA_DIRECTORY CRS_AUTHORITY_EXTRA_DIRECTORY}
      * hint.
@@ -146,10 +140,6 @@ public final class GeoTools {
     public static final String CRS_AUTHORITY_EXTRA_DIRECTORY =
             "org.geotools.referencing.crs-directory";
 
-    static {
-        bind(CRS_AUTHORITY_EXTRA_DIRECTORY, Hints.CRS_AUTHORITY_EXTRA_DIRECTORY);
-    }
-
     /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
      * assigned to the {@link Hints#EPSG_DATA_SOURCE EPSG_DATA_SOURCE} hint.
@@ -158,10 +148,6 @@ public final class GeoTools {
      * @see #getDefaultHints
      */
     public static final String EPSG_DATA_SOURCE = "org.geotools.referencing.epsg-datasource";
-
-    static {
-        bind(EPSG_DATA_SOURCE, Hints.EPSG_DATA_SOURCE);
-    }
 
     /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
@@ -190,10 +176,6 @@ public final class GeoTools {
     public static final String FORCE_LONGITUDE_FIRST_AXIS_ORDER =
             "org.geotools.referencing.forceXY";
 
-    static {
-        bind(FORCE_LONGITUDE_FIRST_AXIS_ORDER, Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER);
-    }
-
     /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
      * assigned to the {@link Hints# ENTITY_RESOLVER} hint.
@@ -204,10 +186,6 @@ public final class GeoTools {
      * @see #getDefaultHints
      */
     public static final String ENTITY_RESOLVER = "org.xml.sax.EntityResolver";
-
-    static {
-        bind(ENTITY_RESOLVER, Hints.ENTITY_RESOLVER);
-    }
 
     /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
@@ -221,10 +199,6 @@ public final class GeoTools {
      */
     public static final String RESAMPLE_TOLERANCE = "org.geotools.referencing.resampleTolerance";
 
-    static {
-        bind(RESAMPLE_TOLERANCE, Hints.RESAMPLE_TOLERANCE);
-    }
-
     /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
      * assigned to the {@link Hints#LOCAL_DATE_TIME_HANDLING} hint.
@@ -236,10 +210,6 @@ public final class GeoTools {
      * @since 15.0
      */
     public static final String LOCAL_DATE_TIME_HANDLING = "org.geotools.localDateTimeHandling";
-
-    static {
-        bind(LOCAL_DATE_TIME_HANDLING, Hints.LOCAL_DATE_TIME_HANDLING);
-    }
 
     /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
@@ -253,10 +223,6 @@ public final class GeoTools {
      * @since 21.0
      */
     public static final String DATE_TIME_FORMAT_HANDLING = "org.geotools.dateTimeFormatHandling";
-
-    static {
-        bind(DATE_TIME_FORMAT_HANDLING, Hints.DATE_TIME_FORMAT_HANDLING);
-    }
 
     /**
      * The {@linkplain System#getProperty(String) system property} key for the default value to be
@@ -272,10 +238,6 @@ public final class GeoTools {
      */
     public static final String ENCODE_WKT = "org.geotools.ecql.ewkt";
 
-    static {
-        bind(ENCODE_WKT, Hints.ENCODE_EWKT);
-    }
-
     /** The initial context. Will be created only when first needed. */
     private static InitialContext context;
 
@@ -287,27 +249,53 @@ public final class GeoTools {
     private static final Set<ClassLoader> addedClassLoaders =
             Collections.synchronizedSet(new HashSet<ClassLoader>());
 
-    /** Do not allow instantiation of this class. */
-    private GeoTools() {}
+    /**
+     * The bindings between {@linkplain System#getProperties system properties} and a hint key.
+     *
+     * <p>This registry is used by {@link #scanForSystemHints} to evaluate which System properties
+     * are present using this map's keys as System property names and its mapped value to resolve
+     * the System property value the correct value type/
+     */
+    private static final Map<String, RenderingHints.Key> BINDINGS;
+
+    static {
+        Map<String, RenderingHints.Key> bindings = new HashMap<>();
+        bind(ENCODE_WKT, Hints.ENCODE_EWKT, bindings);
+        bind(CRS_AUTHORITY_EXTRA_DIRECTORY, Hints.CRS_AUTHORITY_EXTRA_DIRECTORY, bindings);
+        bind(EPSG_DATA_SOURCE, Hints.EPSG_DATA_SOURCE, bindings);
+        bind(FORCE_LONGITUDE_FIRST_AXIS_ORDER, Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, bindings);
+        bind(ENTITY_RESOLVER, Hints.ENTITY_RESOLVER, bindings);
+        bind(RESAMPLE_TOLERANCE, Hints.RESAMPLE_TOLERANCE, bindings);
+        bind(LOCAL_DATE_TIME_HANDLING, Hints.LOCAL_DATE_TIME_HANDLING, bindings);
+        bind(DATE_TIME_FORMAT_HANDLING, Hints.DATE_TIME_FORMAT_HANDLING, bindings);
+        BINDINGS = Collections.unmodifiableMap(bindings);
+    }
 
     /**
      * Binds the specified {@linkplain System#getProperty(String) system property} to the specified
-     * key. Only one key can be binded to a given system property. However the same key can be
-     * binded to more than one system property names, in which case the extra system property names
-     * are aliases.
+     * key. Only one key can be bound to a given system property. However the same key can be binded
+     * to more than one system property names, in which case the extra system property names are
+     * aliases.
      *
      * @param property The system property.
      * @param key The key to bind to the system property.
+     * @param bindings The target registry mapping System properties to RenderingHints
      * @throws IllegalArgumentException if an other key is already bounds to the given system
      *     property.
      */
-    private static void bind(final String property, final RenderingHints.Key key) {
-        final RenderingHints.Key old = BINDINGS.putIfAbsent(property, key);
+    private static void bind(
+            final String property,
+            final RenderingHints.Key key,
+            Map<String, RenderingHints.Key> bindings) {
+        final RenderingHints.Key old = bindings.putIfAbsent(property, key);
         if (old != null) {
             throw new IllegalArgumentException(
                     Errors.format(ErrorKeys.ILLEGAL_ARGUMENT_$2, "property", property));
         }
     }
+
+    /** Do not allow instantiation of this class. */
+    private GeoTools() {}
 
     /**
      * Returns summary information about GeoTools and the current environment. Calls {@linkplain


### PR DESCRIPTION
`GeoTools.scanForSystemHints()` synchronizes on its static
`BINDINGS` variable, which is only modified during the class'
static initialization. The method is side-effect free and
only mutates the argument object, hence there's no need
to synchronize on this field.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.