### PR TITLE
[GEOT-6520] better handling of timezones in geopkg date columns

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgFilterToSQL.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgFilterToSQL.java
@@ -71,10 +71,7 @@ public class GeoPkgFilterToSQL extends PreparedFilterToSQL {
                         + ",'utc')"; // utc -- everything must be consistent -- see
                 // literal visitor
             } else if (java.sql.Date.class.isAssignableFrom(binding)) {
-                return "date("
-                        + super_result
-                        + ",'utc')"; // utc -- everything must be consistent -- see
-                // literal visitor
+                return "date(" + super_result + ")";
             }
         }
         return super_result;
@@ -146,7 +143,7 @@ public class GeoPkgFilterToSQL extends PreparedFilterToSQL {
                 } else if (Timestamp.class.isAssignableFrom(literalValue.getClass())) {
                     sb.append("datetime(?,'utc')");
                 } else if (java.sql.Date.class.isAssignableFrom(literalValue.getClass())) {
-                    sb.append("date(?,'utc')");
+                    sb.append("date(?)");
                 } else if (encodingFunction) {
                     dialect.prepareFunctionArgument(clazz, sb);
                 } else {

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgFilterToSQL.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgFilterToSQL.java
@@ -49,7 +49,15 @@ public class GeoPkgFilterToSQL extends PreparedFilterToSQL {
      *
      * <p>The encoding of the column name ("time") and the literals must be the same!
      *
+     * <p>There is different handling for Date (DATE) and Timestamp (DATETIME).
+     *
+     * <p>For Timestamp (DATETIME), we use the datetime(XYZ, 'utc'):
+     *
      * <p>datetime("Time",'utc') BETWEEN datetime(?,'utc') AND datetime(?,'utc')
+     *
+     * <p>For Date (DATE), we do no conversion in the sql lite:
+     *
+     * <p>datetime("Date") BETWEEN datetime(?) AND datetime(?)
      *
      * <p>For non-time columns, this just relegates to the superclass
      *

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
@@ -26,11 +26,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFinder;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -142,6 +138,27 @@ public class GeoPkgDatetimeTest {
         assertEquals(uniqueSet.size(), features.size());
         for (Object value : uniqueSet) {
             assertThat(value, CoreMatchers.instanceOf(java.sql.Timestamp.class));
+        }
+    }
+
+    // messes with the timezone to do testing in different timezones
+    // Noticed that people in different timezones had different results
+    // So, this tests 3 different timezone a negative TZ, UTC, and a positive TZ
+    @Test
+    public void testMax_Timezone() throws IOException {
+        TimeZone originalTZ = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("EST")); // UTC-5
+            testMax();
+            testMax_timestamp();
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT")); // UTC
+            testMax();
+            testMax_timestamp();
+            TimeZone.setDefault(TimeZone.getTimeZone("CET")); // UTC+1
+            testMax();
+            testMax_timestamp();
+        } finally {
+            TimeZone.setDefault(originalTZ);
         }
     }
 


### PR DESCRIPTION
The date columns were being handles a bit incorrectly - it has to do with how Java and geopkg deal with dates and local timezones.

The fix was to NOT convert the dates (no changes for timestamps);

old old method: SELECT ... datetime(date,'localtime')
old method:  SELECT ... datetime(date,'utc')
new method: SELECT ... datetime(date) -- no conversion info

I also put in a timezone test that messes with the java timezone to help make sure this problem doesn't come back.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
      covered by GEOCAT CLA
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in GEOT-6520
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.
   NA

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
