### PR TITLE
[25.x backport][GEOT-6839] Update Batik from 1.13 to 1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <git.commit.runOnlyOnce>true</git.commit.runOnlyOnce>
     <fmt.action>format</fmt.action>
     <fmt.skip>false</fmt.skip>
-    <batik.version>1.13</batik.version>
+    <batik.version>1.14</batik.version>
     <logging-profile>quiet-logging</logging-profile>
     <errorProneFlags></errorProneFlags>
     <errorProne.version>2.3.4</errorProne.version>


### PR DESCRIPTION
Batik has resolved CVE-2020-11987
As a result of this upgrade xmlgraphics-commons will also be upgraded (from 2.4 to 2.6), resolving CVE-2020-11988

resolves [GEOT-6839](https://osgeo-org.atlassian.net/browse/GEOT-6839)

backports #3396 
