### PR TITLE
[GEOT-6605] Add SqlServer support to ImageMosaic Index - work with default isolation level

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicConfigHandler.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicConfigHandler.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -496,7 +497,10 @@ public class ImageMosaicConfigHandler {
             final SimpleFeatureTypeBuilder featureBuilder = new SimpleFeatureTypeBuilder();
             String typeName = runConfiguration.getParameter(Prop.TYPENAME);
             featureBuilder.setName(typeName != null ? typeName : name);
-            featureBuilder.setNamespaceURI("http://www.geo-solutions.it/");
+            // the image mosaic code makes several lookups by un-qualified local names, best
+            // not to have a namespace here. It also matches the behavior of
+            // DataUtilities.createType, used above in case the indexer contains the target schema
+            featureBuilder.setNamespaceURI((URI) null);
             featureBuilder.add(
                     runConfiguration.getParameter(Prop.LOCATION_ATTRIBUTE).trim(), String.class);
             featureBuilder.add("the_geom", Polygon.class, actualCRS);

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterManager.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterManager.java
@@ -64,6 +64,7 @@ import org.geotools.coverage.grid.io.StructuredGridCoverage2DReader;
 import org.geotools.coverage.util.CoverageUtilities;
 import org.geotools.coverage.util.FeatureUtilities;
 import org.geotools.data.Query;
+import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.visitor.CalcResult;
 import org.geotools.feature.visitor.FeatureCalc;
@@ -1451,7 +1452,7 @@ public class RasterManager implements Cloneable {
             // remove them all, assuming the schema has not changed
             final Query query = new Query(type.getTypeName());
             query.setFilter(Filter.INCLUDE);
-            granuleCatalog.removeGranules(query);
+            granuleCatalog.removeGranules(query, Transaction.AUTO_COMMIT);
         }
     }
 
@@ -1470,7 +1471,7 @@ public class RasterManager implements Cloneable {
             cleanupGranules(query, checkForReferences, forceDelete);
 
             // removing records from the catalog
-            granuleCatalog.removeGranules(query);
+            granuleCatalog.removeGranules(query, Transaction.AUTO_COMMIT);
             granuleCatalog.removeType(typeName);
         }
         if (alternativeCRSCache != null) {
@@ -1599,7 +1600,11 @@ public class RasterManager implements Cloneable {
     }
 
     public void initialize(final boolean checkDomains) throws IOException {
-        final BoundingBox bounds = granuleCatalog.getBounds(typeName);
+        initialize(checkDomains, Transaction.AUTO_COMMIT);
+    }
+
+    public void initialize(final boolean checkDomains, Transaction transaction) throws IOException {
+        final BoundingBox bounds = granuleCatalog.getBounds(typeName, transaction);
         if (checkDomains) {
             initDomains(configuration);
         }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/AbstractGTDataStoreGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/AbstractGTDataStoreGranuleCatalog.java
@@ -371,6 +371,7 @@ abstract class AbstractGTDataStoreGranuleCatalog extends GranuleCatalog {
     protected abstract void disposeTileIndexStore();
 
     @Override
+    @SuppressWarnings("deprecation")
     public int removeGranules(Query query) {
         return removeGranules(query, null);
     }
@@ -402,6 +403,8 @@ abstract class AbstractGTDataStoreGranuleCatalog extends GranuleCatalog {
 
                 return retVal;
             } finally {
+                // rollback/close only if the transaction was created locally, otherwise leave
+                // the caller providing the transaction in control
                 if (t != transaction) {
                     if (rollback) {
                         t.rollback();

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/CachingDataStoreGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/CachingDataStoreGranuleCatalog.java
@@ -132,8 +132,8 @@ class CachingDataStoreGranuleCatalog extends GranuleCatalog {
             Query copy = new Query(q);
             copy.getHints().remove(GranuleSource.NATIVE_BOUNDS);
             q = copy;
-            return new BoundsFeatureCollection(
-                    adaptee.getGranules(q, t), this::getGranuleDescriptor);
+            SimpleFeatureCollection granules = adaptee.getGranules(q, t);
+            return new BoundsFeatureCollection(granules, this::getGranuleDescriptor);
         } else {
             return adaptee.getGranules(q, t);
         }
@@ -245,14 +245,7 @@ class CachingDataStoreGranuleCatalog extends GranuleCatalog {
     @Override
     @SuppressWarnings("deprecation")
     public int removeGranules(Query query) {
-        final int val = adaptee.removeGranules(query);
-        // clear cache if needed
-        // TODO this can be optimized further filtering out elements using the Query's Filter
-        if (val >= 1) {
-            descriptorsCache.clear();
-        }
-
-        return val;
+        return this.removeGranules(query, Transaction.AUTO_COMMIT);
     }
 
     @Override

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GTDataStoreGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GTDataStoreGranuleCatalog.java
@@ -84,7 +84,7 @@ public class GTDataStoreGranuleCatalog extends AbstractGTDataStoreGranuleCatalog
             this.tileIndexStore =
                     new OracleDatastoreWrapper(
                             getTileIndexStore(), FilenameUtils.getFullPath(parentLocation));
-        } else if (Utils.isSQLServerStore(spi) && wrapstore) {
+        } else if (Utils.isSQLServerStore(spi)) {
             this.tileIndexStore =
                     new SQLServerDatastoreWrapper(
                             getTileIndexStore(), FilenameUtils.getFullPath(parentLocation));

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GTDataStoreGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GTDataStoreGranuleCatalog.java
@@ -85,6 +85,7 @@ public class GTDataStoreGranuleCatalog extends AbstractGTDataStoreGranuleCatalog
                     new OracleDatastoreWrapper(
                             getTileIndexStore(), FilenameUtils.getFullPath(parentLocation));
         } else if (Utils.isSQLServerStore(spi)) {
+            // always wrap to ensure the geometry metadata table is there
             this.tileIndexStore =
                     new SQLServerDatastoreWrapper(
                             getTileIndexStore(), FilenameUtils.getFullPath(parentLocation));

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GranuleCatalog.java
@@ -70,7 +70,23 @@ public abstract class GranuleCatalog {
 
     public abstract BoundingBox getBounds(final String typeName);
 
+    public BoundingBox getBounds(final String typeName, Transaction t) {
+        if (t == null || t == Transaction.AUTO_COMMIT) {
+            return getBounds(typeName);
+        }
+        throw new IllegalArgumentException(
+                "This implementation of GranuleCatalog does not override getBounds(t, t), the default implementation can only work with the auto commit transaction");
+    }
+
     public abstract SimpleFeatureCollection getGranules(Query q) throws IOException;
+
+    public SimpleFeatureCollection getGranules(Query q, Transaction t) throws IOException {
+        if (t == null || t == Transaction.AUTO_COMMIT) {
+            return getGranules(q);
+        }
+        throw new IllegalArgumentException(
+                "This implementation of GranuleCatalog does not override getGranules(q, t), the default implementation can only work with the auto commit transaction");
+    }
 
     public abstract int getGranulesCount(Query q) throws IOException;
 
@@ -83,7 +99,18 @@ public abstract class GranuleCatalog {
 
     public abstract void removeType(final String typeName) throws IOException;
 
+    /** @deprecated please use {@link #removeGranules(Query, Transaction)} */
+    @Deprecated
     public abstract int removeGranules(Query query);
+
+    @SuppressWarnings("deprecation")
+    public int removeGranules(Query query, Transaction transaction) {
+        if (transaction == null || transaction == Transaction.AUTO_COMMIT) {
+            return removeGranules(query);
+        }
+        throw new IllegalArgumentException(
+                "This implementation of GranuleCatalog does not override removeGranules(q, t), the default implementation can only work with the auto commit transaction");
+    }
 
     public abstract String[] getTypeNames();
 

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GranuleCatalogStore.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/GranuleCatalogStore.java
@@ -106,13 +106,13 @@ public class GranuleCatalogStore extends GranuleCatalogSource implements Granule
     @Override
     public int removeGranules(Filter filter, Hints hints) {
         try {
-            int removed = catalog.removeGranules(new Query(typeName, filter));
+            int removed = catalog.removeGranules(new Query(typeName, filter), transaction);
 
             // we cannot re-initialize a raster manager if there are no granules
             Query q = new Query(manager.getTypeName());
             q.setMaxFeatures(1);
-            if (DataUtilities.count(catalog.getGranules(q)) > 0) {
-                manager.initialize(true);
+            if (DataUtilities.count(catalog.getGranules(q, transaction)) > 0) {
+                manager.initialize(true, transaction);
             }
             return removed;
         } catch (IOException e) {

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/LockingGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/LockingGranuleCatalog.java
@@ -165,9 +165,24 @@ class LockingGranuleCatalog extends GranuleCatalog {
         }
     }
 
+    public BoundingBox getBounds(final String typeName, Transaction t) {
+        Lock lock = rwLock.readLock();
+        try {
+            lock.lock();
+            return delegate.getBounds(typeName, t);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     @Override
     public SimpleFeatureCollection getGranules(Query q) throws IOException {
         return guardIO(() -> delegate.getGranules(q), rwLock.readLock());
+    }
+
+    @Override
+    public SimpleFeatureCollection getGranules(Query q, Transaction t) throws IOException {
+        return guardIO(() -> delegate.getGranules(q, t), rwLock.readLock());
     }
 
     @Override
@@ -196,8 +211,14 @@ class LockingGranuleCatalog extends GranuleCatalog {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public int removeGranules(Query query) {
         return guard(() -> delegate.removeGranules(query), rwLock.writeLock());
+    }
+
+    @Override
+    public int removeGranules(Query query, Transaction transaction) {
+        return guard(() -> delegate.removeGranules(query, transaction), rwLock.writeLock());
     }
 
     @Override

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/STRTreeGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/STRTreeGranuleCatalog.java
@@ -355,6 +355,12 @@ class STRTreeGranuleCatalog extends GranuleCatalog {
         }
     }
 
+    @Override
+    public SimpleFeatureCollection getGranules(Query q, Transaction t) throws IOException {
+        // in memory, non transactional
+        return getGranules(q);
+    }
+
     private ReferencedEnvelope extractAndCombineBBox(Filter filter) {
         final Utils.BBOXFilterExtractor bboxExtractor = new Utils.BBOXFilterExtractor();
         filter.accept(bboxExtractor, null);
@@ -425,6 +431,12 @@ class STRTreeGranuleCatalog extends GranuleCatalog {
         } finally {
             lock.unlock();
         }
+    }
+
+    @Override
+    public BoundingBox getBounds(String typeName, Transaction t) {
+        // non transactional implementation
+        return getBounds(typeName);
     }
 
     /** @throws IllegalStateException */

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/STRTreeGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/STRTreeGranuleCatalog.java
@@ -531,6 +531,7 @@ class STRTreeGranuleCatalog extends GranuleCatalog {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public int removeGranules(Query query) {
         throw new UnsupportedOperationException("Unsupported operation");
     }

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicReaderTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicReaderTest.java
@@ -4621,7 +4621,8 @@ public class ImageMosaicReaderTest extends Assert {
         ImageMosaicReader reader = new ImageMosaicFormat().getReader(testMosaic);
 
         // remove cached granules on error and reload
-        reader.granuleCatalog.removeGranules(new Query("empty_mosaic", Filter.INCLUDE));
+        reader.granuleCatalog.removeGranules(
+                new Query("empty_mosaic", Filter.INCLUDE), Transaction.AUTO_COMMIT);
         reader.dispose();
         reader = new ImageMosaicFormat().getReader(testMosaic);
 
@@ -4697,7 +4698,8 @@ public class ImageMosaicReaderTest extends Assert {
         coverage.dispose(true);
 
         // now remove granule, reinitialize and test the first tests again
-        reader.granuleCatalog.removeGranules(new Query("empty_mosaic", Filter.INCLUDE));
+        reader.granuleCatalog.removeGranules(
+                new Query("empty_mosaic", Filter.INCLUDE), Transaction.AUTO_COMMIT);
         manager.initialize(false);
 
         // manager should have an empty bbox


### PR DESCRIPTION
SQL Server by default does not allow other transactions to see what has not been yet committed. This causes problems in the image mosaic harvest, as different code paths fail to properly share the same transaction, causing reads not to see what the writes have been working on.  

This required some changes in the GranuleCatalog base class, to allow passing transactions down in read operations too. Also, it made an issue computing bounding boxes in shapefile emerge (the usage of transactions cause the shapefile data store not to report the bbox correctly anymore, as the transaction diff was not being used correctly).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
