### PR TITLE
[GEOT-6623] Add support for jsonPointer to SQL translation in a Postg…

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -837,6 +837,16 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
         encodeBinaryComparisonOperator(filter, extraData, left, right, leftContext, rightContext);
     }
 
+    /**
+     * Encode a BinaryComparisonOperator to SQL
+     *
+     * @param filter the comparison operator to be turned to SQL
+     * @param extraData extraData
+     * @param left left parameter of the binary operator
+     * @param right right parameter of the binary operator
+     * @param leftContext expression type of the right parameter used as context for the left parameter
+     * @param rightContext expression type of the left parameter used as context for the right parameter
+     */
     protected void encodeBinaryComparisonOperator(
             BinaryComparisonOperator filter,
             Object extraData,

--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -834,6 +834,16 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
         Class rightContext = getExpressionType(left);
         Class leftContext = getExpressionType(right);
 
+        encodeBinaryComparisonOperator(filter, extraData, left, right, leftContext, rightContext);
+    }
+
+    protected void encodeBinaryComparisonOperator(
+            BinaryComparisonOperator filter,
+            Object extraData,
+            Expression left,
+            Expression right,
+            Class leftContext,
+            Class rightContext) {
         // case sensitivity
         boolean matchCase = true;
         if (!filter.isMatchingCase()) {
@@ -882,7 +892,6 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
                 f.setParameters(Arrays.asList(right));
                 f.accept(this, Arrays.asList(rightContext));
             }
-
         } catch (java.io.IOException ioe) {
             throw new RuntimeException(IO_ERROR, ioe);
         }

--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -844,8 +844,10 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
      * @param extraData extraData
      * @param left left parameter of the binary operator
      * @param right right parameter of the binary operator
-     * @param leftContext expression type of the right parameter used as context for the left parameter
-     * @param rightContext expression type of the left parameter used as context for the right parameter
+     * @param leftContext expression type of the right parameter used as context for the left
+     *     parameter
+     * @param rightContext expression type of the left parameter used as context for the right
+     *     parameter
      */
     protected void encodeBinaryComparisonOperator(
             BinaryComparisonOperator filter,

--- a/modules/library/main/src/main/java/org/geotools/filter/function/JsonPointerFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/JsonPointerFunction.java
@@ -30,6 +30,7 @@ import java.io.StringWriter;
 import org.geotools.filter.FunctionExpressionImpl;
 import org.geotools.filter.capability.FunctionNameImpl;
 import org.opengis.filter.capability.FunctionName;
+import org.opengis.filter.expression.ExpressionVisitor;
 
 /** Applies a JSON pointer on a given JSON string, extracting a value out of it */
 public class JsonPointerFunction extends FunctionExpressionImpl {
@@ -55,6 +56,7 @@ public class JsonPointerFunction extends FunctionExpressionImpl {
         final String pointerSpec = getExpression(1).evaluate(object, String.class);
 
         JsonPointer expectedPointer = JsonPointer.compile(pointerSpec);
+        if (json == null) return null;
         try (JsonParser parser = factory.createParser(json)) {
             while (parser.nextToken() != END_OF_STREAM) {
                 final JsonPointer pointer = parser.getParsingContext().pathAsPointer();
@@ -151,5 +153,10 @@ public class JsonPointerFunction extends FunctionExpressionImpl {
             }
         }
         generator.writeEndObject();
+    }
+
+    @Override
+    public Object accept(ExpressionVisitor visitor, Object extraData) {
+        return visitor.visit(this, extraData);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/function/JsonPointerFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/JsonPointerFunction.java
@@ -30,7 +30,6 @@ import java.io.StringWriter;
 import org.geotools.filter.FunctionExpressionImpl;
 import org.geotools.filter.capability.FunctionNameImpl;
 import org.opengis.filter.capability.FunctionName;
-import org.opengis.filter.expression.ExpressionVisitor;
 
 /** Applies a JSON pointer on a given JSON string, extracting a value out of it */
 public class JsonPointerFunction extends FunctionExpressionImpl {
@@ -153,10 +152,5 @@ public class JsonPointerFunction extends FunctionExpressionImpl {
             }
         }
         generator.writeEndObject();
-    }
-
-    @Override
-    public Object accept(ExpressionVisitor visitor, Object extraData) {
-        return visitor.visit(this, extraData);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitor.java
@@ -857,7 +857,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     }
 
     public Object visit(Function expression, Object notUsed) {
-        if (!supports(expression.getClass())) {
+        if (!supports(expression)) {
             postStack.push(expression);
             return null;
         }
@@ -1029,6 +1029,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
         boolean supports = false;
         if (value instanceof Class) supports = fcs.supports((Class) value);
         else if (value instanceof Filter) supports = fcs.supports((Filter) value);
+        else if (value instanceof Expression) supports = fcs.supports(value.getClass());
         else if (value instanceof FilterCapabilities)
             supports = fcs.supports((FilterCapabilities) value);
 

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitor.java
@@ -264,7 +264,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
      * @param filter the {@link Filter} to visit
      */
     public void visit(ExcludeFilter filter) {
-        if (fcs.supports(Filter.EXCLUDE)) {
+        if (supports(Filter.EXCLUDE)) {
             preStack.push(filter);
         } else {
             postStack.push(filter);
@@ -281,7 +281,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
         if (original == null) original = filter;
 
         // Do we support this filter type at all?
-        if (fcs.supports(PropertyIsBetween.class)) {
+        if (supports(PropertyIsBetween.class)) {
             // Yes, we do.  Now, can we support the sub-filters?
 
             // first, remember how big the current list of "I can't support these"
@@ -408,7 +408,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
         if (original == null) original = filter;
 
         // supports it as a group -- no need to check the type
-        if (!fcs.supports(FilterCapabilities.SIMPLE_COMPARISONS_OPENGIS)) {
+        if (!supports(FilterCapabilities.SIMPLE_COMPARISONS_OPENGIS)) {
             postStack.push(filter);
             return;
         }
@@ -446,9 +446,9 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     }
 
     public Object visit(BBOX filter, Object notUsed) {
-        if (filter instanceof BBOX3D && !fcs.supports(BBOX3D.class)) {
+        if (filter instanceof BBOX3D && !supports(BBOX3D.class)) {
             postStack.push(filter);
-        } else if (!fcs.supports(BBOX.class)) {
+        } else if (!supports(BBOX.class)) {
             postStack.push(filter);
         } else {
             preStack.push(filter);
@@ -526,7 +526,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
 
         for (int i = 0; i < spatialOps.length; i++) {
             if (spatialOps[i].isAssignableFrom(filter.getClass())) {
-                if (!fcs.supports(spatialOps[i])) {
+                if (!supports(spatialOps[i])) {
                     postStack.push(filter);
                     return;
                 } else {
@@ -575,7 +575,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     public Object visit(PropertyIsLike filter, Object notUsed) {
         if (original == null) original = filter;
 
-        if (!fcs.supports(PropertyIsLike.class)) {
+        if (!supports(PropertyIsLike.class)) {
             postStack.push(filter);
 
             return null;
@@ -614,7 +614,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     private void visitLogicOperator(Filter filter, Class filterInterface) {
         if (original == null) original = filter;
 
-        if (!fcs.supports(filterInterface)) {
+        if (!supports(filterInterface)) {
             postStack.push(filter);
             return;
         }
@@ -717,7 +717,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     }
 
     public Object visit(ExcludeFilter filter, Object notUsed) {
-        if (fcs.supports(Filter.EXCLUDE)) {
+        if (supports(Filter.EXCLUDE)) {
             preStack.push(filter);
         } else {
             postStack.push(filter);
@@ -736,7 +736,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     Object visitNullNil(Filter filter, Expression e) {
         if (original == null) original = filter;
 
-        if (!fcs.supports(PropertyIsNull.class)) {
+        if (!supports(PropertyIsNull.class)) {
             postStack.push(filter);
 
             return null;
@@ -760,7 +760,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     public Object visit(Id filter, Object notUsed) {
         if (original == null) original = filter;
 
-        if (!fcs.supports(filter)) {
+        if (!supports(filter)) {
             postStack.push(filter);
         } else {
             preStack.push(filter);
@@ -817,10 +817,10 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     }
 
     protected void visitMathExpression(BinaryExpression expression) {
-        if (!fcs.supports(Add.class)
-                && !fcs.supports(Subtract.class)
-                && !fcs.supports(Multiply.class)
-                && !fcs.supports(Divide.class)) {
+        if (!supports(Add.class)
+                && !supports(Subtract.class)
+                && !supports(Multiply.class)
+                && !supports(Divide.class)) {
             postStack.push(expression);
             return;
         }
@@ -857,7 +857,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     }
 
     public Object visit(Function expression, Object notUsed) {
-        if (!fcs.supports(expression.getClass())) {
+        if (!supports(expression.getClass())) {
             postStack.push(expression);
             return null;
         }
@@ -980,7 +980,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
         if (original == null) original = filter;
 
         // supports it as a group -- no need to check the type
-        if (!fcs.supports(filter)) {
+        if (!supports(filter)) {
             postStack.push(filter);
             return null;
         }
@@ -1023,5 +1023,15 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
     public Object visit(NativeFilter nativeFilter, Object extraData) {
         preStack.push(nativeFilter);
         return null;
+    }
+
+    protected boolean supports(Object value) {
+        boolean supports = false;
+        if (value instanceof Class) supports = fcs.supports((Class) value);
+        else if (value instanceof Filter) supports = fcs.supports((Filter) value);
+        else if (value instanceof FilterCapabilities)
+            supports = fcs.supports((FilterCapabilities) value);
+
+        return supports;
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
@@ -195,8 +195,6 @@ class FilterToSqlHelper {
             // compare functions
             caps.addType(FilterFunction_equalTo.class);
         }
-
-        caps.addType(JsonPointerFunction.class);
         // native filter support
         caps.addType(NativeFilter.class);
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -37,6 +37,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import org.geotools.data.jdbc.FilterToSQL;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.FilterAttributeExtractor;
+import org.geotools.filter.function.JsonPointerFunction;
+import org.geotools.filter.visitor.PostPreProcessFilterSplittingVisitor;
 import org.geotools.geometry.jts.CircularRing;
 import org.geotools.geometry.jts.CircularString;
 import org.geotools.geometry.jts.CompoundCurve;
@@ -70,6 +74,11 @@ import org.locationtech.jts.io.WKTWriter;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Function;
+import org.opengis.filter.expression.Literal;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 public class PostGISDialect extends BasicSQLDialect {
@@ -1489,5 +1498,43 @@ public class PostGISDialect extends BasicSQLDialect {
         return version == null || version.compareTo(V_2_1_0) >= 0
                 ? "ST_EstimatedExtent"
                 : "ST_Estimated_Extent";
+    }
+
+    public Filter[] splitFilter(Filter filter, SimpleFeatureType schema) {
+        PostPreProcessFilterSplittingVisitor splitter =
+                new PostPreProcessFilterSplittingVisitor(
+                        dataStore.getFilterCapabilities(), schema, null) {
+                    private FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+
+                    @Override
+                    public Object visit(Function expression, Object notUsed) {
+                        if (expression instanceof JsonPointerFunction) {
+                            // takes the json pointer param to check if
+                            // can be encoded
+                            Expression param = expression.getParameters().get(1);
+                            if ((expression.getParameters().get(1) instanceof Literal))
+                                // can encode
+                                fcs.addType(JsonPointerFunction.class);
+                            else {
+                                FilterAttributeExtractor extractor = new FilterAttributeExtractor();
+                                param.accept(extractor, null);
+                                if (extractor.isConstantExpression()) {
+                                    // if constant can encode
+                                    Object result = param.evaluate(null);
+                                    expression.getParameters().set(1, ff.literal(result));
+                                    fcs.addType(JsonPointerFunction.class);
+                                }
+                            }
+                        }
+                        return super.visit(expression, notUsed);
+                    }
+                };
+        filter.accept(splitter, null);
+
+        Filter[] split = new Filter[2];
+        split[0] = splitter.getFilterPre();
+        split[1] = splitter.getFilterPost();
+
+        return split;
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -1506,7 +1506,6 @@ public class PostGISDialect extends BasicSQLDialect {
         PostPreProcessFilterSplittingVisitor splitter =
                 new PostPreProcessFilterSplittingVisitor(
                         dataStore.getFilterCapabilities(), schema, null) {
-                    private boolean supportsJsonPointer = false;
 
                     @Override
                     public Object visit(Function expression, Object notUsed) {
@@ -1514,25 +1513,8 @@ public class PostGISDialect extends BasicSQLDialect {
                             // takes the json pointer param to check if
                             // can be encoded
                             Expression param = expression.getParameters().get(1);
-                            if ((param instanceof Literal)) {
-                                this.supportsJsonPointer = true;
-                            } else {
-                                FilterAttributeExtractor extractor = new FilterAttributeExtractor();
-                                param.accept(extractor, null);
-                                if (extractor.isConstantExpression()) {
-                                    // defensive copy of filter before manipulating it
-                                    DuplicatingFilterVisitor duplicating =
-                                            new DuplicatingFilterVisitor();
-                                    Function duplicated =
-                                            (Function) expression.accept(duplicating, null);
-                                    // if constant can encode
-                                    Object result = param.evaluate(null);
-                                    FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
-                                    // setting constant expression evaluated to literal
-                                    duplicated.getParameters().set(1, ff.literal(result));
-                                    this.supportsJsonPointer = true;
-                                    expression = duplicated;
-                                }
+                            if (!(param instanceof Literal)) {
+                                expression = constantParameterToLiteral(expression, param, 1);
                             }
                         }
                         return super.visit(expression, notUsed);
@@ -1540,9 +1522,10 @@ public class PostGISDialect extends BasicSQLDialect {
 
                     @Override
                     protected boolean supports(Object value) {
-                        if (value.equals(JsonPointerFunction.class)
-                                || value instanceof JsonPointerFunction) return supportsJsonPointer;
-                        else return super.supports(value);
+                        if (value instanceof JsonPointerFunction) {
+                            Expression param = ((Function) value).getParameters().get(1);
+                            return param instanceof Literal;
+                        } else return super.supports(value);
                     }
                 };
         filter.accept(splitter, null);
@@ -1552,5 +1535,26 @@ public class PostGISDialect extends BasicSQLDialect {
         split[1] = splitter.getFilterPost();
 
         return split;
+    }
+
+    // Given a function and one of its parameters check if it is a constant one
+    // and eventually resolve it to Literal setting to the function,
+    // after doing a defensive copy of it.
+    private Function constantParameterToLiteral(
+            Function expression, Expression param, int paramIdx) {
+        FilterAttributeExtractor extractor = new FilterAttributeExtractor();
+        param.accept(extractor, null);
+        if (extractor.isConstantExpression()) {
+            // defensive copy of filter before manipulating it
+            DuplicatingFilterVisitor duplicating = new DuplicatingFilterVisitor();
+            Function duplicated = (Function) expression.accept(duplicating, null);
+            // if constant can encode
+            Object result = param.evaluate(null);
+            FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+            // setting constant expression evaluated to literal
+            duplicated.getParameters().set(paramIdx, ff.literal(result));
+            return duplicated;
+        }
+        return expression;
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISJsonTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISJsonTestSetup.java
@@ -105,14 +105,14 @@ public class PostGISJsonTestSetup extends JDBCDelegatingTestSetup {
                         + "INSERT INTO \"jsontest\" VALUES (6, 'arrayEntry2', '{\"strVal\": \"stringValue\", \"arrayValues\":[3,6,7]}'"
                         + (supportJsonB ? ", '{\"arrayValues\":[3,6,7]}'" : "")
                         + ");"
-                        + "INSERT INTO \"jsontest\" VALUES (7, 'nestedObj', '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedAr\":[3,6,7]}}'"
+                        + "INSERT INTO \"jsontest\" VALUES (7, 'nestedObj', '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedObj2\": {\"numProp\": 3, \"strProp\": \"stringValue2\"},\"nestedAr\":[3,6,7]}}'"
                         + (supportJsonB
-                                ? ", '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedAr\":[3,6,7]}}'"
+                                ? ", '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedObj2\": {\"numProp\": 3, \"strProp\": \"stringValue2\"}, \"nestedAr\":[3,6,7]}}'"
                                 : "")
                         + ");"
-                        + "INSERT INTO \"jsontest\" VALUES (8, 'nestedObj', '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedAr\":[3,5,7]}}'"
+                        + "INSERT INTO \"jsontest\" VALUES (8, 'nestedObj', '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedObj2\": {\"numProp\": 4, \"strProp\": \"stringValue2\"}, \"nestedAr\":[3,5,7]}}'"
                         + (supportJsonB
-                                ? ", '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedAr\":[3,5,7]}}'"
+                                ? ", '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedObj2\": {\"numProp\": 4, \"strProp\": \"stringValue2\"}, \"nestedAr\":[3,5,7]}}'"
                                 : "")
                         + ");";
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISJsonTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISJsonTestSetup.java
@@ -98,7 +98,24 @@ public class PostGISJsonTestSetup extends JDBCDelegatingTestSetup {
                         + ");"
                         + "INSERT INTO \"jsontest\" VALUES (4, 'nullEntry', NULL"
                         + (supportJsonB ? ", NULL" : "")
+                        + ");"
+                        + "INSERT INTO \"jsontest\" VALUES (5, 'arrayEntry', '{\"arrayValues\":[3,5,6]}'"
+                        + (supportJsonB ? ", '{\"arrayValues\":[3,5,6]}'" : "")
+                        + ");"
+                        + "INSERT INTO \"jsontest\" VALUES (6, 'arrayEntry2', '{\"strVal\": \"stringValue\", \"arrayValues\":[3,6,7]}'"
+                        + (supportJsonB ? ", '{\"arrayValues\":[3,6,7]}'" : "")
+                        + ");"
+                        + "INSERT INTO \"jsontest\" VALUES (7, 'nestedObj', '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedAr\":[3,6,7]}}'"
+                        + (supportJsonB
+                                ? ", '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedAr\":[3,6,7]}}'"
+                                : "")
+                        + ");"
+                        + "INSERT INTO \"jsontest\" VALUES (8, 'nestedObj', '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedAr\":[3,5,7]}}'"
+                        + (supportJsonB
+                                ? ", '{\"nestedObj\": {\"nestedProp\":\"stringValue\", \"nestedAr\":[3,5,7]}}'"
+                                : "")
                         + ");";
+
         run(sql);
     }
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
@@ -34,6 +34,8 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Function;
 import org.opengis.filter.spatial.BBOX3D;
 import org.opengis.filter.spatial.Intersects;
 import org.opengis.geometry.MismatchedDimensionException;
@@ -247,5 +249,28 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         filterToSql.encode(like);
         String sql = writer.toString().toLowerCase().trim();
         assertEquals("where lower(teststring) like 'a_literal'", sql);
+    }
+
+    @Test
+    public void testFunctionJsonPointer() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer =
+                ff.function("jsonPointer", ff.property("testJSON"), ff.literal("/arr/0"));
+
+        filterToSql.encode(pointer);
+        String sql = writer.toString().toLowerCase().trim();
+        assertEquals("testjson ::json  -> 'arr' ->> 0", sql);
+    }
+
+    @Test
+    public void testBinaryComparisonWithJsonPointer() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer =
+                ff.function("jsonPointer", ff.property("testJSON"), ff.literal("/arr/0"));
+        Expression literal = ff.literal(3);
+        Filter less = ff.less(pointer, literal);
+        filterToSql.encode(less);
+        String sql = writer.toString().toLowerCase().trim();
+        assertEquals("where (testjson ::json  -> 'arr' ->> 0)::integer < 3", sql);
     }
 }


### PR DESCRIPTION
…reSQL database

Jira ticket https://osgeo-org.atlassian.net/browse/GEOT-6623

This pr add support to translate jsonPointer function to PostgreSQL dialect.
eg. jsonPointer( property, '/path/to/json/attribute') to property::json -> path -> to -> json ->> attribute.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
