### PR TITLE
[GEOT-6722] Fix lost precision bug when saving a Double to GeoPackage

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -234,7 +234,10 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
     @Override
     public void registerSqlTypeNameToClassMappings(Map<String, Class<?>> mappings) {
         super.registerSqlTypeNameToClassMappings(mappings);
+        // preserve SQLite full precision when dealing with a GeoPackage:
+        mappings.put("FLOAT", Double.class);
         mappings.put("DOUBLE", Double.class);
+        mappings.put("REAL", Double.class);
         mappings.put("BOOLEAN", Boolean.class);
         mappings.put("DATE", java.sql.Date.class);
         mappings.put("TIMESTAMP", java.sql.Timestamp.class);
@@ -254,7 +257,8 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
         mappings.put(Short.class, Types.SMALLINT);
         mappings.put(Long.class, Types.BIGINT);
         mappings.put(Integer.class, Types.INTEGER);
-        mappings.put(Double.class, Types.REAL);
+        mappings.put(Float.class, Types.FLOAT);
+        mappings.put(Double.class, Types.DOUBLE);
         mappings.put(Boolean.class, Types.INTEGER);
     }
 
@@ -273,6 +277,7 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
         overrides.put(Types.SMALLINT, "SMALLINT");
         overrides.put(Types.INTEGER, "MEDIUMINT");
         overrides.put(Types.BIGINT, "INTEGER");
+        overrides.put(Types.FLOAT, "FLOAT");
         overrides.put(Types.DOUBLE, "DOUBLE");
         overrides.put(Types.NUMERIC, "NUMERIC");
 

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -470,6 +470,63 @@ public class GeoPackageTest {
     }
 
     @Test
+    public void testDoubleFloatPrecision() throws Exception {
+        double pi = 3.1415926535897932;
+        SimpleFeatureType featureType =
+                createFeatureTypeWithAttribute("double-pi", "pie", Double.class);
+        SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureType);
+        SimpleFeature simpleFeature = createSimpleFeatureWithValue(featureBuilder, pi);
+        SimpleFeatureCollection collection = DataUtilities.collection(simpleFeature);
+        FeatureEntry entry = new FeatureEntry();
+        geopkg.add(entry, collection);
+
+        FeatureEntry readFeature = geopkg.features().get(0);
+        try (SimpleFeatureReader reader = geopkg.reader(readFeature, null, null)) {
+            Object attribute = reader.next().getAttribute("pie");
+            assertTrue(attribute instanceof Double);
+            Double readValue = (Double) attribute;
+            assertEquals(pi, readValue, 1e-10);
+        }
+    }
+
+    @Test
+    public void testSingleFloatPrecision() throws Exception {
+        float pi = 3.14159265f;
+        SimpleFeatureType featureType =
+                createFeatureTypeWithAttribute("single-pi", "pie", Float.class);
+        SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureType);
+        SimpleFeature simpleFeature = createSimpleFeatureWithValue(featureBuilder, pi);
+        SimpleFeatureCollection collection = DataUtilities.collection(simpleFeature);
+        FeatureEntry entry = new FeatureEntry();
+        geopkg.add(entry, collection);
+
+        FeatureEntry readFeature = geopkg.features().get(0);
+        try (SimpleFeatureReader reader = geopkg.reader(readFeature, null, null)) {
+            Object attribute = reader.next().getAttribute("pie");
+            assertTrue(attribute instanceof Double);
+            Double attributeValue = (Double) attribute;
+            assertEquals(pi, attributeValue, 1e-5);
+        }
+    }
+
+    private SimpleFeatureType createFeatureTypeWithAttribute(
+            String featureName, String attributeName, Class<?> attributeClazz) {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName(featureName);
+        builder.setCRS(DefaultGeographicCRS.WGS84);
+        builder.add("the_geom", LineString.class);
+        builder.add(attributeName, attributeClazz);
+        return builder.buildFeatureType();
+    }
+
+    private SimpleFeature createSimpleFeatureWithValue(
+            SimpleFeatureBuilder featureBuilder, Object value) {
+        featureBuilder.add(createGeometry());
+        featureBuilder.add(value);
+        return featureBuilder.buildFeature(null);
+    }
+
+    @Test
     public void testFunctionsNoEnvelope() throws Exception {
         ShapefileDataStore shp = new ShapefileDataStore(setUpShapefile());
         SimpleFeatureReader re = Features.simple(shp.getFeatureReader());


### PR DESCRIPTION
The intention of this PR is to fix the problem with a lost precision while preserving backward-compatibility where possible. Mapping between Java classes and SQL types has been modified from:
```
// Saving:
Float.class -> REAL
Double.class -> REAL
// Reading:
FLOAT -> Double.class (implicit by JDBC read value)
DOUBLE -> Double.class
REAL -> Double.class (implicit by JDBC read value)
```
into:
```
Saving:
Float.class -> FLOAT
Double.class -> DOUBLE
Reading:
FLOAT -> Double.class (explicit)
DOUBLE -> Double.class
REAL -> Double.class (explicit)
```
According to the GeoPackage specification http://www.geopackage.org/spec/ there is no difference between `DOUBLE` and `REAL` types - both can be used interchangeably (Table 1. GeoPackage Data Types).  Moreover, SQLite types are only hints and even `FLOAT` column can contain double-precision floating point numbers (https://sqlite.org/floatingpoint.html). Taking this into consideration and the fact that currently `geoPackage.reader().next().getAttribute()` will return a `Double` value, I believe it makes sense to preserve this behavior and read the attribute as a `Double` even for `FLOAT` type in GeoPackage.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

