### PR TITLE
[GEOT-6643] Shapefile write fails when encountering MULTIPOLYGON EMPTY geometries

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDumper.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDumper.java
@@ -385,9 +385,7 @@ public class ShapefileDumper {
             geometryType = "Line";
         } else {
             throw new RuntimeException(
-                    "This should never happen, "
-                            + "there's a bug in the SHAPE-ZIP output format. I got a geometry of type "
-                            + g.getClass());
+                    "This should never happen, I got a geometry of type " + g.getClass());
         }
 
         Map<String, Object> map = new HashMap<String, Object>();

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureWriter.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureWriter.java
@@ -376,7 +376,13 @@ class ShapefileFeatureWriter implements FeatureWriter<SimpleFeatureType, SimpleF
         }
 
         // convert geometry
-        g = JTSUtilities.convertToCollection(g, shapeType);
+        if (g != null) {
+            if (g.isEmpty()) {
+                g = null;
+            } else {
+                g = JTSUtilities.convertToCollection(g, shapeType);
+            }
+        }
 
         // bounds calculations
         if (g != null) {

--- a/modules/plugin/shapefile/src/test/resources/org/geotools/data/shapefile/test-data/dumper/MultiTypeEmpty.properties
+++ b/modules/plugin/shapefile/src/test/resources/org/geotools/data/shapefile/test-data/dumper/MultiTypeEmpty.properties
@@ -1,0 +1,7 @@
+_=the_geom:Geometry:srid=4326,name:String
+MultiTypeEmpty.1=POLYGON EMPTY|polygon
+MultiTypeEmpty.2=LINESTRING EMPTY|line
+MultiTypeEmpty.3=POINT EMPTY|point
+MultiTypeEmpty.4=MULTIPOLYGON EMPTY|mpolygon
+MultiTypeEmpty.5=MULTILINESTRING EMPTY|mline
+MultiTypeEmpty.6=MULTIPOINT EMPTY|mpoint


### PR DESCRIPTION
Went a bit further and checked all types of empty geometries are correctly handled. Since the shapefile has no notion of "empty", went for replacing those with null geometries (that's a legit geometry type in shapefile, and the only one that can be mixed with other geometry types in the same file).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
