### PR TITLE
[GEOT-6577] Allow plugin to handle multiple valid date formats from elastic

### DIFF
--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticAttribute.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticAttribute.java
@@ -48,6 +48,8 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
 
     private Integer srid;
 
+    private String dateFormat;
+
     private List<String> validDateFormats;
 
     private Boolean analyzed;
@@ -75,6 +77,7 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
         this.use = other.use;
         this.defaultGeometry = other.defaultGeometry;
         this.srid = other.srid;
+        this.dateFormat = other.dateFormat;
         this.validDateFormats = other.validDateFormats;
         this.geometryType = other.geometryType;
         this.analyzed = other.analyzed;
@@ -126,6 +129,14 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
 
     public void setSrid(Integer srid) {
         this.srid = srid;
+    }
+
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    public void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
     }
 
     public List<String> getValidDateFormats() {
@@ -188,6 +199,7 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
                 use,
                 defaultGeometry,
                 srid,
+                dateFormat,
                 validDateFormats,
                 geometryType,
                 analyzed,
@@ -209,6 +221,7 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
             equal &= Objects.equals(use, other.use);
             equal &= Objects.equals(defaultGeometry, other.defaultGeometry);
             equal &= Objects.equals(srid, other.srid);
+            equal &= Objects.equals(dateFormat, other.dateFormat);
             equal &= Objects.equals(validDateFormats, other.validDateFormats);
             equal &= Objects.equals(geometryType, other.geometryType);
             equal &= Objects.equals(analyzed, other.analyzed);

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticAttribute.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticAttribute.java
@@ -17,6 +17,7 @@
 package org.geotools.data.elasticsearch;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -47,7 +48,7 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
 
     private Integer srid;
 
-    private String dateFormat;
+    private List<String> validDateFormats;
 
     private Boolean analyzed;
 
@@ -74,7 +75,7 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
         this.use = other.use;
         this.defaultGeometry = other.defaultGeometry;
         this.srid = other.srid;
-        this.dateFormat = other.dateFormat;
+        this.validDateFormats = other.validDateFormats;
         this.geometryType = other.geometryType;
         this.analyzed = other.analyzed;
         this.stored = other.stored;
@@ -127,12 +128,12 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
         this.srid = srid;
     }
 
-    public String getDateFormat() {
-        return dateFormat;
+    public List<String> getValidDateFormats() {
+        return validDateFormats;
     }
 
-    public void setDateFormat(String dateFormat) {
-        this.dateFormat = dateFormat;
+    public void setValidDateFormats(List<String> validDateFormats) {
+        this.validDateFormats = validDateFormats;
     }
 
     public Boolean getAnalyzed() {
@@ -187,7 +188,7 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
                 use,
                 defaultGeometry,
                 srid,
-                dateFormat,
+                validDateFormats,
                 geometryType,
                 analyzed,
                 stored,
@@ -208,7 +209,7 @@ public class ElasticAttribute implements Serializable, Comparable<ElasticAttribu
             equal &= Objects.equals(use, other.use);
             equal &= Objects.equals(defaultGeometry, other.defaultGeometry);
             equal &= Objects.equals(srid, other.srid);
-            equal &= Objects.equals(dateFormat, other.dateFormat);
+            equal &= Objects.equals(validDateFormats, other.validDateFormats);
             equal &= Objects.equals(geometryType, other.geometryType);
             equal &= Objects.equals(analyzed, other.analyzed);
             equal &= Objects.equals(stored, other.stored);

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStore.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStore.java
@@ -397,7 +397,7 @@ public class ElasticDataStore extends ContentDataStore {
                             }
                         }
                     }
-                    if (validFormats.isEmpty() || validFormats == null) {
+                    if (validFormats.isEmpty()) {
                         validFormats.add("date_optional_time");
                     }
                     elasticAttribute.setValidDateFormats(validFormats);

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStore.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStore.java
@@ -365,23 +365,42 @@ public class ElasticDataStore extends ContentDataStore {
                     binding = Boolean.class;
                     break;
                 case "date":
-                    String format = (String) map.get("format");
-                    if (format != null) {
-                        try {
-                            Joda.forPattern(format);
-                        } catch (Exception e) {
-                            LOGGER.fine(
-                                    "Unable to parse date format ('"
-                                            + format
-                                            + "') for "
-                                            + propertyKey);
-                            format = null;
+                    List<String> validFormats = new ArrayList<String>();
+                    String availableFormat = (String) map.get("format");
+                    if (availableFormat == null) {
+                        validFormats.add("date_optional_time");
+                    } else {
+                        if (!availableFormat.contains("\\|\\|")) {
+                            try {
+                                Joda.forPattern(availableFormat);
+                                validFormats.add(availableFormat);
+                            } catch (Exception e) {
+                                LOGGER.fine(
+                                        "Unable to parse date format ('"
+                                                + availableFormat
+                                                + "') for "
+                                                + propertyKey);
+                            }
+                        } else {
+                            String[] formats = availableFormat.split("\\|\\|");
+                            for (String format : formats) {
+                                try {
+                                    Joda.forPattern(format);
+                                    validFormats.add(format);
+                                } catch (Exception e) {
+                                    LOGGER.fine(
+                                            "Unable to parse date format ('"
+                                                    + format
+                                                    + "') for "
+                                                    + propertyKey);
+                                }
+                            }
                         }
                     }
-                    if (format == null) {
-                        format = "date_optional_time";
+                    if (validFormats.isEmpty() || validFormats == null) {
+                        validFormats.add("date_optional_time");
                     }
-                    elasticAttribute.setDateFormat(format);
+                    elasticAttribute.setValidDateFormats(validFormats);
                     binding = Date.class;
                     break;
                 case "binary":

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticFeatureTypeBuilder.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticFeatureTypeBuilder.java
@@ -92,8 +92,8 @@ class ElasticFeatureTypeBuilder extends SimpleFeatureTypeBuilder {
                                 attributeBuilder.buildDescriptor(
                                         attributeName, attributeBuilder.buildType());
                     }
-                    if (att != null && attribute.getDateFormat() != null) {
-                        att.getUserData().put(DATE_FORMAT, attribute.getDateFormat());
+                    if (att != null && attribute.getValidDateFormats() != null) {
+                        att.getUserData().put(DATE_FORMAT, attribute.getValidDateFormats());
                     }
                     if (att != null) {
                         att.getUserData().put(FULL_NAME, attribute.getName());

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticFeatureTypeBuilder.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticFeatureTypeBuilder.java
@@ -22,6 +22,7 @@ import static org.geotools.data.elasticsearch.ElasticConstants.FULL_NAME;
 import static org.geotools.data.elasticsearch.ElasticConstants.GEOMETRY_TYPE;
 import static org.geotools.data.elasticsearch.ElasticConstants.NESTED;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -92,7 +93,14 @@ class ElasticFeatureTypeBuilder extends SimpleFeatureTypeBuilder {
                                 attributeBuilder.buildDescriptor(
                                         attributeName, attributeBuilder.buildType());
                     }
-                    if (att != null && attribute.getValidDateFormats() != null) {
+                    if (att != null
+                            && (attribute.getValidDateFormats() != null
+                                    || attribute.getDateFormat() != null)) {
+                        if (attribute.getValidDateFormats() == null) {
+                            List<String> validFormats = new ArrayList<String>();
+                            validFormats.add(attribute.getDateFormat());
+                            attribute.setValidDateFormats(validFormats);
+                        }
                         att.getUserData().put(DATE_FORMAT, attribute.getValidDateFormats());
                     }
                     if (att != null) {

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
@@ -1208,9 +1208,9 @@ class FilterToElastic implements FilterVisitor, ExpressionVisitor {
                     }
                 }
             }
-            if (dateFormatter == null) {
-                dateFormatter = DEFAULT_DATE_FORMATTER;
-            }
+        }
+        if (dateFormatter == null) {
+            dateFormatter = DEFAULT_DATE_FORMATTER;
         }
     }
 

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
@@ -1194,11 +1194,22 @@ class FilterToElastic implements FilterVisitor, ExpressionVisitor {
     // END IMPLEMENTING org.opengis.filter.ExpressionVisitor METHODS
 
     private void updateDateFormatter(AttributeDescriptor attType) {
-        dateFormatter = DEFAULT_DATE_FORMATTER;
         if (attType != null) {
-            final String format = (String) attType.getUserData().get(ElasticConstants.DATE_FORMAT);
-            if (format != null) {
-                dateFormatter = Joda.forPattern(format).printer();
+            final List<String> validFormats =
+                    (List<String>) attType.getUserData().get(ElasticConstants.DATE_FORMAT);
+            if (validFormats != null) {
+                for (String format : validFormats) {
+                    try {
+                        dateFormatter = Joda.forPattern(format).printer();
+                        break;
+                    } catch (Exception e) {
+                        LOGGER.fine(
+                                "Unable to parse date format ('" + format + "') for " + attType);
+                    }
+                }
+            }
+            if (dateFormatter == null) {
+                dateFormatter = DEFAULT_DATE_FORMATTER;
             }
         }
     }

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticAttributeTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticAttributeTest.java
@@ -18,6 +18,8 @@ package org.geotools.data.elasticsearch;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +46,7 @@ public class ElasticAttributeTest {
 
     private int order;
 
-    private String dateFormat;
+    private List<String> validDateFormats;
 
     private boolean analyzed;
 
@@ -64,7 +66,8 @@ public class ElasticAttributeTest {
         defaultGeometry = true;
         srid = 10;
         order = 1;
-        dateFormat = "yyyy-mm-dd";
+        validDateFormats = new ArrayList<String>();
+        validDateFormats.add("yyyy-mm-dd");
         analyzed = true;
         stored = true;
         nested = true;
@@ -79,7 +82,7 @@ public class ElasticAttributeTest {
         attr.setDefaultGeometry(defaultGeometry);
         attr.setSrid(srid);
         attr.setOrder(order);
-        attr.setDateFormat(dateFormat);
+        attr.setValidDateFormats(validDateFormats);
         attr.setAnalyzed(analyzed);
         attr.setStored(stored);
         attr.setNested(nested);
@@ -91,7 +94,7 @@ public class ElasticAttributeTest {
         assertEquals(attr.isDefaultGeometry(), defaultGeometry);
         assertEquals(attr.getSrid(), srid, 1e-10);
         assertEquals(attr.getOrder(), Integer.valueOf(order));
-        assertEquals(attr.getDateFormat(), dateFormat);
+        assertEquals(attr.getValidDateFormats(), validDateFormats);
         assertEquals(attr.getAnalyzed(), analyzed);
         assertEquals(attr.isStored(), stored);
         assertEquals(attr.isNested(), nested);

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticAttributeTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticAttributeTest.java
@@ -46,6 +46,8 @@ public class ElasticAttributeTest {
 
     private int order;
 
+    private String dateFormat;
+
     private List<String> validDateFormats;
 
     private boolean analyzed;
@@ -66,8 +68,9 @@ public class ElasticAttributeTest {
         defaultGeometry = true;
         srid = 10;
         order = 1;
+        dateFormat = "yyyy-mm-dd";
         validDateFormats = new ArrayList<String>();
-        validDateFormats.add("yyyy-mm-dd");
+        validDateFormats.add(dateFormat);
         analyzed = true;
         stored = true;
         nested = true;
@@ -82,6 +85,7 @@ public class ElasticAttributeTest {
         attr.setDefaultGeometry(defaultGeometry);
         attr.setSrid(srid);
         attr.setOrder(order);
+        attr.setDateFormat(dateFormat);
         attr.setValidDateFormats(validDateFormats);
         attr.setAnalyzed(analyzed);
         attr.setStored(stored);
@@ -94,6 +98,7 @@ public class ElasticAttributeTest {
         assertEquals(attr.isDefaultGeometry(), defaultGeometry);
         assertEquals(attr.getSrid(), srid, 1e-10);
         assertEquals(attr.getOrder(), Integer.valueOf(order));
+        assertEquals(attr.getDateFormat(), dateFormat);
         assertEquals(attr.getValidDateFormats(), validDateFormats);
         assertEquals(attr.getAnalyzed(), analyzed);
         assertEquals(attr.isStored(), stored);

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFilterTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFilterTest.java
@@ -192,7 +192,9 @@ public class ElasticFilterTest {
         dateAttBuilder.setName("dateAttrWithFormat");
         dateAttBuilder.setBinding(Date.class);
         dateAtt = dateAttBuilder.buildDescriptor("dateAttrWithFormat", dateAttBuilder.buildType());
-        dateAtt.getUserData().put(ElasticConstants.DATE_FORMAT, format);
+        List<String> validFormats = new ArrayList<String>();
+        validFormats.add(format);
+        dateAtt.getUserData().put(ElasticConstants.DATE_FORMAT, validFormats);
         typeBuilder.add(dateAtt);
 
         featureType = typeBuilder.buildFeatureType();


### PR DESCRIPTION
Updates the `dateFormat` field of `ElasticAttribute`s to be a List of Strings, rather than a single String. Because Elasticsearch can serve back multiple valid date formats, separated by `||`, we need to have a way to handle multiple different possible date formats.

An important note: this update breaks previously existing data stores due to changing the underlying attributes. I'm not sure the proper way to do a data store migration for a change like this,

Coincides with GeoServer PR: https://github.com/geoserver/geoserver/pull/4270

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests: 

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
