### PR TITLE
[GEOT-6675] CRS.transform(Envelope, targetCRS) fails to include full target envelope if the source contains a quadrant point (23.x)

### DIFF
--- a/modules/library/referencing/src/test/java/org/geotools/referencing/AbstractCRSTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/AbstractCRSTest.java
@@ -710,4 +710,77 @@ public abstract class AbstractCRSTest extends OnlineTestCase {
             return false;
         }
     }
+
+    public void testNorthPolarStereographicLeftQuadrant() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3995", true);
+        Envelope2D envelope = new Envelope2D(DefaultGeographicCRS.WGS84);
+        envelope.add(-156, 0);
+        envelope.add(-40, 48);
+        Envelope transformed = CRS.transform(envelope, crs);
+
+        // transformation of -90, 0, which is included in the range, and
+        // a extreme point in the reprojected space (quadrant point)
+        assertEquals(-12367396.22, transformed.getMinimum(0), 1d);
+    }
+
+    public void testNorthPolarStereographicRightQuadrant() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3995", true);
+        Envelope2D envelope = new Envelope2D(DefaultGeographicCRS.WGS84);
+        envelope.add(40, 0);
+        envelope.add(156, 48);
+        Envelope transformed = CRS.transform(envelope, crs);
+
+        // transformation of 90, 0, which is included in the range, and
+        // a extreme point in the reprojected space (quadrant point)
+        assertEquals(12367396.22, transformed.getMaximum(0), 1d);
+    }
+
+    public void testNorthPolarStereographicLeftRightQuadrant() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3995", true);
+        Envelope2D envelope = new Envelope2D(DefaultGeographicCRS.WGS84);
+        envelope.add(-156, 0);
+        envelope.add(156, 48);
+        Envelope transformed = CRS.transform(envelope, crs);
+
+        // Touches both ends
+        assertEquals(-12367396.22, transformed.getMinimum(0), 1d);
+        assertEquals(12367396.22, transformed.getMaximum(0), 1d);
+    }
+
+    public void testNorthPolarStereographicUpQuadrant() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3995", true);
+        Envelope2D envelope = new Envelope2D(DefaultGeographicCRS.WGS84);
+        envelope.add(-200, 0);
+        envelope.add(-160, 48);
+        Envelope transformed = CRS.transform(envelope, crs);
+
+        // transformation of -180, 0, which is included in the range, and
+        // a extreme point in the reprojected space (quadrant point)
+        assertEquals(12367396.22, transformed.getMaximum(1), 1d);
+    }
+
+    public void testNorthPolarStereographicDownQuadrant() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3995", true);
+        Envelope2D envelope = new Envelope2D(DefaultGeographicCRS.WGS84);
+        envelope.add(-20, 0);
+        envelope.add(20, 48);
+        Envelope transformed = CRS.transform(envelope, crs);
+
+        // transformation of 0, 0, which is included in the range, and
+        // a extreme point in the reprojected space (quadrant point)
+        assertEquals(-12367396.22, transformed.getMinimum(1), 1d);
+    }
+
+    public void testNorthPolarStereographicUpDownQuadrant() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3995", true);
+        Envelope2D envelope = new Envelope2D(DefaultGeographicCRS.WGS84);
+        envelope.add(-200, 0);
+        envelope.add(20, 48);
+        Envelope transformed = CRS.transform(envelope, crs);
+
+        // transformation of 0, 0, which is included in the range, and
+        // a extreme point in the reprojected space (quadrant point)
+        assertEquals(-12367396.22, transformed.getMinimum(1), 1d);
+        assertEquals(12367396.22, transformed.getMaximum(1), 1d);
+    }
 }


### PR DESCRIPTION
Backport of https://github.com/geotools/geotools/pull/3110

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
