### PR TITLE
[GEOT-6679] Not filter visitor doesn't map property name

### DIFF
--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
@@ -236,7 +236,7 @@ public class FilterToMongo implements FilterVisitor, ExpressionVisitor {
         BasicDBObject expr = (BasicDBObject) filter.getFilter().accept(this, null);
         BasicDBObject dbObject;
         if (pn != null) {
-            String strPn = pn.getPropertyName();
+            String strPn = mapper.getPropertyPath(pn.getPropertyName());
             // get only the operator expression
             Object exprValue = expr.get(strPn);
             dbObject = new BasicDBObject("$not", exprValue);

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
@@ -38,6 +38,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.opengis.filter.And;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.Not;
 import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsEqualTo;
@@ -355,6 +356,16 @@ public class FilterToMongoTest extends TestCase {
                         ff.function("jsonSelectAll", ff.literal("geom")), getGeometryParameter());
         BasicDBObject mongoQuery = (BasicDBObject) intersects.accept(filterToMongo, null);
         testIntersectMongoQuery(mongoQuery);
+    }
+
+    public void testNot() {
+        Not not = ff.not(ff.isNull(ff.property("foo")));
+        BasicDBObject obj = (BasicDBObject) not.accept(filterToMongo, null);
+        assertNotNull(obj);
+        assertEquals(1, obj.keySet().size());
+        BasicDBObject operator = (BasicDBObject) obj.get("properties.foo");
+
+        assertEquals(null, operator.get("$eq"));
     }
 
     private Literal getGeometryParameter() {


### PR DESCRIPTION
Back port fix for https://osgeo-org.atlassian.net/browse/GEOT-6679 to 24.x

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
