### PR TITLE
[24.x backport][GEOT-6765] Update Batik libraries from 1.10 to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <git.commit.runOnlyOnce>true</git.commit.runOnlyOnce>
     <fmt.action>format</fmt.action>
     <fmt.skip>false</fmt.skip>
-    <batik.version>1.10</batik.version>
+    <batik.version>1.13</batik.version>
     <logging-profile>quiet-logging</logging-profile>
     <errorProneFlags></errorProneFlags>
     <errorProne.version>2.3.4</errorProne.version>


### PR DESCRIPTION
Batik has resolved CVE-2019-17566 (a SSRF vulnerability)

backports #3267 to 24.x, resolves resolves [GEOT-6765](https://osgeo-org.atlassian.net/browse/GEOT-6765) for 24.2