### PR TITLE
[23.x backport] [GEOT-6722] Fix lost precision bug when saving a Double to GeoPackage

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -196,7 +196,10 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
     @Override
     public void registerSqlTypeNameToClassMappings(Map<String, Class<?>> mappings) {
         super.registerSqlTypeNameToClassMappings(mappings);
+        // preserve SQLite full precision when dealing with a GeoPackage:
+        mappings.put("FLOAT", Double.class);
         mappings.put("DOUBLE", Double.class);
+        mappings.put("REAL", Double.class);
         mappings.put("BOOLEAN", Boolean.class);
         mappings.put("DATE", java.sql.Date.class);
         mappings.put("TIMESTAMP", java.sql.Timestamp.class);
@@ -216,7 +219,8 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
         mappings.put(Short.class, Types.SMALLINT);
         mappings.put(Long.class, Types.BIGINT);
         mappings.put(Integer.class, Types.INTEGER);
-        mappings.put(Double.class, Types.REAL);
+        mappings.put(Float.class, Types.FLOAT);
+        mappings.put(Double.class, Types.DOUBLE);
         mappings.put(Boolean.class, Types.INTEGER);
     }
 
@@ -235,6 +239,7 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
         overrides.put(Types.SMALLINT, "SMALLINT");
         overrides.put(Types.INTEGER, "MEDIUMINT");
         overrides.put(Types.BIGINT, "INTEGER");
+        overrides.put(Types.FLOAT, "FLOAT");
         overrides.put(Types.DOUBLE, "DOUBLE");
         overrides.put(Types.NUMERIC, "NUMERIC");
 

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -431,6 +431,63 @@ public class GeoPackageTest {
     }
 
     @Test
+    public void testDoubleFloatPrecision() throws Exception {
+        double pi = 3.1415926535897932;
+        SimpleFeatureType featureType =
+                createFeatureTypeWithAttribute("double-pi", "pie", Double.class);
+        SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureType);
+        SimpleFeature simpleFeature = createSimpleFeatureWithValue(featureBuilder, pi);
+        SimpleFeatureCollection collection = DataUtilities.collection(simpleFeature);
+        FeatureEntry entry = new FeatureEntry();
+        geopkg.add(entry, collection);
+
+        FeatureEntry readFeature = geopkg.features().get(0);
+        try (SimpleFeatureReader reader = geopkg.reader(readFeature, null, null)) {
+            Object attribute = reader.next().getAttribute("pie");
+            assertTrue(attribute instanceof Double);
+            Double readValue = (Double) attribute;
+            assertEquals(pi, readValue, 1e-10);
+        }
+    }
+
+    @Test
+    public void testSingleFloatPrecision() throws Exception {
+        float pi = 3.14159265f;
+        SimpleFeatureType featureType =
+                createFeatureTypeWithAttribute("single-pi", "pie", Float.class);
+        SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureType);
+        SimpleFeature simpleFeature = createSimpleFeatureWithValue(featureBuilder, pi);
+        SimpleFeatureCollection collection = DataUtilities.collection(simpleFeature);
+        FeatureEntry entry = new FeatureEntry();
+        geopkg.add(entry, collection);
+
+        FeatureEntry readFeature = geopkg.features().get(0);
+        try (SimpleFeatureReader reader = geopkg.reader(readFeature, null, null)) {
+            Object attribute = reader.next().getAttribute("pie");
+            assertTrue(attribute instanceof Double);
+            Double attributeValue = (Double) attribute;
+            assertEquals(pi, attributeValue, 1e-5);
+        }
+    }
+
+    private SimpleFeatureType createFeatureTypeWithAttribute(
+            String featureName, String attributeName, Class<?> attributeClazz) {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName(featureName);
+        builder.setCRS(DefaultGeographicCRS.WGS84);
+        builder.add("the_geom", LineString.class);
+        builder.add(attributeName, attributeClazz);
+        return builder.buildFeatureType();
+    }
+
+    private SimpleFeature createSimpleFeatureWithValue(
+            SimpleFeatureBuilder featureBuilder, Object value) {
+        featureBuilder.add(createGeometry());
+        featureBuilder.add(value);
+        return featureBuilder.buildFeature(null);
+    }
+
+    @Test
     public void testFunctionsNoEnvelope() throws Exception {
         ShapefileDataStore shp = new ShapefileDataStore(setUpShapefile());
         SimpleFeatureReader re = Features.simple(shp.getFeatureReader());


### PR DESCRIPTION
23.x backport of #3181