### PR TITLE
[GEOT-6546] fix for java.lang.NoSuchMethodError: java.nio.ByteBuffer.clear()Ljava…

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/NIOUtilities.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/NIOUtilities.java
@@ -17,6 +17,7 @@
 package org.geotools.util;
 
 import java.lang.reflect.Method;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.AccessController;
@@ -116,7 +117,7 @@ public final class NIOUtilities {
             }
             // clean up the buffer and return it
             if (buffer != null) {
-                buffer.clear();
+                ((Buffer) buffer).clear();
                 return buffer;
             }
         }
@@ -243,7 +244,7 @@ public final class NIOUtilities {
 
         // clean up the buffer -> we need to zero out its contents as if it was just
         // created or some shapefile tests will start failing
-        buffer.clear();
+        ((Buffer) buffer).clear();
         buffer.order(ByteOrder.BIG_ENDIAN);
 
         // set the buffer back in the cache, either as a soft reference or as


### PR DESCRIPTION
…/nio/ByteBuffer;

I'm seeing java.lang.NoSuchMethodError: java.nio.ByteBuffer.clear()Ljava/nio/ByteBuffer; errors when reading shapefiles on master. Apparently this is seen if you compile with Java 9 but run with Java 8, though I don't have Java 9 installed so I suspect someone backported something into Java 8? 

openjdk version "1.8.0_242"
OpenJDK Runtime Environment (build 1.8.0_242-8u242-b08-0ubuntu3~19.10-b08)
OpenJDK 64-Bit Server VM (build 25.242-b08, mixed mode)

This fixes the issue and probably can't cause any harm to include?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
