### PR TITLE
[GEOT-6507] App-Schema IllegalArgumentException when getting an empty collection on a jdbc multivalue join attribute

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
@@ -1330,11 +1330,12 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
             b.setName(new NameImpl(null, mv.getTargetTable()));
             b.add("id", Object.class);
             b.add("value", Object.class);
-            query.setPropertyNames(mv.getProperties());
+            JoiningQuery jdbcQuery = new JoiningQuery(query);
+            jdbcQuery.setPropertyNames(mv.getProperties());
             SimpleFeatureType featrueType =
                     SimpleFeatureTypeBuilder.retype(
-                            store.getSchema(mv.getTargetTable()), query.getPropertyNames());
-            reader = new JDBCFeatureReader(finalSql.toString(), cx, this, featrueType, query);
+                            store.getSchema(mv.getTargetTable()), jdbcQuery.getPropertyNames());
+            reader = new JDBCFeatureReader(finalSql.toString(), cx, this, featrueType, jdbcQuery);
         } catch (Exception e) {
             // close the connection
             store.closeSafe(cx);

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/DataAccessMappingFeatureIterator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/DataAccessMappingFeatureIterator.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1011,7 +1012,10 @@ public class DataAccessMappingFeatureIterator extends AbstractMappingFeatureIter
         // get the multiple values for the current jdbc multiple values attribute
         Object sourceColumnValue =
                 sourceFeature.getProperty(jdbcMultipleValue.getSourceColumn()).getValue();
-        return candidates.get(sourceColumnValue);
+
+        List<MultiValueContainer> list = candidates.get(sourceColumnValue);
+        // make sure we never return null, instead return an empty list
+        return list != null ? list : Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
App-schema is getting "IllegalArgumentException: Could not find working property accessor for attribute" when it gets an empty collection on a 1..n cardinality attribute (jdbc multivalue).

This issue is replicated using Postgresql and a jdbc configuration following same steps and mappings as Geoserver documentation, but having no items for a root feature multivalue declared element:
https://docs.geoserver.org/stable/en/user/data/app-schema/mapping-file.html#attributes-with-cardinality-1-n

This PR fixes the issue and end to end testing is being added on Geoserver App-Schema tests.

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOT-6507

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.