### PR TITLE
Fix "parent" (should be "paren" for parenthesis)

### DIFF
--- a/modules/library/cql/ECQL.md
+++ b/modules/library/cql/ECQL.md
@@ -37,8 +37,8 @@ is used to describe the grammar.
 
 ```
     <sequence of search conditions> ::=
-                <search condition>
-                   |<sequence of search conditions> <semicolon> <search condition>
+        <search condition>
+        | <sequence of search conditions> <semicolon> <search condition>
 
     <search condition> ::= <boolean value expression>
 ```
@@ -62,7 +62,7 @@ is used to describe the grammar.
 ```
     <boolean primary> ::=
         <predicate>
-        | <left parent> <search condition> <right parent>
+        | <left paren> <search condition> <right paren>
         | <left bracket> <search condition> <right bracket>
 
     <predicate> ::=


### PR DESCRIPTION
The CQL EBNF document appears to have a typo. It says "parent" instead of "paren".


## Checklist


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.