### PR TITLE
[GEOT-6664] Revert to use of xsd as library

### DIFF
--- a/modules/extension/xsd/xsd-core/pom.xml
+++ b/modules/extension/xsd/xsd-core/pom.xml
@@ -120,7 +120,7 @@
       <artifactId>org.eclipse.emf.ecore</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.emf</groupId>
+      <groupId>org.eclipse.xsd</groupId>
       <artifactId>org.eclipse.xsd</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1304,9 +1304,9 @@
         <version>${eclipse.emf.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.emf</groupId>
-        <artifactId>org.eclipse.xsd</artifactId>
-        <version>${eclipse.emf.version}</version>
+          <groupId>org.eclipse.xsd</groupId>
+          <artifactId>org.eclipse.xsd</artifactId>
+          <version>2.12.0</version>
       </dependency>
 
       <!-- Other random non test dependencies -->


### PR DESCRIPTION
This commit reverts the change from https://github.com/geotools/geotools/pull/3072, we found that the xsd dependency included transitive dependencies allowing it to be used as an eclipse plugin.

It is unclear if the `xsd` library is still published, or is only under active development as an eclipse plugin!

* [Use of XSD as a library, avoiding transitive dependencies](https://bugs.eclipse.org/bugs/show_bug.cgi?id=565408)

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
