### PR TITLE
[23.x backport][GEOT-6767] Update Jackson 2 libraries from 2.10.1 to 2.10.5 / 2.10.5.1

### DIFF
--- a/modules/unsupported/mbtiles/pom.xml
+++ b/modules/unsupported/mbtiles/pom.xml
@@ -89,12 +89,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson2.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson2.version}</version>
     </dependency>
     <dependency>
       <groupId>no.ecc.vectortile</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,8 @@
     <pmd.version>6.20.0</pmd.version>
     <checkstyle.skip>false</checkstyle.skip>
     <qa>false</qa>
-    <jackson2.version>2.10.1</jackson2.version>
+    <jackson2.version>2.10.5</jackson2.version>
+    <jackson2.databind.version>2.10.5.1</jackson2.databind.version>
     <lint>deprecation</lint>
   </properties>
 
@@ -1623,7 +1624,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson2.version}</version>
+        <version>${jackson2.databind.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
In the Jackson project the following CVE-2020-25649 was fixed, as well as various other bugfixes.

backports #3266 to resolve [GEOT-6767](https://osgeo-org.atlassian.net/browse/GEOT-6767) for 23.5