### PR TITLE
[GEOT-6538] GeoJson module closes input writers

### DIFF
--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/GeoJSONUtil.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/GeoJSONUtil.java
@@ -119,6 +119,7 @@ public class GeoJSONUtil {
         if (output instanceof OutputStreamWriter) {
             return new Writer() {
                 Writer writer = new BufferedWriter((Writer) output);
+
                 @Override
                 public void write(char[] cbuf, int off, int len) throws IOException {
                     writer.write(cbuf, off, len);
@@ -130,7 +131,7 @@ public class GeoJSONUtil {
                 }
 
                 @Override
-                public void close() throws IOException { }
+                public void close() throws IOException {}
             };
         }
 

--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/GeoJSONUtil.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/GeoJSONUtil.java
@@ -115,6 +115,25 @@ public class GeoJSONUtil {
      * @return A writer.
      */
     public static Writer toWriter(Object output) throws IOException {
+        // If the user passed in an OutputStreamWriter, we'll trust them to close it themselves.
+        if (output instanceof OutputStreamWriter) {
+            return new Writer() {
+                Writer writer = new BufferedWriter((Writer) output);
+                @Override
+                public void write(char[] cbuf, int off, int len) throws IOException {
+                    writer.write(cbuf, off, len);
+                }
+
+                @Override
+                public void flush() throws IOException {
+                    writer.flush();
+                }
+
+                @Override
+                public void close() throws IOException { }
+            };
+        }
+
         if (output instanceof BufferedWriter) {
             return (BufferedWriter) output;
         }

--- a/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
+++ b/modules/unsupported/geojson/src/test/java/org/geotools/geojson/FeatureJSONTest.java
@@ -17,6 +17,8 @@
 package org.geotools.geojson;
 
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.util.List;
 import org.geotools.data.DataUtilities;
@@ -95,6 +97,22 @@ public class FeatureJSONTest extends GeoJSONTestSupport {
         fjson.writeFeature(featureArray(1), writer);
 
         assertEquals(strip(featureArrayText(1, false, false)), strip(writer.toString()));
+    }
+
+    public void testMultipleFeatureArrayWritesWithOutputStreamWriter() throws Exception {
+        OutputStream outputStream = new ByteArrayOutputStream();
+        OutputStreamWriter writer = new OutputStreamWriter(outputStream);
+        fjson.writeFeature(featureArray(1), writer);
+        writer.write(",");
+        fjson.writeFeature(featureArray(2), writer);
+        writer.flush();
+        writer.close();
+
+        assertEquals(
+                strip(featureArrayText(1, false, false))
+                        .concat(",")
+                        .concat(strip(featureArrayText(2, false, false))),
+                strip(outputStream.toString()));
     }
 
     public void testWriteReadNoProperties() throws Exception {


### PR DESCRIPTION
Signed-off-by: Jim Hughes <jnh5y@ccri.com>

This PR adds a wrapper around OutputStreamWriters so that they are not closed.  This allows clients to manage their own writers better.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [X] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
