### PR TITLE
[GEOT-6648] WrappingProjectionHandler::accumulate method doesn't support a mixed Geometry typed GeometryCollection

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/renderer/crs/WrappingProjectionHandler.java
+++ b/modules/library/main/src/main/java/org/geotools/renderer/crs/WrappingProjectionHandler.java
@@ -199,7 +199,7 @@ public class WrappingProjectionHandler extends ProjectionHandler {
         }
 
         // clone and offset as necessary
-        geomType = accumulate(geoms, geometry, geomType);
+        geomType = accumulate(geoms, geometry, geomType, renderingEnvelope);
         while (curr <= highLimit) {
             double offset = curr - base;
             if (Math.abs(offset) >= targetHalfCircle) {
@@ -207,7 +207,7 @@ public class WrappingProjectionHandler extends ProjectionHandler {
                 Geometry offseted = geometry.copy();
                 offseted.apply(new OffsetOrdinateFilter(northEast ? 1 : 0, offset));
                 offseted.geometryChanged();
-                geomType = accumulate(geoms, offseted, geomType);
+                geomType = accumulate(geoms, offseted, geomType, renderingEnvelope);
             }
 
             curr += targetHalfCircle * 2;
@@ -246,15 +246,17 @@ public class WrappingProjectionHandler extends ProjectionHandler {
      * @return the geometry type that all geometries added to the collection conform to. Worst case
      *     it's going to be Geometry.class
      */
-    private Class accumulate(List<Geometry> geoms, Geometry geometry, Class geomType) {
+    static Class accumulate(
+            List<Geometry> geoms, Geometry geometry, Class geomType, ReferencedEnvelope envelope) {
         Class gtype = null;
         for (int i = 0; i < geometry.getNumGeometries(); i++) {
             Geometry g = geometry.getGeometryN(i);
+            Class lastType = gtype;
 
             if (g instanceof GeometryCollection) {
-                gtype = accumulate(geoms, g, geomType);
+                gtype = accumulate(geoms, g, geomType, envelope);
             } else {
-                if (renderingEnvelope.intersects(g.getEnvelopeInternal())) {
+                if (envelope.intersects(g.getEnvelopeInternal())) {
                     geoms.add(g);
                     gtype = g.getClass();
                 }
@@ -262,7 +264,9 @@ public class WrappingProjectionHandler extends ProjectionHandler {
 
             if (gtype == null) {
                 gtype = g.getClass();
-            } else if (geomType != null && !g.getClass().equals(geomType)) {
+            } else if (geomType != null && !g.getClass().equals(geomType)
+                    || lastType != null && !g.getClass().equals(lastType)) {
+                // if we have different types, switch to Geometry type
                 gtype = Geometry.class;
             }
         }

--- a/modules/library/main/src/test/java/org/geotools/renderer/crs/WrappingProjectionHandlerTest.java
+++ b/modules/library/main/src/test/java/org/geotools/renderer/crs/WrappingProjectionHandlerTest.java
@@ -1,0 +1,51 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.crs;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.io.WKTReader;
+
+public class WrappingProjectionHandlerTest {
+
+    final GeometryFactory gf = new GeometryFactory();
+    final WKTReader wktReader = new WKTReader();
+
+    /**
+     * Tests the accumulate function using a Geometry collection with different geometry types,
+     * checking that it should returns a {@link Geometry} class.
+     */
+    @Test
+    public void testAccumulateWithDifferentGeometryTypes() throws Exception {
+        List<Geometry> resultGeoms = new ArrayList<>();
+        Geometry point = wktReader.read("POINT(1 1)");
+        Geometry line = wktReader.read("LINESTRING(1 1, 1 2, 2 2)");
+        GeometryCollection collection = new GeometryCollection(new Geometry[] {point, line}, gf);
+        ReferencedEnvelope envelope = new ReferencedEnvelope(0, 5, 0, 5, CRS.decode("EPSG:4326"));
+        Class resultClass =
+                WrappingProjectionHandler.accumulate(resultGeoms, collection, null, envelope);
+        assertEquals(Geometry.class, resultClass);
+    }
+}


### PR DESCRIPTION
This PR introduces a fix for WrappingProjectionHandler::accumulate method allowing mixed Geometry types use cases.  It also adds a test for the fixed function.

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOT-6648

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer.

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
