### PR TITLE
[23.x backport][GEOT-6692] Update MySQL jdbc driver to current version (8.0.x)

### DIFF
--- a/modules/plugin/imagemosaic-jdbc/src/test/java/org/geotools/gce/imagemosaic/jdbc/MySqlOnlineTest.java
+++ b/modules/plugin/imagemosaic-jdbc/src/test/java/org/geotools/gce/imagemosaic/jdbc/MySqlOnlineTest.java
@@ -99,7 +99,7 @@ public class MySqlOnlineTest extends AbstractTest {
      * @see org.geotools.gce.imagemosaic.jdbc.AbstractTest#getDriverClassName()
      */
     protected String getDriverClassName() {
-        return "com.mysql.jdbc.Driver";
+        return "com.mysql.cj.jdbc.Driver";
     }
 
     /*

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDataStoreFactory.java
@@ -74,7 +74,7 @@ public class MySQLDataStoreFactory extends JDBCDataStoreFactory {
     }
 
     protected String getDriverClassName() {
-        return "com.mysql.jdbc.Driver";
+        return "com.mysql.cj.jdbc.Driver";
     }
 
     protected String getDatabaseID() {

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLTestSetup.java
@@ -99,7 +99,7 @@ public class MySQLTestSetup extends JDBCTestSetup {
     protected Properties createExampleFixture() {
         Properties p = new Properties();
 
-        p.put("driver", "com.mysql.jdbc.Driver");
+        p.put("driver", "com.mysql.cj.jdbc.Driver");
         p.put("url", "jdbc:mysql://localhost/geotools");
         p.put("host", "localhost");
         p.put("port", "3306");

--- a/pom.xml
+++ b/pom.xml
@@ -1254,7 +1254,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>5.1.46</version>
+        <version>8.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
Backports the **driver update only** from #3128 to 23.x
