### PR TITLE
[24.x backport][GEOT-6766] Update sqlite-jdbc from 3.31.1 to 3.34.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1577,7 +1577,7 @@
       <dependency>
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
-        <version>3.31.1</version>
+        <version>3.34.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
The sqlite-jdbc team fixed a number of vulnerabilities in the native code parts (see https://github.com/xerial/sqlite-jdbc/issues/501) in version 3.32.3.
Also support for the new Apple Silicon (M1) was added in 3.32.3.3 as wel as some Arm Cortex improvements

see also: https://github.com/xerial/sqlite-jdbc/blob/master/README.md#news

backports #3268 to 24.x, resolves resolves [GEOT-6766](https://osgeo-org.atlassian.net/browse/GEOT-6766) for 24.2