### PR TITLE
[GEOT-6598] Ogc filter to mongo operator translation fails

### DIFF
--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 import org.bson.types.ObjectId;
 import org.geotools.data.mongodb.complex.JsonSelectAllFunction;
 import org.geotools.data.mongodb.complex.JsonSelectFunction;
+import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.util.Converters;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -211,8 +212,41 @@ public class FilterToMongo implements FilterVisitor, ExpressionVisitor {
     @Override
     public Object visit(Not filter, Object extraData) {
         BasicDBObject output = asDBObject(extraData);
+        // in case of a not operator we cannot simply wrap the child filter
+        // with a $not since mongo syntax is {property:{$not:{operator-expression}}}
+        // thus using a Visitor to find the PropertyName
+        class PropertyNameFinder extends FilterAttributeExtractor {
+            List<PropertyName> pNames = new ArrayList<>();
+
+            @Override
+            public Object visit(PropertyName expression, Object data) {
+                pNames.add(expression);
+                return super.visit(expression, data);
+            }
+
+            PropertyName getPropertyName() {
+                if (pNames.size() > 0) return pNames.get(0);
+                else return null;
+            }
+        }
+        PropertyNameFinder finder = new PropertyNameFinder();
+        filter.getFilter().accept(finder, null);
+        PropertyName pn = finder.getPropertyName();
+        // gets child filter as it is
         BasicDBObject expr = (BasicDBObject) filter.getFilter().accept(this, null);
-        output.put("$not", expr);
+        BasicDBObject dbObject;
+        if (pn != null) {
+            String strPn = pn.getPropertyName();
+            // get only the operator expression
+            Object exprValue = expr.get(strPn);
+            dbObject = new BasicDBObject("$not", exprValue);
+            // move up the PropertyName
+            output.put(strPn, dbObject);
+        } else {
+            // no PropertyName found throwing exception
+            throw new UnsupportedOperationException(
+                    "No propertyName found, cannot use $not as top level operator");
+        }
         return output;
     }
 
@@ -373,9 +407,12 @@ public class FilterToMongo implements FilterVisitor, ExpressionVisitor {
     @Override
     public Object visit(PropertyIsNull filter, Object extraData) {
         BasicDBObject output = asDBObject(extraData);
-        String prop = convert(filter.getExpression().evaluate(null), String.class);
-        // mongodb filter { item: null } supports both: null value and nonexistent attribute
-        output.put(prop, null);
+        String prop = convert(filter.getExpression().accept(this, null), String.class);
+        // $eq matches either contain the item field whose value is null
+        // or that do not contain the field
+        BasicDBObject propIsNull = new BasicDBObject();
+        propIsNull.put("$eq", null);
+        output.put(prop, propIsNull);
         return output;
     }
 

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
@@ -271,7 +271,7 @@ public class FilterToMongo implements FilterVisitor, ExpressionVisitor {
 
     @Override
     public Object visit(PropertyIsEqualTo filter, Object extraData) {
-        return encodeBinaryComparisonOp(filter, null, extraData);
+        return encodeBinaryComparisonOp(filter, "$eq", extraData);
     }
 
     BasicDBObject encodeBinaryComparisonOp(

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
@@ -79,7 +79,8 @@ public class FilterToMongoTest extends TestCase {
         assertNotNull(obj);
 
         assertEquals(1, obj.keySet().size());
-        assertEquals("bar", obj.get("properties.foo"));
+        BasicDBObject operator = (BasicDBObject) obj.get("properties.foo");
+        assertEquals("bar", operator.get("$eq"));
     }
 
     public void testBBOX() {
@@ -300,18 +301,18 @@ public class FilterToMongoTest extends TestCase {
         PropertyIsEqualTo equalTo = ff.equals(ff.property("foo"), ff.literal(10));
         BasicDBObject obj = (BasicDBObject) equalTo.accept(filterToMongo, null);
         assertNotNull(obj);
-
+        BasicDBObject operator = (BasicDBObject) obj.get("properties.foo");
         assertEquals(1, obj.keySet().size());
-        assertEquals(10, obj.get("properties.foo"));
+        assertEquals(10, operator.get("$eq"));
     }
 
     public void testEqualToLong() throws Exception {
         PropertyIsEqualTo equalTo = ff.equals(ff.property("foo"), ff.literal(10L));
         BasicDBObject obj = (BasicDBObject) equalTo.accept(filterToMongo, null);
         assertNotNull(obj);
-
+        BasicDBObject operator = (BasicDBObject) obj.get("properties.foo");
         assertEquals(1, obj.keySet().size());
-        assertEquals(10L, obj.get("properties.foo"));
+        assertEquals(10L, operator.get("$eq"));
     }
 
     public void testEqualToBigInteger() throws Exception {
@@ -319,9 +320,9 @@ public class FilterToMongoTest extends TestCase {
                 ff.equals(ff.property("foo"), ff.literal(BigInteger.valueOf(10L)));
         BasicDBObject obj = (BasicDBObject) equalTo.accept(filterToMongo, null);
         assertNotNull(obj);
-
+        BasicDBObject operator = (BasicDBObject) obj.get("properties.foo");
         assertEquals(1, obj.keySet().size());
-        assertEquals("10", obj.get("properties.foo"));
+        assertEquals("10", operator.get("$eq"));
     }
 
     @Test

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
@@ -272,4 +272,88 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
         SimpleFeature f = features.features().next();
         assertNotNull(pn.evaluate(f));
     }
+
+    public void testNotNotEqualFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyName pnS = ff.property("properties.stringProperty");
+        PropertyIsNotEqualTo notEqualTo = ff.notEqual(pnS, ff.literal("one"));
+        Not not = ff.not(notEqualTo);
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", not);
+        SimpleFeatureCollection features = source.getFeatures(q);
+        assertEquals(1, features.size());
+        SimpleFeature f = features.features().next();
+        assertEquals(pnS.evaluate(f), "one");
+    }
+
+    public void testNotEqualBetweenPropertiesFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyName pnS = ff.property("properties.stringProperty");
+        PropertyIsNotEqualTo notEqualTo = ff.notEqual(pnS, ff.literal("one"));
+        Not not = ff.not(notEqualTo);
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", not);
+        SimpleFeatureCollection features = source.getFeatures(q);
+        assertEquals(1, features.size());
+        SimpleFeature f = features.features().next();
+        assertEquals(pnS.evaluate(f), "one");
+    }
+
+    public void testAndNotFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyName pn = ff.property("properties.stringProperty");
+        PropertyIsNull isNull = ff.isNull(ff.property("properties.nullableAttribute"));
+        PropertyIsNotEqualTo equalTo = ff.notEqual(pn, ff.literal("zero"));
+        Not notFirst = ff.not(isNull);
+        Not notSecond = ff.not(equalTo);
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", ff.and(notFirst, notSecond));
+        SimpleFeatureCollection features = source.getFeatures(q);
+        assertEquals(1, features.size());
+        SimpleFeature f = features.features().next();
+        assertEquals(pn.evaluate(f), "zero");
+    }
+
+    public void testOrNotFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyName pn = ff.property("properties.stringProperty");
+        PropertyIsNull isNull = ff.isNull(ff.property("properties.nullableAttribute"));
+        PropertyIsNotEqualTo equalTo = ff.notEqual(pn, ff.literal("zero"));
+        Not notFirst = ff.not(isNull);
+        Not notSecond = ff.not(equalTo);
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", ff.or(notFirst, notSecond));
+        SimpleFeatureCollection features = source.getFeatures(q);
+        assertEquals(1, features.size());
+        SimpleFeature f = features.features().next();
+        assertEquals(pn.evaluate(f), "zero");
+    }
+
+    public void testEqualFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyName pn = ff.property("properties.stringProperty");
+        PropertyIsEqualTo equalTo = ff.equals(pn, ff.literal("zero"));
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", equalTo);
+        SimpleFeatureCollection features = source.getFeatures(q);
+        assertEquals(1, features.size());
+        SimpleFeature f = features.features().next();
+        assertEquals(pn.evaluate(f), "zero");
+    }
+
+    public void testNotWithEqualFilter() throws Exception {
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        PropertyName pn = ff.property("properties.stringProperty");
+        PropertyIsEqualTo equalTo = ff.equals(pn, ff.literal("zero"));
+        Not not = ff.not(equalTo);
+        SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
+        Query q = new Query("ft1", not);
+        SimpleFeatureCollection features = source.getFeatures(q);
+        SimpleFeatureIterator it = features.features();
+        assertEquals(2, features.size());
+        while (it.hasNext()) {
+            SimpleFeature f = it.next();
+            assertFalse(pn.evaluate(f).equals("zero"));
+        }
+    }
 }


### PR DESCRIPTION
JIRA ticket https://osgeo-org.atlassian.net/browse/GEOT-6598

This pull request fixes the translation mechanism from Not filter to $not operator for mongodb,
by using it as a top level operator only if no property name is specified in the child condition.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
