### PR TITLE
[GEOT-6746] PostPreProcessingFilter indexOutOfBoundsException

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitor.java
@@ -871,7 +871,7 @@ public class PostPreProcessFilterSplittingVisitor implements FilterVisitor, Expr
         int j = preStack.size();
 
         for (int k = 0; k < expression.getParameters().size(); k++) {
-            ((Expression) expression.getParameters().get(i)).accept(this, null);
+            ((Expression) expression.getParameters().get(k)).accept(this, null);
 
             if (i < postStack.size()) {
                 while (j < preStack.size()) preStack.pop();

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/PostPreProcessFilterSplittingVisitorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.function.FilterFunction_geometryType;
+import org.geotools.filter.function.JsonPointerFunction;
 import org.opengis.filter.And;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
@@ -400,5 +401,27 @@ public class PostPreProcessFilterSplittingVisitorTest
         or.accept(visitor, null);
         assertEquals(or, visitor.getFilterPre());
         assertEquals(Filter.INCLUDE, visitor.getFilterPost());
+    }
+
+    public void testIndexOutOfBoundExceptionNotHappensWithTwoInMemoryFilter() {
+        // test a bug doesn't occur when having in the filter a function
+        // with a number of parameters <= the number of filters in the post stack
+        FilterCapabilities caps = new FilterCapabilities();
+        PostPreProcessFilterSplittingVisitor visitor =
+                new PostPreProcessFilterSplittingVisitor(caps, null, null);
+        caps.addAll(FilterCapabilities.SIMPLE_COMPARISONS_OPENGIS);
+        caps.addType(JsonPointerFunction.class);
+        caps.addType(And.class);
+        Filter memoryOne = ff.crosses(null, null);
+        Filter memoryTwo = ff.crosses(null, null);
+        Filter otherFilter =
+                ff.equal(
+                        ff.function("jsonPointer", ff.literal("/pointer"), ff.property("property")),
+                        ff.literal("test"),
+                        false);
+        And and = ff.and(Arrays.asList(memoryOne, memoryTwo, otherFilter));
+        and.accept(visitor, null);
+        assertEquals(ff.and(Arrays.asList(memoryOne, memoryTwo)), visitor.getFilterPost());
+        assertEquals(otherFilter, visitor.getFilterPre());
     }
 }


### PR DESCRIPTION
Jira ticket https://osgeo-org.atlassian.net/browse/GEOT-6746
Fix a bug in PostPreProcessingFilter visitor caused by the usage of the wrong variable to retrieve Functions' parameters

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):
- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by travis-ci after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.
