### PR TITLE
[Backport-23.x][GEOT-6626] Update PostgreSQL driver to 42.2.14

### DIFF
--- a/modules/plugin/epsg-postgresql/src/main/java/org/geotools/referencing/epsg/postgresql/ThreadedPostgreSQLEpsgFactory.java
+++ b/modules/plugin/epsg-postgresql/src/main/java/org/geotools/referencing/epsg/postgresql/ThreadedPostgreSQLEpsgFactory.java
@@ -179,8 +179,8 @@ public class ThreadedPostgreSQLEpsgFactory extends ThreadedEpsgFactory {
             portNumber = 5432;
             Logging.unexpectedException(LOGGER, DataSource.class, "<init>", exception);
         }
-        source.setPortNumber(portNumber);
-        source.setServerName(p.getProperty("serverName", "localhost"));
+        source.setPortNumbers(new int[] {portNumber});
+        source.setServerNames(new String[] {p.getProperty("serverName", "localhost")});
         source.setDatabaseName(p.getProperty("databaseName", "EPSG"));
         source.setUser(p.getProperty("user", "Geotools"));
         source.setPassword(p.getProperty("password", "Geotools"));

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <fork.javac>false</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <postgresql.jdbc.version>42.2.5</postgresql.jdbc.version>
+    <postgresql.jdbc.version>42.2.14</postgresql.jdbc.version>
     <solrj.version>7.2.1</solrj.version>
     <elasticsearch.version>7.4.0</elasticsearch.version>
     <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
@@ -2377,4 +2377,3 @@
     <module>modules</module>
   </modules>
 </project>
-


### PR DESCRIPTION
backport #2992 

Update the PostgreSQL jdbc driver from 42.2.5 to 42.2.14, resolves CVE-2020-13692 (PostgreSQL JDBC Driver (aka PgJDBC) before 42.2.13 allows XXE) .

fix deprecated method use in `ThreadedPostgreSQLEpsgFactory`

see also:

https://jdbc.postgresql.org/documentation/changelog.html#version_42.2.13
https://osgeo-org.atlassian.net/browse/GEOT-6626