### PR TITLE
[GEOT-6595] CRS can't get axis order from compound CRS

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
@@ -2162,6 +2162,11 @@ public final class CRS {
     public static AxisOrder getAxisOrder(CoordinateReferenceSystem crs, boolean useBaseGeoCRS) {
         CoordinateSystem cs = null;
 
+        if (crs instanceof CompoundCRS) {
+            // the first one should contain the EAST and NORTH if applicable
+            crs = ((CompoundCRS) crs).getCoordinateReferenceSystems().get(0);
+        }
+
         if (crs instanceof ProjectedCRS) {
             cs =
                     !useBaseGeoCRS

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/CrsTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/CrsTest.java
@@ -330,6 +330,20 @@ public final class CrsTest {
                         + "  AUTHORITY[\"EPSG\",\"23031\"]]";
         assertEquals(AxisOrder.EAST_NORTH, CRS.getAxisOrder(CRS.parseWKT(wkt)));
         assertEquals(AxisOrder.NORTH_EAST, CRS.getAxisOrder(CRS.parseWKT(wkt), true));
+
+        // test with compound axis
+        wkt =
+                "COMPD_CS[\"ETRS89 + EVRF2000 height\", GEOGCS[\"ETRS89\", "
+                        + "DATUM[\"European Terrestrial Reference System 1989\", "
+                        + "SPHEROID[\"GRS 1980\", 6378137.0, 298.257222101, AUTHORITY[\"EPSG\",\"7019\"]], "
+                        + "TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], AUTHORITY[\"EPSG\",\"6258\"]], "
+                        + "PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], "
+                        + "AXIS[\"Geodetic latitude\", NORTH], AXIS[\"Geodetic longitude\", EAST], AUTHORITY[\"EPSG\",\"4258\"]], "
+                        + "VERT_CS[\"EVRF2000 height\", VERT_DATUM[\"European Vertical Reference Frame 2000\", 2005, "
+                        + "AUTHORITY[\"EPSG\",\"5129\"]], UNIT[\"m\", 1.0], AXIS[\"Gravity-related height\", UP], "
+                        + "AUTHORITY[\"EPSG\",\"5730\"]], AUTHORITY[\"EPSG\",\"7409\"]]";
+        assertEquals(AxisOrder.NORTH_EAST, CRS.getAxisOrder(CRS.parseWKT(wkt)));
+        assertEquals(AxisOrder.NORTH_EAST, CRS.getAxisOrder(CRS.parseWKT(wkt), true));
     }
 
     @Test


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
