### PR TITLE
[GEOT-6618] Add a better default header to SimpleHttpClient

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/ows/SimpleHttpClient.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/SimpleHttpClient.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 import org.geotools.data.Base64;
+import org.geotools.util.factory.GeoTools;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -105,6 +106,9 @@ public class SimpleHttpClient implements HTTPClient {
             ((HttpURLConnection) connection).setRequestMethod("GET");
         }
 
+        // Set User-Agent to a good default
+        connection.addRequestProperty(
+                "User-Agent", "GeoTools HTTPClient (" + GeoTools.getVersion() + ")");
         if (headers != null) {
             for (Map.Entry<String, String> headerNameValue : headers.entrySet()) {
                 if (LOGGER.isLoggable(Level.FINE)) {


### PR DESCRIPTION
Increasingly services such as OSM (see https://osgeo-org.atlassian.net/browse/GEOT-6608 for example) are refusing connections for requests with a default user agent string. 

See https://osgeo-org.atlassian.net/browse/GEOT-6618

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
