### PR TITLE
Fix GeoTiffWriterTest, make default "write no data" value dynamic

### DIFF
--- a/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffFormat.java
+++ b/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffFormat.java
@@ -80,7 +80,7 @@ public class GeoTiffFormat extends AbstractGridFormat implements Format {
 
     static {
         String geotiffWriteNodataProperty = System.getProperty(GEOTIFF_WRITE_NODATA_KEY, "true");
-        DEFAULT_WRITE_NODATA = Boolean.parseBoolean(geotiffWriteNodataProperty);
+        DEFAULT_WRITE_NODATA = Boolean.valueOf(geotiffWriteNodataProperty);
     }
 
     /** Logger. */
@@ -107,7 +107,13 @@ public class GeoTiffFormat extends AbstractGridFormat implements Format {
                     "WRITE_NODATA",
                     Boolean.class,
                     new Boolean[] {Boolean.TRUE, Boolean.FALSE},
-                    DEFAULT_WRITE_NODATA);
+                    DEFAULT_WRITE_NODATA) {
+                private static final long serialVersionUID = 476944281037266742L;
+
+                public @Override Boolean getDefaultValue() {
+                    return Boolean.valueOf(System.getProperty(GEOTIFF_WRITE_NODATA_KEY, "true"));
+                }
+            };
 
     /**
      * This {@link GeneralParameterValue} can be provided to the {@link GeoTiffWriter}s in order to


### PR DESCRIPTION
`GeoTiffWriterTest`'s `setFinalStaticField()` was using reflection to
change the value of the statically initialized `GeoTiffFormat.DEFAULT_WRITE_NODATA`
boolean, to no effect.

The idea being to change the default value of
`GeoTiffFormat.WRITE_NODATA` parameter default value was futil, since
`DEFAULT_WRITE_NODATA` is passed by value and hence the use of
reflection to change it had no effect.

This patch makes `DEFAULT_WRITE_NODATA` default value's dynamic by
returning the current value of the `geotiff.writenodata` System property
(still defaulting to `true`), and fixes the test expectations.

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
