### PR TITLE
Css shield placement support

### DIFF
--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
@@ -217,6 +217,7 @@ public class CssTranslator {
                     put("label-polygon-align", TextSymbolizer.POLYGONALIGN_KEY);
                     put("shield-resize", "graphic-resize");
                     put("shield-margin", "graphic-margin");
+                    put("shield-placement", TextSymbolizer.GRAPHIC_PLACEMENT_KEY);
                 }
             };
 

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
@@ -1749,4 +1749,18 @@ public class TranslatorSyntheticTest extends CssBaseTest {
         assertEquals("circle", mark.getWellKnownName().evaluate(null, String.class));
         assertEquals(Color.yellow, mark.getFill().getColor().evaluate(null, Color.class));
     }
+
+    @Test
+    public void labelShieldIndependent() throws Exception {
+        String css =
+                "* { label: 'test'; shield: symbol(square); shield-placement: independent; shield-anchor: 0.5 1} :shield {fill:black}";
+        Style style = translate(css);
+        Rule rule = assertSingleRule(style);
+        TextSymbolizer2 ts = assertSingleSymbolizer(rule, TextSymbolizer2.class);
+        assertLiteral("test", ts.getLabel());
+        assertEquals("independent", ts.getOptions().get(TextSymbolizer.GRAPHIC_PLACEMENT_KEY));
+        Graphic g = ts.getGraphic();
+        assertEquals(0.5, g.getAnchorPoint().getAnchorPointX().evaluate(null, Double.class), 0d);
+        assertEquals(1, g.getAnchorPoint().getAnchorPointY().evaluate(null, Double.class), 0d);
+    }
 }


### PR DESCRIPTION
Follow up on "[GEOT-6446] Allow to place a text symbolizer Graphic at an offset vs its own label"

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.