### PR TITLE
Couple of changes to improve rendering scalability (FontCache and DBaseFileHeader)

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/style/FontCache.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/FontCache.java
@@ -48,7 +48,7 @@ public class FontCache {
     static volatile FontCache defaultInstance;
 
     /** Set containing the font families known of this machine */
-    Set<String> systemFonts = new HashSet<String>();
+    volatile Set<String> systemFonts = new HashSet<>();
 
     /** Fonts already loaded */
     Map<String, Font> loadedFonts = new ConcurrentHashMap<>();
@@ -67,7 +67,7 @@ public class FontCache {
         return defaultInstance;
     }
 
-    public synchronized Font getFont(String requestedFont) {
+    public Font getFont(String requestedFont) {
         // see if the font has already been loaded
         java.awt.Font javaFont = null;
         if (LOGGER.isLoggable(Level.FINEST)) {

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileHeader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileHeader.java
@@ -63,7 +63,7 @@ public class DbaseFileHeader {
 
     private int largestFieldSize = 0;
 
-    private Logger logger = org.geotools.util.logging.Logging.getLogger(DbaseFileHeader.class);
+    private static final Logger LOGGER = org.geotools.util.logging.Logging.getLogger(DbaseFileHeader.class);
 
     /**
      * Returns the number of millis at January 1st 4713 BC
@@ -235,8 +235,8 @@ public class DbaseFileHeader {
         String fitFieldName = fitStringRegardingCharset(tempFieldName, 10);
         if (!tempFieldName.equals(fitFieldName)) {
             tempFieldName = fitFieldName;
-            if (logger.isLoggable(Level.WARNING)) {
-                logger.warning(
+            if (LOGGER.isLoggable(Level.WARNING)) {
+                LOGGER.warning(
                         "FieldName "
                                 + inFieldName
                                 + " is longer than 10 bytes in given charset, truncating to "
@@ -249,8 +249,8 @@ public class DbaseFileHeader {
         if ((inFieldType == 'C') || (inFieldType == 'c')) {
             tempFieldDescriptors[fields.length].fieldType = 'C';
             if (inFieldLength > 254) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
                             "Field Length for "
                                     + inFieldName
                                     + " set to "
@@ -260,15 +260,15 @@ public class DbaseFileHeader {
             }
         } else if ((inFieldType == 'S') || (inFieldType == 's')) {
             tempFieldDescriptors[fields.length].fieldType = 'C';
-            if (logger.isLoggable(Level.WARNING)) {
-                logger.warning(
+            if (LOGGER.isLoggable(Level.WARNING)) {
+                LOGGER.warning(
                         "Field type for "
                                 + inFieldName
                                 + " set to S which is flat out wrong people!, I am setting this to C, in the hopes you meant character.");
             }
             if (inFieldLength > 254) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
                             "Field Length for "
                                     + inFieldName
                                     + " set to "
@@ -280,8 +280,8 @@ public class DbaseFileHeader {
         } else if ((inFieldType == 'D') || (inFieldType == 'd')) {
             tempFieldDescriptors[fields.length].fieldType = 'D';
             if (inFieldLength != 8) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
                             "Field Length for "
                                     + inFieldName
                                     + " set to "
@@ -293,8 +293,8 @@ public class DbaseFileHeader {
         } else if (inFieldType == '@') {
             tempFieldDescriptors[fields.length].fieldType = '@';
             if (inFieldLength != 8) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
                             "Field Length for "
                                     + inFieldName
                                     + " set to "
@@ -307,8 +307,8 @@ public class DbaseFileHeader {
         } else if ((inFieldType == 'F') || (inFieldType == 'f')) {
             tempFieldDescriptors[fields.length].fieldType = 'F';
             if (inFieldLength > 20) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
                             "Field Length for "
                                     + inFieldName
                                     + " set to "
@@ -319,8 +319,8 @@ public class DbaseFileHeader {
         } else if ((inFieldType == 'N') || (inFieldType == 'n')) {
             tempFieldDescriptors[fields.length].fieldType = 'N';
             if (inFieldLength > 18) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
                             "Field Length for "
                                     + inFieldName
                                     + " set to "
@@ -329,8 +329,8 @@ public class DbaseFileHeader {
                 }
             }
             if (inDecimalCount < 0) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
                             "Field Decimal Position for "
                                     + inFieldName
                                     + " set to "
@@ -340,8 +340,8 @@ public class DbaseFileHeader {
                 tempFieldDescriptors[fields.length].decimalCount = 0;
             }
             if (inDecimalCount > inFieldLength - 1) {
-                if (logger.isLoggable(Level.WARNING)) {
-                    logger.warning(
+                if (LOGGER.isLoggable(Level.WARNING)) {
+                    LOGGER.warning(
                             "Field Decimal Position for "
                                     + inFieldName
                                     + " set to "
@@ -355,8 +355,8 @@ public class DbaseFileHeader {
         } else if ((inFieldType == 'L') || (inFieldType == 'l')) {
             tempFieldDescriptors[fields.length].fieldType = 'L';
             if (inFieldLength != 1) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
                             "Field Length for "
                                     + inFieldName
                                     + " set to "
@@ -405,7 +405,7 @@ public class DbaseFileHeader {
                 // if this is the last field and we still haven't found the
                 // named field
                 if (i == j && i == fields.length - 1) {
-                    logger.warning(
+                    LOGGER.warning(
                             "Could not find a field named '" + inFieldName + "' for removal");
                     return retCol;
                 }


### PR DESCRIPTION
One is a synchronization block that does not need to be synchronized anymore, the other is a wasteful allocation of a logger every time a dbase file is read. Two simple changes.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
