### PR TITLE
Support mbstyle filter expressions [GEOT-6589] 

### DIFF
--- a/docs/user/extension/mbstyle/spec/layers.rst
+++ b/docs/user/extension/mbstyle/spec/layers.rst
@@ -119,10 +119,37 @@ filter
 
 *Optional* :ref:`Expression <expressions>`.
 
-
-
 A expression specifying conditions on source features. Only features
 that match the filter are displayed.
+
+::
+
+    ["to-number", value, fallback: value, fallback: value, ...]: number
+
+.. list-table::
+   :widths: 19, 27, 27, 27
+   :header-rows: 1
+
+   * - Support
+     - Mapbox
+     - GeoTools
+     - OpenLayers
+   * - basic functionality
+     - >= 0.41.0
+     - >= 23.0
+     - 
+   * - collator
+     - >= 0.45.0
+     - >= Not yet supported
+     - 
+   * - other filter
+     - >= 0.10.0
+     - >= 17.1
+     - >= 2.4.0
+   * - other filter ``has``/``!has``
+     - >= 0.19.0
+     - >= 17.1
+     - >= 2.4.0
 
 layout
 ^^^^^^

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBExpression.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBExpression.java
@@ -50,7 +50,12 @@ public abstract class MBExpression extends FunctionImpl {
     protected final MBObjectParser parse;
     protected final MBStyleTransformer transformer;
 
-    public MBExpression(JSONArray json) {
+    /**
+     * Please use factory method {@link #create(JSONArray)}
+     *
+     * @param json
+     */
+    protected MBExpression(JSONArray json) {
         this.json = json;
         this.name = (String) json.get(0);
         this.ff = CommonFactoryFinder.getFilterFactory2();
@@ -123,6 +128,12 @@ public abstract class MBExpression extends FunctionImpl {
     /* A list of zoom expression names */
     public static List zoom = Arrays.asList("zoom");
 
+    /**
+     * Factory method used to produce the correct MBExpression subclass for the provided JSONArray.
+     *
+     * @param json definition
+     * @return MBExpression
+     */
     public static MBExpression create(JSONArray json) {
         String name;
         if (json.get(0) instanceof String) {

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBExpression.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBExpression.java
@@ -162,24 +162,25 @@ public abstract class MBExpression extends FunctionImpl {
             } else if (zoom.contains(name)) {
                 return new MBZoom(json);
             } else {
-                throw new MBFormatException("Expression \"" + name + "\" invalid.");
+                throw new MBFormatException("Expression \"" + name + "\" not supported.");
             }
         }
         throw new MBFormatException("Requires a string name of the expression at position 0");
     }
 
     public static boolean canCreate(final String name) {
-        return colors.contains(name)
-                || decisions.contains(name)
-                || featureData.contains(name)
-                || heatMap.contains(name)
-                || lookUp.contains(name)
-                || math.contains(name)
-                || ramps.contains(name)
-                || string.contains(name)
-                || types.contains(name)
-                || variableBindings.contains(name)
-                || zoom.contains(name);
+        return name != null
+                && (colors.contains(name)
+                        || decisions.contains(name)
+                        || featureData.contains(name)
+                        || heatMap.contains(name)
+                        || lookUp.contains(name)
+                        || math.contains(name)
+                        || ramps.contains(name)
+                        || string.contains(name)
+                        || types.contains(name)
+                        || variableBindings.contains(name)
+                        || zoom.contains(name));
     }
 
     /** Determines which expression to use. */

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBExpression.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBExpression.java
@@ -162,10 +162,14 @@ public abstract class MBExpression extends FunctionImpl {
             } else if (zoom.contains(name)) {
                 return new MBZoom(json);
             } else {
-                throw new MBFormatException("Expression \"" + name + "\" not supported.");
+                throw new MBFormatException(
+                        "Data expression \""
+                                + name
+                                + "\" invalid. It may be misspelled or not supported by this implementation:"
+                                + json);
             }
         }
-        throw new MBFormatException("Requires a string name of the expression at position 0");
+        throw new MBFormatException("Requires a string name of the data expression at position 0");
     }
 
     public static boolean canCreate(final String name) {

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBLookup.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBLookup.java
@@ -56,22 +56,26 @@ public class MBLookup extends MBExpression {
     public Expression lookupGet() {
         if (json.size() == 2 || json.size() == 3) {
             if (json.size() == 2) {
+                // Example: ["get", "propertyName"]
                 if (parse.isString(json, 1)) {
                     String propertyName = parse.get(json, 1);
                     return ff.property(propertyName);
-                } else {
+                }
+                // Example: ["get", key]
+                else {
                     // it is unclear from specification if this is even allowed
                     Expression property = parse.string(json, 1);
                     return ff.function("property", property);
                 }
             }
+            // Example: ["get", key, object]
             if (json.size() == 3) {
                 Expression value = parse.string(json, 1);
                 Expression object = parse.string(json, 2);
                 return ff.function("get", value, object);
             }
         }
-        throw new MBFormatException("Expression \"get\" requires a maximum of 3 arguments.");
+        throw new MBFormatException("Data expression \"get\" requires a maximum of 3 arguments.");
     }
 
     /**

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBLookup.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBLookup.java
@@ -56,8 +56,14 @@ public class MBLookup extends MBExpression {
     public Expression lookupGet() {
         if (json.size() == 2 || json.size() == 3) {
             if (json.size() == 2) {
-                Expression property = parse.string(json, 1);
-                return ff.function("property", property);
+                if (parse.isString(json, 1)) {
+                    String propertyName = parse.get(json, 1);
+                    return ff.property(propertyName);
+                } else {
+                    // it is unclear from specification if this is even allowed
+                    Expression property = parse.string(json, 1);
+                    return ff.function("property", property);
+                }
             }
             if (json.size() == 3) {
                 Expression value = parse.string(json, 1);
@@ -65,7 +71,7 @@ public class MBLookup extends MBExpression {
                 return ff.function("get", value, object);
             }
         }
-        throw new MBFormatException("Expression \"get\" requires a maximum of 2 arguments.");
+        throw new MBFormatException("Expression \"get\" requires a maximum of 3 arguments.");
     }
 
     /**

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBLookup.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/expression/MBLookup.java
@@ -56,20 +56,18 @@ public class MBLookup extends MBExpression {
     public Expression lookupGet() {
         if (json.size() == 2 || json.size() == 3) {
             if (json.size() == 2) {
-                // Example: ["get", "propertyName"]
                 if (parse.isString(json, 1)) {
+                    // example: ["get", "propertyName"]
                     String propertyName = parse.get(json, 1);
                     return ff.property(propertyName);
-                }
-                // Example: ["get", key]
-                else {
-                    // it is unclear from specification if this is even allowed
+                } else {
+                    // example: ["get", key]
                     Expression property = parse.string(json, 1);
                     return ff.function("property", property);
                 }
             }
-            // Example: ["get", key, object]
             if (json.size() == 3) {
+                // example: ["get", key, object]
                 Expression value = parse.string(json, 1);
                 Expression object = parse.string(json, 2);
                 return ff.function("get", value, object);

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/layer/BackgroundMBLayer.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/layer/BackgroundMBLayer.java
@@ -93,7 +93,7 @@ public class BackgroundMBLayer extends MBLayer {
 
     /** @return True if the layer has a background-pattern explicitly provided. */
     public boolean hasBackgroundPattern() {
-        return parse.isPropertyDefined(paint, "background-pattern");
+        return parse.isDefined(paint, "background-pattern");
     }
 
     /**

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/layer/FillMBLayer.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/layer/FillMBLayer.java
@@ -242,7 +242,7 @@ public class FillMBLayer extends MBLayer {
 
     /** @return True if the layer has a fill-pattern explicitly provided. */
     public boolean hasFillPattern() {
-        return parse.isPropertyDefined(paint, "fill-pattern");
+        return parse.isDefined(paint, "fill-pattern");
     }
 
     /**

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/layer/LineMBLayer.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/layer/LineMBLayer.java
@@ -518,12 +518,12 @@ public class LineMBLayer extends MBLayer {
 
     /** @return True if the layer has a line-pattern explicitly provided. */
     public boolean hasLinePattern() {
-        return parse.isPropertyDefined(paint, "line-pattern");
+        return parse.isDefined(paint, "line-pattern");
     }
 
     /** @return True if the layer has a line-gap-width explicitly provided. */
     public boolean hasLineGapWidth() {
-        return parse.isPropertyDefined(paint, "line-gap-width");
+        return parse.isDefined(paint, "line-gap-width");
     }
 
     /**

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/layer/SymbolMBLayer.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/layer/SymbolMBLayer.java
@@ -598,7 +598,7 @@ public class SymbolMBLayer extends MBLayer {
 
     /** @return True if the layer has a icon-image explicitly provided. */
     public boolean hasIconImage() throws MBFormatException {
-        return parse.isPropertyDefined(layout, "icon-image");
+        return parse.isDefined(layout, "icon-image");
     }
 
     /**
@@ -830,7 +830,7 @@ public class SymbolMBLayer extends MBLayer {
 
     /** @return True if the layer has a text-field explicitly provided. */
     private boolean hasTextField() throws MBFormatException {
-        return parse.isPropertyDefined(layout, "text-field");
+        return parse.isDefined(layout, "text-field");
     }
 
     /**
@@ -911,7 +911,7 @@ public class SymbolMBLayer extends MBLayer {
 
     /** @return True if the layer has a text-max-width explicitly provided. */
     public boolean hasTextMaxWidth() throws MBFormatException {
-        return parse.isPropertyDefined(layout, "text-max-width");
+        return parse.isDefined(layout, "text-max-width");
     }
 
     /**
@@ -1098,7 +1098,7 @@ public class SymbolMBLayer extends MBLayer {
 
     /** @return True if the layer has a text-max-angle explicitly provided. */
     private boolean hasTextMaxAngle() throws MBFormatException {
-        return parse.isPropertyDefined(layout, "text-max-angle");
+        return parse.isDefined(layout, "text-max-angle");
     }
 
     /**
@@ -1204,7 +1204,7 @@ public class SymbolMBLayer extends MBLayer {
      * @return true if text-transform provided
      */
     public boolean hasTextTransform() {
-        return parse.isPropertyDefined(layout, "text-transform");
+        return parse.isDefined(layout, "text-transform");
     }
 
     /**
@@ -1260,7 +1260,7 @@ public class SymbolMBLayer extends MBLayer {
     }
 
     private boolean hasTextOffset() {
-        return parse.isPropertyDefined(layout, "text-offset");
+        return parse.isDefined(layout, "text-offset");
     }
 
     /**
@@ -1665,7 +1665,7 @@ public class SymbolMBLayer extends MBLayer {
     }
 
     private boolean hasTextTranslate() {
-        return parse.isPropertyDefined(layout, "text-translate");
+        return parse.isDefined(layout, "text-translate");
     }
 
     /**

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFilter.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFilter.java
@@ -480,6 +480,7 @@ public class MBFilter {
         if (array.size() != 3) {
             throwUnexpectedArgumentCount("==", 2);
         }
+        final FilterFactory2 ff = parse.getFilterFactory();
         if (parse.isString(array, 1)) { // legacy filter syntax
             String key = parse.get(array, 1);
             Object value = parse.value(array, 2);
@@ -502,15 +503,16 @@ public class MBFilter {
         if (array.size() != 3) {
             throwUnexpectedArgumentCount("!=", 2);
         }
+        final FilterFactory2 ff = parse.getFilterFactory();
         if (parse.isString(array, 1)) { // legacy filter syntax
             String key = parse.get(json, 1);
             Object value = parse.value(json, 2);
             return ff.notEqual(ff.property(key), ff.literal(value), false);
         } else {
             // get the comparables
-            Expression comparable1 = parse.string(json, 1);
-            Expression comparable2 = parse.string(json, 2);
-            return ff.function("mbNotEqualTo", comparable1, comparable2);
+            Expression expression1 = parse.string(json, 1);
+            Expression expression2 = parse.string(json, 2);
+            return ff.notEqual(expression1, expression2);
         }
     }
 

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFilter.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFilter.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.geotools.mbstyle.expression.MBExpression;
 import org.json.simple.JSONArray;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
@@ -38,18 +39,33 @@ import org.opengis.style.SemanticType;
  *
  * <p>This wrapper and {@link MBFunction} are a matched set handling dynamic data.
  *
- * <h2>About MapBox Expression</h2>
+ * <h2>Expression: Decision</h2>
  *
- * The value for any filter may be specified as an expression. The result type of an expression in
- * the filter property must be boolean.
+ * <p>Implementation Note:The value for any filter may be specified as an expression. The result type of an expression in
+ * the filter property must be boolean. See {@link org.geotools.mbstyle.expression.MBExpression} for details.
  *
- * <p>See {@link org.geotools.mbstyle.expression.MBExpression} for details.
+ * <p>The expressions in this section can be used to add conditional logic to your styles. For example, the 'case' expression
+ * provides "if/then/else" logic, and 'match' allows you to map specific values of an input expression to different
+ * output expressions.
+ * <ul>
+ *     <li><code>["!", boolean]: boolean</code></li>
+ *     <li><code>["!=", value, value]: boolean</code></li>
+ *     <li><code>&lt;/code></li>
+ *     <li><code>&lt;=</code></li>
+ *     <li><code>==</code></li>
+ *     <li><code>&gt;</code></li>
+ *     <li><code>&gt;=</code></li>
+ *     <li><code>all</code></li>
+ *     <li><code>any</code></li>
+ *     <li><code>case</code></li>
+ *     <li><code>coalesce</code></li>
+ *     <li><code>match</code></li>
+ *     <li><code>within</code></li>
+ * </ul>
  *
- * <p>
+ * <h2>Filter Other</h2>
  *
- * <h2>About MapBox Filter</h2>
- *
- * <p>In previous versions of the style specification, filters were defined using the deprecated
+ * <p>Implementation Note: In previous versions of the style specification, filters were defined using the deprecated
  * syntax documented here.
  *
  * <p>A filter selects specific features from a layer. A filter is an array of one of the following
@@ -100,6 +116,7 @@ import org.opengis.style.SemanticType;
  *
  * @see Filter
  * @see MBFunction
+ * @see org.geotools.mbstyle.expression.MBExpression
  */
 public class MBFilter {
 
@@ -166,7 +183,7 @@ public class MBFilter {
     /**
      * Utility method to convert json to set of {@link SemanticType}.
      *
-     * <p>This method recursively calls itself to handle all and any operators.
+     * <p>This method is recursively calls itself to handle all and any operators.
      *
      * @param array JSON array defining filter
      * @return SemanticTypes from provided json, may be nested
@@ -180,80 +197,95 @@ public class MBFilter {
                         || "!=".equals(operator)
                         || "in".equals(operator)
                         || "!in".equals(operator))
+                && parse.isString(array, 1)
                 && "$type".equals(parse.get(array, 1))) {
+            return semanticTypeByGeometryType(array, operator);
+        }
+        if ("all".equals(operator)) {
+            return semanticTypeAll(array);
+        } else if ("any".equals(operator)) {
+            return semanticTypeAny(array);
+        } else if ("none".equals(operator)) {
+            return semanticTypeNone(array);
+        }
+        return Collections.emptySet();
+    }
 
-            if ("in".equals(operator) || "==".equals(operator)) {
-                Set<SemanticType> semanticTypes = new HashSet<>();
-                List<?> types = array.subList(2, array.size());
-                for (Object type : types) {
-                    if (type instanceof String) {
-                        String jsonText = (String) type;
-                        SemanticType semanticType = translateSemanticType(jsonText);
-                        semanticTypes.add(semanticType);
-                    } else {
-                        throw new MBFormatException(
-                                "[\"in\",\"$type\", ...] limited to Point, LineString, Polygon: "
-                                        + type);
-                    }
-                }
-                if ("==".equals(operator) && types.size() != 1) {
+    private Set<SemanticType> semanticTypeNone(JSONArray array) {
+        Set<SemanticType> semanticTypes = new HashSet<>(Arrays.asList(SemanticType.values()));
+        for (int i = 1; i < array.size(); i++) {
+            Set<SemanticType> types = semanticTypeIdentifiers((JSONArray) array.get(i));
+            semanticTypes.removeAll(types);
+        }
+        return semanticTypes;
+    }
+
+    private Set<SemanticType> semanticTypeAny(JSONArray array) {
+        Set<SemanticType> semanticTypes = new HashSet<>();
+        for (int i = 1; i < array.size(); i++) {
+            Set<SemanticType> types = semanticTypeIdentifiers((JSONArray) array.get(i));
+            semanticTypes.addAll(types);
+        }
+        return semanticTypes;
+    }
+
+    private Set<SemanticType> semanticTypeAll(JSONArray array) {
+        Set<SemanticType> semanticTypes = new HashSet<>();
+        for (int i = 1; i < array.size(); i++) {
+            JSONArray alternative = (JSONArray) array.get(i);
+            Set<SemanticType> types = semanticTypeIdentifiers(alternative);
+            if (types.isEmpty()) {
+                continue;
+            } else {
+                if (semanticTypes.isEmpty()) {
+                    // exactly one alternative is okay
+                    semanticTypes.addAll(types);
+                } else {
                     throw new MBFormatException(
-                            "[\"==\",\"$type\", ...] limited one geometry type, to test more than one use \"in\" operator.");
+                            "Only one \"all\" alternative may be a $type filter");
                 }
-                return semanticTypes;
-            } else if ("!in".equals(operator) || "!=".equals(operator)) {
-                Set<SemanticType> semanticTypes =
-                        new HashSet<>(Arrays.asList(SemanticType.values()));
-                List<?> types = array.subList(2, array.size());
-                for (Object type : types) {
-                    if (type instanceof String) {
-                        String jsonText = (String) type;
-                        SemanticType semanticType = translateSemanticType(jsonText);
-                        semanticTypes.remove(semanticType);
-                    } else {
-                        throw new MBFormatException(
-                                "[\"!in\",\"$type\", ...] limited to Point, LineString, Polygon: "
-                                        + type);
-                    }
-                }
-                if ("!=".equals(operator) && types.size() != 1) {
-                    throw new MBFormatException(
-                            "[\"!=\",\"$type\", ...] limited one geometry type, to test more than one use \"!in\" operator.");
-                }
-                return semanticTypes;
             }
         }
+        return semanticTypes;
+    }
 
-        if ("all".equals(operator)) {
+    private Set<SemanticType> semanticTypeByGeometryType(JSONArray array, String operator) {
+        if ("in".equals(operator) || "==".equals(operator)) {
             Set<SemanticType> semanticTypes = new HashSet<>();
-            for (int i = 1; i < array.size(); i++) {
-                JSONArray alternative = (JSONArray) array.get(i);
-                Set<SemanticType> types = semanticTypeIdentifiers(alternative);
-                if (types.isEmpty()) {
-                    continue;
+            List<?> types = array.subList(2, array.size());
+            for (Object type : types) {
+                if (type instanceof String) {
+                    String jsonText = (String) type;
+                    SemanticType semanticType = translateSemanticType(jsonText);
+                    semanticTypes.add(semanticType);
                 } else {
-                    if (semanticTypes.isEmpty()) {
-                        // exactly one alternative is okay
-                        semanticTypes.addAll(types);
-                    } else {
-                        throw new MBFormatException(
-                                "Only one \"all\" alternative may be a $type filter");
-                    }
+                    throw new MBFormatException(
+                            "[\"in\",\"$type\", ...] limited to Point, LineString, Polygon: "
+                                    + type);
                 }
             }
-            return semanticTypes;
-        } else if ("any".equals(operator)) {
-            Set<SemanticType> semanticTypes = new HashSet<>();
-            for (int i = 1; i < array.size(); i++) {
-                Set<SemanticType> types = semanticTypeIdentifiers((JSONArray) array.get(i));
-                semanticTypes.addAll(types);
+            if ("==".equals(operator) && types.size() != 1) {
+                throw new MBFormatException(
+                        "[\"==\",\"$type\", ...] limited one geometry type, to test more than one use \"in\" operator.");
             }
             return semanticTypes;
-        } else if ("none".equals(operator)) {
+        } else if ("!in".equals(operator) || "!=".equals(operator)) {
             Set<SemanticType> semanticTypes = new HashSet<>(Arrays.asList(SemanticType.values()));
-            for (int i = 1; i < array.size(); i++) {
-                Set<SemanticType> types = semanticTypeIdentifiers((JSONArray) array.get(i));
-                semanticTypes.removeAll(types);
+            List<?> types = array.subList(2, array.size());
+            for (Object type : types) {
+                if (type instanceof String) {
+                    String jsonText = (String) type;
+                    SemanticType semanticType = translateSemanticType(jsonText);
+                    semanticTypes.remove(semanticType);
+                } else {
+                    throw new MBFormatException(
+                            "[\"!in\",\"$type\", ...] limited to Point, LineString, Polygon: "
+                                    + type);
+                }
+            }
+            if ("!=".equals(operator) && types.size() != 1) {
+                throw new MBFormatException(
+                        "[\"!=\",\"$type\", ...] limited one geometry type, to test more than one use \"!in\" operator.");
             }
             return semanticTypes;
         }
@@ -261,7 +293,6 @@ public class MBFilter {
     }
 
     private Filter translateType(String jsonText) {
-        // TODO: How to wildcard geometry
         Expression dimension = ff.function("dimension", ff.function("geometry"));
 
         switch (jsonText) {
@@ -274,7 +305,8 @@ public class MBFilter {
                         ff.equals(dimension, ff.literal(2)),
                         ff.not(ff.equals(ff.function("isCoverage"), ff.literal(true))));
             default:
-                return null;
+                throw new MBFormatException(
+                        "MBStyle restricted to testing Point, LineString, Polygon: " + jsonText);
         }
     }
 
@@ -318,40 +350,7 @@ public class MBFilter {
                         || "!in".equals(operator))
                 && parse.isString(json, 1)
                 && "$type".equals(parse.get(json, 1))) {
-
-            List<Filter> typeFilters = new ArrayList<>();
-            List<?> types = json.subList(2, json.size());
-            for (Object type : types) {
-                Filter typeFilter = null;
-                if (type instanceof String) {
-                    typeFilter = translateType((String) type);
-                }
-                if (typeFilter == null) {
-                    throw new MBFormatException(
-                            "\"$type\" limited to Point, LineString, Polygon: " + type);
-                }
-                typeFilters.add(typeFilter);
-            }
-            if ("==".equals(operator)) {
-                if (typeFilters.size() != 1) {
-                    throw new MBFormatException(
-                            "[\"==\",\"$type\", ...] limited one geometry type, to test more than one use \"in\" operator.");
-                }
-                return typeFilters.get(0);
-            }
-            if ("!=".equals(operator)) {
-                if (typeFilters.size() != 1) {
-                    throw new MBFormatException(
-                            "[\"!=\",\"$type\", ...] limited one geometry type, to test more than one use \"!in\" operator.");
-                }
-                return ff.not(typeFilters.get(0));
-            }
-            if ("in".equals(operator)) {
-                return ff.or(typeFilters);
-            }
-            if ("!in".equals(operator)) {
-                return ff.not(ff.or(typeFilters));
-            }
+            return filterByGeometryType(json, operator);
         }
         //
         // ID
@@ -364,21 +363,7 @@ public class MBFilter {
                         || "!in".equals(operator))
                 && parse.isString(json, 1)
                 && "$id".equals(parse.get(json, 1))) {
-
-            Set<FeatureId> fids = new HashSet<>();
-            for (Object value : json.subList(2, json.size())) {
-                if (value instanceof String) {
-                    String fid = (String) value;
-                    fids.add(ff.featureId(fid));
-                }
-            }
-            if ("has".equals(operator) || "in".equals(operator)) {
-                return ff.id(fids);
-            } else if ("!has".equals(operator) || "!in".equals(operator)) {
-                return ff.not(ff.id(fids));
-            } else {
-                throw new UnsupportedOperationException("$id \"" + operator + "\" not valid");
-            }
+            return filterByFeatureIdentifier(json, operator);
         }
 
         //
@@ -392,8 +377,9 @@ public class MBFilter {
         } else if ("has".equals(operator)) {
             String key = parse.get(json, 1);
             return ff.not(ff.isNull(ff.property(key)));
-            // Comparison Filters
-        } else if ("==".equals(operator)) {
+        }
+        // Comparison Filters
+        else if ("==".equals(operator)) {
             return filterEqualTo(json);
         } else if ("!=".equals(operator)) {
             return filterNotEqual(json);
@@ -408,60 +394,147 @@ public class MBFilter {
         }
         // Set Membership Filters
         else if ("in".equals(operator)) {
-            String key = parse.get(json, 1);
-            Expression[] args = new Expression[json.size() - 1];
-            args[0] = ff.property(key);
-            for (int i = 1; i < args.length; i++) {
-                Object value = parse.value(json, i + 1); // TODO: Allow for expressions in `in`
-                args[i] = ff.literal(value);
-            }
-            Function in = ff.function("in", args);
-            return ff.equals(in, ff.literal(true));
+            return filterIn(json, true);
         } else if ("!in".equals(operator)) {
-            String key = parse.get(json, 1);
-            Expression[] args = new Expression[json.size() - 1];
-            args[0] = ff.property(key);
-            for (int i = 1; i < args.length; i++) {
-                Object value = parse.value(json, i + 1); // TODO: Allow for expressions in `!in`
-                args[i] = ff.literal(value);
-            }
-            Function in = ff.function("in", args);
-            return ff.equals(in, ff.literal(false));
+            return filterIn(json, false);
         }
         // Combining Filters
         else if ("all".equals(operator)) {
-            List<Filter> all = new ArrayList<>();
-            for (int i = 1; i < json.size(); i++) {
-                MBFilter mbFilter = new MBFilter((JSONArray) json.get(i));
-                Filter filter = mbFilter.filter();
-                if (filter != Filter.INCLUDE) {
-                    all.add(filter);
-                }
-            }
-            return ff.and(all);
+            return filterAll(json);
         } else if ("any".equals(operator)) {
-            List<Filter> any = new ArrayList<>();
-            for (int i = 1; i < json.size(); i++) {
-                MBFilter mbFilter = new MBFilter((JSONArray) json.get(i));
-                Filter filter = mbFilter.filter();
-                if (filter != Filter.INCLUDE) {
-                    any.add(filter);
-                }
-            }
-            return ff.or(any);
+            return filterAny(json);
         } else if ("none".equals(operator)) {
-            List<Filter> none = new ArrayList<>();
-            for (int i = 1; i < json.size(); i++) {
+            return filterNone(json);
+        }
+        // MBExpression filters
+        else if ("case".equals(operator)) {
+            Expression caseExpr = MBExpression.transformExpression(json);
+            return ff.equals(caseExpr, ff.literal(true));
+        } else if ("coalesce".equals(operator)) {
+            Expression coalesce = MBExpression.transformExpression(json);
+            return ff.equals(coalesce, ff.literal(true));
+        } else if ("match".equals(operator)) {
+            Expression match = MBExpression.transformExpression(json);
+            return ff.equals(match, ff.literal(true));
+        } else if ("within".equals(operator)) {
+            Expression within = MBExpression.transformExpression(json);
+            return ff.equals(within, ff.literal(true));
+        } else {
+            throw new MBFormatException("Unsupported filter " + json);
+        }
+    }
+
+    private Filter filterNone(JSONArray array) {
+        List<Filter> none = new ArrayList<>();
+        for (int i = 1; i < array.size(); i++) {
+            if (parse.isArray(array, i)) {
                 // using not here so we can short circuit the and filter below
-                MBFilter mbFilter = new MBFilter((JSONArray) json.get(i));
+                MBFilter mbFilter = new MBFilter((JSONArray) array.get(i));
                 Filter filter = mbFilter.filter();
                 if (filter != Filter.INCLUDE) {
                     none.add(ff.not(filter));
                 }
+            } else {
+                throw new MBFormatException(
+                        "None filter does not support: \"" + json.get(i) + "\"");
             }
-            return ff.and(none);
+        }
+        return ff.and(none);
+    }
+
+    private Filter filterAny(JSONArray array) {
+        List<Filter> any = new ArrayList<>();
+        for (int i = 1; i < array.size(); i++) {
+            if (parse.isArray(array, i)) {
+                MBFilter mbFilter = new MBFilter((JSONArray) array.get(i));
+                Filter filter = mbFilter.filter();
+                if (filter != Filter.INCLUDE) {
+                    any.add(filter);
+                }
+            } else {
+                throw new MBFormatException("Any filter does not support: \"" + json.get(i) + "\"");
+            }
+        }
+        return ff.or(any);
+    }
+
+    private Filter filterAll(JSONArray array) {
+        List<Filter> all = new ArrayList<>();
+        for (int i = 1; i < array.size(); i++) {
+            if (parse.isArray(array, i)) {
+                MBFilter mbFilter = new MBFilter((JSONArray) array.get(i));
+                Filter filter = mbFilter.filter();
+                if (filter != Filter.INCLUDE) {
+                    all.add(filter);
+                }
+            } else {
+                throw new MBFormatException("All filter does not support: \"" + json.get(i) + "\"");
+            }
+        }
+        return ff.and(all);
+    }
+
+    private Filter filterIn(JSONArray array, boolean in) {
+        String key = parse.get(array, 1);
+        Expression[] args = new Expression[array.size() - 1];
+        args[0] = ff.property(key);
+        for (int i = 1; i < args.length; i++) {
+            Expression expression = parse.string(array, i + 1);
+            args[i] = expression;
+        }
+        Function function = ff.function("in", args);
+        return ff.equals(function, ff.literal(in));
+    }
+
+    private Filter filterByFeatureIdentifier(JSONArray array, String operator) {
+        Set<FeatureId> fids = new HashSet<>();
+        for (Object value : array.subList(2, array.size())) {
+            if (value instanceof String) {
+                String fid = (String) value;
+                fids.add(ff.featureId(fid));
+            }
+        }
+        if ("has".equals(operator) || "in".equals(operator)) {
+            return ff.id(fids);
+        } else if ("!has".equals(operator) || "!in".equals(operator)) {
+            return ff.not(ff.id(fids));
         } else {
-            throw new MBFormatException("Unsupported filter " + json);
+            throw new UnsupportedOperationException("$id \"" + operator + "\" not valid");
+        }
+    }
+
+    private Filter filterByGeometryType(JSONArray json, String operator) {
+        List<Filter> typeFilters = new ArrayList<>();
+        List<?> types = json.subList(2, json.size());
+        for (Object type : types) {
+            Filter typeFilter = null;
+            if (type instanceof String) {
+                typeFilter = translateType((String) type);
+            }
+            if (typeFilter == null) {
+                throw new MBFormatException(
+                        "\"$type\" limited to Point, LineString, Polygon: " + type);
+            }
+            typeFilters.add(typeFilter);
+        }
+        if ("==".equals(operator)) {
+            if (typeFilters.size() != 1) {
+                throw new MBFormatException(
+                        "[\"==\",\"$type\", ...] limited one geometry type, to test more than one use \"in\" operator.");
+            }
+            return typeFilters.get(0);
+        } else if ("!=".equals(operator)) {
+            if (typeFilters.size() != 1) {
+                throw new MBFormatException(
+                        "[\"!=\",\"$type\", ...] limited one geometry type, to test more than one use \"!in\" operator.");
+            }
+            return ff.not(typeFilters.get(0));
+        } else if ("in".equals(operator)) {
+            return ff.or(typeFilters);
+        } else if ("!in".equals(operator)) {
+            return ff.not(ff.or(typeFilters));
+        } else {
+            throw new MBFormatException("Unsupported $type operator \"" + json + "\"");
         }
     }
 
@@ -476,15 +549,9 @@ public class MBFilter {
         if (array.size() != 3) {
             throwUnexpectedArgumentCount("==", 2);
         }
-        if (parse.isString(array, 1)) { // legacy filter syntax
-            String key = parse.get(array, 1);
-            Object value = parse.value(array, 2);
-            return ff.equal(ff.property(key), ff.literal(value), false);
-        } else {
-            Expression expression1 = parse.string(array, 1);
-            Expression expression2 = parse.string(array, 2);
-            return ff.equal(expression1, expression2, false);
-        }
+        Expression expression1 = comparisonExpression1(array);
+        Expression expression2 = comparisonExpression2(array);
+        return ff.equals(expression1, expression2);
     }
 
     /**
@@ -498,75 +565,45 @@ public class MBFilter {
         if (array.size() != 3) {
             throwUnexpectedArgumentCount("!=", 2);
         }
-        if (parse.isString(array, 1)) { // legacy filter syntax
-            String key = parse.get(json, 1);
-            Object value = parse.value(json, 2); // legacy filter restricted to literals
-            return ff.notEqual(ff.property(key), ff.literal(value), false);
-        } else {
-            Expression expression1 = parse.string(json, 1);
-            Expression expression2 = parse.string(json, 2);
-            return ff.notEqual(expression1, expression2);
-        }
+        Expression expression1 = comparisonExpression1(array);
+        Expression expression2 = comparisonExpression2(array);
+        return ff.notEqual(expression1, expression2);
     }
 
     private Filter filterLessOrEqual(JSONArray array) {
         if (json.size() != 3) {
             throwUnexpectedArgumentCount("<=", 2);
         }
-        if (parse.isString(array, 1)) { // legacy filter syntax
-            String key = parse.get(json, 1);
-            Object value = parse.value(json, 2); // legacy filter restricted to literals
-            return ff.lessOrEqual(ff.property(key), ff.literal(value), false);
-        } else {
-            Expression expression1 = parse.string(json, 1);
-            Expression expression2 = parse.string(json, 2);
-            return ff.lessOrEqual(expression1, expression2);
-        }
+        Expression expression1 = comparisonExpression1(array);
+        Expression expression2 = comparisonExpression2(array);
+        return ff.lessOrEqual(expression1, expression2);
     }
 
     private Filter filterLess(JSONArray array) {
         if (json.size() != 3) {
             throwUnexpectedArgumentCount("<", 2);
         }
-        if (parse.isString(array, 1)) { // legacy filter syntax
-            String key = parse.get(json, 1);
-            Object value = parse.value(json, 2);
-            return ff.less(ff.property(key), ff.literal(value), false);
-        } else {
-            Expression expression1 = parse.string(json, 1);
-            Expression expression2 = parse.string(json, 2);
-            return ff.less(expression1, expression2);
-        }
+        Expression expression1 = comparisonExpression1(array);
+        Expression expression2 = comparisonExpression2(array);
+        return ff.less(expression1, expression2);
     }
 
     private Filter filterGreaterOrEqual(JSONArray array) {
         if (json.size() != 3) {
             throwUnexpectedArgumentCount(">=", 2);
         }
-        if (parse.isString(array, 1)) { // legacy filter syntax
-            String key = parse.get(json, 1);
-            Object value = parse.value(json, 2);
-            return ff.greaterOrEqual(ff.property(key), ff.literal(value), false);
-        } else {
-            Expression expression1 = parse.string(json, 1);
-            Expression expression2 = parse.string(json, 2);
-            return ff.greaterOrEqual(expression1, expression2);
-        }
+        Expression expression1 = comparisonExpression1(array);
+        Expression expression2 = comparisonExpression2(array);
+        return ff.greaterOrEqual(expression1, expression2);
     }
 
     private Filter filterGreater(JSONArray array) {
         if (json.size() != 3) {
             throwUnexpectedArgumentCount(">", 2);
         }
-        if (parse.isString(array, 1)) { // legacy filter syntax
-            String key = parse.get(json, 1);
-            Object value = parse.value(json, 2);
-            return ff.greater(ff.property(key), ff.literal(value), false);
-        } else {
-            Expression expression1 = parse.string(json, 1);
-            Expression expression2 = parse.string(json, 2);
-            return ff.greater(expression1, expression2);
-        }
+        Expression expression1 = comparisonExpression1(array);
+        Expression expression2 = comparisonExpression2(array);
+        return ff.greater(expression1, expression2);
     }
 
     private void throwUnexpectedArgumentCount(String expression, int argCount)
@@ -575,5 +612,34 @@ public class MBFilter {
                 String.format(
                         "Expression \"%s\" should have exactly %d argument(s)",
                         expression, argCount));
+    }
+
+    /**
+     * Comparison value1 defined as an expression (or legacy key reference).
+     *
+     * @param array JSON filter definition
+     * @return Expression for comparison
+     */
+    private Expression comparisonExpression1(JSONArray array) {
+        if (parse.isString(array, 1)) { // legacy filter syntax
+            String key = parse.get(array, 1);
+            return ff.property(key);
+        } else {
+            return parse.string(array, 1);
+        }
+    }
+    /**
+     * Comparison value1 defined as an expression (or legacy literal reference).
+     *
+     * @param array JSON filter definition
+     * @return Expression for comparison
+     */
+    private Expression comparisonExpression2(JSONArray array) {
+        if (parse.isString(array, 1)) { // legacy filter syntax
+            Object value = parse.value(array, 2);
+            return ff.literal(value);
+        } else {
+            return parse.string(array, 2);
+        }
     }
 }

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFilter.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFilter.java
@@ -37,11 +37,11 @@ import org.opengis.style.SemanticType;
  * <p>This wrapper class is used by {@link MBObjectParser} to generate rule filters when
  * transforming MBStyle.
  *
- * <p>This wrapper and {@link MBFunction} are a matched set handling dynamic data.
+ * <p>This wrapper and {@link MBFunction} are a matched set handling data expression.
  *
- * <h2>Expression: Decision</h2>
+ * <h2>Data expression: Decision</h2>
  *
- * <p>Implementation Note:The value for any filter may be specified as an expression. The result type of an expression in
+ * <p>Implementation Note: The value for any filter may be specified as an data expression. The result type of an data expression in
  * the filter property must be boolean. See {@link org.geotools.mbstyle.expression.MBExpression} for details.
  *
  * <p>The expressions in this section can be used to add conditional logic to your styles. For example, the 'case' expression
@@ -65,8 +65,8 @@ import org.opengis.style.SemanticType;
  *
  * <h2>Filter Other</h2>
  *
- * <p>Implementation Note: In previous versions of the style specification, filters were defined using the deprecated
- * syntax documented here.
+ * <p>Implementation Note: GeoTools also supports the depreciated syntax documented here (provided
+ * by a previous versions of the Mapbox style specification).
  *
  * <p>A filter selects specific features from a layer. A filter is an array of one of the following
  * forms:
@@ -89,7 +89,7 @@ import org.opengis.style.SemanticType;
  *   <li>["&lt;=", key, value] less than or equal: feature[key] ≤ value
  * </ul>
  *
- * <p>Set Memmbership Filters:
+ * <p>Set Membership Filters:
  *
  * <ul>
  *   <li>["in", key, v0, ..., vn] set inclusion: feature[key] ∈ {v0, ..., vn}
@@ -183,7 +183,8 @@ public class MBFilter {
     /**
      * Utility method to convert json to set of {@link SemanticType}.
      *
-     * <p>This method is recursively calls itself to handle all and any operators.
+     * <p>This method is called recursively to handle <code>all</code> and <code>any</code> filter
+     * operators.
      *
      * @param array JSON array defining filter
      * @return SemanticTypes from provided json, may be nested
@@ -420,7 +421,11 @@ public class MBFilter {
             Expression within = MBExpression.transformExpression(json);
             return ff.equals(within, ff.literal(true));
         } else {
-            throw new MBFormatException("Unsupported filter " + json);
+            throw new MBFormatException(
+                    "Data expression or filter \""
+                            + operator
+                            + "\" invalid. It may be misspelled or not supported by this implementation:"
+                            + json);
         }
     }
 
@@ -615,7 +620,7 @@ public class MBFilter {
     }
 
     /**
-     * Comparison value1 defined as an expression (or legacy key reference).
+     * Comparison value1 defined as an data expression (or legacy key reference).
      *
      * @param array JSON filter definition
      * @return Expression for comparison
@@ -629,7 +634,7 @@ public class MBFilter {
         }
     }
     /**
-     * Comparison value1 defined as an expression (or legacy literal reference).
+     * Comparison value2 defined as an data expression (or legacy literal reference).
      *
      * @param array JSON filter definition
      * @return Expression for comparison

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFunction.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFunction.java
@@ -37,7 +37,7 @@ import org.opengis.filter.expression.Function;
 /**
  * MBFunction json wrapper, allowing conversion of function to a GeoTools Expression.
  *
- * <p>As of v0.41.0, data expressions is the preferred method for styling features based on zoom
+ * <p>As of v0.41.0, data expressions are the preferred method for styling features based on zoom
  * level or the feature's properties.
  *
  * <p>Each function is evaluated according type: {@link FunctionType#IDENTITY}, {@link

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFunction.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFunction.java
@@ -35,7 +35,10 @@ import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Function;
 
 /**
- * MBFunction json wrapper, allowing conversion to a GeoTools Expression.
+ * MBFunction json wrapper, allowing conversion of function to a GeoTools Expression.
+ *
+ * <p>As of MapBox Style Specification v0.41.0, property expressions are the preferred approach for
+ * dynamically styling features.
  *
  * <p>Each function is evaluated according type: {@link FunctionType#IDENTITY}, {@link
  * FunctionType#INTERVAL}, {@link FunctionType#CATEGORICAL}, {@link FunctionType#EXPONENTIAL}.

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFunction.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBFunction.java
@@ -37,8 +37,8 @@ import org.opengis.filter.expression.Function;
 /**
  * MBFunction json wrapper, allowing conversion of function to a GeoTools Expression.
  *
- * <p>As of MapBox Style Specification v0.41.0, property expressions are the preferred approach for
- * dynamically styling features.
+ * <p>As of v0.41.0, data expressions is the preferred method for styling features based on zoom
+ * level or the feature's properties.
  *
  * <p>Each function is evaluated according type: {@link FunctionType#IDENTITY}, {@link
  * FunctionType#INTERVAL}, {@link FunctionType#CATEGORICAL}, {@link FunctionType#EXPONENTIAL}.

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -875,6 +875,10 @@ public class MBObjectParser {
         return array == null ? fallback : Arrays.stream(array).mapToDouble(i -> i).toArray();
     }
 
+    //
+    // Percentage
+    //
+
     /**
      * Convert json to Expression number between 0 and 1, or a function.
      *

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -1443,12 +1443,10 @@ public class MBObjectParser {
     //
     // structure checks
     //
-    /**
-     * @return True if json has the provided property explicitly provided, False otherwise.
-     */
+    /** @return True if json has the provided property explicitly provided, False otherwise. */
     public boolean isPropertyDefined(JSONObject json, String propertyName)
             throws MBFormatException {
-        return isDefined(json,propertyName);
+        return isDefined(json, propertyName);
     }
     /** @return True if json has the property explicitly provided, False otherwise. */
     public boolean isDefined(JSONObject json, String propertyName) throws MBFormatException {

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -178,21 +178,21 @@ public class MBObjectParser {
      * MBFormatException} if not available.
      *
      * @param json The JSONObject in which to lookup the provided tag and return a JSONObject
-     * @param tag The tag to look up in the provided JSONObject
+     * @param name The tag to look up in the provided JSONObject
      * @return The JSONObject at the provided tag
      * @throws MBFormatException If JSONObject not available for the provided tag
      */
-    public JSONObject getJSONObject(JSONObject json, String tag) {
+    public JSONObject getJSONObject(JSONObject json, String name) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
         }
-        if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
+        if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
         }
-        if (json.containsKey(tag) && json.get(tag) instanceof JSONObject) {
-            return (JSONObject) json.get(tag);
+        if (json.containsKey(name) && json.get(name) instanceof JSONObject) {
+            return (JSONObject) json.get(name);
         } else {
-            throw new MBFormatException("\"" + tag + "\" requires JSONObject");
+            throw new MBFormatException("\"" + name + "\" requires JSONObject");
         }
     }
 
@@ -201,20 +201,20 @@ public class MBObjectParser {
      * contain a JSONObject for that tag.
      *
      * @param json The JSONObject in which to lookup the provided tag and return a JSONObject
-     * @param tag The tag to look up in the provided JSONObject
+     * @param name The tag to look up in the provided JSONObject
      * @param fallback The JSONObject to return if the provided json does not contain a JSONObject
      *     for that tag.
      * @return The JSONObject at the provided tag, or the fallback object.
      */
-    public JSONObject getJSONObject(JSONObject json, String tag, JSONObject fallback) {
+    public JSONObject getJSONObject(JSONObject json, String name, JSONObject fallback) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
         }
-        if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
+        if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
         }
-        if (json.containsKey(tag) && json.get(tag) instanceof JSONObject) {
-            return (JSONObject) json.get(tag);
+        if (json.containsKey(name) && json.get(name) instanceof JSONObject) {
+            return (JSONObject) json.get(name);
         } else {
             return fallback;
         }
@@ -228,17 +228,17 @@ public class MBObjectParser {
      * @return JSONObject
      * @throws MBFormatException If JSONObject not available for the provided tag
      */
-    public JSONArray getJSONArray(JSONObject json, String tag) {
+    public JSONArray getJSONArray(JSONObject json, String name) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
         }
-        if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
+        if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
         }
-        if (json.containsKey(tag) && json.get(tag) instanceof JSONArray) {
-            return (JSONArray) json.get(tag);
+        if (json.containsKey(name) && json.get(name) instanceof JSONArray) {
+            return (JSONArray) json.get(name);
         } else {
-            throw new MBFormatException("\"" + tag + "\" requires JSONArray");
+            throw new MBFormatException("\"" + name + "\" requires JSONArray");
         }
     }
 
@@ -247,22 +247,22 @@ public class MBObjectParser {
      * JSONArray is found at that tag.
      *
      * @param json The JSONObject in which to lookup the provided tag and return a JSONArray
-     * @param tag The tag to look up in the provided JSONObject
+     * @param name The tag to look up in the provided JSONObject
      * @param fallback The JSONArray to return if the provided json does not contain a JSONArray for
      *     that tag.
      * @return The JSONArray at the provided tag, or the fallback JSONArray.
      */
-    public JSONArray getJSONArray(JSONObject json, String tag, JSONArray fallback) {
+    public JSONArray getJSONArray(JSONObject json, String name, JSONArray fallback) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
-        } else if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
-        } else if (!json.containsKey(tag) || json.get(tag) == null) {
+        } else if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
+        } else if (!json.containsKey(name) || json.get(name) == null) {
             return fallback;
-        } else if (json.containsKey(tag) && json.get(tag) instanceof JSONArray) {
-            return (JSONArray) json.get(tag);
+        } else if (json.containsKey(name) && json.get(name) instanceof JSONArray) {
+            return (JSONArray) json.get(name);
         } else {
-            throw new MBFormatException("\"" + tag + "\" requires JSONArray");
+            throw new MBFormatException("\"" + name + "\" requires JSONArray");
         }
     }
 
@@ -296,12 +296,12 @@ public class MBObjectParser {
      * @return required string, numeric or boolean
      * @throws MBFormatException if required tag not available.
      */
-    public Object value(JSONObject json, String tag) {
+    public Object value(JSONObject json, String name) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
         }
-        if (json.containsKey(tag)) {
-            Object value = json.get(tag);
+        if (json.containsKey(name)) {
+            Object value = json.get(name);
             if (value == null
                     || value instanceof String
                     || value instanceof Boolean
@@ -311,13 +311,13 @@ public class MBObjectParser {
             throw new MBFormatException(
                     context.getSimpleName()
                             + " requires \""
-                            + tag
+                            + name
                             + "\" literal required (was "
                             + value.getClass().getSimpleName()
                             + ")");
         }
         throw new MBFormatException(
-                context.getSimpleName() + " requires \"" + tag + "\" required.");
+                context.getSimpleName() + " requires \"" + name + "\" required.");
     }
 
     /**
@@ -332,10 +332,6 @@ public class MBObjectParser {
         }
         if (index < json.size() && json.get(index) instanceof String) {
             return (String) json.get(index);
-            //        }
-            //        if (index < json.size() && json.get(index) instanceof JSONArray) {
-            //            return MBExpression.transformExpression((JSONArray)
-            // json.get(index)).toString();
         } else {
             throw new MBFormatException(
                     context.getSimpleName() + " requires [" + index + "] string");
@@ -346,22 +342,22 @@ public class MBObjectParser {
      * Quickly access required json tag (as a String).
      *
      * @param json The object in which to look up the String
-     * @param tag Tag to lookup
+     * @param name Tag to lookup
      * @return required string
      * @throws MBFormatException if required tag not available.
      */
-    public String get(JSONObject json, String tag) {
+    public String get(JSONObject json, String name) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
         }
-        if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
+        if (name == null) {
+            throw new IllegalArgumentException("name required for json access");
         }
-        if (json.containsKey(tag) && json.get(tag) instanceof String) {
-            return (String) json.get(tag);
+        if (json.containsKey(name) && json.get(name) instanceof String) {
+            return (String) json.get(name);
         } else {
             throw new MBFormatException(
-                    context.getSimpleName() + " requires \"" + tag + "\" string field");
+                    context.getSimpleName() + " requires \"" + name + "\" string field");
         }
     }
 
@@ -369,21 +365,21 @@ public class MBObjectParser {
      * Quickly access optional json tag.
      *
      * @param json The object in which to look up the String
-     * @param tag Tag to lookup
+     * @param name Tag to lookup
      * @param fallback default string
      * @return required string, or fallback if unavailable
      */
-    public String get(JSONObject json, String tag, String fallback) {
-        if (tag == null || json == null) {
+    public String get(JSONObject json, String name, String fallback) {
+        if (name == null || json == null) {
             return fallback;
-        } else if (!json.containsKey(tag) || json.get(tag) == null) {
+        } else if (!json.containsKey(name) || json.get(name) == null) {
             return fallback;
         }
-        if (json.containsKey(tag) && json.get(tag) instanceof String) {
-            return (String) json.get(tag);
+        if (json.containsKey(name) && json.get(name) instanceof String) {
+            return (String) json.get(name);
         } else {
             throw new MBFormatException(
-                    context.getSimpleName() + " requires \"" + tag + "\" string field");
+                    context.getSimpleName() + " requires \"" + name + "\" string field");
         }
     }
 
@@ -412,21 +408,21 @@ public class MBObjectParser {
      * {@link MBFormatException}.
      *
      * @param json The object in which to look up the Double
-     * @param tag The tag at which to look up the Double
+     * @param name The tag at which to look up the Double
      * @return The Double from the object at 'tag'
      */
-    public Double getNumeric(JSONObject json, String tag) {
+    public Double getNumeric(JSONObject json, String name) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
         }
-        if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
+        if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
         }
-        if (json.containsKey(tag) && json.get(tag) instanceof Number) {
-            return ((Number) json.get(tag)).doubleValue();
+        if (json.containsKey(name) && json.get(name) instanceof Number) {
+            return ((Number) json.get(name)).doubleValue();
         } else {
             throw new MBFormatException(
-                    context.getSimpleName() + " requires \"" + tag + "\" numeric field");
+                    context.getSimpleName() + " requires \"" + name + "\" numeric field");
         }
     }
 
@@ -455,21 +451,21 @@ public class MBObjectParser {
      * {@link MBFormatException}.
      *
      * @param json The object in which to look up the Boolean
-     * @param tag The tag at which to look up the Boolean
+     * @param name The tag at which to look up the Boolean
      * @return The Boolean from the object at 'tag'
      */
-    public Boolean getBoolean(JSONObject json, String tag) {
+    public Boolean getBoolean(JSONObject json, String name) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
         }
-        if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
+        if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
         }
-        if (json.containsKey(tag) && json.get(tag) instanceof Boolean) {
-            return (Boolean) json.get(tag);
+        if (json.containsKey(name) && json.get(name) instanceof Boolean) {
+            return (Boolean) json.get(name);
         } else {
             throw new MBFormatException(
-                    context.getSimpleName() + " requires \"" + tag + "\" boolean field");
+                    context.getSimpleName() + " requires \"" + name + "\" boolean field");
         }
     }
 
@@ -478,22 +474,22 @@ public class MBObjectParser {
      * {@link MBFormatException}, with a fallback if the json is null or contains no such 'tag'.
      *
      * @param json The object in which to look up the Boolean
-     * @param tag The tag at which to look up the Boolean
+     * @param name The tag at which to look up the Boolean
      * @param fallback The value to return if the json is null or contains no such 'tag'.
      * @return The Boolean from the object at 'tag', or the fallback value
      */
-    public Boolean getBoolean(JSONObject json, String tag, Boolean fallback) {
+    public Boolean getBoolean(JSONObject json, String name, Boolean fallback) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
-        } else if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
-        } else if (!json.containsKey(tag) || json.get(tag) == null) {
+        } else if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
+        } else if (!json.containsKey(name) || json.get(name) == null) {
             return fallback;
-        } else if (json.get(tag) instanceof Boolean) {
-            return (Boolean) json.get(tag);
+        } else if (json.get(name) instanceof Boolean) {
+            return (Boolean) json.get(name);
         } else {
             throw new MBFormatException(
-                    context.getSimpleName() + " requires \"" + tag + "\" boolean field");
+                    context.getSimpleName() + " requires \"" + name + "\" boolean field");
         }
     }
 
@@ -526,23 +522,23 @@ public class MBObjectParser {
      * @param <T> Class to return
      * @param type The type of the object to retrieve.
      * @param json The JSONObject in which to retrieve the object.
-     * @param tag The index in the JSONObject at which to retrieve the object.
+     * @param name The index in the JSONObject at which to retrieve the object.
      * @return The object of the required type in the JSONObject at the tag.
      */
-    public <T> T require(Class<T> type, JSONObject json, String tag) {
+    public <T> T require(Class<T> type, JSONObject json, String name) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
         }
-        if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
+        if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
         }
-        if (json.containsKey(tag) && type.isInstance(json.get(tag))) {
-            return type.cast(json.get(tag));
+        if (json.containsKey(name) && type.isInstance(json.get(name))) {
+            return type.cast(json.get(name));
         } else {
             throw new MBFormatException(
                     context.getSimpleName()
                             + " requires \""
-                            + tag
+                            + name
                             + "\" "
                             + type.getSimpleName()
                             + " field");
@@ -555,22 +551,22 @@ public class MBObjectParser {
      * @param <T> Class to return
      * @param type Type to lookup
      * @param json The JSONObject in which to lookup the value
-     * @param tag The tag at which to lookupthe value in the JSONObject
+     * @param name The tag at which to lookupthe value in the JSONObject
      * @param fallback The fallback value to use if the JSONObject is null or does not contain the
      *     provided tag
      * @return value for the provided tag, or fallback if not available
      * @throws MBFormatException If value is found and is not the expected type
      */
-    public <T> T optional(Class<T> type, JSONObject json, String tag, T fallback) {
+    public <T> T optional(Class<T> type, JSONObject json, String name, T fallback) {
         if (json == null) {
             throw new IllegalArgumentException("json required");
-        } else if (tag == null) {
-            throw new IllegalArgumentException("tag required for json access");
-        } else if (!json.containsKey(tag)) {
+        } else if (name == null) {
+            throw new IllegalArgumentException("name required for json object access");
+        } else if (!json.containsKey(name)) {
             return fallback;
         } else {
-            Object value = json.get(tag);
-            if (!json.containsKey(tag) || json.get(tag) == null) {
+            Object value = json.get(name);
+            if (!json.containsKey(name) || json.get(name) == null) {
                 return fallback;
             } else if (Number.class.isAssignableFrom(type)) {
                 T number = Converters.convert(value, type);
@@ -578,7 +574,7 @@ public class MBObjectParser {
                     throw new MBFormatException(
                             context.getSimpleName()
                                     + " optional \""
-                                    + tag
+                                    + name
                                     + "\" expects "
                                     + type.getSimpleName()
                                     + " value");
@@ -591,7 +587,7 @@ public class MBObjectParser {
                 throw new MBFormatException(
                         context.getSimpleName()
                                 + " optional \""
-                                + tag
+                                + name
                                 + "\" expects "
                                 + type.getSimpleName()
                                 + " value");
@@ -604,7 +600,7 @@ public class MBObjectParser {
      *
      * @param <T> Enumeration type to return
      * @param json The json object to parse the value from
-     * @param tag The key used to retrieve the value from the json.
+     * @param name The key used to retrieve the value from the json.
      * @param enumeration The enum to convert the value to.
      * @param fallback default value if json is null
      * @return The enum value from the string, or the fallback value.
@@ -612,8 +608,8 @@ public class MBObjectParser {
      *     enumeration.
      */
     public <T extends Enum<?>> T getEnum(
-            JSONObject json, String tag, Class<T> enumeration, T fallback) {
-        Object value = json.get(tag);
+            JSONObject json, String name, Class<T> enumeration, T fallback) {
+        Object value = json.get(name);
 
         if (value == null) {
             return fallback;
@@ -629,13 +625,15 @@ public class MBObjectParser {
             }
             throw new MBFormatException(
                     "\""
-                            + tag
-                            + "\" contains invalid value for enumeration "
+                            + name
+                            + "\" contains invalid \""
+                            + stringVal
+                            + "\" for enumeration "
                             + enumeration.getSimpleName());
         } else {
             throw new MBFormatException(
                     "Conversion of \""
-                            + tag
+                            + name
                             + "\" value from "
                             + value.getClass().getSimpleName()
                             + " to "
@@ -652,7 +650,7 @@ public class MBObjectParser {
      * value "bevel", or {@link LineJoin#MITER} to an expression that evaluates to "mitre".
      *
      * @param json The json object containing the property
-     * @param tag The json key corresponding to the property
+     * @param name The json key corresponding to the property
      * @param enumeration The Mapbox enumeration that the value should be an instance of
      * @param fallback The fallback enumeration value, if the value is missing or invalid for the
      *     provided enumeration.
@@ -660,9 +658,9 @@ public class MBObjectParser {
      *     GeoTools constant.
      */
     public <T extends Enum<?>> Expression enumToExpression(
-            JSONObject json, String tag, Class<T> enumeration, T fallback) {
+            JSONObject json, String name, Class<T> enumeration, T fallback) {
         // Function name is inconsistent because "enum" is not a valid function name.
-        Object value = json.get(tag);
+        Object value = json.get(name);
         if (value == null) {
             return constant(fallback.toString(), enumeration);
         } else if (value instanceof String) {
@@ -677,7 +675,9 @@ public class MBObjectParser {
                         Level.WARNING,
                         "\""
                                 + stringVal
-                                + "\" Exception parsing value for enumeration "
+                                + "\" Exception parsing value \""
+                                + stringVal
+                                + "\" for enumeration "
                                 + enumeration.getSimpleName()
                                 + ", falling back to default value.");
                 return constant(fallback.toString(), enumeration);
@@ -688,7 +688,7 @@ public class MBObjectParser {
         } else {
             throw new MBFormatException(
                     "Conversion of \""
-                            + tag
+                            + name
                             + "\" value from "
                             + value.getClass().getSimpleName()
                             + " to "
@@ -812,14 +812,14 @@ public class MBObjectParser {
      *
      * @param type The type of the array
      * @param json The JSONObject in which to look up the array
-     * @param tag The tag at which to look up the array
+     * @param name The tag at which to look up the array
      * @param fallback The fallback array
      * @return An array of the provided type, or the fallback array.
      */
     @SuppressWarnings("unchecked")
-    public <T> T[] array(Class<T> type, JSONObject json, String tag, T[] fallback) {
-        if (json.containsKey(tag)) {
-            Object obj = json.get(tag);
+    public <T> T[] array(Class<T> type, JSONObject json, String name, T[] fallback) {
+        if (json.containsKey(name)) {
+            Object obj = json.get(name);
             if (obj instanceof JSONArray) {
                 JSONArray array = (JSONArray) obj;
                 T[] returnArray = (T[]) Array.newInstance(type, array.size());
@@ -840,7 +840,7 @@ public class MBObjectParser {
             } else {
                 throw new MBFormatException(
                         "\""
-                                + tag
+                                + name
                                 + "\" required as JSONArray of "
                                 + type.getSimpleName()
                                 + ": Unexpected "
@@ -851,12 +851,12 @@ public class MBObjectParser {
     }
 
     /** Convert to int[] */
-    public int[] array(JSONObject json, String tag, int[] fallback) {
+    public int[] array(JSONObject json, String name, int[] fallback) {
         Integer[] array =
                 array(
                         Integer.class,
                         json,
-                        tag,
+                        name,
                         fallback == null
                                 ? null
                                 : Arrays.stream(fallback).mapToObj(i -> i).toArray(Integer[]::new));
@@ -864,12 +864,12 @@ public class MBObjectParser {
     }
 
     /** Convert to double[] */
-    public double[] array(JSONObject json, String tag, double[] fallback) {
+    public double[] array(JSONObject json, String name, double[] fallback) {
         Double[] array =
                 array(
                         Double.class,
                         json,
-                        tag,
+                        name,
                         fallback == null
                                 ? null
                                 : Arrays.stream(fallback).mapToObj(i -> i).toArray(Double[]::new));
@@ -884,25 +884,26 @@ public class MBObjectParser {
      * Convert json to Expression number between 0 and 1, or a function.
      *
      * @param json json representation
-     * @return Expression based on provided json, or null if not provided
+     * @return Percentage GeoTools Expression based on provided json, or null if not provided
      */
-    public Expression percentage(JSONObject json, String tag) throws MBFormatException {
-        return percentage(json, tag, null);
+    public Expression percentage(JSONObject json, String name) throws MBFormatException {
+        return percentage(json, name, null);
     }
 
     /**
      * Convert json to Expression number between 0 and 1, or a function.
      *
      * @param json json representation
+     * @param name The tag at which to look up the percentage
      * @param fallback default value if json is null
-     * @return Expression based on provided json, or literal if json was null.
+     * @return Percentage GeoTools Expression based on provided json, or literal if json was null.
      */
-    public Expression percentage(JSONObject json, String tag, Number fallback)
+    public Expression percentage(JSONObject json, String name, Number fallback)
             throws MBFormatException {
         if (json == null) {
             return fallback == null ? null : ff.literal(fallback);
         }
-        Object obj = json.get(tag);
+        Object obj = json.get(name);
 
         if (obj == null) {
             return ff.literal(fallback);
@@ -915,7 +916,7 @@ public class MBObjectParser {
         } else if (obj instanceof Boolean) {
             throw new MBFormatException(
                     "\""
-                            + tag
+                            + name
                             + "\" percentage from boolean "
                             + obj
                             + " not supported, expected value between 0 and 1");
@@ -931,7 +932,7 @@ public class MBObjectParser {
         } else {
             throw new IllegalArgumentException(
                     "json contents invalid, \""
-                            + tag
+                            + name
                             + "\" value limited to Number or JSONObject but was "
                             + obj.getClass().getSimpleName());
         }
@@ -941,19 +942,20 @@ public class MBObjectParser {
     // Font
     //
     /**
-     * Convert the provided object to a numeric Expression (or function), with a fallback value if
-     * the object is null.
+     * Convert the provided object to a font Expression (or function), with a fallback value if the
+     * object is null.
      *
      * @param json The json context of the object, used for error messages.
-     * @param tag The object to convert
+     * @param name Tag used to lookup font value
      * @param fallback The fallback value, used when the provided object is null.
-     * @return A numeric expression for the provided object
+     * @return Font GeoTools Expression for the provided object
      */
-    private Expression font(JSONObject json, String tag, String fallback) throws MBFormatException {
+    private Expression font(JSONObject json, String name, String fallback)
+            throws MBFormatException {
         if (json == null) {
             return fallback == null ? null : ff.literal(fallback);
         }
-        Object obj = json.get(tag);
+        Object obj = json.get(name);
 
         if (obj == null) {
             return ff.literal(fallback);
@@ -970,15 +972,21 @@ public class MBObjectParser {
             }
         } else {
             throw new IllegalArgumentException(
-                    "json contents invalid, "
-                            + tag
-                            + " value limited to JSONArray, or JSONObject but was "
+                    "json contents invalid font, "
+                            + name
+                            + " value expected JSONArray, or JSONObject but was "
                             + obj.getClass().getSimpleName());
         }
     }
-
-    public Expression font(JSONObject json, String tag) throws MBFormatException {
-        return font(json, tag, null);
+    /**
+     * Convert the provided object to a font Expression (or function).
+     *
+     * @param json The json context of the object, used for error messages.
+     * @param name Tag used to lookup font value
+     * @return Font GeoTools Expression for the provided object
+     */
+    public Expression font(JSONObject json, String name) throws MBFormatException {
+        return font(json, name, null);
     }
 
     //
@@ -1031,7 +1039,7 @@ public class MBObjectParser {
      *
      * @param json The JSONArray in which to look up a value
      * @param index The index in the JSONArray
-     * @return Numeric Expression based on provided json, or null.
+     * @return Numeric GeoTools Expression based on provided json, or null.
      */
     public Expression number(JSONArray json, int index) throws MBFormatException {
         return number(json, index, null);
@@ -1044,7 +1052,7 @@ public class MBObjectParser {
      * @param json The JSONArray in which to look up the value
      * @param index The index in the JSONArray at which to look up the value
      * @param fallback default value if json is null
-     * @return Expression based on provided json, or literal if json was null.
+     * @return Numeric GeoTools Expression based on provided json, or Literal if json was null.
      */
     public Expression number(JSONArray json, int index, Number fallback) throws MBFormatException {
         if (json == null) {
@@ -1055,14 +1063,15 @@ public class MBObjectParser {
     }
 
     /**
-     * Convert the value in the provided JSONObject at 'tag' to a numeric Expression, or a function.
+     * Convert the value in the provided JSONObject at 'tag' to a numeric GeoTools Expression, or a
+     * Function.
      *
      * @param json The JSONObject in which to look up the value
-     * @param tag The tag in the JSONObject at which to look up the value
-     * @return Expression based on provided json, or null
+     * @param name The tag in the JSONObject at which to look up the value
+     * @return Numeric GeoTools Expression based on provided json, or null
      */
-    public Expression number(JSONObject json, String tag) throws MBFormatException {
-        return number(json, tag, null);
+    public Expression number(JSONObject json, String name) throws MBFormatException {
+        return number(json, name, null);
     }
 
     /**
@@ -1070,17 +1079,18 @@ public class MBObjectParser {
      * with a fallback if the json is null.
      *
      * @param json The JSONObject in which to look up the value
-     * @param tag The tag in the JSONObject at which to look up the value
+     * @param name The tag in the JSONObject at which to look up the value
      * @param fallback default value if the JSONObject is null
-     * @return Expression based on provided json, or literal if json was null.
+     * @return Numeric GeoTools Expression based on provided json, or fallback Literal if json was
+     *     null.
      */
-    public Expression number(JSONObject json, String tag, Number fallback)
+    public Expression number(JSONObject json, String name, Number fallback)
             throws MBFormatException {
         if (json == null) {
             return ff.literal(fallback);
         }
-        Object obj = json.get(tag);
-        return number("\"" + tag + "\"", obj, fallback);
+        Object obj = json.get(name);
+        return number("\"" + name + "\"", obj, fallback);
     }
 
     //
@@ -1094,7 +1104,7 @@ public class MBObjectParser {
      * @param context The json context of the object, used for error messages.
      * @param obj The object to convert
      * @param fallback The fallback value, used when the provided object is null.
-     * @return A string expression for the provided object
+     * @return A string GeoTools Expression for the provided json object
      */
     private Expression string(String context, Object obj, String fallback) {
         if (obj == null) {
@@ -1127,11 +1137,11 @@ public class MBObjectParser {
     }
 
     /**
-     * Convert the value in the provided JSONArray at index to a string Expression, or a function.
+     * Convert the value in the provided JSONArray at index to a string Literal, or a Function.
      *
      * @param json The JSONArray in which to look up the value
      * @param index The index in the JSONArray at which to look up the value
-     * @return Expression based on provided json, or literal if json was null.
+     * @return String GeoTools Expression based on provided json, or literal if json was null.
      */
     public Expression string(JSONArray json, int index) {
         Object obj = json.get(index);
@@ -1158,50 +1168,52 @@ public class MBObjectParser {
                 } else {
                     throw new MBFormatException(
                             context
-                                    + " string unavailable: expression' "
+                                    + " string unavailable: data expression \""
                                     + expressionName
-                                    + "' not supported.");
+                                    + "\" invalid. It may be misspelled or not supported by this implementation");
                 }
             } else {
-                throw new MBFormatException(context + " string from JSONArray not a supported");
+                throw new MBFormatException(
+                        context
+                                + " string unavailable: Conversion from a JSONArray not a supported: "
+                                + array);
             }
         } else {
             throw new IllegalArgumentException(
-                    "json contents invalid, "
-                            + context
-                            + " value limited to String, Number, Boolean, JSONArray or JSONObject but was "
+                    context
+                            + " string unavailable: json contents invalid - value limited to String, Number, Boolean, JSONArray or JSONObject but was "
                             + obj.getClass().getSimpleName());
         }
     }
 
     /**
-     * Convert json to Expression string, or a function.
+     * Convert json to GeoTools Expression string, or a function.
      *
      * @param json json representation
      * @param fallback default value if json is null
-     * @return Expression based on provided json, or literal if json was null.
+     * @return String GeoTools Expression based on provided json, or literal if json was null.
      */
-    public Expression string(JSONObject json, String tag, String fallback)
+    public Expression string(JSONObject json, String name, String fallback)
             throws MBFormatException {
         if (json == null) {
             return fallback == null ? null : ff.literal(fallback);
         }
-        return string("\"" + tag + "\"", json.get(tag), fallback);
+        return string("\"" + name + "\"", json.get(name), fallback);
     }
 
     /**
-     * Convert json to Expression color, or a function.
+     * Convert json to GeoTools Expression color, or a function.
      *
      * @param json json representation
      * @param fallback default value (string representation of color) if json is null
-     * @return Expression based on provided json, or literal if json was null.
+     * @return String GeoTools Expression based on provided json, or literal if json was null.
      */
-    public Expression color(JSONObject json, String tag, Color fallback) throws MBFormatException {
-        if (json.get(tag) == null) {
+    public Expression color(JSONObject json, String name, Color fallback) throws MBFormatException {
+        if (json.get(name) == null) {
             return fallback == null ? null : ff.literal(fallback);
         }
-        Object obj = json.get(tag);
-        return color("\"" + tag + "\"", obj, fallback);
+        Object obj = json.get(name);
+        return color("\"" + name + "\"", obj, fallback);
     }
 
     /**
@@ -1341,21 +1353,22 @@ public class MBObjectParser {
      *
      * @param json json representation
      * @param fallback default value if json is null
-     * @return Expression based on provided json, or literal if json was null.
+     * @return String GeoTools Expression based on provided json, or literal if json was null.
      */
-    public Expression bool(JSONObject json, String tag, boolean fallback) throws MBFormatException {
-        if (json.get(tag) == null) {
+    public Expression bool(JSONObject json, String name, boolean fallback)
+            throws MBFormatException {
+        if (json.get(name) == null) {
             return ff.literal(fallback);
         }
 
-        Object obj = json.get(tag);
+        Object obj = json.get(name);
 
         if (obj instanceof String) {
             String str = (String) obj;
             return ff.literal(str);
         } else if (obj instanceof Number) {
             throw new UnsupportedOperationException(
-                    "\"" + tag + "\": boolean from Number not supported");
+                    "\"" + name + "\": boolean from Number not supported");
         } else if (obj instanceof Boolean) {
             Boolean b = (Boolean) obj;
             return ff.literal(b);
@@ -1371,7 +1384,7 @@ public class MBObjectParser {
         } else {
             throw new IllegalArgumentException(
                     "json contents invalid, \""
-                            + tag
+                            + name
                             + "\" value limited to String, Boolean or JSONObject but was "
                             + obj.getClass().getSimpleName());
         }
@@ -1381,12 +1394,12 @@ public class MBObjectParser {
      * Maps a json value at 'tag' in the provided JSONObject to a {@link Displacement}.
      *
      * @param json The JSONObject in which to look up a displacement value
-     * @param tag The tag in the JSONObject
+     * @param name The tag in the JSONObject
      * @param fallback The fallback displacement, if no value is found at that tag.
      * @return A displacement from the json
      */
-    public Displacement displacement(JSONObject json, String tag, Displacement fallback) {
-        Object defn = json.get(tag);
+    public Displacement displacement(JSONObject json, String name, Displacement fallback) {
+        Object defn = json.get(name);
         if (defn == null) {
             return fallback;
         } else if (defn instanceof JSONArray) {
@@ -1398,7 +1411,7 @@ public class MBObjectParser {
             if (!function.isArrayFunction()) {
                 throw new MBFormatException(
                         "\""
-                                + tag
+                                + name
                                 + "\": Exception parsing displacement from Mapbox function: function values must all be arrays with length 2.");
             }
 
@@ -1408,14 +1421,14 @@ public class MBObjectParser {
             } catch (ParseException pe) {
                 throw new MBFormatException(
                         "\""
-                                + tag
+                                + name
                                 + "\": Exception parsing displacement from Mapbox function: "
                                 + pe.getMessage(),
                         pe);
             } catch (Exception e) {
                 throw new MBFormatException(
                         "\""
-                                + tag
+                                + name
                                 + "\": Exception parsing displacement from Mapbox function: "
                                 + e.getMessage(),
                         e);
@@ -1424,7 +1437,7 @@ public class MBObjectParser {
             if (functionForEachDimension.size() != 2) {
                 throw new MBFormatException(
                         "\""
-                                + tag
+                                + name
                                 + "\": Exception parsing displacement from Mapbox function: function values must all be arrays with length 2.");
             }
 
@@ -1434,7 +1447,7 @@ public class MBObjectParser {
         } else {
             throw new MBFormatException(
                     "\""
-                            + tag
+                            + name
                             + "\": Expected array or function, but was "
                             + defn.getClass().getSimpleName());
         }
@@ -1443,68 +1456,138 @@ public class MBObjectParser {
     //
     // structure checks
     //
-    /** @return True if json has the provided property explicitly provided, False otherwise. */
+    /** @return True if json has a value for the property, False otherwise. */
+    @Deprecated
     public boolean isPropertyDefined(JSONObject json, String propertyName)
             throws MBFormatException {
         return isDefined(json, propertyName);
     }
-    /** @return True if json has the property explicitly provided, False otherwise. */
-    public boolean isDefined(JSONObject json, String propertyName) throws MBFormatException {
-        return json.containsKey(propertyName) && json.get(propertyName) != null;
+    /**
+     * True if json has a value for the provided name, False otherwise.
+     *
+     * @param json JSON object
+     * @param name Name used to look up a value
+     * @return True if json has a value for the provided name, False otherwise.
+     */
+    public boolean isDefined(JSONObject json, String name) throws MBFormatException {
+        return json.containsKey(name) && json.get(name) != null;
     }
-    /** @return True if array has the property explicitly provided, False otherwise. */
+
+    /**
+     * True if array has an element at the provided index, False otherwise.
+     *
+     * @param json JSON array
+     * @param index Index of array element
+     * @return True if array has an element at the provided index, False otherwise.
+     */
     public boolean isDefined(JSONArray json, int index) throws MBFormatException {
         return index < json.size() && json.get(index) != null;
     }
-    /** @return True if json has the string property explicitly provided, False otherwise. */
-    public boolean isString(JSONObject json, String propertyName) throws MBFormatException {
-        return json.containsKey(propertyName)
-                && json.get(propertyName) != null
-                && json.get(propertyName) instanceof String;
+    /**
+     * True if json has a string value for the provided name, False otherwise.
+     *
+     * @param json JSON object
+     * @param name Name used to look up a value
+     * @return True if json has a string value for the provided name, False otherwise.
+     */
+    public boolean isString(JSONObject json, String name) throws MBFormatException {
+        return json.containsKey(name) && json.get(name) != null && json.get(name) instanceof String;
     }
-    /** @return True if array has the string property explicitly provided, False otherwise. */
+    /**
+     * True if array has a string element at the provided index, False otherwise.
+     *
+     * @param json JSON array
+     * @param index Index of array element
+     * @return True if array has a string element at the provided index, False otherwise.
+     */
     public boolean isString(JSONArray json, int index) throws MBFormatException {
         return index < json.size() && json.get(index) != null && json.get(index) instanceof String;
     }
-    /** @return True if json has the number property explicitly provided, False otherwise. */
-    public boolean isNumeric(JSONObject json, String propertyName) throws MBFormatException {
-        return json.containsKey(propertyName)
-                && json.get(propertyName) != null
-                && json.get(propertyName) instanceof Number;
+    /**
+     * True if json has a numeric value for the provided name, False otherwise.
+     *
+     * @param json JSON object
+     * @param name Name used to look up a value
+     * @return True if json has a numeric value for the provided name, False otherwise.
+     */
+    public boolean isNumeric(JSONObject json, String name) throws MBFormatException {
+        return json.containsKey(name) && json.get(name) != null && json.get(name) instanceof Number;
     }
-    /** @return True if array has the number property explicitly provided, False otherwise. */
+    /**
+     * True if array has a numeric element at the provided index, False otherwise.
+     *
+     * @param json JSON array
+     * @param index Index of array element
+     * @return True if array has a numeric element at the provided index, False otherwise.
+     */
     public boolean isNumeric(JSONArray json, int index) throws MBFormatException {
         return index < json.size() && json.get(index) != null && json.get(index) instanceof Number;
     }
-    /** @return True if json has the boolean property explicitly provided, False otherwise. */
-    public boolean isBoolean(JSONObject json, String propertyName) throws MBFormatException {
-        return json.containsKey(propertyName)
-                && json.get(propertyName) != null
-                && json.get(propertyName) instanceof Boolean;
+    /**
+     * True if json has a boolean value for the provided name, False otherwise.
+     *
+     * @param json JSON object
+     * @param name Name used to look up a value
+     * @return True if json has a boolean value for the provided name, False otherwise.
+     */
+    public boolean isBoolean(JSONObject json, String name) throws MBFormatException {
+        return json.containsKey(name)
+                && json.get(name) != null
+                && json.get(name) instanceof Boolean;
     }
-    /** @return True if array has the boolean property explicitly provided, False otherwise. */
+    /**
+     * True if array has a boolean element at the provided index, False otherwise.
+     *
+     * @param json JSON array
+     * @param index Index of array element
+     * @return True if array has a boolean element at the provided index, False otherwise.
+     */
     public boolean isBoolean(JSONArray json, int index) throws MBFormatException {
         return index < json.size() && json.get(index) != null && json.get(index) instanceof Boolean;
     }
-    /** @return True if json has the array property explicitly provided, False otherwise. */
-    public boolean isArray(JSONObject json, String propertyName) throws MBFormatException {
-        return json.containsKey(propertyName)
-                && json.get(propertyName) != null
-                && json.get(propertyName) instanceof JSONArray;
+    /**
+     * True if json has an array value for the provided name, False otherwise.
+     *
+     * @param json JSON object
+     * @param name Name used to look up a value
+     * @return True if json has an array value for the provided name, False otherwise.
+     */
+    public boolean isArray(JSONObject json, String name) throws MBFormatException {
+        return json.containsKey(name)
+                && json.get(name) != null
+                && json.get(name) instanceof JSONArray;
     }
-    /** @return True if array has the array property explicitly provided, False otherwise. */
+    /**
+     * True if array has an array element at the provided index, False otherwise.
+     *
+     * @param json JSON array
+     * @param index Index of array element
+     * @return True if array has an array element at the provided index, False otherwise.
+     */
     public boolean isArray(JSONArray json, int index) throws MBFormatException {
         return index < json.size()
                 && json.get(index) != null
                 && json.get(index) instanceof JSONArray;
     }
-    /** @return True json has the object property explicitly provided, False otherwise. */
-    public boolean isObject(JSONObject json, String propertyName) throws MBFormatException {
-        return json.containsKey(propertyName)
-                && json.get(propertyName) != null
-                && json.get(propertyName) instanceof JSONObject;
+    /**
+     * True if json has an object value for the provided name, False otherwise.
+     *
+     * @param json JSON object
+     * @param name Name used to look up a value
+     * @return True if json has an object value for the provided name, False otherwise.
+     */
+    public boolean isObject(JSONObject json, String name) throws MBFormatException {
+        return json.containsKey(name)
+                && json.get(name) != null
+                && json.get(name) instanceof JSONObject;
     }
-    /** @return True if array has the object property explicitly provided, False otherwise. */
+    /**
+     * True if array has an object element at the provided index, False otherwise.
+     *
+     * @param json JSON array
+     * @param index Index of array element
+     * @return True if array has an object element at the provided index, False otherwise.
+     */
     public boolean isObject(JSONArray json, int index) throws MBFormatException {
         return index < json.size()
                 && json.get(index) != null

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -332,9 +332,9 @@ public class MBObjectParser {
         }
         if (index < json.size() && json.get(index) instanceof String) {
             return (String) json.get(index);
-        }
-        if (index < json.size() && json.get(index) instanceof JSONArray) {
-            return MBExpression.transformExpression((JSONArray) json.get(index)).toString();
+//        }
+//        if (index < json.size() && json.get(index) instanceof JSONArray) {
+//            return MBExpression.transformExpression((JSONArray) json.get(index)).toString();
         } else {
             throw new MBFormatException(
                     context.getSimpleName() + " requires [" + index + "] string");

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -332,9 +332,10 @@ public class MBObjectParser {
         }
         if (index < json.size() && json.get(index) instanceof String) {
             return (String) json.get(index);
-//        }
-//        if (index < json.size() && json.get(index) instanceof JSONArray) {
-//            return MBExpression.transformExpression((JSONArray) json.get(index)).toString();
+            //        }
+            //        if (index < json.size() && json.get(index) instanceof JSONArray) {
+            //            return MBExpression.transformExpression((JSONArray)
+            // json.get(index)).toString();
         } else {
             throw new MBFormatException(
                     context.getSimpleName() + " requires [" + index + "] string");
@@ -1442,63 +1443,65 @@ public class MBObjectParser {
         return json.containsKey(propertyName) && json.get(propertyName) != null;
     }
     /** @return True if json has the property explicitly provided, False otherwise. */
-    public boolean isDefined(JSONObject json, String propertyName)
-            throws MBFormatException {
+    public boolean isDefined(JSONObject json, String propertyName) throws MBFormatException {
         return json.containsKey(propertyName) && json.get(propertyName) != null;
     }
     /** @return True if array has the property explicitly provided, False otherwise. */
-    public boolean isDefined(JSONArray json, int index)
-            throws MBFormatException {
+    public boolean isDefined(JSONArray json, int index) throws MBFormatException {
         return index < json.size() && json.get(index) != null;
     }
     /** @return True if json has the string property explicitly provided, False otherwise. */
-    public boolean isString(JSONObject json, String propertyName)
-            throws MBFormatException {
-        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof String;
+    public boolean isString(JSONObject json, String propertyName) throws MBFormatException {
+        return json.containsKey(propertyName)
+                && json.get(propertyName) != null
+                && json.get(propertyName) instanceof String;
     }
     /** @return True if array has the string property explicitly provided, False otherwise. */
-    public boolean isString(JSONArray json, int index)
-            throws MBFormatException {
-        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof String;
+    public boolean isString(JSONArray json, int index) throws MBFormatException {
+        return index < json.size() && json.get(index) != null && json.get(index) instanceof String;
     }
     /** @return True if json has the number property explicitly provided, False otherwise. */
-    public boolean isNumeric(JSONObject json, String propertyName)
-            throws MBFormatException {
-        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof Number;
+    public boolean isNumeric(JSONObject json, String propertyName) throws MBFormatException {
+        return json.containsKey(propertyName)
+                && json.get(propertyName) != null
+                && json.get(propertyName) instanceof Number;
     }
     /** @return True if array has the number property explicitly provided, False otherwise. */
-    public boolean isNumeric(JSONArray json, int index)
-            throws MBFormatException {
-        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof Number;
+    public boolean isNumeric(JSONArray json, int index) throws MBFormatException {
+        return index < json.size() && json.get(index) != null && json.get(index) instanceof Number;
     }
     /** @return True if json has the boolean property explicitly provided, False otherwise. */
-    public boolean isBoolean(JSONObject json, String propertyName)
-            throws MBFormatException {
-        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof Boolean;
+    public boolean isBoolean(JSONObject json, String propertyName) throws MBFormatException {
+        return json.containsKey(propertyName)
+                && json.get(propertyName) != null
+                && json.get(propertyName) instanceof Boolean;
     }
     /** @return True if array has the boolean property explicitly provided, False otherwise. */
-    public boolean isBoolean(JSONArray json, int index)
-            throws MBFormatException {
-        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof Boolean;
+    public boolean isBoolean(JSONArray json, int index) throws MBFormatException {
+        return index < json.size() && json.get(index) != null && json.get(index) instanceof Boolean;
     }
     /** @return True if json has the array property explicitly provided, False otherwise. */
-    public boolean isArray(JSONObject json, String propertyName)
-            throws MBFormatException {
-        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof JSONArray;
+    public boolean isArray(JSONObject json, String propertyName) throws MBFormatException {
+        return json.containsKey(propertyName)
+                && json.get(propertyName) != null
+                && json.get(propertyName) instanceof JSONArray;
     }
     /** @return True if array has the array property explicitly provided, False otherwise. */
-    public boolean isArray(JSONArray json, int index)
-            throws MBFormatException {
-        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof JSONArray;
+    public boolean isArray(JSONArray json, int index) throws MBFormatException {
+        return index < json.size()
+                && json.get(index) != null
+                && json.get(index) instanceof JSONArray;
     }
     /** @return True json has the object property explicitly provided, False otherwise. */
-    public boolean isObject(JSONObject json, String propertyName)
-            throws MBFormatException {
-        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof JSONObject;
+    public boolean isObject(JSONObject json, String propertyName) throws MBFormatException {
+        return json.containsKey(propertyName)
+                && json.get(propertyName) != null
+                && json.get(propertyName) instanceof JSONObject;
     }
     /** @return True if array has the object property explicitly provided, False otherwise. */
-    public boolean isObject(JSONArray json, int index)
-            throws MBFormatException {
-        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof JSONObject;
+    public boolean isObject(JSONArray json, int index) throws MBFormatException {
+        return index < json.size()
+                && json.get(index) != null
+                && json.get(index) instanceof JSONObject;
     }
 }

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -1150,11 +1150,20 @@ public class MBObjectParser {
             MBFunction function = new MBFunction(this, (JSONObject) obj);
             return function.function(String.class);
         } else if (obj instanceof JSONArray) {
-            if (((JSONArray) obj).get(0) instanceof String
-                    && MBExpression.canCreate(((JSONArray) obj).get(0).toString())) {
-                return MBExpression.transformExpression((JSONArray) obj);
+            JSONArray array = (JSONArray) obj;
+            if (isString(array, 0)) {
+                String expressionName = get(array, 0);
+                if (MBExpression.canCreate(expressionName)) {
+                    return MBExpression.transformExpression(array);
+                } else {
+                    throw new MBFormatException(
+                            context
+                                    + " string unavailable: expression' "
+                                    + expressionName
+                                    + "' not supported.");
+                }
             } else {
-                throw new MBFormatException(context + " string from JSONArray not supported");
+                throw new MBFormatException(context + " string from JSONArray not a supported");
             }
         } else {
             throw new IllegalArgumentException(

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -1426,9 +1426,75 @@ public class MBObjectParser {
         }
     }
 
-    /** @return True if the layer has the provided property explicitly provided, False otherwise. */
+    //
+    // structure checks
+    //
+    /**
+     * @return True if json has the provided property explicitly provided, False otherwise.
+     * @deprecated please use isDefined( json, propertyName)
+     */
     public boolean isPropertyDefined(JSONObject json, String propertyName)
             throws MBFormatException {
         return json.containsKey(propertyName) && json.get(propertyName) != null;
+    }
+    /** @return True if json has the property explicitly provided, False otherwise. */
+    public boolean isDefined(JSONObject json, String propertyName)
+            throws MBFormatException {
+        return json.containsKey(propertyName) && json.get(propertyName) != null;
+    }
+    /** @return True if array has the property explicitly provided, False otherwise. */
+    public boolean isDefined(JSONArray json, int index)
+            throws MBFormatException {
+        return index < json.size() && json.get(index) != null;
+    }
+    /** @return True if json has the string property explicitly provided, False otherwise. */
+    public boolean isString(JSONObject json, String propertyName)
+            throws MBFormatException {
+        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof String;
+    }
+    /** @return True if array has the string property explicitly provided, False otherwise. */
+    public boolean isString(JSONArray json, int index)
+            throws MBFormatException {
+        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof String;
+    }
+    /** @return True if json has the number property explicitly provided, False otherwise. */
+    public boolean isNumeric(JSONObject json, String propertyName)
+            throws MBFormatException {
+        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof Number;
+    }
+    /** @return True if array has the number property explicitly provided, False otherwise. */
+    public boolean isNumeric(JSONArray json, int index)
+            throws MBFormatException {
+        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof Number;
+    }
+    /** @return True if json has the boolean property explicitly provided, False otherwise. */
+    public boolean isBoolean(JSONObject json, String propertyName)
+            throws MBFormatException {
+        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof Boolean;
+    }
+    /** @return True if array has the boolean property explicitly provided, False otherwise. */
+    public boolean isBoolean(JSONArray json, int index)
+            throws MBFormatException {
+        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof Boolean;
+    }
+    /** @return True if json has the array property explicitly provided, False otherwise. */
+    public boolean isArray(JSONObject json, String propertyName)
+            throws MBFormatException {
+        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof JSONArray;
+    }
+    /** @return True if array has the array property explicitly provided, False otherwise. */
+    public boolean isArray(JSONArray json, int index)
+            throws MBFormatException {
+        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof JSONArray;
+    }
+    /** @return True json has the object property explicitly provided, False otherwise. */
+    public boolean isObject(JSONObject json, String propertyName)
+            throws MBFormatException {
+        return json.containsKey(propertyName) && json.get(propertyName) != null && json.get(propertyName) instanceof JSONObject;
+    }
+    /** @return True if array has the object property explicitly provided, False otherwise. */
+    public boolean isObject(JSONArray json, int index)
+            throws MBFormatException {
+        return index < json.size() && json.get(index) != null &&  && json.get(index) instanceof JSONObject;
     }
 }

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/parse/MBObjectParser.java
@@ -1445,11 +1445,10 @@ public class MBObjectParser {
     //
     /**
      * @return True if json has the provided property explicitly provided, False otherwise.
-     * @deprecated please use isDefined( json, propertyName)
      */
     public boolean isPropertyDefined(JSONObject json, String propertyName)
             throws MBFormatException {
-        return json.containsKey(propertyName) && json.get(propertyName) != null;
+        return isDefined(json,propertyName);
     }
     /** @return True if json has the property explicitly provided, False otherwise. */
     public boolean isDefined(JSONObject json, String propertyName) throws MBFormatException {

--- a/modules/extension/mbstyle/src/test/java/org/geotools/mbstyle/expression/MBLookupTest.java
+++ b/modules/extension/mbstyle/src/test/java/org/geotools/mbstyle/expression/MBLookupTest.java
@@ -54,9 +54,7 @@ public class MBLookupTest extends AbstractMBExpressionTest {
         List<FeatureTypeStyle> getFeatures = testLayer.transformInternal(getTest);
         try {
             String xml = new SLDTransformer().transform(getFeatures.get(0));
-            assertTrue(
-                    xml.contains(
-                            "<ogc:Function name=\"property\"><ogc:Literal>Name</ogc:Literal></ogc:Function>"));
+            assertTrue(xml.contains("<ogc:PropertyName>Name</ogc:PropertyName>"));
         } catch (Exception e) {
         }
         // test nested "get expression

--- a/modules/extension/mbstyle/src/test/java/org/geotools/mbstyle/parse/MBFilterTest.java
+++ b/modules/extension/mbstyle/src/test/java/org/geotools/mbstyle/parse/MBFilterTest.java
@@ -209,6 +209,46 @@ public class MBFilterTest {
     }
 
     @Test
+    public void comparisonFilterExpressions() throws ParseException {
+        JSONArray json;
+        MBFilter mbfilter;
+
+        json = array("['==', ['get', 'key'], 'value']");
+        mbfilter = new MBFilter(json);
+        PropertyIsEqualTo equal = (PropertyIsEqualTo) mbfilter.filter();
+        assertEquals("key", ((PropertyName) equal.getExpression1()).getPropertyName());
+        assertEquals("value", ((Literal) equal.getExpression2()).getValue());
+
+        // okay that takes too long just check ECQL
+        assertEquals("key = 'value'", ECQL.toCQL(equal));
+
+        json = array("['!=', ['get', 'key'], 'value']");
+        mbfilter = new MBFilter(json);
+        Filter filter = mbfilter.filter();
+        assertEquals("key <> 'value'", ECQL.toCQL(filter));
+
+        json = array("['>', ['get', 'key'], 'value']");
+        mbfilter = new MBFilter(json);
+        filter = mbfilter.filter();
+        assertEquals("key > 'value'", ECQL.toCQL(filter));
+
+        json = array("['<', ['get', 'key'], 'value']");
+        mbfilter = new MBFilter(json);
+        filter = mbfilter.filter();
+        assertEquals("key < 'value'", ECQL.toCQL(filter));
+
+        json = array("['>=', ['get', 'key'], 'value']");
+        mbfilter = new MBFilter(json);
+        filter = mbfilter.filter();
+        assertEquals("key >= 'value'", ECQL.toCQL(filter));
+
+        json = array("['<=', ['get', 'key'], 'value']");
+        mbfilter = new MBFilter(json);
+        filter = mbfilter.filter();
+        assertEquals("key <= 'value'", ECQL.toCQL(filter));
+    }
+
+    @Test
     public void membership() throws ParseException {
         JSONArray json = array("['in', 'a', 1, 2, 3]");
 

--- a/modules/extension/mbstyle/src/test/java/org/geotools/mbstyle/parse/MBFilterTest.java
+++ b/modules/extension/mbstyle/src/test/java/org/geotools/mbstyle/parse/MBFilterTest.java
@@ -282,6 +282,29 @@ public class MBFilterTest {
     }
 
     @Test
+    public void decisionExpression() throws ParseException {
+        // Examples from expressionMBDecisionTest.json
+        JSONArray json = array("['case', true, 10, false, 'aString', true]");
+        MBFilter mbfilter = new MBFilter(json);
+        Filter filter = mbfilter.filter();
+        assertEquals("case(true,10,false,'aString',true) = true", ECQL.toCQL(filter));
+
+        json = array("['coalesce', 'aString', false, 5]");
+        mbfilter = new MBFilter(json);
+        filter = mbfilter.filter();
+        assertEquals("coalesce('aString',false,5) = true", ECQL.toCQL(filter));
+
+        json =
+                array(
+                        "[\"match\",'bLabel','aLabel', 'firstLabel','bLabel','secondLabel','defaultLabel']");
+        mbfilter = new MBFilter(json);
+        filter = mbfilter.filter();
+        assertEquals(
+                "match('bLabel','aLabel','firstLabel','bLabel','secondLabel','defaultLabel') = true",
+                ECQL.toCQL(filter));
+    }
+
+    @Test
     public void nestedAllSemanticIdentifiers() throws ParseException {
         JSONArray json =
                 array(

--- a/modules/library/cql/src/main/java/org/geotools/filter/text/commons/ExpressionToText.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/commons/ExpressionToText.java
@@ -250,8 +250,12 @@ public class ExpressionToText implements ExpressionVisitor {
         } else if (literal instanceof Boolean) {
             output.append(literal);
         } else {
-            String escaped = literal.toString().replaceAll("'", "''");
-            output.append("'" + escaped + "'");
+            if (literal == null) {
+                throw new NullPointerException("ECQL does not support null literal value");
+            } else {
+                String escaped = literal.toString().replaceAll("'", "''");
+                output.append("'" + escaped + "'");
+            }
         }
         return output;
     }


### PR DESCRIPTION
The filter support used by GeoTools has been moved to "Legacy - Other filter":
```
filter: [">", "scalerank", 2]
```

This has been replaced with the use of expressions:

```
filter: [">", ["get","scalerank"], 2]
```

This means we can no longer use style examples available online.

See https://osgeo-org.atlassian.net/browse/GEOT-6589 for details.

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue https://osgeo-org.atlassian.net/browse/GEOT-6589
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it. 
- [ ] PR for bug fixes and small new features are presented as a single commit: use squash changes when merging
- [ ] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket": use squash changes when merging
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
