### PR TITLE
[GEOT-6713] StreamingRenderer doesn't extract property transforms for xpath expressions

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/style/StyleAttributeExtractor.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/StyleAttributeExtractor.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Set;
 import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.styling.*;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
@@ -34,6 +35,14 @@ import org.opengis.style.GraphicalSymbol;
  * @author Andrea Aime - OpenGeo
  */
 public class StyleAttributeExtractor extends FilterAttributeExtractor implements StyleVisitor {
+
+    /** Just extract the property names; don't check against a feature type. */
+    public StyleAttributeExtractor() {}
+
+    /** Use the provided feature type as a sanity check when extracting property names. */
+    public StyleAttributeExtractor(SimpleFeatureType featureType) {
+        super(featureType);
+    }
 
     /**
      * Returns PropertyNames rather than strings (includes namespace info)

--- a/modules/library/render/src/test/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
+++ b/modules/library/render/src/test/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
@@ -1,1 +1,2 @@
 org.geotools.renderer.lite.FastBBOXTest$MockPropertyAccessorFactory
+org.geotools.renderer.lite.StreamingRendererTest$MockPropertyAccessorFactory


### PR DESCRIPTION
* Add xpath descriptors to style attribute extraction

This pull request fixes an issue in the StreamingRenderer where property transforms are not extracted correctly for complex xpath expressions, resulting in a failure rendering.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
