### PR TITLE
[GEOT-6588] : SortBy element not encoded with FESConfiguration

### DIFF
--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/FESConfiguration.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/FESConfiguration.java
@@ -18,9 +18,7 @@ package org.geotools.filter.v2_0;
 
 import net.opengis.fes20.Fes20Factory;
 import org.geotools.filter.FilterFactoryImpl;
-import org.geotools.filter.v1_1.SortByTypeBinding;
 import org.geotools.filter.v1_1.SortOrderTypeBinding;
-import org.geotools.filter.v1_1.SortPropertyTypeBinding;
 import org.geotools.filter.v2_0.bindings.AfterBinding;
 import org.geotools.filter.v2_0.bindings.AndBinding;
 import org.geotools.filter.v2_0.bindings.AnyInteractsBinding;
@@ -76,6 +74,8 @@ import org.geotools.filter.v2_0.bindings.PropertyIsNullTypeBinding;
 import org.geotools.filter.v2_0.bindings.ResourceIdTypeBinding;
 import org.geotools.filter.v2_0.bindings.ResourceIdentifierTypeBinding;
 import org.geotools.filter.v2_0.bindings.Scalar_CapabilitiesTypeBinding;
+import org.geotools.filter.v2_0.bindings.SortByTypeBinding;
+import org.geotools.filter.v2_0.bindings.SortPropertyTypeBinding;
 import org.geotools.filter.v2_0.bindings.SpatialOperatorTypeBinding;
 import org.geotools.filter.v2_0.bindings.SpatialOperatorsTypeBinding;
 import org.geotools.filter.v2_0.bindings.Spatial_CapabilitiesTypeBinding;

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/SortByTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/SortByTypeBinding.java
@@ -1,0 +1,73 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.v2_0.bindings;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.emf.common.util.UniqueEList;
+import org.geotools.filter.v2_0.FES;
+import org.opengis.filter.FilterFactory;
+
+/**
+ * Binding object for the type http://www.opengis.net/ogc:SortByType.
+ *
+ * <p>
+ *
+ * <pre>
+ *         <code>
+ *  &lt;xsd:complexType name="SortByType"&gt;
+ *      &lt;xsd:sequence&gt;
+ *          &lt;xsd:element maxOccurs="unbounded" name="SortProperty" type="ogc:SortPropertyType"/&gt;
+ *      &lt;/xsd:sequence&gt;
+ *  &lt;/xsd:complexType&gt;
+ *
+ *          </code>
+ * </pre>
+ *
+ * @generated
+ */
+public class SortByTypeBinding extends org.geotools.filter.v1_1.SortByTypeBinding {
+
+	public SortByTypeBinding(FilterFactory filterfactory) {
+		super(filterfactory);
+	}
+
+	/** @generated */
+	public QName getTarget() {
+		return FES.SortByType;
+	}
+
+	/**
+	 *
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated modifiable
+	 */
+	public Class getType() {
+		return UniqueEList.class;
+	}
+
+	public Object getProperty(Object object, QName name) throws Exception {
+		if ("SortProperty".equals(name.getLocalPart())) {
+			UniqueEList sortBy = (UniqueEList) object;
+
+			return sortBy;
+		}
+
+		return null;
+	}
+}

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/SortByTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/SortByTypeBinding.java
@@ -17,7 +17,6 @@
 package org.geotools.filter.v2_0.bindings;
 
 import javax.xml.namespace.QName;
-
 import org.eclipse.emf.common.util.UniqueEList;
 import org.geotools.filter.v2_0.FES;
 import org.opengis.filter.FilterFactory;
@@ -42,32 +41,33 @@ import org.opengis.filter.FilterFactory;
  */
 public class SortByTypeBinding extends org.geotools.filter.v1_1.SortByTypeBinding {
 
-	public SortByTypeBinding(FilterFactory filterfactory) {
-		super(filterfactory);
-	}
+    public SortByTypeBinding(FilterFactory filterfactory) {
+        super(filterfactory);
+    }
 
-	/** @generated */
-	public QName getTarget() {
-		return FES.SortByType;
-	}
+    /** @generated */
+    public QName getTarget() {
+        return FES.SortByType;
+    }
 
-	/**
-	 *
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
-	 * @generated modifiable
-	 */
-	public Class getType() {
-		return UniqueEList.class;
-	}
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    public Class getType() {
+        return UniqueEList.class;
+    }
 
-	public Object getProperty(Object object, QName name) throws Exception {
-		if ("SortProperty".equals(name.getLocalPart())) {
-			UniqueEList sortBy = (UniqueEList) object;
+    public Object getProperty(Object object, QName name) throws Exception {
+        if ("SortProperty".equals(name.getLocalPart())) {
+            UniqueEList sortBy = (UniqueEList) object;
 
-			return sortBy;
-		}
+            return sortBy;
+        }
 
-		return null;
-	}
+        return null;
+    }
 }

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/SortPropertyTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/SortPropertyTypeBinding.java
@@ -1,0 +1,80 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.v2_0.bindings;
+
+import javax.xml.namespace.QName;
+
+import org.geotools.filter.v2_0.FES;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.sort.SortBy;
+
+import net.opengis.fes20.SortPropertyType;
+
+/**
+ * Binding object for the type http://www.opengis.net/ogc:SortPropertyType.
+ *
+ * <p>
+ *
+ * <pre>
+ *         <code>
+ *  &lt;xsd:complexType name="SortPropertyType"&gt;
+ *      &lt;xsd:sequence&gt;
+ *          &lt;xsd:element ref="ogc:PropertyName"/&gt;
+ *          &lt;xsd:element minOccurs="0" name="SortOrder" type="ogc:SortOrderType"/&gt;
+ *      &lt;/xsd:sequence&gt;
+ *  &lt;/xsd:complexType&gt;
+ *
+ *          </code>
+ * </pre>
+ *
+ * @generated
+ */
+public class SortPropertyTypeBinding extends org.geotools.filter.v1_1.SortPropertyTypeBinding {
+
+	public SortPropertyTypeBinding(FilterFactory filterfactory) {
+		super(filterfactory);
+	}
+
+	/** @generated */
+	public QName getTarget() {
+		return FES.SortPropertyType;
+	}
+
+	/**
+	 *
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 *
+	 * @generated modifiable
+	 */
+	public Class getType() {
+		return SortPropertyType.class;
+	}
+
+	public Object getProperty(Object object, QName name) throws Exception {
+		SortBy sortBy = (SortBy) object;
+
+		if (FES.ValueReference.equals(name)) {
+			return sortBy.getPropertyName();
+		}
+
+		if ("SortOrder".equals(name.getLocalPart())) {
+			return sortBy.getSortOrder();
+		}
+
+		return null;
+	}
+}

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/SortPropertyTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/SortPropertyTypeBinding.java
@@ -17,12 +17,10 @@
 package org.geotools.filter.v2_0.bindings;
 
 import javax.xml.namespace.QName;
-
+import net.opengis.fes20.SortPropertyType;
 import org.geotools.filter.v2_0.FES;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.sort.SortBy;
-
-import net.opengis.fes20.SortPropertyType;
 
 /**
  * Binding object for the type http://www.opengis.net/ogc:SortPropertyType.
@@ -45,36 +43,37 @@ import net.opengis.fes20.SortPropertyType;
  */
 public class SortPropertyTypeBinding extends org.geotools.filter.v1_1.SortPropertyTypeBinding {
 
-	public SortPropertyTypeBinding(FilterFactory filterfactory) {
-		super(filterfactory);
-	}
+    public SortPropertyTypeBinding(FilterFactory filterfactory) {
+        super(filterfactory);
+    }
 
-	/** @generated */
-	public QName getTarget() {
-		return FES.SortPropertyType;
-	}
+    /** @generated */
+    public QName getTarget() {
+        return FES.SortPropertyType;
+    }
 
-	/**
-	 *
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 *
-	 * @generated modifiable
-	 */
-	public Class getType() {
-		return SortPropertyType.class;
-	}
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    public Class getType() {
+        return SortPropertyType.class;
+    }
 
-	public Object getProperty(Object object, QName name) throws Exception {
-		SortBy sortBy = (SortBy) object;
+    public Object getProperty(Object object, QName name) throws Exception {
+        SortBy sortBy = (SortBy) object;
 
-		if (FES.ValueReference.equals(name)) {
-			return sortBy.getPropertyName();
-		}
+        if (FES.ValueReference.equals(name)) {
+            return sortBy.getPropertyName();
+        }
 
-		if ("SortOrder".equals(name.getLocalPart())) {
-			return sortBy.getSortOrder();
-		}
+        if ("SortOrder".equals(name.getLocalPart())) {
+            return sortBy.getSortOrder();
+        }
 
-		return null;
-	}
+        return null;
+    }
 }

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/SortByTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/SortByTypeBindingTest.java
@@ -33,18 +33,17 @@ public class SortByTypeBindingTest extends FESTestSupport {
         assertEquals("myns:temperature", sortBy[1].getPropertyName().getPropertyName());
         assertEquals(SortOrder.DESCENDING, sortBy[1].getSortOrder());
     }
-    
-    public void testEncode() throws Exception {
-    	FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
-    	SortBy sortBy=ff.sort("myProperty",SortOrder.ASCENDING);
-    	
-    	UniqueEList<SortBy> list = new UniqueEList<>();
-    	list.add(sortBy);
-    	
-    	Document doc = encode(list, FES.SortBy);
-		assertEquals("fes:SortBy", doc.getDocumentElement().getNodeName());
-		assertEquals(1, doc.getElementsByTagNameNS(FES.NAMESPACE, "SortProperty").getLength());
-		assertEquals(1, doc.getElementsByTagNameNS(FES.NAMESPACE, "SortOrder").getLength());
 
-	}
+    public void testEncode() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        SortBy sortBy = ff.sort("myProperty", SortOrder.ASCENDING);
+
+        UniqueEList<SortBy> list = new UniqueEList<>();
+        list.add(sortBy);
+
+        Document doc = encode(list, FES.SortBy);
+        assertEquals("fes:SortBy", doc.getDocumentElement().getNodeName());
+        assertEquals(1, doc.getElementsByTagNameNS(FES.NAMESPACE, "SortProperty").getLength());
+        assertEquals(1, doc.getElementsByTagNameNS(FES.NAMESPACE, "SortOrder").getLength());
+    }
 }

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/SortByTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/SortByTypeBindingTest.java
@@ -1,8 +1,13 @@
 package org.geotools.filter.v2_0.bindings;
 
+import org.eclipse.emf.common.util.UniqueEList;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.v2_0.FES;
 import org.geotools.filter.v2_0.FESTestSupport;
+import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
+import org.w3c.dom.Document;
 
 public class SortByTypeBindingTest extends FESTestSupport {
 
@@ -28,4 +33,18 @@ public class SortByTypeBindingTest extends FESTestSupport {
         assertEquals("myns:temperature", sortBy[1].getPropertyName().getPropertyName());
         assertEquals(SortOrder.DESCENDING, sortBy[1].getSortOrder());
     }
+    
+    public void testEncode() throws Exception {
+    	FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+    	SortBy sortBy=ff.sort("myProperty",SortOrder.ASCENDING);
+    	
+    	UniqueEList<SortBy> list = new UniqueEList<>();
+    	list.add(sortBy);
+    	
+    	Document doc = encode(list, FES.SortBy);
+		assertEquals("fes:SortBy", doc.getDocumentElement().getNodeName());
+		assertEquals(1, doc.getElementsByTagNameNS(FES.NAMESPACE, "SortProperty").getLength());
+		assertEquals(1, doc.getElementsByTagNameNS(FES.NAMESPACE, "SortOrder").getLength());
+
+	}
 }

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/WfsQueryTypeTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/WfsQueryTypeTest.java
@@ -18,9 +18,9 @@
 package org.geotools.wfs.v2_0.bindings;
 
 import java.util.HashMap;
-
 import javax.xml.namespace.QName;
-
+import net.opengis.wfs20.QueryType;
+import net.opengis.wfs20.Wfs20Factory;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
@@ -33,42 +33,40 @@ import org.opengis.filter.sort.SortOrder;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import net.opengis.wfs20.QueryType;
-import net.opengis.wfs20.Wfs20Factory;
-
 public class WfsQueryTypeTest extends WFSTestSupport {
 
-	public void testEncode() throws Exception {
-		QName typeName = new QName("http://www.test.com/query", "theType");
-		QueryType query = Wfs20Factory.eINSTANCE.createQueryType();
-		query.getTypeNames().add(typeName);
+    public void testEncode() throws Exception {
+        QName typeName = new QName("http://www.test.com/query", "theType");
+        QueryType query = Wfs20Factory.eINSTANCE.createQueryType();
+        query.getTypeNames().add(typeName);
 
-		FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
-		query.getSortBy().add(ff.sort("myProperty", SortOrder.ASCENDING));
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        query.getSortBy().add(ff.sort("myProperty", SortOrder.ASCENDING));
 
-		Document doc = encode(query, WFS.Query);
+        Document doc = encode(query, WFS.Query);
 
-		Element root = doc.getDocumentElement();
-		String attr = root.getAttribute("typeNames");
-		assertNotNull(attr);
+        Element root = doc.getDocumentElement();
+        String attr = root.getAttribute("typeNames");
+        assertNotNull(attr);
 
-		String tmp = typeName.getLocalPart();
+        String tmp = typeName.getLocalPart();
 
-		assertFalse(attr.startsWith("[{"));
-		assertTrue(attr.indexOf(tmp) != -1);
-		assertEquals(attr.length(), attr.indexOf(tmp) + tmp.length()); // 8 == ":theType".length
+        assertFalse(attr.startsWith("[{"));
+        assertTrue(attr.indexOf(tmp) != -1);
+        assertEquals(attr.length(), attr.indexOf(tmp) + tmp.length()); // 8 == ":theType".length
 
-		HashMap<String, String> m = new HashMap<String, String>();
-		m.put("wfs", WFS.NAMESPACE);
-		m.put("fes", FES.NAMESPACE);
-		XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(m));
-		XMLAssert.assertXpathExists("//wfs:Query", doc);
-		XMLAssert.assertXpathExists("//wfs:Query/fes:SortBy", doc);
-		XMLAssert.assertXpathExists("//wfs:Query/fes:SortBy/fes:SortProperty", doc);
-		XMLAssert.assertXpathExists("//wfs:Query/fes:SortBy/fes:SortProperty/fes:ValueReference", doc);
-		XMLAssert.assertXpathEvaluatesTo("myProperty", "//wfs:Query/fes:SortBy/fes:SortProperty/fes:ValueReference",
-				doc);
-		XMLAssert.assertXpathEvaluatesTo("ASC", "//wfs:Query/fes:SortBy/fes:SortProperty/fes:SortOrder",
-				doc);
-	}
+        HashMap<String, String> m = new HashMap<String, String>();
+        m.put("wfs", WFS.NAMESPACE);
+        m.put("fes", FES.NAMESPACE);
+        XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(m));
+        XMLAssert.assertXpathExists("//wfs:Query", doc);
+        XMLAssert.assertXpathExists("//wfs:Query/fes:SortBy", doc);
+        XMLAssert.assertXpathExists("//wfs:Query/fes:SortBy/fes:SortProperty", doc);
+        XMLAssert.assertXpathExists(
+                "//wfs:Query/fes:SortBy/fes:SortProperty/fes:ValueReference", doc);
+        XMLAssert.assertXpathEvaluatesTo(
+                "myProperty", "//wfs:Query/fes:SortBy/fes:SortProperty/fes:ValueReference", doc);
+        XMLAssert.assertXpathEvaluatesTo(
+                "ASC", "//wfs:Query/fes:SortBy/fes:SortProperty/fes:SortOrder", doc);
+    }
 }

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/WfsQueryTypeTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/WfsQueryTypeTest.java
@@ -17,30 +17,58 @@
 
 package org.geotools.wfs.v2_0.bindings;
 
+import java.util.HashMap;
+
 import javax.xml.namespace.QName;
-import net.opengis.wfs20.QueryType;
-import net.opengis.wfs20.Wfs20Factory;
+
+import org.custommonkey.xmlunit.SimpleNamespaceContext;
+import org.custommonkey.xmlunit.XMLAssert;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.v2_0.FES;
 import org.geotools.wfs.v2_0.WFS;
 import org.geotools.wfs.v2_0.WFSTestSupport;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.sort.SortOrder;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import net.opengis.wfs20.QueryType;
+import net.opengis.wfs20.Wfs20Factory;
+
 public class WfsQueryTypeTest extends WFSTestSupport {
 
-    public void testEncode() throws Exception {
-        QName typeName = new QName("http://www.test.com/query", "theType");
-        QueryType query = Wfs20Factory.eINSTANCE.createQueryType();
-        query.getTypeNames().add(typeName);
+	public void testEncode() throws Exception {
+		QName typeName = new QName("http://www.test.com/query", "theType");
+		QueryType query = Wfs20Factory.eINSTANCE.createQueryType();
+		query.getTypeNames().add(typeName);
 
-        Document doc = encode(query, WFS.Query);
-        Element root = doc.getDocumentElement();
-        String attr = root.getAttribute("typeNames");
-        assertNotNull(attr);
+		FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+		query.getSortBy().add(ff.sort("myProperty", SortOrder.ASCENDING));
 
-        String tmp = typeName.getLocalPart();
+		Document doc = encode(query, WFS.Query);
 
-        assertFalse(attr.startsWith("[{"));
-        assertTrue(attr.indexOf(tmp) != -1);
-        assertEquals(attr.length(), attr.indexOf(tmp) + tmp.length()); // 8 == ":theType".length
-    }
+		Element root = doc.getDocumentElement();
+		String attr = root.getAttribute("typeNames");
+		assertNotNull(attr);
+
+		String tmp = typeName.getLocalPart();
+
+		assertFalse(attr.startsWith("[{"));
+		assertTrue(attr.indexOf(tmp) != -1);
+		assertEquals(attr.length(), attr.indexOf(tmp) + tmp.length()); // 8 == ":theType".length
+
+		HashMap<String, String> m = new HashMap<String, String>();
+		m.put("wfs", WFS.NAMESPACE);
+		m.put("fes", FES.NAMESPACE);
+		XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(m));
+		XMLAssert.assertXpathExists("//wfs:Query", doc);
+		XMLAssert.assertXpathExists("//wfs:Query/fes:SortBy", doc);
+		XMLAssert.assertXpathExists("//wfs:Query/fes:SortBy/fes:SortProperty", doc);
+		XMLAssert.assertXpathExists("//wfs:Query/fes:SortBy/fes:SortProperty/fes:ValueReference", doc);
+		XMLAssert.assertXpathEvaluatesTo("myProperty", "//wfs:Query/fes:SortBy/fes:SortProperty/fes:ValueReference",
+				doc);
+		XMLAssert.assertXpathEvaluatesTo("ASC", "//wfs:Query/fes:SortBy/fes:SortProperty/fes:SortOrder",
+				doc);
+	}
 }


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

Fix for [GEOT-6558](https://osgeo-org.atlassian.net/browse/GEOT-6588) . Element SortBy is not encoded in getFeature request (WFS 2.0)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
