### PR TITLE
Fix typos in several DataStore classes

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/GranuleStore.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/GranuleStore.java
@@ -98,7 +98,7 @@ public interface GranuleStore extends GranuleSource {
      *
      * <pre>
      * <code>
-     * Transation t = new DefaultTransaction();
+     * Transaction t = new DefaultTransaction();
      * GranuleStore.setTransaction(t);
      * try {
      *     GranuleStore.addGranules (granules);

--- a/modules/library/main/src/main/java/org/geotools/data/DataStore.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataStore.java
@@ -147,7 +147,7 @@ public interface DataStore extends DataAccess<SimpleFeatureType, SimpleFeature> 
      *
      * @param typeName the type name for features that will be accessible
      * @param filter defines additional constraints on the features that will be accessible
-     * @param transaction the transation that the returned writer operates against
+     * @param transaction the transaction that the returned writer operates against
      * @return an instance of {@code FeatureWriter}
      * @throws IOException if data access errors occur
      * @see #getFeatureWriterAppend(String, Transaction)
@@ -162,7 +162,7 @@ public interface DataStore extends DataAccess<SimpleFeatureType, SimpleFeature> 
      * <p>The returned writer does <b>not</b> allow features to be added.
      *
      * @param typeName the type name for features that will be accessible
-     * @param transaction the transation that the returned writer operates against
+     * @param transaction the transaction that the returned writer operates against
      * @return an instance of {@code FeatureWriter}
      * @throws IOException if data access errors occur
      * @see #getFeatureWriterAppend(String, Transaction)

--- a/modules/library/main/src/main/java/org/geotools/data/FeatureStore.java
+++ b/modules/library/main/src/main/java/org/geotools/data/FeatureStore.java
@@ -119,7 +119,7 @@ public interface FeatureStore<T extends FeatureType, F extends Feature>
      * FeatureStore}.
      *
      * <pre><code>
-     * Transation t = new DefaultTransaction();
+     * Transaction t = new DefaultTransaction();
      * featureStore.setTransaction(t);
      * try {
      *     featureStore.addFeatures( someFeatures );

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLTransactionOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLTransactionOnlineTest.java
@@ -20,7 +20,7 @@ import org.geotools.jdbc.JDBCTestSetup;
 import org.geotools.jdbc.JDBCTransactionOnlineTest;
 
 /**
- * Transation test for MySQL.
+ * Transaction test for MySQL.
  *
  * @author Justin Deoliveira, The Open Planning Project
  */


### PR DESCRIPTION
Just fix some typos.

## Checklist

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).
