### PR TITLE
[GEOT-6829] Remove dependency on xpp3, use standard StAX API

### DIFF
--- a/modules/extension/app-schema/app-schema/pom.xml
+++ b/modules/extension/app-schema/app-schema/pom.xml
@@ -123,10 +123,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_min</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.geotools.ogc</groupId>
             <artifactId>net.opengis.wfs</artifactId>
             <version>${project.version}</version>

--- a/modules/extension/complex/pom.xml
+++ b/modules/extension/complex/pom.xml
@@ -29,12 +29,6 @@
         </dependency>
 	
 	 <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_min</artifactId>
-	  </dependency>
-	  
-	  
-	 <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
             <version>${project.version}</version>

--- a/modules/extension/complex/src/main/java/org/geotools/data/complex/util/EmfComplexFeatureReader.java
+++ b/modules/extension/complex/src/main/java/org/geotools/data/complex/util/EmfComplexFeatureReader.java
@@ -16,9 +16,14 @@
  */
 package org.geotools.data.complex.util;
 
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import org.geotools.appschema.resolver.xml.AppSchemaConfiguration;
 import org.geotools.xml.resolver.SchemaCatalog;
 import org.geotools.xml.resolver.SchemaResolver;
@@ -28,9 +33,6 @@ import org.geotools.xsd.SchemaIndex;
 import org.geotools.xsd.Schemas;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.AttributeType;
-import org.xmlpull.mxp1.MXParser;
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
 
 /**
  * Parses an application schema given by a gtxml {@link Configuration} into a set of {@link
@@ -128,22 +130,27 @@ public class EmfComplexFeatureReader {
         // create stream parser
 
         try (InputStream input = resolvedLocation.openStream()) {
-            // parse root element
-            XmlPullParser parser = new MXParser();
-            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
-            parser.setInput(input, "UTF-8");
-            parser.nextTag();
+            XMLInputFactory factory = XMLInputFactory.newFactory();
+            // disable DTDs
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            // disable external entities
+            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            XMLStreamReader parser = factory.createXMLStreamReader(input, "UTF-8");
+            // position at root element
+            while (parser.hasNext()) {
+                if (START_ELEMENT == parser.next()) {
+                    break;
+                }
+            }
 
             // look for schema location
             for (int i = 0; i < parser.getAttributeCount(); i++) {
-                if ("targetNamespace".equals(parser.getAttributeName(i))) {
+                if ("targetNamespace".equals(parser.getAttributeLocalName(i))) {
                     targetNamespace = parser.getAttributeValue(i);
                     break;
                 }
             }
-            // reset input stream
-            parser.setInput(null);
-        } catch (XmlPullParserException e) {
+        } catch (XMLStreamException e) {
             String msg = "Cannot find target namespace for schema document " + resolvedLocation;
             throw (RuntimeException) new RuntimeException(msg).initCause(e);
         }

--- a/modules/unsupported/wfs-ng/pom.xml
+++ b/modules/unsupported/wfs-ng/pom.xml
@@ -154,10 +154,6 @@
       <type>jar</type>
     </dependency>
     <dependency>
-      <groupId>xpp3</groupId>
-      <artifactId>xpp3_min</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-epsg-hsql</artifactId>
       <version>${project.version}</version>

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/v1_1/XXEProtectionTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/v1_1/XXEProtectionTest.java
@@ -79,12 +79,10 @@ public class XXEProtectionTest {
         try {
             DataUtilities.first(fs.getFeatures());
         } catch (Exception e) {
-            // custom check as MXParser does not use the EntityResolver, does not offer a way to
-            // configure it
+            // custom check, the XMLInputFactory shall have external entities disabled
             final String msg = e.getMessage();
             assertNotNull(msg);
-            assertTrue(msg.contains("could not resolve entity"));
-            assertTrue(msg.contains("xxe"));
+            assertTrue(msg.contains("The entity \"xxe\" was referenced, but not declared"));
         }
     }
 

--- a/modules/unsupported/wps/pom.xml
+++ b/modules/unsupported/wps/pom.xml
@@ -107,10 +107,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-       <groupId>xpp3</groupId>
-       <artifactId>xpp3_min</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geotools</groupId>
 			<artifactId>gt-xml</artifactId>
 			<version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1283,16 +1283,6 @@
         <artifactId>velocity</artifactId>
         <version>1.4</version>
       </dependency>
-     <dependency>
-       <groupId>xpp3</groupId>
-       <artifactId>xpp3</artifactId>
-       <version>1.1.3.4.O</version>
-     </dependency>
-     <dependency>
-       <groupId>xpp3</groupId>
-       <artifactId>xpp3_min</artifactId>
-       <version>1.1.4c</version>
-     </dependency>
 
       <!-- Databases -->
       <dependency>


### PR DESCRIPTION
Remove dependency on xpp3 and use the standard StAX API instead.

[xpp3](https://mvnrepository.com/artifact/xpp3/xpp3) is an XML pull parser. Last released version is 14 years old. The
JRE comes with a standard StAX pull parser since Java 1.6.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/master/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.
