### PR TITLE
remove comment from grammar

### DIFF
--- a/modules/library/cql/ECQL.md
+++ b/modules/library/cql/ECQL.md
@@ -384,7 +384,7 @@ New Syntax (since 2.7.rc1)
     <vertical bar> ::= |
     <left brace> ::={
     <right brace> ::=}
-    <separator> ::= { <comment> | <space> | <newline> }...
+
     /* The next section of the BNF defines the tokens available to the
        language. I have deleted the concepts of bit string, hex string and
        national character string literal. Keywords have been added to support the


### PR DESCRIPTION
The grammar indicates comments are supported, they are not.