### PR TITLE
[23.x backport][GEOT-6737] Update PostgreSQL (to 42.2.18) and MS SQL Server (to 8.4.1.jre8) JDBC drivers

### DIFF
--- a/modules/plugin/jdbc/jdbc-sqlserver/pom.xml
+++ b/modules/plugin/jdbc/jdbc-sqlserver/pom.xml
@@ -66,17 +66,10 @@
 		<dependency>
 			<groupId>net.sourceforge.jtds</groupId>
 			<artifactId>jtds</artifactId>
-			<version>${jtdsDriverVersion}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<version>${sqlServerDriverVersion}</version>
 		</dependency>
 	</dependencies>
-
-	<properties>
-		<sqlServerDriverVersion>8.2.2.jre8</sqlServerDriverVersion>
-		<jtdsDriverVersion>1.3.1</jtdsDriverVersion>
-	</properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,9 @@
     <fork.javac>false</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <postgresql.jdbc.version>42.2.14</postgresql.jdbc.version>
+    <postgresql.jdbc.version>42.2.18</postgresql.jdbc.version>
+    <mssql-jdbc.version>8.4.1.jre8</mssql-jdbc.version>
+    <jtds.jdbc.version>1.3.1</jtds.jdbc.version>
     <solrj.version>7.2.1</solrj.version>
     <elasticsearch.version>7.4.0</elasticsearch.version>
     <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
@@ -1277,6 +1279,17 @@
         <artifactId>sdoapi</artifactId>
         <groupId>com.oracle</groupId>
         <version>10.2.0</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>net.sourceforge.jtds</groupId>
+        <artifactId>jtds</artifactId>
+        <version>${jtds.jdbc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.sqlserver</groupId>
+        <artifactId>mssql-jdbc</artifactId>
+        <version>${mssql-jdbc.version}</version>
       </dependency>
 
       <!-- H2 -->


### PR DESCRIPTION
All of these have had some patch releases, so they should be upgraded.
```
org.postgresql:postgresql ......................... 42.2.14 -> 42.2.18
com.microsoft.sqlserver:mssql-jdbc .......... 8.2.2.jre8 -> 8.4.1.jre8
```
also move SQL Server drivers into `dependencyManagement` section

resolves https://osgeo-org.atlassian.net/browse/GEOT-6737

backports #3207 to 23.x (note that the oracle driver is not upgraded for 23.x as it was never upgraded to ojdbc8 in 23.x to begin with)