### PR TITLE
[GEOT-6733] Add new expression functions to support And && Or operators

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
@@ -63,6 +63,6 @@ public class AndFunction extends FunctionExpressionImpl {
                     "Filter Function problem for function And argument #1 - expected type boolean");
         }
         
-        return Boolean.valueOf(left && right);
+        return left && right;
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
@@ -42,10 +42,27 @@ public class AndFunction extends FunctionExpressionImpl {
         super(NAME);
     }
 
+    @Override
     public Object evaluate(Object feature) {
-        Object left;
-        Object right;
+        boolean left;
+        boolean right;
 
-        return true;
+        try { // attempt to get the left value and perform conversion
+            left = (getExpression(0).evaluate(feature, Boolean.class));
+        } catch (Exception e) // probably a type error
+        {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function and argument #0 - expected type boolean");
+        }
+        
+        try { // attempt to get the right value and perform conversion
+            right = (getExpression(1).evaluate(feature, Boolean.class));
+        } catch (Exception e) // probably a type error
+        {
+            throw new IllegalArgumentException(
+                    "Filter Function problem for function and argument #1 - expected type boolean");
+        }
+        
+        return Boolean.valueOf(left && right);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
@@ -1,0 +1,51 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ */
+package org.geotools.filter.function;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.opengis.filter.capability.FunctionName;
+
+/**
+ * This function is used to evaluate a and operator with a left and right operands
+ *
+ * @author Erwan Bocher, CNRS, 2020
+ */
+public class AndFunction extends FunctionExpressionImpl {
+
+    public static FunctionName NAME =
+            new FunctionNameImpl(
+                    "And",
+                    Boolean.class,
+                    parameter("left", Boolean.class),
+                    parameter("right", Boolean.class));
+
+    /** Creates a new instance of AndFunction */
+    public AndFunction() {
+        super(NAME);
+    }
+
+    public Object evaluate(Object feature) {
+        Object left;
+        Object right;
+
+        return true;
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/AndFunction.java
@@ -54,7 +54,7 @@ public class AndFunction extends FunctionExpressionImpl {
             throw new IllegalArgumentException(
                     "Filter Function problem for function And argument #0 - expected type boolean");
         }
-        
+
         try { // attempt to get the right value and perform conversion
             right = (getExpression(1).evaluate(feature, Boolean.class));
         } catch (Exception e) // probably a type error
@@ -62,7 +62,7 @@ public class AndFunction extends FunctionExpressionImpl {
             throw new IllegalArgumentException(
                     "Filter Function problem for function And argument #1 - expected type boolean");
         }
-        
+
         return left && right;
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/function/OrFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/OrFunction.java
@@ -63,6 +63,6 @@ public class OrFunction extends FunctionExpressionImpl {
                     "Filter Function problem for function Or argument #1 - expected type boolean");
         }
         
-        return Boolean.valueOf(left || right);
+        return left || right;
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/function/OrFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/OrFunction.java
@@ -54,7 +54,7 @@ public class OrFunction extends FunctionExpressionImpl {
             throw new IllegalArgumentException(
                     "Filter Function problem for function Or argument #0 - expected type boolean");
         }
-        
+
         try { // attempt to get the right value and perform conversion
             right = (getExpression(1).evaluate(feature, Boolean.class));
         } catch (Exception e) // probably a type error
@@ -62,7 +62,7 @@ public class OrFunction extends FunctionExpressionImpl {
             throw new IllegalArgumentException(
                     "Filter Function problem for function Or argument #1 - expected type boolean");
         }
-        
+
         return left || right;
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/function/OrFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/OrFunction.java
@@ -24,21 +24,21 @@ import org.geotools.filter.capability.FunctionNameImpl;
 import org.opengis.filter.capability.FunctionName;
 
 /**
- * This function is used to evaluate a And operator with a left and right operands
+ * This function is used to evaluate a or operator with a left and right operands
  *
  * @author Erwan Bocher, CNRS, 2020
  */
-public class AndFunction extends FunctionExpressionImpl {
+public class OrFunction extends FunctionExpressionImpl {
 
     public static FunctionName NAME =
             new FunctionNameImpl(
-                    "And",
+                    "Or",
                     Boolean.class,
                     parameter("left", Boolean.class),
                     parameter("right", Boolean.class));
 
     /** Creates a new instance of AndFunction */
-    public AndFunction() {
+    public OrFunction() {
         super(NAME);
     }
 
@@ -52,7 +52,7 @@ public class AndFunction extends FunctionExpressionImpl {
         } catch (Exception e) // probably a type error
         {
             throw new IllegalArgumentException(
-                    "Filter Function problem for function And argument #0 - expected type boolean");
+                    "Filter Function problem for function Or argument #0 - expected type boolean");
         }
         
         try { // attempt to get the right value and perform conversion
@@ -60,9 +60,9 @@ public class AndFunction extends FunctionExpressionImpl {
         } catch (Exception e) // probably a type error
         {
             throw new IllegalArgumentException(
-                    "Filter Function problem for function And argument #1 - expected type boolean");
+                    "Filter Function problem for function Or argument #1 - expected type boolean");
         }
         
-        return Boolean.valueOf(left && right);
+        return Boolean.valueOf(left || right);
     }
 }

--- a/modules/library/main/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/modules/library/main/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -201,3 +201,4 @@ org.geotools.filter.function.color.ConstrastFunction
 org.geotools.filter.function.BoundedByFunction
 org.geotools.filter.function.DateDifferenceFunction
 org.geotools.filter.function.JsonPointerFunction
+org.geotools.filter.function.AndFunction

--- a/modules/library/main/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/modules/library/main/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -202,3 +202,4 @@ org.geotools.filter.function.BoundedByFunction
 org.geotools.filter.function.DateDifferenceFunction
 org.geotools.filter.function.JsonPointerFunction
 org.geotools.filter.function.AndFunction
+org.geotools.filter.function.OrFunction

--- a/modules/library/main/src/test/java/org/geotools/filter/AndFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/AndFunctionTest.java
@@ -16,8 +16,9 @@
  */
 package org.geotools.filter;
 
-import junit.framework.TestCase;
 import static org.junit.Assert.assertThrows;
+
+import junit.framework.TestCase;
 import org.junit.Test;
 import org.opengis.filter.expression.Function;
 
@@ -39,32 +40,43 @@ public class AndFunctionTest extends TestCase {
     @Test
     public void testAndFunction2() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
-        Function equalsTo_left = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
-        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+        Function equalsTo_left =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function equalsTo_right =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
         Function andFunction = ff.function("and", equalsTo_left, equalsTo_right);
         assertFalse((Boolean) andFunction.evaluate(new Object()));
     }
 
     @Test
     public void testAndFunction3() throws IllegalFilterException {
-        Throwable exception = assertThrows(
-                IllegalArgumentException.class, () -> {
-                    FilterFactoryImpl ff = new FilterFactoryImpl();
-                    Function abs_left = ff.function("abs", ff.literal(-12));
-                    Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
-                    Function andFunction = ff.function("and", abs_left, equalsTo_right);
-                    andFunction.evaluate(new Object());
-                }
-        );
+        Throwable exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            FilterFactoryImpl ff = new FilterFactoryImpl();
+                            Function abs_left = ff.function("abs", ff.literal(-12));
+                            Function equalsTo_right =
+                                    ff.function(
+                                            "equalTo",
+                                            ff.literal("string1"),
+                                            ff.literal("string2"));
+                            Function andFunction = ff.function("and", abs_left, equalsTo_right);
+                            andFunction.evaluate(new Object());
+                        });
     }
-    
+
     @Test
     public void testAndFunction4() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
-        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
-        Function geom_area = ff.function("area",geom);        
+        Function geom =
+                ff.function(
+                        "geomFromWKT",
+                        ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area", geom);
         Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
-        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function equalsTo_right =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
         Function andFunction = ff.function("and", equalsTo_left, equalsTo_right);
         assertTrue((Boolean) andFunction.evaluate(new Object()));
     }
@@ -72,12 +84,17 @@ public class AndFunctionTest extends TestCase {
     @Test
     public void testAndFunction5() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
-        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
-        Function geom_area = ff.function("area",geom);
+        Function geom =
+                ff.function(
+                        "geomFromWKT",
+                        ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area", geom);
         Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
-        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function equalsTo_right =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
         Function andFunction = ff.function("and", equalsTo_left, equalsTo_right);
-        Function if_then_elseFunction = ff.function("if_then_else", andFunction, ff.literal(10), ff.literal(-1));
+        Function if_then_elseFunction =
+                ff.function("if_then_else", andFunction, ff.literal(10), ff.literal(-1));
         assertEquals(10, if_then_elseFunction.evaluate(new Object()));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/AndFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/AndFunctionTest.java
@@ -1,0 +1,37 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.opengis.filter.expression.Function;
+
+/**
+ * Unit test for AndFunction
+ *
+ * @author Erwan Bocher, CNRS, 2020
+ */
+public class AndFunctionTest extends TestCase {
+
+    @Test
+    public void testAndFunction() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function equalsTo = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function andFunction = ff.function("and", equalsTo, equalsTo);
+        assertFalse((Boolean) andFunction.evaluate(new Object()));
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/filter/AndFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/AndFunctionTest.java
@@ -68,4 +68,16 @@ public class AndFunctionTest extends TestCase {
         Function andFunction = ff.function("and", equalsTo_left, equalsTo_right);
         assertTrue((Boolean) andFunction.evaluate(new Object()));
     }
+
+    @Test
+    public void testAndFunction5() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area",geom);
+        Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
+        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function andFunction = ff.function("and", equalsTo_left, equalsTo_right);
+        Function if_then_elseFunction = ff.function("if_then_else", andFunction, ff.literal(10), ff.literal(-1));
+        assertEquals(10, if_then_elseFunction.evaluate(new Object()));
+    }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/AndFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/AndFunctionTest.java
@@ -17,6 +17,7 @@
 package org.geotools.filter;
 
 import junit.framework.TestCase;
+import static org.junit.Assert.assertThrows;
 import org.junit.Test;
 import org.opengis.filter.expression.Function;
 
@@ -28,10 +29,43 @@ import org.opengis.filter.expression.Function;
 public class AndFunctionTest extends TestCase {
 
     @Test
-    public void testAndFunction() throws IllegalFilterException {
+    public void testAndFunction1() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
         Function equalsTo = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
         Function andFunction = ff.function("and", equalsTo, equalsTo);
+        assertTrue((Boolean) andFunction.evaluate(new Object()));
+    }
+
+    @Test
+    public void testAndFunction2() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function equalsTo_left = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+        Function andFunction = ff.function("and", equalsTo_left, equalsTo_right);
         assertFalse((Boolean) andFunction.evaluate(new Object()));
+    }
+
+    @Test
+    public void testAndFunction3() throws IllegalFilterException {
+        Throwable exception = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    FilterFactoryImpl ff = new FilterFactoryImpl();
+                    Function abs_left = ff.function("abs", ff.literal(-12));
+                    Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+                    Function andFunction = ff.function("and", abs_left, equalsTo_right);
+                    andFunction.evaluate(new Object());
+                }
+        );
+    }
+    
+    @Test
+    public void testAndFunction4() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area",geom);        
+        Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
+        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function andFunction = ff.function("and", equalsTo_left, equalsTo_right);
+        assertTrue((Boolean) andFunction.evaluate(new Object()));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/OrFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/OrFunctionTest.java
@@ -16,8 +16,9 @@
  */
 package org.geotools.filter;
 
-import junit.framework.TestCase;
 import static org.junit.Assert.assertThrows;
+
+import junit.framework.TestCase;
 import org.junit.Test;
 import org.opengis.filter.expression.Function;
 
@@ -39,56 +40,76 @@ public class OrFunctionTest extends TestCase {
     @Test
     public void testOrFunction2() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
-        Function equalsTo_left = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
-        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+        Function equalsTo_left =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function equalsTo_right =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
         Function orFunction = ff.function("or", equalsTo_left, equalsTo_right);
         assertTrue((Boolean) orFunction.evaluate(new Object()));
     }
 
     @Test
     public void testOrFunction3() throws IllegalFilterException {
-        Throwable exception = assertThrows(
-                IllegalArgumentException.class, () -> {
-                    FilterFactoryImpl ff = new FilterFactoryImpl();
-                    Function abs_left = ff.function("abs", ff.literal(-12));
-                    Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
-                    Function orFunction = ff.function("or", abs_left, equalsTo_right);
-                    orFunction.evaluate(new Object());
-                }
-        );
+        Throwable exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> {
+                            FilterFactoryImpl ff = new FilterFactoryImpl();
+                            Function abs_left = ff.function("abs", ff.literal(-12));
+                            Function equalsTo_right =
+                                    ff.function(
+                                            "equalTo",
+                                            ff.literal("string1"),
+                                            ff.literal("string2"));
+                            Function orFunction = ff.function("or", abs_left, equalsTo_right);
+                            orFunction.evaluate(new Object());
+                        });
     }
-    
+
     @Test
     public void testOrFunction4() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
-        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
-        Function geom_area = ff.function("area",geom);        
+        Function geom =
+                ff.function(
+                        "geomFromWKT",
+                        ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area", geom);
         Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
-        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function equalsTo_right =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
         Function orFunction = ff.function("or", equalsTo_left, equalsTo_right);
         assertTrue((Boolean) orFunction.evaluate(new Object()));
     }
-    
+
     @Test
     public void testOrFunction5() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
-        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
-        Function geom_area = ff.function("area",geom);        
+        Function geom =
+                ff.function(
+                        "geomFromWKT",
+                        ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area", geom);
         Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
-        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+        Function equalsTo_right =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
         Function orFunction = ff.function("or", equalsTo_left, equalsTo_right);
         assertTrue((Boolean) orFunction.evaluate(new Object()));
     }
-    
+
     @Test
     public void testAndFunction6() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
-        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
-        Function geom_area = ff.function("area",geom);        
+        Function geom =
+                ff.function(
+                        "geomFromWKT",
+                        ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area", geom);
         Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
-        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+        Function equalsTo_right =
+                ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
         Function orFunction = ff.function("or", equalsTo_left, equalsTo_right);
-        Function if_then_elseFunction = ff.function("if_then_else", orFunction, ff.literal(10), ff.literal(-1));
+        Function if_then_elseFunction =
+                ff.function("if_then_else", orFunction, ff.literal(10), ff.literal(-1));
         assertEquals(10, if_then_elseFunction.evaluate(new Object()));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/OrFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/OrFunctionTest.java
@@ -32,8 +32,8 @@ public class OrFunctionTest extends TestCase {
     public void testOrFunction1() throws IllegalFilterException {
         FilterFactoryImpl ff = new FilterFactoryImpl();
         Function equalsTo = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
-        Function andFunction = ff.function("or", equalsTo, equalsTo);
-        assertTrue((Boolean) andFunction.evaluate(new Object()));
+        Function orFunction = ff.function("or", equalsTo, equalsTo);
+        assertTrue((Boolean) orFunction.evaluate(new Object()));
     }
 
     @Test
@@ -41,8 +41,8 @@ public class OrFunctionTest extends TestCase {
         FilterFactoryImpl ff = new FilterFactoryImpl();
         Function equalsTo_left = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
         Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
-        Function andFunction = ff.function("or", equalsTo_left, equalsTo_right);
-        assertTrue((Boolean) andFunction.evaluate(new Object()));
+        Function orFunction = ff.function("or", equalsTo_left, equalsTo_right);
+        assertTrue((Boolean) orFunction.evaluate(new Object()));
     }
 
     @Test
@@ -52,8 +52,8 @@ public class OrFunctionTest extends TestCase {
                     FilterFactoryImpl ff = new FilterFactoryImpl();
                     Function abs_left = ff.function("abs", ff.literal(-12));
                     Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
-                    Function andFunction = ff.function("or", abs_left, equalsTo_right);
-                    andFunction.evaluate(new Object());
+                    Function orFunction = ff.function("or", abs_left, equalsTo_right);
+                    orFunction.evaluate(new Object());
                 }
         );
     }
@@ -65,8 +65,8 @@ public class OrFunctionTest extends TestCase {
         Function geom_area = ff.function("area",geom);        
         Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
         Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
-        Function andFunction = ff.function("or", equalsTo_left, equalsTo_right);
-        assertTrue((Boolean) andFunction.evaluate(new Object()));
+        Function orFunction = ff.function("or", equalsTo_left, equalsTo_right);
+        assertTrue((Boolean) orFunction.evaluate(new Object()));
     }
     
     @Test
@@ -76,7 +76,19 @@ public class OrFunctionTest extends TestCase {
         Function geom_area = ff.function("area",geom);        
         Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
         Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
-        Function andFunction = ff.function("or", equalsTo_left, equalsTo_right);
-        assertTrue((Boolean) andFunction.evaluate(new Object()));
+        Function orFunction = ff.function("or", equalsTo_left, equalsTo_right);
+        assertTrue((Boolean) orFunction.evaluate(new Object()));
+    }
+    
+    @Test
+    public void testAndFunction6() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area",geom);        
+        Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
+        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+        Function orFunction = ff.function("or", equalsTo_left, equalsTo_right);
+        Function if_then_elseFunction = ff.function("if_then_else", orFunction, ff.literal(10), ff.literal(-1));
+        assertEquals(10, if_then_elseFunction.evaluate(new Object()));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/OrFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/OrFunctionTest.java
@@ -1,0 +1,82 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter;
+
+import junit.framework.TestCase;
+import static org.junit.Assert.assertThrows;
+import org.junit.Test;
+import org.opengis.filter.expression.Function;
+
+/**
+ * Unit test for OrFunction
+ *
+ * @author Erwan Bocher, CNRS, 2020
+ */
+public class OrFunctionTest extends TestCase {
+
+    @Test
+    public void testOrFunction1() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function equalsTo = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function andFunction = ff.function("or", equalsTo, equalsTo);
+        assertTrue((Boolean) andFunction.evaluate(new Object()));
+    }
+
+    @Test
+    public void testOrFunction2() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function equalsTo_left = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+        Function andFunction = ff.function("or", equalsTo_left, equalsTo_right);
+        assertTrue((Boolean) andFunction.evaluate(new Object()));
+    }
+
+    @Test
+    public void testOrFunction3() throws IllegalFilterException {
+        Throwable exception = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    FilterFactoryImpl ff = new FilterFactoryImpl();
+                    Function abs_left = ff.function("abs", ff.literal(-12));
+                    Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+                    Function andFunction = ff.function("or", abs_left, equalsTo_right);
+                    andFunction.evaluate(new Object());
+                }
+        );
+    }
+    
+    @Test
+    public void testOrFunction4() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area",geom);        
+        Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
+        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
+        Function andFunction = ff.function("or", equalsTo_left, equalsTo_right);
+        assertTrue((Boolean) andFunction.evaluate(new Object()));
+    }
+    
+    @Test
+    public void testOrFunction5() throws IllegalFilterException {
+        FilterFactoryImpl ff = new FilterFactoryImpl();
+        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
+        Function geom_area = ff.function("area",geom);        
+        Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
+        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string2"));
+        Function andFunction = ff.function("or", equalsTo_left, equalsTo_right);
+        assertTrue((Boolean) andFunction.evaluate(new Object()));
+    }
+}


### PR DESCRIPTION
This PR adds two new functions And and Or and provides capabilities to manage logical operators on FilterFactory.

e.g

```
IF AREA(geomFromWKT('POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))'))>0 and 'string1'='string1' THEN 10 ELSE -1"

```

can be translated to  : 

```java
        FilterFactoryImpl ff = new FilterFactoryImpl();
        Function geom = ff.function("geomFromWKT", ff.literal("POLYGON ((150 330, 220 330, 220 230, 150 230, 150 330))"));
        Function geom_area = ff.function("area",geom);
        Function equalsTo_left = ff.function("greaterThan", geom_area, ff.literal(0));
        Function equalsTo_right = ff.function("equalTo", ff.literal("string1"), ff.literal("string1"));
        Function andFunction = ff.function("and", equalsTo_left, equalsTo_right);
        Function if_then_elseFunction = ff.function("if_then_else", andFunction, ff.literal(10), ff.literal(-1));
        assertEquals(10, if_then_elseFunction.evaluate(new Object()));
```



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
