### PR TITLE
[GEOT-6732] GroupCandidateSelection RT throws NPE if operation attribute return null

### DIFF
--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/GroupCandidateSelectionProcess.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/GroupCandidateSelectionProcess.java
@@ -154,12 +154,11 @@ public class GroupCandidateSelectionProcess implements VectorProcess {
         // produces new PropertyName to add to the query
         List<PropertyName> propertiesToAdd =
                 Stream.of(sortBy).map(s -> s.getPropertyName()).collect(Collectors.toList());
-        propertiesToAdd.add(ff.property(operationAttribute));
-
+        PropertyName operationAttributeProp = ff.property(operationAttribute);
+        propertiesToAdd.add(operationAttributeProp);
         // eventually merge with existing ones
         List<PropertyName> pns = getNewProperties(propertiesToAdd, properties);
         q.setProperties(pns);
-
         return q;
     }
 
@@ -298,15 +297,21 @@ public class GroupCandidateSelectionProcess implements VectorProcess {
             Feature bestFeature = null;
             while (super.hasNext()) {
                 Feature f = super.next();
+                Comparable operationValue = getComparableFromEvaluation(f);
                 if (bestFeature == null) {
-                    // no features in the list this is the first of the group
-                    // takes the values to check the following features if belong to the same group
-                    groupingValues = getGroupingValues(groupingValues, f);
-                    bestFeature = f;
+                    // if null skipping
+                    if (operationValue != null) {
+                        // no features in the list this is the first of the group
+                        // takes the values to check the following features if belong to the same
+                        // group
+                        groupingValues = getGroupingValues(groupingValues, f);
+                        bestFeature = f;
+                    }
                 } else {
                     // is the feature in the group?
                     if (featureComparison(groupingValues, f)) {
-                        bestFeature = updateBestFeature(f, bestFeature);
+                        // if operationValue is null skip
+                        if (operationValue != null) bestFeature = updateBestFeature(f, bestFeature);
                     } else {
                         ((PushBackFeatureIterator) delegate).pushBack();
                         break;

--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/GroupCandidateSelectionProcess.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/GroupCandidateSelectionProcess.java
@@ -298,20 +298,17 @@ public class GroupCandidateSelectionProcess implements VectorProcess {
             while (super.hasNext()) {
                 Feature f = super.next();
                 Comparable operationValue = getComparableFromEvaluation(f);
-                if (bestFeature == null) {
-                    // if null skipping
-                    if (operationValue != null) {
-                        // no features in the list this is the first of the group
-                        // takes the values to check the following features if belong to the same
-                        // group
-                        groupingValues = getGroupingValues(groupingValues, f);
-                        bestFeature = f;
-                    }
-                } else {
+                if (bestFeature == null && operationValue != null) {
+                    // no features in the list this is the first of the group
+                    // takes the values to check the following features if belong to the same
+                    // group
+                    groupingValues = getGroupingValues(groupingValues, f);
+                    bestFeature = f;
+                } else if (bestFeature != null && operationValue != null) {
                     // is the feature in the group?
                     if (featureComparison(groupingValues, f)) {
                         // if operationValue is null skip
-                        if (operationValue != null) bestFeature = updateBestFeature(f, bestFeature);
+                        bestFeature = updateBestFeature(f, bestFeature);
                     } else {
                         ((PushBackFeatureIterator) delegate).pushBack();
                         break;

--- a/modules/unsupported/process-feature/src/test/java/org/geotools/process/vector/GroupCandidateSelectionProcessTest.java
+++ b/modules/unsupported/process-feature/src/test/java/org/geotools/process/vector/GroupCandidateSelectionProcessTest.java
@@ -114,4 +114,36 @@ public class GroupCandidateSelectionProcessTest {
         assertEquals(57, numericResults.get(4).intValue());
         assertEquals(91, numericResults.get(5).intValue());
     }
+
+    @Test
+    public void testFeatureCollectionFilteringByMinWithNullValues() throws Exception {
+        SimpleFeatureSource source = store.getFeatureSource("featuresToGroupWithNullValues");
+        Query query = new Query();
+        query.setFilter(Filter.INCLUDE);
+        SortBy[] sorts =
+                new SortBy[] {
+                    ff.sort("group", SortOrder.ASCENDING), ff.sort("group", SortOrder.ASCENDING)
+                };
+        query.setSortBy(sorts);
+        FeatureCollection collection = source.getFeatures(query);
+        int size = collection.size();
+        assertEquals(12, size);
+        List<String> props = Arrays.asList("group", "group2");
+        PropertyName pn = ff.property("numericVal");
+        FeatureCollection features =
+                new GroupCandidateSelectionProcess()
+                        .execute(collection, "MIN", "numericVal", props);
+        FeatureIterator it = features.features();
+        List<Integer> numericResults = new ArrayList<>(6);
+        while (it.hasNext()) {
+            numericResults.add((Integer) pn.evaluate(it.next()));
+        }
+        it.close();
+        assertEquals(40, numericResults.get(0).intValue());
+        assertEquals(43, numericResults.get(1).intValue());
+        assertEquals(22, numericResults.get(2).intValue());
+        assertEquals(65, numericResults.get(3).intValue());
+        assertEquals(47, numericResults.get(4).intValue());
+        assertEquals(91, numericResults.get(5).intValue());
+    }
 }

--- a/modules/unsupported/process-feature/src/test/resources/org/geotools/process/vector/test-data/featuresToGroupWithNullValues.properties
+++ b/modules/unsupported/process-feature/src/test/resources/org/geotools/process/vector/test-data/featuresToGroupWithNullValues.properties
@@ -1,0 +1,13 @@
+_=the_geom:MultiPolygon:srid=4326,cat:java.lang.Long,group:String,group2:String,numericVal:java.lang.Integer
+features.1=MULTIPOLYGON(((2 2,2 3,3 3,3 2,2 2)), ((3 9,3 12,5 12,5 9,3 9)))|10|group1|secondGroup1|null
+features.2=MULTIPOLYGON(((10 4,10 6,12 6,12 4,10 4)))|20|group1|secondGroup1|40
+features.3=MULTIPOLYGON(((2 2,2 3,3 3,3 2,2 2)), ((3 9,3 12,5 12,5 9,3 9)))|10|group1|secondGroup2|50
+features.4=MULTIPOLYGON(((10 4,10 6,12 6,12 4,10 4)))|20|group1|secondGroup2|43
+features.5=MULTIPOLYGON(((15 7,15 8,16 8,16 7,15 7)))|30|group2|secondGroup1|null
+features.6=MULTIPOLYGON(((3 10,3 12,5 12,5 10,3 10)))|40|group2|secondGroup1|22
+features.7=MULTIPOLYGON(((15 7,15 8,16 8,16 7,15 7)))|30|group2|secondGroup2|80
+features.8=MULTIPOLYGON(((3 10,3 12,5 12,5 10,3 10)))|40|group2|secondGroup2|65
+features.9=MULTIPOLYGON(((9 9,9 11,12 11,12 9,9 9)))|50|group3|secondGroup1|57
+features.10=MULTIPOLYGON(((12 12,12 15, 16 15,16 12, 12 12)))|60|group3|secondGroup1|47
+features.11=MULTIPOLYGON(((9 9,9 11,12 11,12 9,9 9)))|50|group3|secondGroup2|null
+features.12=MULTIPOLYGON(((12 12,12 15, 16 15,16 12, 12 12)))|60|group3|secondGroup2|91


### PR DESCRIPTION
Fix a bug causing npe when operationAttribute propertyName returns null in GroupCandidateSelection vectorProcess.

Jira ticket https://osgeo-org.atlassian.net/browse/GEOT-6732

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
