### PR TITLE
[GEOT-6614]: WKB FootprintLoader messup when concurrently loading

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/footprint/WKBLoaderSPI.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/footprint/WKBLoaderSPI.java
@@ -35,14 +35,13 @@ public class WKBLoaderSPI implements FootprintLoaderSpi {
     /** Loads WKB files */
     public class WKBLoader implements FootprintLoader {
 
-        WKBReader reader = new WKBReader();
-
         @Override
         public Geometry loadFootprint(String pathNoExtension) throws Exception {
             File file = new File(pathNoExtension + ".wkb");
             if (file.exists()) {
                 try (FileInputStream is = new FileInputStream(file); ) {
-                    return reader.read(new InputStreamInStream(is));
+                    // WKBReader is not thread-safe. Instantiate a new one
+                    return new WKBReader().read(new InputStreamInStream(is));
                 }
             }
 


### PR DESCRIPTION
WKB FootprintLoader messup when concurrently loading since it was using a shared WKBReader instance which is not thread-safe 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
