### PR TITLE
Change build_release to carefully build maven plugins single threaded

### DIFF
--- a/build/release/build_release.sh
+++ b/build/release/build_release.sh
@@ -139,11 +139,17 @@ ant -f rename.xml -Drelease=$tag -Dseries=$series
 popd > /dev/null
 
 # build the release
-
 if [ "$SKIP_BUILD" != true ]; then
-  echo "building release"
   export MAVEN_OPTS="-Xmx2048m"
-  mvn $MAVEN_FLAGS -DskipTests -Dall clean -Pcollect install
+  echo "building release: clean"
+  mvn $MAVEN_FLAGS -Dall clean
+  echo "building release: maven plugins"
+  pushd build
+  mvn $MAVEN_FLAGS -DskipTests -Dall install -T1
+  popd > /dev/null
+  echo "building release: full build"
+  mvn $MAVEN_FLAGS -DskipTests -Dall -Pcollect install
+  echo "building release: assemble artifacts"
   mvn $MAVEN_FLAGS -DskipTests assembly:assembly
 fi
 


### PR DESCRIPTION
## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
