### PR TITLE
[GEOT-6586] GeometryClipper - doesn't handle polygon x polygon when result is multipolygon

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometryClipper.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometryClipper.java
@@ -542,6 +542,8 @@ public class GeometryClipper {
                 }
             }
 
+            flattenCollection(result);
+
             if (gc instanceof MultiPoint) {
                 result = filterCollection(Point.class, result);
             } else if (gc instanceof MultiLineString) {

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/GeometryClipperTest.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/GeometryClipperTest.java
@@ -60,6 +60,29 @@ public class GeometryClipperTest {
         boundsPoly = wkt.read("POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))");
     }
 
+    // case:
+    // polygon being clipped returns a multipolygon.
+    @Test
+    public void testMulti() throws Exception {
+        Polygon polygon =
+                (Polygon)
+                        wkt.read(
+                                "POLYGON ((1.0201465201465183 12.338461538461548, 3.272161172161173 7.7956043956044, 3.893406593406595 11.60073260073261, 6.456043956043961 7.679120879120883, 6.223076923076928 12.64908424908426, 1.0201465201465183 12.338461538461548))");
+        MultiPolygon clipped = (MultiPolygon) clipper.clip(polygon, true);
+
+        assertEquals(2, clipped.getNumGeometries());
+
+        // verify it works if the polygon is a multipolygon
+        // note - this is the same polygon as above.
+        MultiPolygon mpoly =
+                (MultiPolygon)
+                        wkt.read(
+                                "MULTIPOLYGON (((1.0201465201465183 12.338461538461548, 3.272161172161173 7.7956043956044, 3.893406593406595 11.60073260073261, 6.456043956043961 7.679120879120883, 6.223076923076928 12.64908424908426, 1.0201465201465183 12.338461538461548)))");
+        clipped = (MultiPolygon) clipper.clip(mpoly, true);
+
+        assertEquals(2, clipped.getNumGeometries());
+    }
+
     @Test
     public void testFullyInside() throws Exception {
         LineString ls = (LineString) wkt.read("LINESTRING(1 1, 2 5, 9 1)");


### PR DESCRIPTION
I noticed an issue with vector tiles - polygons kept "disappearing."

Root cause - when GeometryClipper clips a polygon-polyon, the result might be multipolygon. Unfortunately, filterCollection() will remove this.

Fix - flattenCollection() before the filter.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
