### PR TITLE
[GEOT-6672] gt-jdbc-hana - Spatial filters against views don't always…

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
@@ -180,8 +180,7 @@ public class HanaDialect extends PreparedStatementSQLDialect {
         return GEOMETRY_TYPE_NAME;
     }
 
-    @Override
-    public Integer getGeometrySRID(
+    private Integer getGeometrySRIDFromView(
             String schemaName, String tableName, String columnName, Connection cx)
             throws SQLException {
         PreparedStatement ps = null;
@@ -210,6 +209,45 @@ public class HanaDialect extends PreparedStatementSQLDialect {
             dataStore.closeSafe(rs);
             dataStore.closeSafe(ps);
         }
+    }
+
+    private Integer getGeometrySRIDViaSelect(
+            String schemaName, String tableName, String columnName, Connection cx)
+            throws SQLException {
+        // Try the first non-NULL geometry
+        StringBuffer sql = new StringBuffer();
+        sql.append("SELECT ");
+        encodeIdentifiers(sql, columnName);
+        sql.append(".ST_SRID() FROM ");
+        encodeIdentifiers(sql, schemaName, tableName);
+        sql.append(" WHERE ");
+        encodeIdentifiers(sql, columnName);
+        sql.append(" IS NOT NULL LIMIT 1");
+
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            ps = cx.prepareStatement(sql.toString());
+            rs = ps.executeQuery();
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+            return null;
+        } finally {
+            dataStore.closeSafe(rs);
+            dataStore.closeSafe(ps);
+        }
+    }
+
+    @Override
+    public Integer getGeometrySRID(
+            String schemaName, String tableName, String columnName, Connection cx)
+            throws SQLException {
+        Integer srid = getGeometrySRIDFromView(schemaName, tableName, columnName, cx);
+        if (srid == null) {
+            srid = getGeometrySRIDViaSelect(schemaName, tableName, columnName, cx);
+        }
+        return srid;
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSpatialFilterOnViewOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSpatialFilterOnViewOnlineTest.java
@@ -16,12 +16,19 @@
  */
 package org.geotools.data.hana;
 
+import org.geotools.data.Query;
 import org.geotools.data.store.ContentFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.jdbc.JDBCTestSetup;
 import org.geotools.jdbc.JDBCTestSupport;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.opengis.filter.FilterFactory;
+import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.spatial.BBOX;
+import org.opengis.filter.spatial.Intersects;
 
 /** @author Stefan Uhrig, SAP SE */
 public class HanaSpatialFilterOnViewOnlineTest extends JDBCTestSupport {
@@ -37,5 +44,18 @@ public class HanaSpatialFilterOnViewOnlineTest extends JDBCTestSupport {
         ContentFeatureCollection features =
                 dataStore.getFeatureSource(tname("viewoftab")).getFeatures(bbox);
         assertEquals(1, features.size());
+    }
+
+    public void testCountWithFilterOnView() throws Exception {
+        GeometryFactory gf = new GeometryFactory();
+        PackedCoordinateSequenceFactory sf = new PackedCoordinateSequenceFactory();
+        LinearRing shell =
+                gf.createLinearRing(sf.create(new double[] {0, 0, 4, 0, 4, 4, 0, 4, 0, 0}, 2));
+        Polygon polygon = gf.createPolygon(shell, null);
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        Intersects intersects = ff.intersects(ff.property(aname("geom")), ff.literal(polygon));
+        Query q = new Query(aname("geom"), intersects);
+        int count = dataStore.getFeatureSource(tname("viewoftab")).getCount(q);
+        assertEquals(1, count);
     }
 }


### PR DESCRIPTION
… work

If the HANA dialect is asked for the SRID of a geometry column in a view
(via HanaDialect#getGeometrySRID()), it returns null.

This leads to a faulty query generation in
HanaDialect#prepareGeometryValue() because -1 is used as SRID instead of
the SRID of the geometries in the view's column. As a result the
database returns an error stating that a spatial reference system with
SRID -1 does not exist.

We extend the getGeometrySRID() function to return the SRID of the first
non-null geometry in the view's column to fix the issue.
