### PR TITLE
[GEOT-6373] Error in geoserver 2.16.0:  "org.geotools.data.DataSourceException: An exception occurred while parsing WKB data"

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
@@ -75,9 +75,9 @@ public class GeometryColumnEncoder {
             encodeGeography(gatt, prefix, sql);
         } else {
             if (force2D) {
-                sql.append("ST_AsBinary(");
+                sql.append("ST_AsBinary(").append(dialect.getForce2DFunction()).append("(");
                 dialect.encodeColumnName(prefix, gatt.getLocalName(), sql);
-                sql.append(")");
+                sql.append("))");
             } else {
                 sql.append("ST_AsEWKB(");
                 dialect.encodeColumnName(prefix, gatt.getLocalName(), sql);

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -1507,7 +1507,7 @@ public class PostGISDialect extends BasicSQLDialect {
      *
      * @return Force2D function name
      */
-    protected String getForce2DFunction() {
+    String getForce2DFunction() {
         return version == null || version.compareTo(V_2_1_0) >= 0 ? "ST_Force2D" : "ST_Force_2D";
     }
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGIS3DOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGIS3DOnlineTest.java
@@ -16,13 +16,52 @@
  */
 package org.geotools.data.postgis;
 
+import java.io.IOException;
+import java.util.function.Predicate;
+import org.geotools.data.Query;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
 import org.geotools.jdbc.JDBC3DOnlineTest;
 import org.geotools.jdbc.JDBC3DTestSetup;
+import org.geotools.util.factory.Hints;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.simple.SimpleFeature;
 
 public class PostGIS3DOnlineTest extends JDBC3DOnlineTest {
 
     @Override
     protected JDBC3DTestSetup createTestSetup() {
         return new PostGIS3DTestSetup(new PostGISTestSetup());
+    }
+
+    public void testForce2DHint() throws Exception {
+
+        Query q = new Query(tname(getLine3d()));
+        ContentFeatureSource fs = dataStore.getFeatureSource(tname(getLine3d()));
+        // no force2D hint, tests that Z is present
+        checkGeometryDimension(q, fs, c -> !Double.isNaN(c.getZ()));
+        Hints hints = new Hints(Hints.FEATURE_2D, true);
+        q.setHints(hints);
+
+        // now 2D should be forced, tests Z is NaN
+        checkGeometryDimension(q, fs, c -> Double.isNaN(c.getZ()));
+    }
+
+    private void checkGeometryDimension(
+            Query q, ContentFeatureSource fs, Predicate<Coordinate> testCondition)
+            throws IOException {
+        FeatureCollection fc = fs.getFeatures(q);
+        FeatureIterator<SimpleFeature> fi = fc.features();
+        while (fi.hasNext()) {
+            SimpleFeature f = fi.next();
+            Geometry geom = (Geometry) f.getDefaultGeometry();
+            Coordinate[] coors = geom.getCoordinates();
+            for (Coordinate c : coors) {
+                assertTrue(testCondition.test(c));
+            }
+        }
+        fi.close();
     }
 }


### PR DESCRIPTION
This pr fixes a bug occuring when rendering 3D geometry, that was leading to aWKB exception due missing ST_Force2D postgis function.
Jira ticket https://osgeo-org.atlassian.net/browse/GEOT-6373

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
