### PR TITLE
[GEOT-6636] Raster to Vector rendering transformations can lose nodata values when crossing the dateline

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/ExtendedRandomIter.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/ExtendedRandomIter.java
@@ -17,6 +17,7 @@
 package org.geotools.coverage.processing.operation;
 
 import it.geosolutions.jaiext.iterators.RandomIterFactory;
+import it.geosolutions.jaiext.range.NoDataContainer;
 import javax.media.jai.BorderExtender;
 import javax.media.jai.PlanarImage;
 import javax.media.jai.RenderedOp;
@@ -44,6 +45,9 @@ class ExtendedRandomIter implements RandomIter {
         RandomIter iterSource;
         if (extender != null) {
             ImageWorker w = new ImageWorker(src).setRenderingHints(GeoTools.getDefaultHints());
+            if (w.getNoData() != null) {
+                w.setBackground(new NoDataContainer(w.getNoData()).getAsArray());
+            }
             RenderedOp op =
                     w.border(leftPad, rightPad, topPad, bottomPad, extender).getRenderedOperation();
             RandomIter it = RandomIterFactory.create(op, op.getBounds(), true, true);

--- a/modules/library/coverage/src/main/java/org/geotools/image/ImageWorker.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/ImageWorker.java
@@ -5099,7 +5099,7 @@ public class ImageWorker {
         pb.add(nodata);
         if (isNoDataNeeded()) {
             if (background != null && background.length > 0) {
-                pb.add(background);
+                pb.add(background[0]);
             }
         }
         image = JAI.create("Border", pb, getRenderingHints());

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/RasterAsPointCollectionProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/RasterAsPointCollectionProcessTest.java
@@ -17,7 +17,7 @@
  */
 package org.geotools.process.raster;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -409,15 +409,21 @@ public class RasterAsPointCollectionProcessTest {
 
         Raster raster = image.getData(new Rectangle(minX, 0, reducedWidth, reducedHeight));
 
-        int whiteSamples = 0;
+        int blackSamples = 0;
+        int graySamples = 0;
         for (int i = 0; i < reducedWidth; i++) {
             for (int j = 0; j < reducedHeight; j++) {
-                whiteSamples += raster.getSample(minX + i, j, 0) == 255 ? 1 : 0;
+                blackSamples += raster.getSample(minX + i, j, 0) == 0 ? 1 : 0;
+                graySamples += raster.getSample(minX + i, j, 0) == 128 ? 1 : 0;
             }
         }
         // Check that we aren't getting a whole white image on a big part of the rightern
         // side of the image. this was happening before the fix on wrapping on rendering
         // transformation since it was only rendering a smaller area (NO wrapping at all)
-        assertFalse(whiteSamples == reducedHeight * reducedWidth);
+        assertNotEquals(0, blackSamples);
+        // Confirm that the NODATA values (-32767.0 in the test image) were preserved
+        // by checking for samples in the image that are not black (non-NODATA values)
+        // or white (background).
+        assertNotEquals(0, graySamples);
     }
 }

--- a/modules/unsupported/process-raster/src/test/resources/org/geotools/process/raster/test-data/arrows.sld
+++ b/modules/unsupported/process-raster/src/test/resources/org/geotools/process/raster/test-data/arrows.sld
@@ -15,30 +15,26 @@
           </ogc:Function>
         </Transformation> 
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsNotEqualTo>
-              <ogc:PropertyName>GRAY_INDEX</ogc:PropertyName>
-              <ogc:Literal>NaN</ogc:Literal>
-            </ogc:PropertyIsNotEqualTo>
-          </ogc:Filter>
-          <TextSymbolizer> 
-            <Label><![CDATA[ ]]></Label> <!-- fake label -->
-             <Graphic>
-                  <Mark>
-                    <WellKnownName>circle</WellKnownName>
-                    <Fill>
-                      <CssParameter name="fill">0x000000
-                      </CssParameter>
-                    </Fill>
-                  </Mark>
-                 <Size>
-                    <ogc:Mul>
-                      <ogc:PropertyName>GRAY_INDEX</ogc:PropertyName>
-                      <ogc:Literal>0.5</ogc:Literal>
-                    </ogc:Mul>
-                  </Size>
-            </Graphic> 
-          </TextSymbolizer> 
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">
+                    <ogc:Function name="if_then_else">
+                      <ogc:Function name="equalTo">
+                        <ogc:PropertyName>GRAY_INDEX</ogc:PropertyName>
+                        <ogc:Literal>-32767.0</ogc:Literal>
+                      </ogc:Function>
+                      <ogc:Literal>#808080</ogc:Literal>
+                      <ogc:Literal>#000000</ogc:Literal>
+                    </ogc:Function>
+                  </CssParameter>
+                </Fill>
+              </Mark>
+              <Size>1</Size>
+            </Graphic>
+          </PointSymbolizer>
         </Rule> 
       </FeatureTypeStyle> 
     </UserStyle> 


### PR DESCRIPTION
This pull request fixes nodata values being converted to zero when using a raster to vector rendering transformation across the dateline by setting the background of the Border operation to be the same as the nodata value when resampling a coverage with a nodata value.

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
