### PR TITLE
[GEOT-6129] WFS GetPropertyValue requests fail with App-Schema define…

### DIFF
--- a/modules/extension/app-schema/app-schema/pom.xml
+++ b/modules/extension/app-schema/app-schema/pom.xml
@@ -206,6 +206,12 @@
             <version>9.4.12.v20180830</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-wfs</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/FeatureChainingTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/FeatureChainingTest.java
@@ -45,10 +45,7 @@ import org.opengis.feature.Attribute;
 import org.opengis.feature.ComplexAttribute;
 import org.opengis.feature.Feature;
 import org.opengis.feature.Property;
-import org.opengis.feature.type.AttributeDescriptor;
-import org.opengis.feature.type.FeatureType;
-import org.opengis.feature.type.Name;
-import org.opengis.feature.type.PropertyDescriptor;
+import org.opengis.feature.type.*;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Expression;
@@ -798,7 +795,8 @@ public class FeatureChainingTest extends AppSchemaTestSupport {
         Iterator it = propertyValueCollection.iterator();
         while (it.hasNext()) {
             Attribute attribute = (Attribute) it.next();
-            assertFalse(attribute instanceof ComplexAttribute);
+            // attribute.getType() was causing Class cast exception to ComplexType
+            assertFalse(attribute.getType() instanceof ComplexType);
         }
     }
 

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/FeatureChainingTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/FeatureChainingTest.java
@@ -17,10 +17,7 @@
 
 package org.geotools.data.complex;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.net.URL;
@@ -40,17 +37,22 @@ import org.geotools.feature.FeatureImpl;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.gml3.bindings.GML3EncodingUtils;
 import org.geotools.test.AppSchemaTestSupport;
+import org.geotools.wfs.PropertyValueCollection;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.locationtech.jts.util.Stopwatch;
+import org.opengis.feature.Attribute;
 import org.opengis.feature.ComplexAttribute;
 import org.opengis.feature.Feature;
 import org.opengis.feature.Property;
+import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.Name;
+import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.PropertyName;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.NamespaceSupport;
 
@@ -779,6 +781,25 @@ public class FeatureChainingTest extends AppSchemaTestSupport {
         assertEquals(3, size(guFeatures));
         assertEquals(4, size(cpFeatures));
         assertEquals(6, size(cgiFeatures));
+    }
+
+    @Test
+    public void testPropertyValueCollection() {
+        // test that the Attribute return from a PropertyValueCollection iteration,
+        // when a PropertyName points to a SimpleAttribute in a ComplexFeature,
+        // doesn't throws a ClassCastException on getType method
+
+        PropertyName pn = ff.property("gsml:specification/gsml:GeologicUnit/gsml:purpose");
+
+        PropertyDescriptor descriptor = pn.evaluate(mfFeatures.getSchema(), null);
+
+        PropertyValueCollection propertyValueCollection =
+                new PropertyValueCollection(mfFeatures, (AttributeDescriptor) descriptor, pn);
+        Iterator it = propertyValueCollection.iterator();
+        while (it.hasNext()) {
+            Attribute attribute = (Attribute) it.next();
+            assertFalse(attribute instanceof ComplexAttribute);
+        }
     }
 
     private static int size(FeatureCollection<FeatureType, Feature> features) {

--- a/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/PropertyValueCollection.java
+++ b/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/PropertyValueCollection.java
@@ -33,10 +33,7 @@ import org.geotools.feature.NameImpl;
 import org.geotools.feature.type.FeatureTypeFactoryImpl;
 import org.geotools.gml3.v3_2.GML;
 import org.geotools.xs.XS;
-import org.opengis.feature.Attribute;
-import org.opengis.feature.Feature;
-import org.opengis.feature.FeatureFactory;
-import org.opengis.feature.Property;
+import org.opengis.feature.*;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.AttributeType;
@@ -180,7 +177,8 @@ public class PropertyValueCollection extends AbstractCollection<Attribute> {
                             descriptor.isNillable(),
                             descriptor.getDefaultValue());
 
-            if (next instanceof SimpleFeature) {
+            if (next instanceof SimpleFeature || !(value instanceof ComplexAttribute)) {
+                if (value instanceof Attribute) value = ((Attribute) value).getValue();
                 return factory.createAttribute(value, newDescriptor, null);
             } else {
                 return factory.createComplexAttribute(

--- a/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/PropertyValueCollection.java
+++ b/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/PropertyValueCollection.java
@@ -34,7 +34,6 @@ import org.geotools.feature.type.FeatureTypeFactoryImpl;
 import org.geotools.gml3.v3_2.GML;
 import org.geotools.xs.XS;
 import org.opengis.feature.*;
-import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.AttributeType;
 import org.opengis.feature.type.FeatureTypeFactory;
@@ -177,13 +176,18 @@ public class PropertyValueCollection extends AbstractCollection<Attribute> {
                             descriptor.isNillable(),
                             descriptor.getDefaultValue());
 
-            if (next instanceof SimpleFeature || !(value instanceof ComplexAttribute)) {
-                if (value instanceof Attribute) value = ((Attribute) value).getValue();
-                return factory.createAttribute(value, newDescriptor, null);
+            Object result;
+            if (value instanceof ComplexAttribute) {
+                result =
+                        factory.createComplexAttribute(
+                                Collections.<Property>singletonList((Property) value),
+                                newDescriptor,
+                                null);
             } else {
-                return factory.createComplexAttribute(
-                        Collections.<Property>singletonList((Property) value), newDescriptor, null);
+                value = value instanceof Attribute ? ((Attribute) value).getValue() : value;
+                result = factory.createAttribute(value, newDescriptor, null);
             }
+            return result;
         }
 
         @Override


### PR DESCRIPTION
…d feature types

This pr fixes a bug issued by a GetPropertyValue operation with a propertyName pointing to a SimpleAttribute in a ComplexFeature. JIRA ticket https://osgeo-org.atlassian.net/browse/GEOT-6129

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
