### PR TITLE
[19.x backport] Coverage performance fixes GEOT-6408 GEOT-6411 backport

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverageWriter.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverageWriter.java
@@ -70,6 +70,8 @@ public abstract class AbstractGridCoverageWriter implements GridCoverageWriter {
                 } catch (Throwable e) {
 
                 }
+                outStream = null;
+                destination = null;
             }
         }
     }

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/ReadResolutionCalculator.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/ReadResolutionCalculator.java
@@ -77,7 +77,7 @@ public class ReadResolutionCalculator {
         // the reader might not know (e.g., wms cascading reader) in this case we
         // pick the classic computation results, it's better than nothing
         if (fullResolution == null) {
-            this.fullResolution = computeClassicResolution();
+            this.fullResolution = computeClassicResolution(requestedBBox);
             isFullResolutionInRequestedCRS = true;
         }
         CoordinateReferenceSystem requestedCRS =
@@ -117,7 +117,7 @@ public class ReadResolutionCalculator {
                     if (accurateResolution) {
                         return computeAccurateResolution(readBounds);
                     } else {
-                        return computeClassicResolution();
+                        return computeClassicResolution(readBounds);
                     }
                 } else {
                     // the crs of the request and the one of the coverage are the
@@ -153,14 +153,14 @@ public class ReadResolutionCalculator {
      *
      * @return
      */
-    private double[] computeClassicResolution() {
+    private double[] computeClassicResolution(ReferencedEnvelope readBounds) {
         final GridToEnvelopeMapper geMapper =
-                new GridToEnvelopeMapper(new GridEnvelope2D(requestedRasterArea), requestedBBox);
+                new GridToEnvelopeMapper(new GridEnvelope2D(requestedRasterArea), readBounds);
         final AffineTransform tempTransform = geMapper.createAffineTransform();
 
-        return new double[] {
-            XAffineTransform.getScaleX0(tempTransform), XAffineTransform.getScaleY0(tempTransform)
-        };
+        final double scaleX = XAffineTransform.getScaleX0(tempTransform);
+        final double scaleY = XAffineTransform.getScaleY0(tempTransform);
+        return new double[] {scaleX, scaleY};
     }
 
     /**

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageReaderHelper.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageReaderHelper.java
@@ -52,6 +52,7 @@ import org.geotools.util.logging.Logging;
 import org.opengis.geometry.BoundingBox;
 import org.opengis.geometry.MismatchedDimensionException;
 import org.opengis.parameter.GeneralParameterValue;
+import org.opengis.parameter.ParameterValue;
 import org.opengis.parameter.ParameterValueGroup;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -372,7 +373,8 @@ public class GridCoverageReaderHelper {
 
         GridGeometry2D gg = new GridGeometry2D(new GridEnvelope2D(mapRasterArea), mapExtent);
         GridGeometry2D readingGridGeometry =
-                computeReadingGeometry(gg, readerCRS, polygon, handler);
+                computeReadingGeometry(gg, readerCRS, polygon, handler, readParams);
+
         if (readingGridGeometry == null) {
             return null;
         }
@@ -464,7 +466,8 @@ public class GridCoverageReaderHelper {
             GridGeometry2D gg,
             CoordinateReferenceSystem readerCRS,
             Polygon polygon,
-            ProjectionHandler handler)
+            ProjectionHandler handler,
+            GeneralParameterValue[] readParams)
             throws TransformException, FactoryException, IOException {
         GridGeometry2D readingGridGeometry;
         MathTransform2D crsToGrid2D = gg.getCRSToGrid2D();
@@ -512,7 +515,25 @@ public class GridCoverageReaderHelper {
                             localGridGeometry,
                             readerCRS,
                             resolutionLevels != null ? resolutionLevels[0] : null);
-            calculator.setAccurateResolution(isAccurateResolutionComputationSafe(readEnvelope));
+            final String name = "Accurate resolution computation";
+            boolean accurateResolution = true;
+            if (readParams != null) {
+                for (GeneralParameterValue gParam : readParams) {
+                    if (gParam != null
+                            && name.equalsIgnoreCase(gParam.getDescriptor().getName().toString())) {
+                        if (gParam instanceof ParameterValue<?>) {
+                            final ParameterValue<?> param = (ParameterValue<?>) gParam;
+                            final Object value = param.getValue();
+                            if (value != null) {
+                                accurateResolution = (Boolean) value;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+            calculator.setAccurateResolution(
+                    accurateResolution && isAccurateResolutionComputationSafe(readEnvelope));
             double[] readResolution = calculator.computeRequestedResolution(reducedEnvelope);
             int width =
                     (int)


### PR DESCRIPTION
Backporting some fixes for 19.x and ensuring it builds

* GEOT-6408: Do not use AccurateResolutionComputation when disabled
* GEOT-6411, Have AbstractGridCoverageWriter release both output stream and destination on dispose()

I would like to keep this PR open for a bit to ensure everything builds and deploys for a 19.4.1 patch release.

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
