### PR TITLE
Revert "[GEOT-6608] Fix user-agent for OSM tiles"

### DIFF
--- a/modules/extension/tile-client/src/main/java/org/geotools/tile/Tile.java
+++ b/modules/extension/tile-client/src/main/java/org/geotools/tile/Tile.java
@@ -22,14 +22,9 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.geotools.data.ows.HTTPClient;
-import org.geotools.data.ows.SimpleHttpClient;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.image.io.ImageIOExt;
 import org.geotools.util.logging.Logging;
@@ -176,19 +171,8 @@ public abstract class Tile implements ImageLoader {
         }
     }
 
-    @Override
     public BufferedImage loadImageTileImage(Tile tile) throws IOException {
-
-        Map<String, String> headers = new HashMap<>();
-        headers.put("User-Agent", "Geotools Http client");
-        try (InputStream is = setupInputStream(getUrl(), headers)) {
-            return ImageIOExt.readBufferedImage(is);
-        }
-    }
-
-    private InputStream setupInputStream(URL url, Map<String, String> headers) throws IOException {
-        HTTPClient client = new SimpleHttpClient();
-        return client.get(url, headers).getResponseStream();
+        return ImageIOExt.readBufferedImage(getUrl());
     }
 
     /**
@@ -388,7 +372,6 @@ public abstract class Tile implements ImageLoader {
         return getUrl().equals(((Tile) other).getUrl());
     }
 
-    @Override
     public String toString() {
         return this.getId(); // this.getUrl().toString();
     }

--- a/modules/extension/tile-client/src/test/java/org/geotools/tile/impl/osm/OSMTileTest.java
+++ b/modules/extension/tile-client/src/test/java/org/geotools/tile/impl/osm/OSMTileTest.java
@@ -16,11 +16,6 @@
  */
 package org.geotools.tile.impl.osm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.awt.image.BufferedImage;
-import java.io.IOException;
 import org.geotools.tile.Tile;
 import org.geotools.tile.TileService;
 import org.geotools.tile.impl.WebMercatorZoomLevel;
@@ -53,18 +48,5 @@ public class OSMTileTest {
     public void testGetURL() {
         Assert.assertEquals(
                 "http://tile.openstreetmap.org/5/10/12.png", this.tile.getUrl().toString());
-    }
-
-    /**
-     * Make sure we can actually fetch the image of the tile for display.
-     *
-     * @throws IOException
-     */
-    @Test
-    public void testFetchTile() throws IOException {
-        BufferedImage img = tile.loadImageTileImage(tile);
-        assertNotNull(img);
-        assertEquals("wrong height", OSMTile.DEFAULT_TILE_SIZE, img.getHeight());
-        assertEquals("wrong width", OSMTile.DEFAULT_TILE_SIZE, img.getWidth());
     }
 }


### PR DESCRIPTION
Reverts geotools/geotools#2954 - as in combination with https://osgeo-org.atlassian.net/browse/GEOT-6618 it sends a double user-agent header which breaks some servers,