### PR TITLE
[Backport 22.x][GEOT-6511] PostGIS JDBC does not request Point geometry column in TWKB with prepared statements enabled

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
@@ -311,4 +311,9 @@ public class PostGISPSDialect extends PreparedStatementSQLDialect {
     public void initializeConnection(Connection cx) throws SQLException {
         delegate.initializeConnection(cx);
     }
+
+    @Override
+    public boolean canSimplifyPoints() {
+        return delegate.canSimplifyPoints();
+    }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryPreparedTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryPreparedTest.java
@@ -1,0 +1,30 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ */
+
+package org.geotools.data.postgis;
+
+import org.geotools.data.postgis.ps.PostGISPSTestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+public class PostgisSimplifiedGeometryPreparedTest extends PostgisSimplifiedGeometryTest {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new PostgisSimplifiedGeometryTestSetup(new PostGISPSTestSetup());
+    }
+}


### PR DESCRIPTION


backport of https://github.com/geotools/geotools/pull/2797

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.