### PR TITLE
[GEOT-6789]:limit read resolution on oversampling factor

### DIFF
--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/io/ReadResolutionCalculatorTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/io/ReadResolutionCalculatorTest.java
@@ -93,8 +93,8 @@ public class ReadResolutionCalculatorTest {
         calcDefault.setAccurateResolution(true);
         double[] resolutionsDefault = calcDefault.computeRequestedResolution(readBounds);
         // due to high stretch this far up north, should be using almost the native resolution
-        assertEquals(0.0331, resolutionsDefault[0], 1e-4);
-        assertEquals(0.0331, resolutionsDefault[1], 1e-4);
+        assertEquals(0.0333, resolutionsDefault[0], 1e-4);
+        assertEquals(0.0333, resolutionsDefault[1], 1e-4);
 
         // limit oversampling factor and try again
         ReadResolutionCalculator calcLimited =
@@ -105,5 +105,34 @@ public class ReadResolutionCalculatorTest {
         // this time it should be limited to oversampling 10 times the native resolution
         assertEquals(0.1, resolutionsLimited[0], 1e-4);
         assertEquals(0.1, resolutionsLimited[1], 1e-4);
+    }
+
+    @Test
+    public void testOversamplingLimitOnReprojection() throws Exception {
+        final CoordinateReferenceSystem requestCRS = CRS.decode("EPSG:3395", true);
+        final CoordinateReferenceSystem nativeCRS = CRS.decode("EPSG:4326", true);
+        final ReferencedEnvelope requestBounds =
+                new ReferencedEnvelope(-30000000, 30000000, -20000000, 20000000, requestCRS);
+        GridGeometry2D gg = new GridGeometry2D(new GridEnvelope2D(0, 0, 768, 512), requestBounds);
+        ReferencedEnvelope readBounds = requestBounds.transform(nativeCRS, true);
+
+        // calculation with high oversampling, but not above the default limits
+        ReadResolutionCalculator calcDefault =
+                new ReadResolutionCalculator(gg, nativeCRS, new double[] {8.6E-5, 8.6E-5});
+        calcDefault.setAccurateResolution(true);
+        double[] resolutionsDefault = calcDefault.computeRequestedResolution(readBounds);
+
+        assertEquals(0.06086, resolutionsDefault[0], 1e-4);
+        assertEquals(0.06086, resolutionsDefault[1], 1e-4);
+
+        // limit oversampling factor and try again
+        ReadResolutionCalculator calcLimited =
+                new ReadResolutionCalculator(gg, nativeCRS, new double[] {8.6E-5, 8.6E-5});
+        calcLimited.setAccurateResolution(true);
+        calcLimited.setMaxOversamplingFactor(3);
+        double[] resolutionsLimited = calcLimited.computeRequestedResolution(readBounds);
+        // this time it should be limited to oversampling 3 times the classic resolution
+        assertEquals(0.23, resolutionsLimited[0], 1e-2);
+        assertEquals(0.11, resolutionsLimited[1], 1e-2);
     }
 }


### PR DESCRIPTION
Support the max oversampling factor on read resolution computation.

# Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.
