### PR TITLE
Upgrade to JTS 1.17.1 [GEOT-6688]

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/CircularRing.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/CircularRing.java
@@ -173,7 +173,12 @@ public class CircularRing extends LinearRing
         return new CircularRing(ncp, factory, delegate.getTolerance());
     }
 
-    public Geometry reverseInternal() {
+    public CircularRing reverse() {
+        return (CircularRing) super.reverse();
+    }
+
+    // should be protected when fixed in LinearRing
+    public CircularRing reverseInternal() {
         double[] controlPoints = delegate.controlPoints;
         GrowableOrdinateArray array = new GrowableOrdinateArray();
         array.addAll(controlPoints);

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/CircularString.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/CircularString.java
@@ -212,7 +212,11 @@ public class CircularString extends LineString implements SingleCurvedGeometry<L
         return "CircularString";
     }
 
-    protected Geometry reverseInternal() {
+    public CircularString reverse() {
+        return (CircularString) super.reverse();
+    }
+
+    protected CircularString reverseInternal() {
         // reverse the control points
         double[] reversed = new double[controlPoints.length];
         System.arraycopy(controlPoints, 0, reversed, 0, controlPoints.length);

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/CompoundCurve.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/CompoundCurve.java
@@ -187,11 +187,16 @@ public class CompoundCurve extends LineString implements CompoundCurvedGeometry<
         return "CompoundCurve";
     }
 
-    protected Geometry reverseInternal() {
+    public CompoundCurve reverse() {
+        return (CompoundCurve) super.reverse();
+    }
+
+    // should be protected when fixed in LinearRing
+    public CompoundCurve reverseInternal() {
         // reverse the component, and reverse each component internal elements
         List<LineString> reversedComponents = new ArrayList<>(components.size());
         for (LineString ls : components) {
-            LineString reversed = (LineString) ((Geometry) ls).reverse();
+            LineString reversed = (LineString) ls.reverse();
             reversedComponents.add(0, reversed);
         }
         return new CompoundCurve(reversedComponents, getFactory(), tolerance);

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/CompoundRing.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/CompoundRing.java
@@ -113,8 +113,13 @@ public class CompoundRing extends LinearRing
         return "CompoundRing";
     }
 
-    public Geometry reverseInternal() {
-        CompoundCurve reversedDelegate = (CompoundCurve) ((Geometry) delegate).reverse();
+    public CompoundRing reverse() {
+        return (CompoundRing) super.reverse();
+    }
+
+    // should be protected when fixed in LinearRing
+    public CompoundRing reverseInternal() {
+        CompoundCurve reversedDelegate = (CompoundCurve) delegate.reverse();
         return new CompoundRing(reversedDelegate);
     }
 

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/CurvedGeometryTest.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/CurvedGeometryTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
@@ -86,7 +85,7 @@ public class CurvedGeometryTest {
                 wkt);
 
         // check reversing
-        CircularString reversed = (CircularString) ((Geometry) cs).reverse();
+        CircularString reversed = cs.reverse();
         assertEquals(reversed.controlPoints[0], cs.controlPoints[4], 0d);
         assertEquals(reversed.controlPoints[1], cs.controlPoints[5], 0d);
         assertEquals(reversed.controlPoints[2], cs.controlPoints[2], 0d);
@@ -139,7 +138,7 @@ public class CurvedGeometryTest {
                 wkt);
 
         // check reversing
-        CircularString reversed = (CircularString) ((Geometry) cs).reverse();
+        CircularString reversed = cs.reverse();
         double[] controlPoints = cs.controlPoints;
         double[] controlPointsReverse = reversed.controlPoints;
         assertEquals(controlPointsReverse[0], controlPoints[8], 0d);
@@ -194,7 +193,7 @@ public class CurvedGeometryTest {
                 wkt);
 
         // check reversing
-        CircularRing reversed = (CircularRing) ((Geometry) cr).reverse();
+        CircularRing reversed = cr.reverse();
         // System.out.println(cr.toCurvedText());
         // System.out.println(reversed.toCurvedText());
         double[] controlPoints = cr.delegate.controlPoints;

--- a/modules/library/metadata/src/test/java/org/geotools/util/factory/GeoToolsTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/factory/GeoToolsTest.java
@@ -161,10 +161,6 @@ public final class GeoToolsTest {
         version = GeoTools.getVersion(LogFactory.class);
         assertNotNull(version);
         assertEquals("1.1.1", version.toString());
-
-        version = GeoTools.getVersion(Geometry.class);
-        assertNotNull(version);
-        assertTrue(version.toString().startsWith("1.17"));
     }
     /** Tests the use of system properties. */
     @Test

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LineStringCursor.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LineStringCursor.java
@@ -22,7 +22,6 @@ import java.util.logging.Logger;
 import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 
 /**
@@ -395,7 +394,7 @@ public class LineStringCursor {
 
     /** Returns a line string cursor based on the opposite walking direction. */
     public LineStringCursor reverse() {
-        return new LineStringCursor((LineString) ((Geometry) lineString).reverse());
+        return new LineStringCursor(lineString.reverse());
     }
 
     /** The linestrings wrapped by this cursor */

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/SimpleGeometryFactory.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/SimpleGeometryFactory.java
@@ -300,8 +300,8 @@ class SimpleGeometryFactory extends GeometryFactory {
             return geometry.relate(g);
         }
 
-        protected Geometry reverseInternal() {
-            return geometry.reverse();
+        public GeometryCollection reverse() {
+            return new GeometryCollection(new Geometry[] {geometry.reverse()}, factory);
         }
 
         public void setSRID(int SRID) {
@@ -595,8 +595,8 @@ class SimpleGeometryFactory extends GeometryFactory {
             return lineString.relate(g);
         }
 
-        protected Geometry reverseInternal() {
-            return ((Geometry) lineString).reverse();
+        public MultiLineString reverse() {
+            return new MultiLineString(new LineString[] {lineString.reverse()}, factory);
         }
 
         public void setSRID(int SRID) {
@@ -869,8 +869,8 @@ class SimpleGeometryFactory extends GeometryFactory {
             return polygon.relate(g);
         }
 
-        protected Geometry reverseInternal() {
-            return ((Geometry) polygon).reverse();
+        public MultiPolygon reverse() {
+            return new MultiPolygon(new Polygon[] {polygon.reverse()}, factory);
         }
 
         public void setSRID(int SRID) {
@@ -1142,8 +1142,8 @@ class SimpleGeometryFactory extends GeometryFactory {
             return point.relate(g);
         }
 
-        protected Geometry reverseInternal() {
-            return ((Geometry) point).reverse();
+        public MultiPoint reverse() {
+            return new MultiPoint(new Point[] {point.reverse()}, factory);
         }
 
         public void setSRID(int SRID) {

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoGeometryBuilder.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoGeometryBuilder.java
@@ -273,7 +273,7 @@ public class MongoGeometryBuilder {
         BasicDBList l = new BasicDBList();
 
         if (!Orientation.isCCW(p.getExteriorRing().getCoordinates())) {
-            l.add(toList(((Geometry) p.getExteriorRing()).reverse().getCoordinates()));
+            l.add(toList(p.getExteriorRing().reverse().getCoordinates()));
         } else {
             l.add(toList(p.getExteriorRing().getCoordinateSequence()));
         }

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/shp/JTSUtilitiesTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/shp/JTSUtilitiesTest.java
@@ -7,7 +7,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LinearRing;
 
@@ -41,7 +40,7 @@ public class JTSUtilitiesTest {
 
         LinearRing after = JTSUtilities.reverseRing(before);
 
-        assertTrue(after.equalsTopo(((Geometry) before).reverse()));
+        assertTrue(after.equalsTopo(before.reverse()));
 
         assertEquals(after.getCoordinateN(0), coordinates[3]);
         assertEquals(after.getCoordinateN(1), coordinates[2]);

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <test.args></test.args>
     <src.output>${basedir}/target</src.output>
     <imageio.ext.version>1.3.2</imageio.ext.version>
-    <jts.version>1.17.0</jts.version>
+    <jts.version>1.17.1</jts.version>
     <jaiext.version>1.1.17</jaiext.version>
     <netcdf.version>4.6.15</netcdf.version>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>


### PR DESCRIPTION
This pull request upgrades to JTS 1.17.1 release:

* Performance improvement for CoordinateArraySequence required use of CoordianteArrays.enforceConsitency in GeoTools ClipProcess (previously the constructor enforced consistency)

* The unintended problems method visibility of Geometry reverse and reverseInternal methods introduced in JTS 1.7.0 have been addressed.

See https://osgeo-org.atlassian.net/browse/GEOT-6688

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in Jira: https://osgeo-org.atlassian.net/browse/GEOT-6688
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
