### PR TITLE
[GEOT-6565] GeoPackage spatial index creation fails with particular feature type names

### DIFF
--- a/modules/plugin/geopkg/src/main/resources/org/geotools/geopkg/gpkg_spatial_index.sql
+++ b/modules/plugin/geopkg/src/main/resources/org/geotools/geopkg/gpkg_spatial_index.sql
@@ -1,43 +1,43 @@
-CREATE VIRTUAL TABLE rtree_${t}_${c} USING rtree(id, minx, maxx, miny, maxy);
+CREATE VIRTUAL TABLE "rtree_${t}_${c}" USING rtree(id, minx, maxx, miny, maxy);
 
-INSERT OR REPLACE INTO rtree_${t}_${c}
-  SELECT ${i}, ST_MinX(${c}), ST_MaxX(${c}), ST_MinY(${c}), ST_MaxY(${c}) FROM ${t}
-  WHERE NOT ST_IsEmpty(${c});
+INSERT OR REPLACE INTO "rtree_${t}_${c}"
+  SELECT "${i}", ST_MinX("${c}"), ST_MaxX("${c}"), ST_MinY("${c}"), ST_MaxY("${c}") FROM "${t}"
+  WHERE NOT ST_IsEmpty("${c}");
 
 -- Conditions: Insertion of non-empty geometry
 --   Actions   : Insert record into rtree 
-CREATE TRIGGER rtree_${t}_${c}_insert AFTER INSERT ON ${t}
-  WHEN (new.${c} NOT NULL AND NOT ST_IsEmpty(NEW.${c}))
+CREATE TRIGGER "rtree_${t}_${c}_insert" AFTER INSERT ON "${t}"
+  WHEN (NEW."${c}" NOT NULL AND NOT ST_IsEmpty(NEW."${c}"))
 BEGIN
-  INSERT OR REPLACE INTO rtree_${t}_${c} VALUES (
-    NEW.${i},
-    ST_MinX(NEW.${c}), ST_MaxX(NEW.${c}),
-    ST_MinY(NEW.${c}), ST_MaxY(NEW.${c})
+  INSERT OR REPLACE INTO "rtree_${t}_${c}" VALUES (
+    NEW."${i}",
+    ST_MinX(NEW."${c}"), ST_MaxX(NEW."${c}"),
+    ST_MinY(NEW."${c}"), ST_MaxY(NEW."${c}")
   );
 END;
 
 -- Conditions: Update of geometry column to non-empty geometry
 --               No row ID change
 --   Actions   : Update record in rtree 
-CREATE TRIGGER rtree_${t}_${c}_update1 AFTER UPDATE OF ${c} ON ${t}
-  WHEN OLD.${i} = NEW.${i} AND
-       (NEW.${c} NOTNULL AND NOT ST_IsEmpty(NEW.${c}))
+CREATE TRIGGER "rtree_${t}_${c}_update1" AFTER UPDATE OF "${c}" ON "${t}"
+  WHEN OLD."${i}" = NEW."${i}" AND
+       (NEW."${c}" NOTNULL AND NOT ST_IsEmpty(NEW."${c}"))
 BEGIN
-  INSERT OR REPLACE INTO rtree_${t}_${c} VALUES (
-    NEW.${i},
-    ST_MinX(NEW.${c}), ST_MaxX(NEW.${c}),
-    ST_MinY(NEW.${c}), ST_MaxY(NEW.${c})
+  INSERT OR REPLACE INTO "rtree_${t}_${c}" VALUES (
+    NEW."${i}",
+    ST_MinX(NEW."${c}"), ST_MaxX(NEW."${c}"),
+    ST_MinY(NEW."${c}"), ST_MaxY(NEW."${c}")
   );
 END;
 
 -- Conditions: Update of geometry column to empty geometry
 --               No row ID change
 --   Actions   : Remove record from rtree 
-CREATE TRIGGER rtree_${t}_${c}_update2 AFTER UPDATE OF ${c} ON ${t}
-  WHEN OLD.${i} = NEW.${i} AND
-       (NEW.${c} ISNULL OR ST_IsEmpty(NEW.${c}))
+CREATE TRIGGER "rtree_${t}_${c}_update2" AFTER UPDATE OF "${c}" ON "${t}"
+  WHEN OLD."${i}" = NEW."${i}" AND
+       (NEW."${c}" ISNULL OR ST_IsEmpty(NEW."${c}"))
 BEGIN
-  DELETE FROM rtree_${t}_${c} WHERE id = OLD.${i};
+  DELETE FROM "rtree_${t}_${c}" WHERE id = OLD."${i}";
 END;
 
 -- Conditions: Update of any column
@@ -45,15 +45,15 @@ END;
 --              Non-empty geometry
 --   Actions   : Remove record from rtree for old ${i}
 --               Insert record into rtree for new ${i}
-CREATE TRIGGER rtree_${t}_${c}_update3 AFTER UPDATE OF ${c} ON ${t}
-  WHEN OLD.${i} != NEW.${i} AND
-       (NEW.${c} NOTNULL AND NOT ST_IsEmpty(NEW.${c}))
+CREATE TRIGGER "rtree_${t}_${c}_update3" AFTER UPDATE OF "${c}" ON "${t}"
+  WHEN OLD."${i}" != NEW."${i}" AND
+       (NEW."${c}" NOTNULL AND NOT ST_IsEmpty(NEW."${c}"))
 BEGIN
-  DELETE FROM rtree_${t}_${c} WHERE id = OLD.${i};
-  INSERT OR REPLACE INTO rtree_${t}_${c} VALUES (
-    NEW.${i},
-    ST_MinX(NEW.${c}), ST_MaxX(NEW.${c}),
-    ST_MinY(NEW.${c}), ST_MaxY(NEW.${c})
+  DELETE FROM "rtree_${t}_${c}" WHERE id = OLD."${i}";
+  INSERT OR REPLACE INTO "rtree_${t}_${c}" VALUES (
+    NEW."${i}",
+    ST_MinX(NEW."${c}"), ST_MaxX(NEW."${c}"),
+    ST_MinY(NEW."${c}"), ST_MaxY(NEW."${c}")
   );
 END;
 
@@ -61,19 +61,19 @@ END;
 --               Row ID change
 --               Empty geometry
 --   Actions   : Remove record from rtree for old and new ${i} 
-CREATE TRIGGER rtree_${t}_${c}_update4 AFTER UPDATE ON ${t}
-  WHEN OLD.${i} != NEW.${i} AND
-       (NEW.${c} ISNULL OR ST_IsEmpty(NEW.${c}))
+CREATE TRIGGER "rtree_${t}_${c}_update4" AFTER UPDATE ON "${t}"
+  WHEN OLD."${i}" != NEW."${i}" AND
+       (NEW."${c}" ISNULL OR ST_IsEmpty(NEW."${c}"))
 BEGIN
-  DELETE FROM rtree_${t}_${c} WHERE id IN (OLD.${i}, NEW.${i});
+  DELETE FROM "rtree_${t}_${c}" WHERE id IN (OLD."${i}", NEW."${i}");
 END;
 
 -- Conditions: Row deleted
 --   Actions   : Remove record from rtree for old ${i} 
-CREATE TRIGGER rtree_${t}_${c}_delete AFTER DELETE ON ${t}
-  WHEN old.${c} NOT NULL
+CREATE TRIGGER "rtree_${t}_${c}_delete" AFTER DELETE ON "${t}"
+  WHEN OLD."${c}" NOT NULL
 BEGIN
-  DELETE FROM rtree_${t}_${c} WHERE id = OLD.${i};
+  DELETE FROM "rtree_${t}_${c}" WHERE id = OLD."${i}";
 END;
 
 -- Register the spatial index extension for this table/column


### PR DESCRIPTION
Fixes [GEOT-6565](https://osgeo-org.atlassian.net/browse/GEOT-6565) bug. 
Identifiers in SQL queries for spatial index creation has been quoted to allow more names to be used for feature types.

The bug has been discovered while trying to create a spatial index for GeoPackage with a feature type named "all".

## Checklist
- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

