### PR TITLE
[GEOT-6520] GeoPackage store aggregates performance regression - timestamp not properly recognized

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -642,7 +642,7 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
             List<Class> resultTypes = maybeResultTypes.get();
             if (resultTypes.size() == 1) {
                 Class targetType = resultTypes.get(0);
-                if (Date.class.isAssignableFrom(targetType)) {
+                if (java.util.Date.class.isAssignableFrom(targetType)) {
                     return v -> {
                         Object converted = Converters.convert(v, targetType);
                         if (converted == null) {

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
@@ -164,6 +164,22 @@ public class GeoPkgDatetimeTest {
         assertEquals(java.sql.Date.valueOf("2020-02-20"), results.get(singletonList("2")));
     }
 
+    @Test
+    public void testUniqueTimestamp() throws IOException {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        UniqueVisitor visitor =
+                new UniqueVisitor(
+                        "datetime", gpkg.getFeatureSource(gpkg.getTypeNames()[0]).getSchema());
+
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+        SimpleFeatureCollection features = fs.getFeatures();
+        features.accepts(visitor, NULL_LISTENER);
+        List results = visitor.getResult().toList();
+        for (Object result : results) {
+            assertThat(result, CoreMatchers.instanceOf(Timestamp.class));
+        }
+    }
+
     /**
      * Test avoidance of aggregate between filter (as this needed some help to respect date and
      * timestamp)


### PR DESCRIPTION
@davidblasby  this should fix the issue you reported, could you have a look?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
