### PR TITLE
GEOT-6520 - fix geopkg filter and aggregates

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -496,7 +496,9 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
                 ps.setString(column, ((Time) value).toString());
                 break;
             case Types.TIMESTAMP:
-                ps.setString(column, ((Timestamp) value).toString());
+                //2020-02-19 23:00:00.0  --> 2020-02-19 23:00:00.0Z
+                //We need the "Z" or sql lite will interpret the value as local time
+                ps.setString(column, ((Timestamp) value).toString()+"Z");
                 break;
             default:
                 super.setValue(value, binding, ps, column, cx);
@@ -642,7 +644,7 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
             List<Class> resultTypes = maybeResultTypes.get();
             if (resultTypes.size() == 1) {
                 Class targetType = resultTypes.get(0);
-                if (Date.class.isAssignableFrom(targetType)) {
+                if (java.util.Date.class.isAssignableFrom(targetType)) {
                     return v -> {
                         Object converted = Converters.convert(v, targetType);
                         if (converted == null) {

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -496,9 +496,9 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
                 ps.setString(column, ((Time) value).toString());
                 break;
             case Types.TIMESTAMP:
-                //2020-02-19 23:00:00.0  --> 2020-02-19 23:00:00.0Z
-                //We need the "Z" or sql lite will interpret the value as local time
-                ps.setString(column, ((Timestamp) value).toString()+"Z");
+                // 2020-02-19 23:00:00.0  --> 2020-02-19 23:00:00.0Z
+                // We need the "Z" or sql lite will interpret the value as local time
+                ps.setString(column, ((Timestamp) value).toString() + "Z");
                 break;
             default:
                 super.setValue(value, binding, ps, column, cx);

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgFilterToSQL.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgFilterToSQL.java
@@ -49,7 +49,7 @@ public class GeoPkgFilterToSQL extends PreparedFilterToSQL {
      *
      * <p>The encoding of the column name ("time") and the literals must be the same!
      *
-     * <p>datetime("Time",'localtime') BETWEEN datetime(?,'localtime') AND datetime(?,'localtime')
+     * <p>datetime("Time",'utc') BETWEEN datetime(?,'utc') AND datetime(?,'utc')
      *
      * <p>For non-time columns, this just relegates to the superclass
      *
@@ -62,18 +62,18 @@ public class GeoPkgFilterToSQL extends PreparedFilterToSQL {
         // desc might be null in the case of joins et al
         if ((desc != null) && (desc.getType().getBinding() != null)) {
             Class<?> binding = desc.getType().getBinding();
-            // localtime -- everything must be consistent -- see literal visitor
+            // utc -- everything must be consistent -- see literal visitor
             if (Time.class.isAssignableFrom(binding)) {
-                return "time(" + super_result + ",'localtime')";
+                return "time(" + super_result + ",'utc')";
             } else if (Timestamp.class.isAssignableFrom(binding)) {
                 return "datetime("
                         + super_result
-                        + ",'localtime')"; // localtime -- everything must be consistent -- see
+                        + ",'utc')"; // utc -- everything must be consistent -- see
                 // literal visitor
             } else if (java.sql.Date.class.isAssignableFrom(binding)) {
                 return "date("
                         + super_result
-                        + ",'localtime')"; // localtime -- everything must be consistent -- see
+                        + ",'utc')"; // utc -- everything must be consistent -- see
                 // literal visitor
             }
         }
@@ -142,11 +142,11 @@ public class GeoPkgFilterToSQL extends PreparedFilterToSQL {
                     dialect.prepareGeometryValue(
                             (Geometry) literalValue, dimension, srid, Geometry.class, sb);
                 } else if (Time.class.isAssignableFrom(literalValue.getClass())) {
-                    sb.append("time(?,'localtime')");
+                    sb.append("time(?,'utc')");
                 } else if (Timestamp.class.isAssignableFrom(literalValue.getClass())) {
-                    sb.append("datetime(?,'localtime')");
+                    sb.append("datetime(?,'utc')");
                 } else if (java.sql.Date.class.isAssignableFrom(literalValue.getClass())) {
-                    sb.append("date(?,'localtime')");
+                    sb.append("date(?,'utc')");
                 } else if (encodingFunction) {
                     dialect.prepareFunctionArgument(clazz, sb);
                 } else {

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
@@ -127,6 +127,7 @@ public class GeoPkgDatetimeTest {
     /**
      * Tests attribute "time" (timestamp) as is used by LIST in WMS time dimension GetCapabilities
      * CF. testUnique()
+     *
      * @throws IOException
      */
     @Test
@@ -143,7 +144,6 @@ public class GeoPkgDatetimeTest {
             assertThat(value, CoreMatchers.instanceOf(java.sql.Timestamp.class));
         }
     }
-
 
     @Test
     public void testMax() throws IOException {
@@ -166,7 +166,6 @@ public class GeoPkgDatetimeTest {
 
         assertEquals(java.sql.Timestamp.valueOf("2020-03-19 01:00:00"), max.getMax());
     }
-
 
     @Test
     public void testMin() throws IOException {
@@ -223,13 +222,23 @@ public class GeoPkgDatetimeTest {
         features.accepts(visitor, NULL_LISTENER);
         Map results = (Map) visitor.getResult().toMap();
 
-        assertEquals(5,results.size());
+        assertEquals(5, results.size());
 
-        assertEquals(java.sql.Timestamp.valueOf("2020-02-19 22:00:00.0"), results.get(singletonList("1")));
-        assertEquals(java.sql.Timestamp.valueOf("2020-02-19 23:00:00.0"), results.get(singletonList("2")));
-        assertEquals(java.sql.Timestamp.valueOf("2020-03-19 00:00:00.0"), results.get(singletonList("3")));
-        assertEquals(java.sql.Timestamp.valueOf("2020-03-19 01:00:00.0"), results.get(singletonList("4")));
-        assertEquals(java.sql.Timestamp.valueOf("2020-02-20 02:00:00.0"), results.get(singletonList("5")));
+        assertEquals(
+                java.sql.Timestamp.valueOf("2020-02-19 22:00:00.0"),
+                results.get(singletonList("1")));
+        assertEquals(
+                java.sql.Timestamp.valueOf("2020-02-19 23:00:00.0"),
+                results.get(singletonList("2")));
+        assertEquals(
+                java.sql.Timestamp.valueOf("2020-03-19 00:00:00.0"),
+                results.get(singletonList("3")));
+        assertEquals(
+                java.sql.Timestamp.valueOf("2020-03-19 01:00:00.0"),
+                results.get(singletonList("4")));
+        assertEquals(
+                java.sql.Timestamp.valueOf("2020-02-20 02:00:00.0"),
+                results.get(singletonList("5")));
     }
 
     /**
@@ -249,7 +258,8 @@ public class GeoPkgDatetimeTest {
 
     @Test
     public void testBetween_timestamp() throws IOException, CQLException {
-        Filter between = ECQL.toFilter("time BETWEEN '2020-02-19 23:00:00' AND '2020-03-19 00:00:00'");
+        Filter between =
+                ECQL.toFilter("time BETWEEN '2020-02-19 23:00:00' AND '2020-03-19 00:00:00'");
 
         SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
         SimpleFeatureCollection features = fs.getFeatures(between);

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
@@ -124,6 +124,27 @@ public class GeoPkgDatetimeTest {
         }
     }
 
+    /**
+     * Tests attribute "time" (timestamp) as is used by LIST in WMS time dimension GetCapabilities
+     * CF. testUnique()
+     * @throws IOException
+     */
+    @Test
+    public void testUnique_timestamp() throws IOException {
+        UniqueVisitor highlander = new UniqueVisitor("time");
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+
+        SimpleFeatureCollection features = fs.getFeatures();
+        features.accepts(highlander, NULL_LISTENER);
+
+        Set uniqueSet = highlander.getUnique();
+        assertEquals(uniqueSet.size(), features.size());
+        for (Object value : uniqueSet) {
+            assertThat(value, CoreMatchers.instanceOf(java.sql.Timestamp.class));
+        }
+    }
+
+
     @Test
     public void testMax() throws IOException {
         MaxVisitor max = new MaxVisitor("date");
@@ -136,6 +157,18 @@ public class GeoPkgDatetimeTest {
     }
 
     @Test
+    public void testMax_timestamp() throws IOException {
+        MaxVisitor max = new MaxVisitor("time");
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+
+        SimpleFeatureCollection features = fs.getFeatures();
+        features.accepts(max, NULL_LISTENER);
+
+        assertEquals(java.sql.Timestamp.valueOf("2020-03-19 01:00:00"), max.getMax());
+    }
+
+
+    @Test
     public void testMin() throws IOException {
         MinVisitor min = new MinVisitor("date");
         SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
@@ -144,6 +177,17 @@ public class GeoPkgDatetimeTest {
         features.accepts(min, NULL_LISTENER);
 
         assertEquals(java.sql.Date.valueOf("2020-02-19"), min.getMin());
+    }
+
+    @Test
+    public void testMin_timestamp() throws IOException {
+        MinVisitor min = new MinVisitor("time");
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+
+        SimpleFeatureCollection features = fs.getFeatures();
+        features.accepts(min, NULL_LISTENER);
+
+        assertEquals(java.sql.Timestamp.valueOf("2020-02-19 22:00:00"), min.getMin());
     }
 
     @Test
@@ -164,6 +208,30 @@ public class GeoPkgDatetimeTest {
         assertEquals(java.sql.Date.valueOf("2020-02-20"), results.get(singletonList("2")));
     }
 
+    @Test
+    public void testGroupBy_timestamp() throws IOException {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        GroupByVisitor visitor =
+                new GroupByVisitor(
+                        Aggregate.MAX,
+                        ff.property("time"),
+                        Arrays.asList(ff.property("txt")),
+                        NULL_LISTENER);
+
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+        SimpleFeatureCollection features = fs.getFeatures();
+        features.accepts(visitor, NULL_LISTENER);
+        Map results = (Map) visitor.getResult().toMap();
+
+        assertEquals(5,results.size());
+
+        assertEquals(java.sql.Timestamp.valueOf("2020-02-19 22:00:00.0"), results.get(singletonList("1")));
+        assertEquals(java.sql.Timestamp.valueOf("2020-02-19 23:00:00.0"), results.get(singletonList("2")));
+        assertEquals(java.sql.Timestamp.valueOf("2020-03-19 00:00:00.0"), results.get(singletonList("3")));
+        assertEquals(java.sql.Timestamp.valueOf("2020-03-19 01:00:00.0"), results.get(singletonList("4")));
+        assertEquals(java.sql.Timestamp.valueOf("2020-02-20 02:00:00.0"), results.get(singletonList("5")));
+    }
+
     /**
      * Test avoidance of aggregate between filter (as this needed some help to respect date and
      * timestamp)
@@ -173,6 +241,15 @@ public class GeoPkgDatetimeTest {
     @Test
     public void testBetween() throws IOException, CQLException {
         Filter between = ECQL.toFilter("date BETWEEN '2020-02-20' AND '2020-02-22'");
+
+        SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
+        SimpleFeatureCollection features = fs.getFeatures(between);
+        assertEquals(3, features.size());
+    }
+
+    @Test
+    public void testBetween_timestamp() throws IOException, CQLException {
+        Filter between = ECQL.toFilter("time BETWEEN '2020-02-19 23:00:00' AND '2020-03-19 00:00:00'");
 
         SimpleFeatureSource fs = gpkg.getFeatureSource(gpkg.getTypeNames()[0]);
         SimpleFeatureCollection features = fs.getFeatures(between);


### PR DESCRIPTION
When testing andrea's PR (https://github.com/geotools/geotools/pull/2822 - with a TIME dimension enabled geopkg in WMS getcap), I noticed a few problems, and made some fixes;

a) GeoPkgDialect.java -- it was using sql.Date instead of util.Date to determine if needed to do a conversion

b) I added timestamp-related test cases to GeoPkgDatetimeTest.java

c) When looking at the date test cases in a timezone that is negative (i.e. GMT-8 PST) that I was getting incorrect results.  In GMT or a +ive offset timezone (europe) it works.  This had to so with how geotools/sql lite interpret dates local-timezone vs UTC
    * use "utc" instead of "localtime" in GeoPkgFilterToSQL.java (sql lite "datetime" function)   

d) When adding testBetween_timestamp() test case, I noticed that sql lite was not doing "as expected."  I switched so that it was doing everything in UTC.  This meant a change;
         * add "Z" to end of timestamp literals (or sql lite's "datetime" function will interpret it as local time)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
     * covered by GeoCAT  CLA
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.
    N/A

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
