### PR TITLE
[GEOT-6520] GeoPackage store aggregates performance regression

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/AverageVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/AverageVisitor.java
@@ -18,6 +18,7 @@ package org.geotools.feature.visitor;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.IllegalFilterException;
@@ -84,6 +85,20 @@ public class AverageVisitor implements FeatureCalc, FeatureAttributeVisitor {
     @Override
     public List<Expression> getExpressions() {
         return Arrays.asList(expr);
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        if (inputTypes == null || inputTypes.size() != 1)
+            throw new IllegalArgumentException(
+                    "Expecting a single type in input, not " + inputTypes);
+
+        Class type = inputTypes.get(0);
+        if (Number.class.isAssignableFrom(type)) {
+            return Optional.of(inputTypes);
+        }
+        throw new IllegalArgumentException(
+                "The input type for sum must be numeric, instead this was found: " + type);
     }
 
     /**

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/AverageVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/AverageVisitor.java
@@ -17,6 +17,7 @@
 package org.geotools.feature.visitor;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -95,7 +96,7 @@ public class AverageVisitor implements FeatureCalc, FeatureAttributeVisitor {
 
         Class type = inputTypes.get(0);
         if (Number.class.isAssignableFrom(type)) {
-            return Optional.of(inputTypes);
+            return Optional.of(Collections.singletonList(Double.class));
         }
         throw new IllegalArgumentException(
                 "The input type for sum must be numeric, instead this was found: " + type);

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/CalcUtil.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/CalcUtil.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.feature.visitor;
 
+import java.util.List;
+import java.util.Optional;
+
 public class CalcUtil {
 
     /**
@@ -263,5 +266,22 @@ public class CalcUtil {
 
         // now do the comparison
         return val1.compareTo(val2);
+    }
+
+    /**
+     * Utility method for {@link FeatureAttributeVisitor} implementations that are simply returnin
+     * the same type as the inputs
+     *
+     * @param inputTypes
+     * @return
+     */
+    public static Optional<List<Class>> reflectInputTypes(
+            int expectedInputCount, List<Class> inputTypes) {
+        if (inputTypes == null || inputTypes.size() != 1)
+            throw new IllegalArgumentException(
+                    "Expecting " + expectedInputCount + " types in input, but got " + inputTypes);
+
+        // same as the input
+        return Optional.of(inputTypes);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/FeatureAttributeVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/FeatureAttributeVisitor.java
@@ -17,6 +17,7 @@
 package org.geotools.feature.visitor;
 
 import java.util.List;
+import java.util.Optional;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.filter.expression.Expression;
 
@@ -30,4 +31,15 @@ public interface FeatureAttributeVisitor extends FeatureVisitor {
 
     /** List of expressions used by visitor. */
     List<Expression> getExpressions();
+
+    /**
+     * Returns the expected output type given the input type.
+     *
+     * @param inputTypes The type of the input expressions
+     * @throws IllegalArgumentException If the list of input types is not a match for the {@link
+     *     #getExpressions()} result or is not acceptable for this visito
+     */
+    default Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        return Optional.empty();
+    }
 }

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/GroupByVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/GroupByVisitor.java
@@ -353,12 +353,20 @@ public class GroupByVisitor implements FeatureCalc, FeatureAttributeVisitor {
     @Override
     public Optional<List<Class>> getResultType(List<Class> inputTypes) {
         // the set of expressions includes the group by attributes and the actual attribute
-        // being computed onto,
+        // being computed onto
         int expectedInputCount = groupByAttributes.size() + 1;
         if (inputTypes == null || inputTypes.size() != expectedInputCount)
             throw new IllegalArgumentException(
                     "Expecting " + expectedInputCount + " types, get: " + inputTypes);
 
-        return Optional.of(Arrays.asList(inputTypes.get(expectedInputCount - 1)));
+        Class expressionType = inputTypes.get(expectedInputCount - 1);
+        switch (aggregate) {
+            case AVERAGE:
+            case STD_DEV:
+            case SUMAREA:
+                return Optional.of(Arrays.asList(Double.class));
+            default:
+                return Optional.of(Arrays.asList(expressionType));
+        }
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/GroupByVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/GroupByVisitor.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Envelope;
@@ -347,5 +348,17 @@ public class GroupByVisitor implements FeatureCalc, FeatureAttributeVisitor {
         List<Expression> result = new ArrayList<>(groupByAttributes);
         result.add(expression);
         return result;
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        // the set of expressions includes the group by attributes and the actual attribute
+        // being computed onto,
+        int expectedInputCount = groupByAttributes.size() + 1;
+        if (inputTypes == null || inputTypes.size() != expectedInputCount)
+            throw new IllegalArgumentException(
+                    "Expecting " + expectedInputCount + " types, get: " + inputTypes);
+
+        return Optional.of(Arrays.asList(inputTypes.get(expectedInputCount - 1)));
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/MaxVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/MaxVisitor.java
@@ -18,6 +18,7 @@ package org.geotools.feature.visitor;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.IllegalFilterException;
@@ -67,6 +68,11 @@ public class MaxVisitor implements FeatureCalc, FeatureAttributeVisitor {
     @Override
     public List<Expression> getExpressions() {
         return Arrays.asList(expr);
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        return CalcUtil.reflectInputTypes(1, inputTypes);
     }
 
     /**

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/MedianVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/MedianVisitor.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.IllegalFilterException;
@@ -72,6 +73,11 @@ public class MedianVisitor implements FeatureCalc, FeatureAttributeVisitor {
     @Override
     public List<Expression> getExpressions() {
         return Arrays.asList(expr);
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        return CalcUtil.reflectInputTypes(1, inputTypes);
     }
 
     public void visit(SimpleFeature feature) {

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/MinVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/MinVisitor.java
@@ -18,6 +18,7 @@ package org.geotools.feature.visitor;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.IllegalFilterException;
@@ -65,6 +66,11 @@ public class MinVisitor implements FeatureCalc, FeatureAttributeVisitor {
     @Override
     public List<Expression> getExpressions() {
         return Arrays.asList(expr);
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        return CalcUtil.reflectInputTypes(1, inputTypes);
     }
 
     /**

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/NearestVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/NearestVisitor.java
@@ -19,6 +19,7 @@ package org.geotools.feature.visitor;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.geotools.util.Converters;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.type.PropertyDescriptor;
@@ -175,6 +176,11 @@ public class NearestVisitor implements FeatureCalc, FeatureAttributeVisitor {
     @Override
     public List<Expression> getExpressions() {
         return Arrays.asList(expr);
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        return CalcUtil.reflectInputTypes(1, inputTypes);
     }
 
     static interface NearestAccumulator<T> {

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/StandardDeviationVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/StandardDeviationVisitor.java
@@ -17,7 +17,9 @@
 package org.geotools.feature.visitor;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.filter.expression.Expression;
@@ -78,6 +80,15 @@ public class StandardDeviationVisitor implements FeatureCalc, FeatureAttributeVi
     @Override
     public List<Expression> getExpressions() {
         return Arrays.asList(expr);
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        if (inputTypes == null || inputTypes.size() != 1)
+            throw new IllegalArgumentException(
+                    "Expecting a single type in input, not " + inputTypes);
+
+        return Optional.of(Collections.singletonList(Double.class));
     }
 
     public CalcResult getResult() {

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/SumAreaVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/SumAreaVisitor.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.feature.visitor;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.IllegalFilterException;
 import org.opengis.feature.Feature;
@@ -23,6 +26,7 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.expression.Expression;
+import org.opengis.geometry.Geometry;
 
 /**
  * Calculates the Sum of Areas for geometric fields
@@ -57,6 +61,20 @@ public class SumAreaVisitor extends SumVisitor {
 
     public SumAreaVisitor(String attrName, SimpleFeatureType type) throws IllegalFilterException {
         this(factory.property(type.getDescriptor(attrName).getLocalName()));
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        if (inputTypes == null || inputTypes.size() != 1)
+            throw new IllegalArgumentException(
+                    "Expecting a single type in input, not " + inputTypes);
+
+        Class type = inputTypes.get(0);
+        if (Geometry.class.isAssignableFrom(type)) {
+            return Optional.of(Collections.singletonList(Double.class));
+        }
+        throw new IllegalArgumentException(
+                "The input type for sum must be geometric, instead this was found: " + type);
     }
 
     static class SumAreaStrategy implements SumStrategy {

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/SumVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/SumVisitor.java
@@ -18,6 +18,7 @@ package org.geotools.feature.visitor;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.visitor.AverageVisitor.AverageResult;
@@ -73,6 +74,20 @@ public class SumVisitor implements FeatureCalc, FeatureAttributeVisitor {
     @Override
     public List<Expression> getExpressions() {
         return Arrays.asList(expr);
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        if (inputTypes == null || inputTypes.size() != 1)
+            throw new IllegalArgumentException(
+                    "Expecting a single type in input, not " + inputTypes);
+
+        Class type = inputTypes.get(0);
+        if (Number.class.isAssignableFrom(type)) {
+            return Optional.of(inputTypes);
+        }
+        throw new IllegalArgumentException(
+                "The input type for sum must be numeric, instead this was found: " + type);
     }
 
     /**

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/UniqueVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/UniqueVisitor.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
@@ -98,6 +99,11 @@ public class UniqueVisitor implements FeatureCalc, FeatureAttributeVisitor, Limi
     @Override
     public List<Expression> getExpressions() {
         return Arrays.asList(expr);
+    }
+
+    @Override
+    public Optional<List<Class>> getResultType(List<Class> inputTypes) {
+        return CalcUtil.reflectInputTypes(1, inputTypes);
     }
 
     public void visit(SimpleFeature feature) {

--- a/modules/library/main/src/test/java/org/geotools/feature/visitor/VisitorResultTypeTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/visitor/VisitorResultTypeTest.java
@@ -1,0 +1,94 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.feature.visitor;
+
+import java.util.Arrays;
+import java.util.List;
+import org.geotools.data.DataTestCase;
+import org.geotools.data.util.NullProgressListener;
+
+public class VisitorResultTypeTest extends DataTestCase {
+
+    public void testAverageInteger() {
+        AverageVisitor visitor = new AverageVisitor(ff.property("id"));
+        assertEquals(Arrays.asList(Double.class), getResultTypes(visitor, Integer.class));
+    }
+
+    public void testAverageDouble() {
+        AverageVisitor visitor = new AverageVisitor(ff.property("flow"));
+        assertEquals(Arrays.asList(Double.class), getResultTypes(visitor, Double.class));
+    }
+
+    public void testMaxInteger() {
+        MaxVisitor visitor = new MaxVisitor(ff.property("id"));
+        assertEquals(Arrays.asList(Integer.class), getResultTypes(visitor, Integer.class));
+    }
+
+    public void testMaxDouble() {
+        MaxVisitor visitor = new MaxVisitor(ff.property("flow"));
+        assertEquals(Arrays.asList(Double.class), getResultTypes(visitor, Double.class));
+    }
+
+    public void testGroupByAverageInteger() {
+        GroupByVisitor visitor =
+                new GroupByVisitor(
+                        Aggregate.AVERAGE,
+                        ff.property("id"),
+                        Arrays.asList(ff.property("id")),
+                        new NullProgressListener());
+        assertEquals(
+                Arrays.asList(Double.class), getResultTypes(visitor, Integer.class, Integer.class));
+    }
+
+    public void testGroupByAverageDouble() {
+        GroupByVisitor visitor =
+                new GroupByVisitor(
+                        Aggregate.AVERAGE,
+                        ff.property("id"),
+                        Arrays.asList(ff.property("flow")),
+                        new NullProgressListener());
+        assertEquals(
+                Arrays.asList(Double.class), getResultTypes(visitor, Integer.class, Double.class));
+    }
+
+    public void testGroupByMaxInteger() {
+        GroupByVisitor visitor =
+                new GroupByVisitor(
+                        Aggregate.MAX,
+                        ff.property("id"),
+                        Arrays.asList(ff.property("id")),
+                        new NullProgressListener());
+        assertEquals(
+                Arrays.asList(Integer.class),
+                getResultTypes(visitor, Integer.class, Integer.class));
+    }
+
+    public void testGroupByMaxDouble() {
+        GroupByVisitor visitor =
+                new GroupByVisitor(
+                        Aggregate.MAX,
+                        ff.property("id"),
+                        Arrays.asList(ff.property("flow")),
+                        new NullProgressListener());
+        assertEquals(
+                Arrays.asList(Double.class), getResultTypes(visitor, Integer.class, Double.class));
+    }
+
+    private List<Class> getResultTypes(FeatureAttributeVisitor visitor, Class... inputTypes) {
+        return visitor.getResultType(Arrays.asList(inputTypes)).get();
+    }
+}

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
@@ -16,7 +16,11 @@
  */
 package org.geotools.geopkg;
 
-import static org.junit.Assert.*;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
@@ -25,6 +29,7 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFinder;
@@ -32,18 +37,26 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.util.NullProgressListener;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.visitor.Aggregate;
+import org.geotools.feature.visitor.GroupByVisitor;
+import org.geotools.feature.visitor.MaxVisitor;
+import org.geotools.feature.visitor.MinVisitor;
 import org.geotools.feature.visitor.UniqueVisitor;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.test.TestData;
 import org.geotools.util.URLs;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
 
 public class GeoPkgDatetimeTest {
+    private static final NullProgressListener NULL_LISTENER = new NullProgressListener();
     private DataStore gpkg;
 
     /** @throws java.lang.Exception */
@@ -102,10 +115,53 @@ public class GeoPkgDatetimeTest {
         SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
 
         SimpleFeatureCollection features = fs.getFeatures();
-        features.accepts(highlander, new NullProgressListener());
+        features.accepts(highlander, NULL_LISTENER);
 
-        Set<Date> uniqueSet = highlander.getUnique();
+        Set uniqueSet = highlander.getUnique();
         assertEquals(uniqueSet.size(), features.size());
+        for (Object value : uniqueSet) {
+            assertThat(value, CoreMatchers.instanceOf(Date.class));
+        }
+    }
+
+    @Test
+    public void testMax() throws IOException {
+        MaxVisitor max = new MaxVisitor("date");
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+
+        SimpleFeatureCollection features = fs.getFeatures();
+        features.accepts(max, NULL_LISTENER);
+
+        assertEquals(java.sql.Date.valueOf("2020-02-23"), max.getMax());
+    }
+
+    @Test
+    public void testMin() throws IOException {
+        MinVisitor min = new MinVisitor("date");
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+
+        SimpleFeatureCollection features = fs.getFeatures();
+        features.accepts(min, NULL_LISTENER);
+
+        assertEquals(java.sql.Date.valueOf("2020-02-19"), min.getMin());
+    }
+
+    @Test
+    public void testGroupBy() throws IOException {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        GroupByVisitor visitor =
+                new GroupByVisitor(
+                        Aggregate.MAX,
+                        ff.property("date"),
+                        Arrays.asList(ff.property("txt")),
+                        NULL_LISTENER);
+
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+        SimpleFeatureCollection features = fs.getFeatures();
+        features.accepts(visitor, NULL_LISTENER);
+        Map results = (Map) visitor.getResult().toMap();
+        assertEquals(java.sql.Date.valueOf("2020-02-19"), results.get(singletonList("1")));
+        assertEquals(java.sql.Date.valueOf("2020-02-20"), results.get(singletonList("2")));
     }
 
     /**


### PR DESCRIPTION
Follows up https://github.com/geotools/geotools/pull/2811 to restore in-database aggregation.
I've basically followed the suggestion outlined in the previous PR, reporting it here since the comment was marked as "resolved" and it's thus not visible unless one knows where to search.

------------

Thinking out loud here... the visitor does not really know what the type is, because it's determined at runtime evaluating expressions (besides the visitors that only work on a specific type). JDBCDataStore on the other hand [has the aggregateExpression](https://github.com/geotools/geotools/blob/d8d38228e57638927b745f31bc0b5623f48e61b9/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java#L1432), from which one can determine the type of the visitor input by using the ExpressionTypeVisitor. 
Now, that is not enough, many visitors just return the same type as the input, but for example avg and sttdev do not.
It would be easy however to add a default method to FeatureCalc or FeatureAttributeVisitor or to the implementations (getExpression is really not present in FeatureCalc for example, but determined through reflection.. not sure why, since there is FeatureAttributeVisitor that can do the job, probably historical reasons).

```
/**
 * Returns the expected output type given the input type, or null if uknown
Class[] getResultType(Class[] inputs);
*/
```

With that one could do the right type conversion no?

------

I've isolated the changes so that only the dialects that actually need the conversion dance use it, others will just go with the good behavior of the database.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is a ticket in Jira describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
