### PR TITLE
Fix RuntimeException when adding boolean to sqlserver datastore

### DIFF
--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
@@ -155,6 +155,9 @@ public class SQLServerDialect extends BasicSQLDialect {
         // override since sql server maps all date times to timestamp
         mappings.put(Date.class, Types.TIMESTAMP);
         mappings.put(Time.class, Types.TIMESTAMP);
+
+        mappings.put(Boolean.class, Integer.valueOf(Types.BIT));
+        mappings.put(boolean.class, Integer.valueOf(Types.BIT));
     }
 
     @Override
@@ -165,6 +168,7 @@ public class SQLServerDialect extends BasicSQLDialect {
         mappings.put("uniqueidentifier", UUID.class);
         mappings.put("time", Time.class);
         mappings.put("date", Date.class);
+        mappings.put("bit", Boolean.class);
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
@@ -770,6 +770,8 @@ public class SQLServerDialect extends BasicSQLDialect {
             for (byte item : b) {
                 sql.append(Integer.toString((item & 0xff) + 0x100, 16).substring(1));
             }
+        } else if (Boolean.class.equals(type) || boolean.class.equals(type)) {
+            sql.append("'").append(value).append("'");
         } else {
             super.encodeValue(value, type, sql);
         }

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerBooleanTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerBooleanTestSetup.java
@@ -30,6 +30,7 @@ public class SQLServerBooleanTestSetup extends JDBCBooleanTestSetup {
         run("CREATE TABLE b (id int IDENTITY(1,1) PRIMARY KEY, boolProperty BIT)");
         run("INSERT INTO b (boolProperty) VALUES (0)");
         run("INSERT INTO b (boolProperty) VALUES (1)");
+        run("INSERT INTO b (boolProperty) VALUES (true)");
     }
 
     @Override


### PR DESCRIPTION
When trying to add an FeatureType in GeoServer with type java.lang.Boolean to an MS SQL-Server an NPE is raised due to no declared mapping for booleans. The provided commit fixes this problem.

Stacktrace:
```
geoserver_1  | java.io.IOException: Error occurred creating table
geoserver_1  |  at org.geotools.jdbc.JDBCDataStore.createSchema(JDBCDataStore.java:795)
geoserver_1  |  at org.geotools.jdbc.JDBCDataStore.createSchema(JDBCDataStore.java:150)
geoserver_1  |  at org.geoserver.rest.catalog.FeatureTypeController.featureTypePost(FeatureTypeController.java:221)
geoserver_1  |  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
geoserver_1  |  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
geoserver_1  |  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
geoserver_1  |  at java.lang.reflect.Method.invoke(Method.java:498)
geoserver_1  |  at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
geoserver_1  |  at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:133)
geoserver_1  |  at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:97)
geoserver_1  |  at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:827)
geoserver_1  |  at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:738)
geoserver_1  |  at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:85)
geoserver_1  |  at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:967)
geoserver_1  |  at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:901)
geoserver_1  |  at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:970)
geoserver_1  |  at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:872)
geoserver_1  |  at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
geoserver_1  |  at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:846)
geoserver_1  |  at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:808)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1669)
geoserver_1  |  at org.geoserver.filters.ThreadLocalsCleanupFilter.doFilter(ThreadLocalsCleanupFilter.java:26)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.geoserver.filters.SpringDelegatingFilter$Chain.doFilter(SpringDelegatingFilter.java:69)
geoserver_1  |  at org.geoserver.wms.animate.AnimatorFilter.doFilter(AnimatorFilter.java:73)
geoserver_1  |  at org.geoserver.filters.SpringDelegatingFilter$Chain.doFilter(SpringDelegatingFilter.java:66)
geoserver_1  |  at org.geoserver.filters.SpringDelegatingFilter.doFilter(SpringDelegatingFilter.java:41)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.geoserver.platform.AdvancedDispatchFilter.doFilter(AdvancedDispatchFilter.java:37)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:317)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter$NestedFilterChain.doFilter(GeoServerCompositeFilter.java:70)
geoserver_1  |  at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.invoke(FilterSecurityInterceptor.java:127)
geoserver_1  |  at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.doFilter(FilterSecurityInterceptor.java:91)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter$NestedFilterChain.doFilter(GeoServerCompositeFilter.java:74)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter.doFilter(GeoServerCompositeFilter.java:91)
geoserver_1  |  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter$NestedFilterChain.doFilter(GeoServerCompositeFilter.java:70)
geoserver_1  |  at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:114)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter$NestedFilterChain.doFilter(GeoServerCompositeFilter.java:74)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter.doFilter(GeoServerCompositeFilter.java:91)
geoserver_1  |  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
geoserver_1  |  at org.geoserver.security.filter.GeoServerAnonymousAuthenticationFilter.doFilter(GeoServerAnonymousAuthenticationFilter.java:51)
geoserver_1  |  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter$NestedFilterChain.doFilter(GeoServerCompositeFilter.java:70)
geoserver_1  |  at org.springframework.security.web.authentication.www.BasicAuthenticationFilter.doFilterInternal(BasicAuthenticationFilter.java:215)
geoserver_1  |  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter$NestedFilterChain.doFilter(GeoServerCompositeFilter.java:74)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter.doFilter(GeoServerCompositeFilter.java:91)
geoserver_1  |  at org.geoserver.security.filter.GeoServerBasicAuthenticationFilter.doFilter(GeoServerBasicAuthenticationFilter.java:81)
geoserver_1  |  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter$NestedFilterChain.doFilter(GeoServerCompositeFilter.java:70)
geoserver_1  |  at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:105)
geoserver_1  |  at org.geoserver.security.filter.GeoServerSecurityContextPersistenceFilter$1.doFilter(GeoServerSecurityContextPersistenceFilter.java:52)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter$NestedFilterChain.doFilter(GeoServerCompositeFilter.java:74)
geoserver_1  |  at org.geoserver.security.filter.GeoServerCompositeFilter.doFilter(GeoServerCompositeFilter.java:91)
geoserver_1  |  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:331)
geoserver_1  |  at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:214)
geoserver_1  |  at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:177)
geoserver_1  |  at org.geoserver.security.GeoServerSecurityFilterChainProxy.doFilter(GeoServerSecurityFilterChainProxy.java:141)
geoserver_1  |  at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:347)
geoserver_1  |  at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:263)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.geoserver.filters.LoggingFilter.doFilter(LoggingFilter.java:90)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.geoserver.filters.XFrameOptionsFilter.doFilter(XFrameOptionsFilter.java:79)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.geoserver.filters.GZIPFilter.doFilter(GZIPFilter.java:48)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.geoserver.filters.SessionDebugFilter.doFilter(SessionDebugFilter.java:46)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.geoserver.filters.FlushSafeFilter.doFilter(FlushSafeFilter.java:42)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:197)
geoserver_1  |  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585)
geoserver_1  |  at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
geoserver_1  |  at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577)
geoserver_1  |  at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223)
geoserver_1  |  at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
geoserver_1  |  at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
geoserver_1  |  at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
geoserver_1  |  at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
geoserver_1  |  at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
geoserver_1  |  at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:215)
geoserver_1  |  at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:110)
geoserver_1  |  at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
geoserver_1  |  at org.eclipse.jetty.server.Server.handle(Server.java:499)
geoserver_1  |  at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310)
geoserver_1  |  at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
geoserver_1  |  at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
geoserver_1  |  at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
geoserver_1  |  at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
geoserver_1  |  at java.lang.Thread.run(Thread.java:748)
geoserver_1  | Caused by: java.lang.RuntimeException: Unable to map IsExactTimeFrame( java.lang.Boolean)
geoserver_1  |  at org.geotools.jdbc.JDBCDataStore.createTableSQL(JDBCDataStore.java:2360)
geoserver_1  |  at org.geotools.jdbc.JDBCDataStore.createSchema(JDBCDataStore.java:781)
geoserver_1  |  ... 95 more
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
