### PR TITLE
[24.x backport] [GEOT-6690] [GEOT-6692] MySQL 8 support and upgrade MySQL driver to 8.0.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
        sh ".travis/start-oracle-xe.sh";
        sh ".travis/setup-oracle.sh";
     fi
-  - if [ "$TRAVIS_JOB_NAME" == "MySQL" ]; then
-       sh ".travis/start-mysql.sh";
+  - if [[ "$TRAVIS_JOB_NAME" == MySQL* ]]; then
+       sh ".travis/start-mysql.sh" $MYSQL;
        sh ".travis/setup-mysql.sh";
     fi
 
@@ -56,9 +56,19 @@ matrix:
           packages:
             - docker-ce
     - jdk: openjdk8
-      env: ARGS="-pl :gt-jdbc-mysql -Ponline -Dfmt.skip=true -am"
+      env: ARGS="-pl :gt-jdbc-mysql -Ponline -Dfmt.skip=true -am" MYSQL="5"
       dist: bionic
-      name: "MySQL"
+      name: "MySQL 5"
+      services:
+        - docker
+      addons:
+        apt:
+          packages:
+            - docker-ce
+    - jdk: openjdk11
+      env: ARGS="-pl :gt-jdbc-mysql -Ponline -Dfmt.skip=true -am" MYSQL="8"
+      dist: bionic
+      name: "MySQL 8"
       services:
         - docker
       addons:

--- a/.travis/setup-mysql.sh
+++ b/.travis/setup-mysql.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
-printf "\nCopy database connection resource file"
+printf "\nCopy database connection resource file...\n"
 mkdir --parents --verbose ~/.geotools
 cp --verbose --force ./.travis/mysql.properties ~/.geotools/
 
-printf "\nCreate GEOTOOLS database\n"
+printf "\nCreate GEOTOOLS database...\n"
 docker exec -i geotools mysql -uroot -pgeotools < .travis/mysql_setup.sql

--- a/.travis/start-mysql.sh
+++ b/.travis/start-mysql.sh
@@ -1,29 +1,28 @@
 #!/bin/bash -e
 docker version
+docker pull mysql:$1
 
-docker pull mysql:5
-
+printf "\n\nStarting MySQL $1 container, this could take a while..."
 # start the dockerized mysql instance (the container will be destroyed/removed on stopping)
 # this container can be stopped using: docker stop geotools
-docker run --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD=geotools --name geotools -h geotools -d mysql:5
+docker run --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD=geotools --name geotools -h geotools -d mysql:$1
 
-# print logs
-# docker logs geotools
-
-printf "\n\nStarting MySQL container, this could take a few minutes..."
-printf "\nWaiting for MySQL database to start up.... "
+# the mysql docker images start a temporary server to init and then restart listening on 3306
+printf "\nWaiting for MySQL $1 database to start up.... "
 _WAIT=0;
 while :
 do
     printf " $_WAIT"
-    if $(docker logs geotools 2>&1 | grep -q 'ready for connections'); then
+    # look for a line with: "mysqld: ready for connections."
+    # followed by a line with "port: 3306 " (maybe on the same line)
+    if $(docker logs geotools 2>&1 | grep -A2 'ready for connections' | grep -q 'port: 3306 '); then
         printf "\nMySQL ready for connections\n\n"
         break
     fi
+
     sleep 10
     _WAIT=$(($_WAIT+10))
 done
 
-# docker ps -a
 # print logs
 docker logs geotools

--- a/docs/developer/conventions/test/online.rst
+++ b/docs/developer/conventions/test/online.rst
@@ -273,6 +273,11 @@ Use the following to create and start a MySQL 5 (5.7.31 at the time of writing) 
     docker pull mysql:5
     docker run --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD=geotools --name geotools -h geotools -d mysql:5
 
+or use the following to create and start a MySQL 8 (8.0.22 at the time of writing) container listening on port 3306:::
+
+    docker pull mysql:8
+    docker run --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD=geotools --name geotools -h geotools -d mysql:8
+
 Note that the ``--rm`` option will delete the container after stopping it, the image is preserved so you won't need
 to pull it next time, but you may want to preserve the container so you don't have to build a new one.
 

--- a/docs/user/library/jdbc/mysql.rst
+++ b/docs/user/library/jdbc/mysql.rst
@@ -1,8 +1,7 @@
 MySQL Plugin
 ------------
 
-Supports direct access to a MySQL database. Currently supported versions include 5.6 and 5.7.
-Version 8 is currently not supported due to MySQL having renamed all spatial functions.
+Supports direct access to a MySQL database. Currently supported versions include 5.6 and 5.7 and 8.
 
 **Maven**
 

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -1278,7 +1278,7 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
                 rs = ((PreparedStatement) st).executeQuery();
             } else {
                 String sql = selectBoundsSQL(featureType, query);
-                LOGGER.log(Level.FINE, "Retriving bounding box: {0}", sql);
+                LOGGER.log(Level.FINE, "Retrieving bounding box: {0}", sql);
 
                 st = cx.createStatement();
                 rs = st.executeQuery(sql);

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialect.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialect.java
@@ -74,6 +74,9 @@ public class MySQLDialect extends SQLDialect {
      */
     protected boolean usePreciseSpatialOps;
 
+    /** flag indicating we are using MySQL v8.0 or higher. */
+    protected boolean isMySqlVersion80OrAbove;
+
     public MySQLDialect(JDBCDataStore dataStore) {
         super(dataStore);
     }
@@ -94,6 +97,14 @@ public class MySQLDialect extends SQLDialect {
         return usePreciseSpatialOps;
     }
 
+    public boolean isMySqlVersion80OrAbove() {
+        return this.isMySqlVersion80OrAbove;
+    }
+
+    public void setMySqlVersion80OrAbove(boolean mySqlVersion80OrAbove) {
+        this.isMySqlVersion80OrAbove = mySqlVersion80OrAbove;
+    }
+
     @Override
     public boolean includeTable(String schemaName, String tableName, Connection cx)
             throws SQLException {
@@ -104,7 +115,7 @@ public class MySQLDialect extends SQLDialect {
     }
 
     public String getNameEscape() {
-        return "";
+        return (usePreciseSpatialOps ? "`" : "");
     }
 
     public String getGeometryTypeName(Integer type) {
@@ -186,7 +197,11 @@ public class MySQLDialect extends SQLDialect {
 
         // execute SELECT srid(<columnName>) FROM <tableName> LIMIT 1;
         sql = new StringBuffer();
-        sql.append("SELECT srid(");
+        if (this.usePreciseSpatialOps) {
+            sql.append("SELECT ST_SRID(");
+        } else {
+            sql.append("SELECT srid(");
+        }
         encodeColumnName(null, columnName, sql);
         sql.append(") ");
         sql.append("FROM ");
@@ -225,28 +240,66 @@ public class MySQLDialect extends SQLDialect {
     @Override
     public void encodeGeometryColumn(
             GeometryDescriptor gatt, String prefix, int srid, Hints hints, StringBuffer sql) {
-        sql.append("asWKB(");
+        if (this.usePreciseSpatialOps) {
+            sql.append("ST_asWKB(");
+        } else {
+            sql.append("asWKB(");
+        }
         encodeColumnName(prefix, gatt.getLocalName(), sql);
         sql.append(")");
     }
 
     public void encodeGeometryEnvelope(String tableName, String geometryColumn, StringBuffer sql) {
-        sql.append("asWKB(");
-        sql.append("envelope(");
-        encodeColumnName(null, geometryColumn, sql);
+        if (this.usePreciseSpatialOps) {
+            if (this.isMySqlVersion80OrAbove) {
+                // since mysql 8 fails to execute st_envelope on geography we need to
+                // work around that casting to srid:0 and back. Example:
+                //
+                //            SELECT ST_asWkB(
+                //                -- restore srid
+                //                ST_srid(
+                //                    -- get envelope
+                //                    ST_Envelope(
+                //                            -- cast to cartesian/srid 0
+                //                            ST_srid(geom, 0)
+                //                    ),
+                //                    ST_SRID(geom)
+                //                )
+                //            ) FROM `road`
+                sql.append("ST_asWKB(ST_SRID(ST_Envelope(ST_SRID(");
+                encodeColumnName(null, geometryColumn, sql);
+                sql.append(",0)),ST_SRID(");
+                encodeColumnName(null, geometryColumn, sql);
+                sql.append(")");
+            } else {
+                // 5.6/5.7 has a different syntax for ST_SRID so we can't use the above
+                // also it doesn't care about projections
+                sql.append("ST_asWKB(ST_Envelope(");
+                encodeColumnName(null, geometryColumn, sql);
+            }
+        } else {
+            sql.append("asWKB(");
+            sql.append("envelope(");
+            encodeColumnName(null, geometryColumn, sql);
+        }
         sql.append("))");
     }
 
     public Envelope decodeGeometryEnvelope(ResultSet rs, int column, Connection cx)
             throws SQLException, IOException {
-        // String wkb = rs.getString( column );
         byte[] wkb = rs.getBytes(column);
 
         try {
+            /**
+             * As of MySQL 5.7.6, if the argument is a point or a vertical or horizontal line
+             * segment, ST_Envelope() returns the point or the line segment as its MBR rather than
+             * returning an invalid polygon therefore we must override behavior and check for a
+             * geometry and not a polygon
+             */
             // TODO: srid
-            Polygon polygon = (Polygon) new WKBReader().read(wkb);
+            Geometry geom = new WKBReader().read(wkb);
 
-            return polygon.getEnvelopeInternal();
+            return geom.getEnvelopeInternal();
         } catch (ParseException e) {
             String msg = "Error decoding wkb for envelope";
             throw (IOException) new IOException(msg).initCause(e);
@@ -307,7 +360,7 @@ public class MySQLDialect extends SQLDialect {
         mappings.put("MULTILINESTRING", MultiLineString.class);
         mappings.put("MULTIPOLYGON", MultiPolygon.class);
         mappings.put("GEOMETRY", Geometry.class);
-        mappings.put("GEOMETRYCOLLETION", GeometryCollection.class);
+        mappings.put("GEOMETRYCOLLECTION", GeometryCollection.class);
     }
 
     @Override
@@ -401,7 +454,7 @@ public class MySQLDialect extends SQLDialect {
             }
 
             CoordinateReferenceSystem crs = gd.getCoordinateReferenceSystem();
-            int srid = -1;
+            int srid = 0;
             if (crs != null) {
                 Integer i = null;
                 try {

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectPrepared.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectPrepared.java
@@ -65,6 +65,14 @@ public class MySQLDialectPrepared extends PreparedStatementSQLDialect {
         return delegate.getUsePreciseSpatialOps();
     }
 
+    public boolean isMySqlVersion80OrAbove() {
+        return delegate.isMySqlVersion80OrAbove;
+    }
+
+    public void setMySqlVersion80OrAbove(boolean mySqlVersion80OrAbove) {
+        delegate.isMySqlVersion80OrAbove = mySqlVersion80OrAbove;
+    }
+
     @Override
     public boolean includeTable(String schemaName, String tableName, Connection cx)
             throws SQLException {
@@ -198,7 +206,11 @@ public class MySQLDialectPrepared extends PreparedStatementSQLDialect {
             Class binding,
             StringBuffer sql) {
         if (gClass != null) {
-            sql.append("GeomFromWKB(?)");
+            if (delegate.usePreciseSpatialOps) {
+                sql.append("ST_GeometryFromWKB(?)");
+            } else {
+                sql.append("GeomFromWKB(?)");
+            }
         } else {
             super.prepareGeometryValue(gClass, dimension, srid, binding, sql);
         }

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLAggregateTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLAggregateTestSetup.java
@@ -32,15 +32,15 @@ public class MySQLAggregateTestSetup extends JDBCAggregateTestSetup {
 
         run(
                 "INSERT INTO aggregate (id,geom,name) VALUES ( 0,"
-                        + "GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
+                        + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
                         + "'muddy1')");
         run(
                 "INSERT INTO aggregate (id,geom,name) VALUES ( 1,"
-                        + "GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
+                        + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
                         + "'muddy1')");
         run(
                 "INSERT INTO aggregate (id,geom,name) VALUES ( 2,"
-                        + "GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
+                        + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
                         + "'muddy2')");
     }
 

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreAPITestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreAPITestSetup.java
@@ -33,15 +33,15 @@ public class MySQLDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
                         + "geom LINESTRING, name varchar(255) ) ENGINE=InnoDB;");
         run(
                 "INSERT INTO road (id,geom,name) VALUES (0,"
-                        + "GeomFromText('LINESTRING(1 1, 2 2, 4 2, 5 1)',4326),"
+                        + "ST_GeomFromText('LINESTRING(1 1, 2 2, 4 2, 5 1)',4326),"
                         + "'r1')");
         run(
                 "INSERT INTO road (id,geom,name) VALUES ( 1,"
-                        + "GeomFromText('LINESTRING(3 0, 3 2, 3 3, 3 4)',4326),"
+                        + "ST_GeomFromText('LINESTRING(3 0, 3 2, 3 3, 3 4)',4326),"
                         + "'r2')");
         run(
                 "INSERT INTO road (id,geom,name) VALUES ( 2,"
-                        + "GeomFromText('LINESTRING(3 2, 4 2, 5 3)',4326),"
+                        + "ST_GeomFromText('LINESTRING(3 2, 4 2, 5 3)',4326),"
                         + "'r3')");
     }
 
@@ -52,11 +52,11 @@ public class MySQLDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
 
         run(
                 "INSERT INTO river (id,geom,river, flow)  VALUES ( 0,"
-                        + "GeomFromText('MULTILINESTRING((5 5, 7 4),(7 5, 9 7, 13 7),(7 5, 9 3, 11 3))',4326),"
+                        + "ST_GeomFromText('MULTILINESTRING((5 5, 7 4),(7 5, 9 7, 13 7),(7 5, 9 3, 11 3))',4326),"
                         + "'rv1', 4.5)");
         run(
                 "INSERT INTO river (id,geom,river, flow) VALUES ( 1,"
-                        + "GeomFromText('MULTILINESTRING((4 6, 4 8, 6 10))',4326),"
+                        + "ST_GeomFromText('MULTILINESTRING((4 6, 4 8, 6 10))',4326),"
                         + "'rv2', 3.0)");
     }
 
@@ -67,7 +67,7 @@ public class MySQLDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
 
         run(
                 "INSERT INTO lake (id,geom,name) VALUES ( 0,"
-                        + "GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
+                        + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))', 4326),"
                         + "'muddy')");
     }
 

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreAutoEnhandedSpatialSupportTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreAutoEnhandedSpatialSupportTest.java
@@ -31,8 +31,11 @@ public class MySQLDataStoreAutoEnhandedSpatialSupportTest extends JDBCTestSuppor
     }
 
     public void testEnhancedSpatialSupportDetection() throws Exception {
-        boolean isMySQL56 = MySQLDataStoreFactory.isMySqlVersion56(dataStore);
+        boolean isMySQL56 = MySQLDataStoreFactory.isMySqlVersion56OrAbove(dataStore);
+        boolean isMySQL80 = MySQLDataStoreFactory.isMySqlVersion80OrAbove(dataStore);
         if (isMySQL56) {
+            assertTrue(((MySQLDialectBasic) dialect).getUsePreciseSpatialOps());
+        } else if (isMySQL80) {
             assertTrue(((MySQLDialectBasic) dialect).getUsePreciseSpatialOps());
         } else {
             assertFalse(((MySQLDialectBasic) dialect).getUsePreciseSpatialOps());

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreFactoryTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreFactoryTest.java
@@ -52,7 +52,7 @@ public class MySQLDataStoreFactoryTest extends TestCase {
         // actually exist. Test ensures that no NPE is thrown
         // from final block of method
         try {
-            factory.isMySqlVersion56(store);
+            factory.isMySqlVersion56OrAbove(store);
         } catch (NullPointerException e) {
             fail("an exception occured during checking of MySQL version " + e);
         }

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreManualEnhandedSpatialSupportTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreManualEnhandedSpatialSupportTest.java
@@ -42,7 +42,7 @@ public class MySQLDataStoreManualEnhandedSpatialSupportTest extends JDBCTestSupp
     public void testManualEnhancedSpatialSupportDetection() throws Exception {
         // ensure that if not version 5.6 or later then PreciseSpatialOps are
         // disabled
-        boolean isMySQL56 = MySQLDataStoreFactory.isMySqlVersion56(dataStore);
+        boolean isMySQL56 = MySQLDataStoreFactory.isMySqlVersion56OrAbove(dataStore);
         if (!isMySQL56) {
             assertFalse(((MySQLDialectBasic) dialect).getUsePreciseSpatialOps());
         }

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLEmptyTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLEmptyTestSetup.java
@@ -26,11 +26,12 @@ public class MySQLEmptyTestSetup extends JDBCEmptyTestSetup {
 
     @Override
     protected void createEmptyTable() throws Exception {
-        run("CREATE TABLE empty (id int, geom GEOMETRY) ");
+        // since v 8.0.4 EMPTY is a reserved keyword
+        run("CREATE TABLE `empty` (id int, geom GEOMETRY) ");
     }
 
     @Override
     protected void dropEmptyTable() throws Exception {
-        runSafe("DROP TABLE empty");
+        runSafe("DROP TABLE `empty`");
     }
 }

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLJoinTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLJoinTestSetup.java
@@ -38,19 +38,19 @@ public class MySQLJoinTestSetup extends JDBCJoinTestSetup {
         sb = new StringBuffer();
         sb.append("INSERT INTO ftjoin VALUES (")
                 .append(
-                        "0, 'zero', GeometryFromText('POLYGON ((-0.1 -0.1, -0.1 0.1, 0.1 0.1, 0.1 -0.1, -0.1 -0.1))',4326), 0);");
+                        "0, 'zero', ST_GeomFromText('POLYGON ((-0.1 -0.1, -0.1 0.1, 0.1 0.1, 0.1 -0.1, -0.1 -0.1))',4326), 0);");
         run(sb.toString());
 
         sb = new StringBuffer();
         sb.append("INSERT INTO ftjoin VALUES (")
                 .append(
-                        "1, 'one', GeometryFromText('POLYGON ((-1.1 -1.1, -1.1 1.1, 1.1 1.1, 1.1 -1.1, -1.1 -1.1))',4326), 1);");
+                        "1, 'one', ST_GeomFromText('POLYGON ((-1.1 -1.1, -1.1 1.1, 1.1 1.1, 1.1 -1.1, -1.1 -1.1))',4326), 1);");
         run(sb.toString());
 
         sb = new StringBuffer();
         sb.append("INSERT INTO ftjoin VALUES (")
                 .append(
-                        "2, 'two', GeometryFromText('POLYGON ((-10 -10, -10 10, 10 10, 10 -10, -10 -10))',4326), 2);");
+                        "2, 'two', ST_GeomFromText('POLYGON ((-10 -10, -10 10, 10 10, 10 -10, -10 -10))',4326), 2);");
         run(sb.toString());
 
         sb = new StringBuffer();

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLNoPrimaryKeyTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLNoPrimaryKeyTestSetup.java
@@ -29,7 +29,7 @@ public class MySQLNoPrimaryKeyTestSetup extends JDBCNoPrimaryKeyTestSetup {
 
         run(
                 "INSERT INTO lake (id,geom,name) VALUES ( 0,"
-                        + "GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
+                        + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
                         + "'muddy')");
     }
 

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLTestSetup.java
@@ -76,17 +76,17 @@ public class MySQLTestSetup extends JDBCTestSetup {
 
         sb = new StringBuffer();
         sb.append("INSERT INTO ft1 VALUES (")
-                .append("0,GeometryFromText('POINT(0 0)',4326), 0, 0.0,'zero');");
+                .append("0,ST_GeomFromText('POINT(0 0)',4326), 0, 0.0,'zero');");
         run(sb.toString());
 
         sb = new StringBuffer();
         sb.append("INSERT INTO ft1 VALUES (")
-                .append("1,GeometryFromText('POINT(1 1)',4326), 1, 1.1,'one');");
+                .append("1,ST_GeomFromText('POINT(1 1)',4326), 1, 1.1,'one');");
         run(sb.toString());
 
         sb = new StringBuffer();
         sb.append("INSERT INTO ft1 VALUES (")
-                .append("2,GeometryFromText('POINT(2 2)',4326), 2, 2.2,'two');");
+                .append("2,ST_GeomFromText('POINT(2 2)',4326), 2, 2.2,'two');");
         run(sb.toString());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1223,7 +1223,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>8.0.21</version>
+        <version>8.0.22</version>
       </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
backports #3191 to 24.x

Brings support for MySQL 8 (which now has some sort of Geography datatype)

- [GEOT-6690](https://osgeo-org.atlassian.net/browse/GEOT-6690) - support MySQL 8
- [GEOT-6692](https://osgeo-org.atlassian.net/browse/GEOT-6692) - upgrade driver
