### PR TITLE
Fix accidental exceptions on shapefile locking while running tests

### DIFF
--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/shp/ZMHandlersTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/shp/ZMHandlersTest.java
@@ -57,6 +57,7 @@ public class ZMHandlersTest {
         assertEquals("wrong y", 5, geom.getCoordinate().getY(), 0.00001);
         assertEquals("wrong z", 1, geom.getCoordinate().getZ(), 0.00001);
         assertEquals("wrong m", 20, geom.getCoordinate().getM(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -69,6 +70,7 @@ public class ZMHandlersTest {
         assertEquals("wrong y", 5, geom.getCoordinate().getY(), 0.00001);
 
         assertEquals("wrong m", 20, geom.getCoordinate().getM(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -85,6 +87,7 @@ public class ZMHandlersTest {
                 assertNotNull(f.getDefaultGeometry());
             }
         }
+        store.dispose();
     }
 
     @Test
@@ -99,6 +102,7 @@ public class ZMHandlersTest {
         assertEquals("wrong y", 924.8555, coordinate.getY(), 0.001);
         assertEquals("wrong z", 20, coordinate.getZ(), 0.00001);
         assertEquals("wrong m", 10, coordinate.getM(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -113,6 +117,7 @@ public class ZMHandlersTest {
         assertEquals("wrong x", 24.54682976316134, coordinate.getX(), 0d);
         assertEquals("wrong y", 60.81447758588624, coordinate.getY(), 0d);
         assertEquals("wrong z", 0d, coordinate.getZ(), 0d);
+        store.dispose();
     }
 
     @Test
@@ -126,6 +131,7 @@ public class ZMHandlersTest {
         assertEquals("wrong x", 1208.5983, coordinate.getX(), 0.001);
         assertEquals("wrong y", 924.8555, coordinate.getY(), 0.001);
         assertEquals("wrong m", 10, coordinate.getM(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -141,6 +147,7 @@ public class ZMHandlersTest {
         assertEquals("wrong y", 909.9963, coordinate.getY(), 0.001);
         assertEquals("wrong z", 20, coordinate.getZ(), 0.00001);
         assertEquals("wrong m", 10, coordinate.getM(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -154,6 +161,7 @@ public class ZMHandlersTest {
         assertEquals("wrong x", 589.4648, coordinate.getX(), 0.001);
         assertEquals("wrong y", 909.9963, coordinate.getY(), 0.001);
         assertEquals("wrong m", 10, coordinate.getM(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -167,6 +175,7 @@ public class ZMHandlersTest {
         assertEquals("wrong x", 340d, coordinate.getX(), 0.001);
         assertEquals("wrong y", 377d, coordinate.getY(), 0.001);
         assertEquals("wrong z", 3d, coordinate.getZ(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -230,6 +239,7 @@ public class ZMHandlersTest {
         //                System.out.println(f.getDefaultGeometryProperty());
         //            }
         //        }
+        store.dispose();
     }
 
     /**
@@ -241,16 +251,20 @@ public class ZMHandlersTest {
         int numFeatures = 0;
         URL url = TestData.url(ShapefileDataStore.class, filename);
         ShapefileDataStore store = new ShapefileDataStore(url);
-        Query q = new Query(store.getTypeNames()[0]);
-        q.getHints().put(Hints.FEATURE_2D, Boolean.TRUE);
-        try (FeatureReader<SimpleFeatureType, SimpleFeature> reader =
-                store.getFeatureReader(q, Transaction.AUTO_COMMIT)) {
-            while (reader.hasNext()) {
-                SimpleFeature f = reader.next();
-                assertNotNull(f.getDefaultGeometry());
-                numFeatures++;
+        try {
+            Query q = new Query(store.getTypeNames()[0]);
+            q.getHints().put(Hints.FEATURE_2D, Boolean.TRUE);
+            try (FeatureReader<SimpleFeatureType, SimpleFeature> reader =
+                    store.getFeatureReader(q, Transaction.AUTO_COMMIT)) {
+                while (reader.hasNext()) {
+                    SimpleFeature f = reader.next();
+                    assertNotNull(f.getDefaultGeometry());
+                    numFeatures++;
+                }
+                return numFeatures;
             }
-            return numFeatures;
+        } finally {
+            store.dispose();
         }
     }
 
@@ -284,15 +298,19 @@ public class ZMHandlersTest {
         int numFeatures = 0;
         URL url = TestData.url(ShapefileDataStore.class, filename);
         ShapefileDataStore store = new ShapefileDataStore(url);
-        Query q = new Query(store.getTypeNames()[0]);
-        try (FeatureReader<SimpleFeatureType, SimpleFeature> reader =
-                store.getFeatureReader(q, Transaction.AUTO_COMMIT)) {
-            while (reader.hasNext()) {
-                SimpleFeature f = reader.next();
-                assertNotNull(f.getDefaultGeometry());
-                numFeatures++;
+        try {
+            Query q = new Query(store.getTypeNames()[0]);
+            try (FeatureReader<SimpleFeatureType, SimpleFeature> reader =
+                    store.getFeatureReader(q, Transaction.AUTO_COMMIT)) {
+                while (reader.hasNext()) {
+                    SimpleFeature f = reader.next();
+                    assertNotNull(f.getDefaultGeometry());
+                    numFeatures++;
+                }
+                return numFeatures;
             }
-            return numFeatures;
+        } finally {
+            store.dispose();
         }
     }
 
@@ -356,6 +374,7 @@ public class ZMHandlersTest {
         assertEquals("wrong y", 653.67509, coordinate.getY(), 0.001);
         assertEquals("wrong z", 20, coordinate.getZ(), 0.00001);
         assertEquals("wrong m", 10, coordinate.getM(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -369,6 +388,7 @@ public class ZMHandlersTest {
         assertEquals("wrong x", 96.944404, coordinate.getX(), 0.001);
         assertEquals("wrong y", 653.67509, coordinate.getY(), 0.001);
         assertEquals("wrong m", 10, coordinate.getM(), 0.00001);
+        store.dispose();
     }
 
     @Test
@@ -383,6 +403,7 @@ public class ZMHandlersTest {
         assertEquals("wrong x", 665d, coordinate.getX(), 0.001);
         assertEquals("wrong y", 294d, coordinate.getY(), 0.001);
         assertEquals("wrong z", 1d, coordinate.getZ(), 0.00001);
+        store.dispose();
     }
 
     /**
@@ -438,6 +459,7 @@ public class ZMHandlersTest {
             e.printStackTrace();
             fail();
         }
+        store.dispose();
     }
 
     @Test
@@ -455,5 +477,6 @@ public class ZMHandlersTest {
                 assertNotNull(f.getDefaultGeometry());
             }
         }
+        store.dispose();
     }
 }


### PR DESCRIPTION
This is small change that should fix annoing exceptions which show up occasionally while running tests on shapefile plugin. The PR does nothing more than dispose the shapefile store after test.

Typical exception looks like the following after running `mvn -pl modules/plugin/shapefile clean test`:

```
[INFO] Running org.geotools.data.shapefile.shp.ZMHandlersTest
java.lang.IllegalArgumentException: Expected requestor org.geotools.data.shapefile.dbf.DbaseFileReader@cb4df892 to have locked the url but it does not hold the lock for the URL
```

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.
