### PR TITLE
[GEOT-6533] Selection of source matrixset when cascading WMTS layers does not take into account Longitudefirst CRSs

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
@@ -102,7 +102,10 @@ public class WMTSCapabilities extends Capabilities {
     public WMTSCapabilities(CapabilitiesType capabilities) throws ServiceException {
         caps = capabilities;
         setService(new WMTSService(caps.getServiceIdentification(), caps.getServiceProvider()));
-        setVersion(caps.getServiceIdentification().getServiceTypeVersion().toString());
+
+        if (caps.getServiceIdentification() != null) {
+            setVersion(caps.getServiceIdentification().getServiceTypeVersion().toString());
+        }
         ContentsType contents = caps.getContents();
 
         // Parse layers

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
@@ -102,10 +102,7 @@ public class WMTSCapabilities extends Capabilities {
     public WMTSCapabilities(CapabilitiesType capabilities) throws ServiceException {
         caps = capabilities;
         setService(new WMTSService(caps.getServiceIdentification(), caps.getServiceProvider()));
-
-        if (caps.getServiceIdentification() != null) {
-            setVersion(caps.getServiceIdentification().getServiceTypeVersion().toString());
-        }
+        setVersion(caps.getServiceIdentification().getServiceTypeVersion().toString());
         ContentsType contents = caps.getContents();
 
         // Parse layers

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -354,10 +354,10 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
         // See if the layer supports the requested SRS. Matching against the SRS rather than the
         // full CRS will avoid missing matches due to Longitude first being set on the request
         // CRS and therefore minimise transformations that need to be performed on the received tile
+        String requestSRS = CRS.toSRS(requestCRS);
         for (TileMatrixSet matrixSet : capabilities.getMatrixSets()) {
 
             CoordinateReferenceSystem matrixCRS = matrixSet.getCoordinateReferenceSystem();
-            String requestSRS = CRS.toSRS(requestCRS);
             String matrixSRS = CRS.toSRS(matrixCRS);
             if (requestSRS.equals(matrixSRS)) { // matching SRS
                 if (links.containsKey((matrixSet.getIdentifier()))) { // and available for

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -351,12 +351,15 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
             }
         }
 
-        // If the layer provides the requested CRS, use it
+        // See if the layer supports the requested SRS. Matching against the SRS rather than the
+        // full CRS will avoid missing matches due to Longitude first being set on the request
+        // CRS and therefore minimise transformations that need to be performed on the received tile
         for (TileMatrixSet matrixSet : capabilities.getMatrixSets()) {
 
             CoordinateReferenceSystem matrixCRS = matrixSet.getCoordinateReferenceSystem();
-
-            if (CRS.equalsIgnoreMetadata(requestCRS, matrixCRS)) { // matching SRS
+            String requestSRS = CRS.toSRS(requestCRS);
+            String matrixSRS = CRS.toSRS(matrixCRS);
+            if (requestSRS.equals(matrixSRS)) { // matching SRS
                 if (links.containsKey((matrixSet.getIdentifier()))) { // and available for
                     // this layer
                     if (LOGGER.isLoggable(Level.FINE)) {

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
@@ -19,7 +19,6 @@ package org.geotools.ows.wmts;
 import static junit.framework.TestCase.*;
 import static org.geotools.ows.wmts.WMTSTestUtils.createCapabilities;
 
-import java.io.PrintStream;
 import java.util.Set;
 import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -34,8 +33,6 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /** @author Emanuele Tajariol (etj at geo-solutions dot it) */
 public class WebMapTileServerTest {
-
-    private static PrintStream out = System.out;
 
     @Test
     public void nasaGetEnvelopeTest() throws Exception {
@@ -112,7 +109,6 @@ public class WebMapTileServerTest {
         tileRequest1.setRequestedWidth(1024);
         Set<Tile> receivedTiles = tileRequest1.getTiles();
         assertTrue(receivedTiles.size() > 0);
-        out.println("Checking received tile CRSs for requested CRS of EPSG:4326");
         for (Tile t : receivedTiles) {
 
             String recvdTileCRS =
@@ -121,7 +117,7 @@ public class WebMapTileServerTest {
                             .getIdentifiers()
                             .toArray()[0]
                             .toString();
-            out.println(recvdTileCRS);
+
             assertEquals("EPSG:25831", recvdTileCRS);
         }
 
@@ -135,7 +131,6 @@ public class WebMapTileServerTest {
         tileRequest2.setRequestedWidth(1024);
         Set<Tile> receivedTiles2 = tileRequest2.getTiles();
         assertTrue(receivedTiles2.size() > 0);
-        out.println("Checking received tile CRSs for requested CRS of EPSG:3857");
         for (Tile t : receivedTiles2) {
             String recvdTileCRS =
                     t.getExtent()
@@ -143,7 +138,7 @@ public class WebMapTileServerTest {
                             .getIdentifiers()
                             .toArray()[0]
                             .toString();
-            out.println(recvdTileCRS);
+
             assertEquals("EPSG:3857", recvdTileCRS);
         }
 
@@ -156,7 +151,6 @@ public class WebMapTileServerTest {
         tileRequest3.setRequestedWidth(1024);
         Set<Tile> receivedTiles3 = tileRequest3.getTiles();
         assertTrue(receivedTiles3.size() > 0);
-        out.println("Checking received tile CRSs for requested CRS of EPSG:3857 Longitude first");
         for (Tile t : receivedTiles3) {
             String recvdTileCRS =
                     t.getExtent()
@@ -164,7 +158,7 @@ public class WebMapTileServerTest {
                             .getIdentifiers()
                             .toArray()[0]
                             .toString();
-            out.println(recvdTileCRS);
+
             assertEquals("EPSG:3857", recvdTileCRS);
         }
     }

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
@@ -16,20 +16,26 @@
  */
 package org.geotools.ows.wmts;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.*;
 import static org.geotools.ows.wmts.WMTSTestUtils.createCapabilities;
 
+import java.io.PrintStream;
+import java.util.Set;
 import org.geotools.geometry.GeneralEnvelope;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.ows.wms.Layer;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
+import org.geotools.ows.wmts.model.WMTSLayer;
+import org.geotools.ows.wmts.request.GetTileRequest;
 import org.geotools.referencing.CRS;
+import org.geotools.tile.Tile;
 import org.junit.Test;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /** @author Emanuele Tajariol (etj at geo-solutions dot it) */
 public class WebMapTileServerTest {
+
+    private static PrintStream out = System.out;
 
     @Test
     public void nasaGetEnvelopeTest() throws Exception {
@@ -87,5 +93,85 @@ public class WebMapTileServerTest {
         assertEquals(5.140242, envelope.getMinimum(0), 0.0001);
         assertEquals(48.230651, envelope.getMaximum(1), 0.0001);
         assertEquals(11.47757, envelope.getMaximum(0), 0.0001);
+    }
+
+    @Test
+    public void testMapRequestCRS() throws Exception {
+
+        WebMapTileServer server = createServer("geodata.nationaalgeoregister.nl.xml");
+        WMTSLayer layer = server.getCapabilities().getLayer("brtachtergrondkaartwater");
+        ReferencedEnvelope bbox = new ReferencedEnvelope(51, 53, 4, 6, CRS.decode("EPSG:4326"));
+
+        // Try with a CRS that doesn't exist in the layer and expect the first CRS supported by the
+        // layer
+        GetTileRequest tileRequest1 = server.createGetTileRequest();
+        tileRequest1.setLayer(layer);
+        tileRequest1.setCRS(CRS.decode("EPSG:4326"));
+        tileRequest1.setRequestedBBox(bbox);
+        tileRequest1.setRequestedHeight(768);
+        tileRequest1.setRequestedWidth(1024);
+        Set<Tile> receivedTiles = tileRequest1.getTiles();
+        assertTrue(receivedTiles.size() > 0);
+        out.println("Checking received tile CRSs for requested CRS of EPSG:4326");
+        for (Tile t : receivedTiles) {
+
+            String recvdTileCRS =
+                    t.getExtent()
+                            .getCoordinateReferenceSystem()
+                            .getIdentifiers()
+                            .toArray()[0]
+                            .toString();
+            out.println(recvdTileCRS);
+            assertEquals("EPSG:25831", recvdTileCRS);
+        }
+
+        // Now try with a specific  CRS that isn't the first one declared for the layer and expect
+        // that one
+        GetTileRequest tileRequest2 = server.createGetTileRequest();
+        tileRequest2.setLayer(layer);
+        tileRequest2.setCRS(CRS.decode("EPSG:3857"));
+        tileRequest2.setRequestedBBox(bbox);
+        tileRequest2.setRequestedHeight(768);
+        tileRequest2.setRequestedWidth(1024);
+        Set<Tile> receivedTiles2 = tileRequest2.getTiles();
+        assertTrue(receivedTiles2.size() > 0);
+        out.println("Checking received tile CRSs for requested CRS of EPSG:3857");
+        for (Tile t : receivedTiles2) {
+            String recvdTileCRS =
+                    t.getExtent()
+                            .getCoordinateReferenceSystem()
+                            .getIdentifiers()
+                            .toArray()[0]
+                            .toString();
+            out.println(recvdTileCRS);
+            assertEquals("EPSG:3857", recvdTileCRS);
+        }
+
+        // Now try with a CRS that exists but is in longitude first format
+        GetTileRequest tileRequest3 = server.createGetTileRequest();
+        tileRequest3.setLayer(layer);
+        tileRequest3.setCRS(CRS.decode("EPSG:3857", true));
+        tileRequest3.setRequestedBBox(bbox);
+        tileRequest3.setRequestedHeight(768);
+        tileRequest3.setRequestedWidth(1024);
+        Set<Tile> receivedTiles3 = tileRequest3.getTiles();
+        assertTrue(receivedTiles3.size() > 0);
+        out.println("Checking received tile CRSs for requested CRS of EPSG:3857 Longitude first");
+        for (Tile t : receivedTiles3) {
+            String recvdTileCRS =
+                    t.getExtent()
+                            .getCoordinateReferenceSystem()
+                            .getIdentifiers()
+                            .toArray()[0]
+                            .toString();
+            out.println(recvdTileCRS);
+            assertEquals("EPSG:3857", recvdTileCRS);
+        }
+    }
+
+    private WebMapTileServer createServer(String resourceName) throws Exception {
+
+        WMTSCapabilities capa = createCapabilities(resourceName);
+        return new WebMapTileServer(capa);
     }
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/AbstractIdentifiedObject.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/AbstractIdentifiedObject.java
@@ -896,13 +896,13 @@ public class AbstractIdentifiedObject extends Formattable
      *
      * <p>Some subclasses (especially {@link org.geotools.referencing.datum.AbstractDatum} and
      * {@link org.geotools.parameter.AbstractParameterDescriptor}) will test for the {@linkplain
-     * #getName() name}, since objects with different name have completly different meaning. For
+     * #getName() name}, since objects with different name have completely different meaning. For
      * example nothing differentiate the {@code "semi_major"} and {@code "semi_minor"} parameters
-     * except the name. The name comparaison may be loose however, i.e. we may accept a name
-     * matching an alias.
+     * except the name. The name comparison may be loose however, i.e. we may accept a name matching
+     * an alias.
      *
      * @param object The object to compare to {@code this}.
-     * @param compareMetadata {@code true} for performing a strict comparaison, or {@code false} for
+     * @param compareMetadata {@code true} for performing a strict comparison, or {@code false} for
      *     comparing only properties relevant to transformations.
      * @return {@code true} if both objects are equal.
      */

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/DirectEpsgFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/DirectEpsgFactory.java
@@ -482,7 +482,7 @@ public abstract class DirectEpsgFactory extends DirectAuthorityFactory
     /**
      * The buffered authority factory, or {@code this} if none. This field is set to a different
      * value by {@link ThreadedEpsgFactory} only, which will point toward a buffered factory
-     * wrapping this {@code DirectEpsgFactory} for efficienty.
+     * wrapping this {@code DirectEpsgFactory} for efficiency.
      */
     AbstractAuthorityFactory buffered = this;
 

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
@@ -409,7 +409,7 @@ public final class RendererUtilities {
         // Compute the distances on the requested image using the provided DPI.
         //
         // //
-        // pythagorus theorm
+        // pythagoras theorem
         double diagonalPixelDistancePixels =
                 Math.sqrt(imageWidth * imageWidth + imageHeight * imageHeight);
         double diagonalPixelDistanceMeters =


### PR DESCRIPTION
- Changed the way in which the source matrixset is selected so that it compares the request SRS and the matrixset SRS names rather than comparing the whole CRS. This will reduce the amount of transformation that will be needed when the tiles are returned
- Added unit tests to verify that the changes work as expected
- Some spelling corrections

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 

- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [X] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
