### PR TITLE
[GEOT-6270] SimplifyingFilterVisitor does not account for null values

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/SimplifyingFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/SimplifyingFilterVisitor.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.geotools.filter.FilterAttributeExtractor;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.FeatureType;
@@ -426,10 +425,13 @@ public class SimplifyingFilterVisitor extends DuplicatingFilterVisitor {
                 PropertyName pn = (PropertyName) pb.getExpression();
                 String pName = pn.getPropertyName();
                 Filter nullFilter = null;
-                if(isNillable(pName)) {
-                	nullFilter = ff.isNull(pb.getExpression());
+                if (isNillable(pName)) {
+                    nullFilter = ff.isNull(pb.getExpression());
                 }
-                return ff.or(Stream.of(lt,gt,nullFilter).filter(Objects::nonNull).collect(Collectors.toList()));
+                return ff.or(
+                        Stream.of(lt, gt, nullFilter)
+                                .filter(Objects::nonNull)
+                                .collect(Collectors.toList()));
             } else if (simplified instanceof PropertyIsEqualTo) {
                 PropertyIsEqualTo pe = (PropertyIsEqualTo) simplified;
                 return ff.notEqual(pe.getExpression1(), pe.getExpression2(), pe.isMatchingCase());
@@ -622,7 +624,7 @@ public class SimplifyingFilterVisitor extends DuplicatingFilterVisitor {
     public void setRangeSimplicationEnabled(boolean rangeSimplicationEnabled) {
         this.rangeSimplicationEnabled = rangeSimplicationEnabled;
     }
-    
+
     /**
      * Returns if a property can contain null values, or not. If we don't have the featureType
      * information, or we don't know the property, we are going to assume the property is nillable

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/SimplifyingFilterVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/SimplifyingFilterVisitorTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
+import junit.framework.TestCase;
 import org.geotools.data.DataUtilities;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -40,8 +40,6 @@ import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.Literal;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.identity.Identifier;
-
-import junit.framework.TestCase;
 
 public class SimplifyingFilterVisitorTest extends TestCase {
 
@@ -248,41 +246,55 @@ public class SimplifyingFilterVisitorTest extends TestCase {
         Filter f = ff.not(ff.between(prop, l10, l20));
         Filter result = (Filter) f.accept(simpleVisitor, null);
         assertEquals(
-                ff.or(Arrays.asList((Filter) ff.less(prop, l10), ff.greater(prop, l20), ff.isNull(prop))), result);
+                ff.or(
+                        Arrays.asList(
+                                (Filter) ff.less(prop, l10),
+                                ff.greater(prop, l20),
+                                ff.isNull(prop))),
+                result);
     }
-    
+
     public void testNegateBetweenWithNullability() {
-    	SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
         tb.nillable(true);
         tb.add("prop", String.class);
         tb.nillable(false);
         tb.add("prop2", String.class);
         tb.setName("test");
-    	
-        //when FeatureType is null
+
+        // when FeatureType is null
         PropertyName prop = ff.property("prop");
         Literal l10 = ff.literal(10);
         Literal l20 = ff.literal(20);
         Filter f = ff.not(ff.between(prop, l10, l20));
         Filter result = (Filter) f.accept(simpleVisitor, null);
         assertEquals(
-                ff.or(Arrays.asList((Filter) ff.less(prop, l10), ff.greater(prop, l20), ff.isNull(prop))), result);
+                ff.or(
+                        Arrays.asList(
+                                (Filter) ff.less(prop, l10),
+                                ff.greater(prop, l20),
+                                ff.isNull(prop))),
+                result);
 
-        //when FeatureType is not null and property is nullable
+        // when FeatureType is not null and property is nullable
         simpleVisitor.setFeatureType(tb.buildFeatureType());
         prop = ff.property("prop");
         f = ff.not(ff.between(prop, l10, l20));
         result = (Filter) f.accept(simpleVisitor, null);
         assertEquals(
-                ff.or(Arrays.asList((Filter) ff.less(prop, l10), ff.greater(prop, l20), ff.isNull(prop))), result);
-        
-      //when FeatureType is not null and property is not nullable
+                ff.or(
+                        Arrays.asList(
+                                (Filter) ff.less(prop, l10),
+                                ff.greater(prop, l20),
+                                ff.isNull(prop))),
+                result);
+
+        // when FeatureType is not null and property is not nullable
         prop = ff.property("prop2");
         f = ff.not(ff.between(prop, l10, l20));
         result = (Filter) f.accept(simpleVisitor, null);
         assertEquals(
                 ff.or(Arrays.asList((Filter) ff.less(prop, l10), ff.greater(prop, l20))), result);
-        
     }
 
     public void testDoubleNegation() {


### PR DESCRIPTION
when simplifying negations

"not(a between 10 and 20)" results in "a < 10 or a > 20", but it should be "a < 10 or a > 20 or a is null" in SimplifyingFilterVisitor

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
