### PR TITLE
[GEOT-6704] BaseRequestTypeImpl.extendedProperties must not be shared…

### DIFF
--- a/modules/ogc/net.opengis.wfs/pom.xml
+++ b/modules/ogc/net.opengis.wfs/pom.xml
@@ -34,6 +34,15 @@
       <artifactId>gt-main</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+       <groupId>junit</groupId>
+       <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/modules/ogc/net.opengis.wfs/src/net/opengis/wfs20/impl/BaseRequestTypeImpl.java
+++ b/modules/ogc/net.opengis.wfs/src/net/opengis/wfs20/impl/BaseRequestTypeImpl.java
@@ -142,17 +142,17 @@ public abstract class BaseRequestTypeImpl extends EObjectImpl implements BaseReq
    * @generated
    * @ordered
    */
-    protected static final Map EXTENDED_PROPERTIES_EDEFAULT = new HashMap<>();
+    protected static final Map EXTENDED_PROPERTIES_EDEFAULT = null;
 
     /**
    * The cached value of the '{@link #getExtendedProperties() <em>Extended Properties</em>}' attribute.
    * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
    * @see #getExtendedProperties()
-   * @generated
+   * @generated NOT
    * @ordered
    */
-    protected Map extendedProperties = EXTENDED_PROPERTIES_EDEFAULT;
+    protected Map extendedProperties = new HashMap();
 
     /**
    * <!-- begin-user-doc -->

--- a/modules/ogc/net.opengis.wfs/test/net/opengis/wfs/impl/BaseRequestTypeImplTest.java
+++ b/modules/ogc/net.opengis.wfs/test/net/opengis/wfs/impl/BaseRequestTypeImplTest.java
@@ -1,0 +1,43 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package net.opengis.wfs.impl;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+import net.opengis.wfs20.TransactionType;
+import net.opengis.wfs20.Wfs20Factory;
+import net.opengis.wfs20.impl.BaseRequestTypeImpl;
+
+/**
+ * Contains tests for {@link BaseRequestTypeImpl}
+ * 
+ * @author awaterme
+ */
+public class BaseRequestTypeImplTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testOwnExtendedProperties() {
+        TransactionType lTransaction1 = Wfs20Factory.eINSTANCE.createTransactionType();
+        lTransaction1.getExtendedProperties().put("foo", "bar");
+        TransactionType lTransaction2 = Wfs20Factory.eINSTANCE.createTransactionType();
+        assertFalse(lTransaction2.getExtendedProperties().containsKey("foo"));
+    }
+
+}

--- a/modules/ogc/net.opengis.wfs/test/net/opengis/wfs20/impl/BaseRequestTypeImplTest.java
+++ b/modules/ogc/net.opengis.wfs/test/net/opengis/wfs20/impl/BaseRequestTypeImplTest.java
@@ -1,0 +1,42 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package net.opengis.wfs20.impl;
+
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+import net.opengis.wfs20.TransactionType;
+import net.opengis.wfs20.Wfs20Factory;
+
+/**
+ * Contains tests for {@link BaseRequestTypeImpl} 
+ * @author awaterme
+ */
+public class BaseRequestTypeImplTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testOwnExtendedProperties() {
+        TransactionType lTransaction1 = Wfs20Factory.eINSTANCE.createTransactionType();
+        lTransaction1.getExtendedProperties().put("foo", "bar");
+        TransactionType lTransaction2 = Wfs20Factory.eINSTANCE.createTransactionType();
+        assertFalse(lTransaction2.getExtendedProperties().containsKey("foo"));
+    }
+
+}

--- a/modules/ogc/pom.xml
+++ b/modules/ogc/pom.xml
@@ -43,6 +43,7 @@
 
   <build>
     <sourceDirectory>src</sourceDirectory>
+    <testSourceDirectory>test</testSourceDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-eclipse-plugin</artifactId>


### PR DESCRIPTION
PR for [GEOT-6704](https://osgeo-org.atlassian.net/browse/GEOT-6704). 

I also wrote to the developers list regarding this issue, but I received no response.

Problem:
**WFS 2.0** `net.opengis.wfs20.impl.BaseRequestTypeImpl.extendedProperties` is initialized with a static default map from the same type. As result all instance of `BaseRequestTypeImpl` share the same map.
This was introduced with EMF upgrade, AFAICS in GT 21.

Analysis:
* When I regenerate `net.opengis.wfs20.impl.BaseRequestTypeImpl` the static default field is null. This is different from the current state in GT. This is the first part of the solution. Now `extendedProperties` is always null, not shared any more.
* Looking at the **WFS 1** variant of the class I saw the JavaDoc comment `@generated NOT` on the field. A new map is assigned here:

From **WFS 1** `net.opengis.wfs.impl.BaseRequestTypeImpl`:
```
	/**
	 * The cached value of the '{@link #getExtendedProperties() <em>Extended Properties</em>}' attribute.
	 * <!-- begin-user-doc -->
	 * <!-- end-user-doc -->
	 * @see #getExtendedProperties()
	 * @generated NOT
	 * @ordered
	 */
	protected Map extendedProperties = new HashMap();
```

* So I suppose that prior to GeoTools 21 the `extendedProperties` were adjusted by hand, to have an own, not-null map instance assigned. 
* This PR restores the state before GeoTools 21 for WFS 2, which is as one would expect.

I think the solution to modify generated code is not optimal. I  added two unit test cases to prevent from future problems.

An alternative approach would be to keep the `extendedProperties` in WFS 1 _and_ WFS 2 BaseRequestTypeImpl null as intended by the generator. However this is quite ugly for users.

I am open to other suggestions.

PS:
I used Eclipse 2020-09 for generating the class, which contains EMF 2.21.0.v20200708-0547.



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
