### PR TITLE
[GEOT-6854] AppSchema JDBCMultipleValue directive fails to encode ClientProperties if targetValue is not specified - [GEOT-6855] AppSchema JDBCMultipleValue might generate ambiguous query when ClientProperty is defined

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
@@ -1063,9 +1063,9 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
                             query.getRootMapping(), typeName, getDataStore(), topIds);
                     // apply filter
                     if (filter != null) {
-                        filterToSQL.setFieldEncoder(
-                                new JoiningFieldEncoder(typeName, getDataStore()));
                         if (NestedFilterToSQL.isNestedFilter(filter)) {
+                            filterToSQL.setFieldEncoder(
+                                    new JoiningFieldEncoder(typeName, getDataStore()));
                             topIds.append(" WHERE ")
                                     .append(createNestedFilter(filter, query, filterToSQL));
                         } else {

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
@@ -55,6 +55,7 @@ import org.geotools.jdbc.JDBCFeatureReader;
 import org.geotools.jdbc.JDBCFeatureSource;
 import org.geotools.jdbc.JDBCFeatureStore;
 import org.geotools.jdbc.JoinInfo.JoinQualifier;
+import org.geotools.jdbc.JoinPropertyName;
 import org.geotools.jdbc.PreparedFilterToSQL;
 import org.geotools.jdbc.PreparedStatementSQLDialect;
 import org.geotools.jdbc.PrimaryKey;
@@ -69,6 +70,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.filter.Filter;
+import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
 
@@ -1140,7 +1142,22 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
             split[1] = splitter.getFilterPost();
         }
 
-        SimplifyingFilterVisitor visitor = new SimplifyingFilterVisitor();
+        SimplifyingFilterVisitor visitor =
+                new SimplifyingFilterVisitor() {
+
+                    @Override
+                    public Object visit(PropertyName propertyName, Object extraData) {
+                        // preserve the JoinPropertyName
+                        if (propertyName instanceof JoinPropertyName) {
+                            JoinPropertyName joinPropertyName = (JoinPropertyName) propertyName;
+                            return new JoinPropertyName(
+                                    joinPropertyName.getFeatureType(),
+                                    joinPropertyName.getAlias(),
+                                    joinPropertyName.getPropertyName());
+                        }
+                        return super.visit(propertyName, extraData);
+                    }
+                };
         visitor.setFIDValidator(new PrimaryKeyFIDValidator(this));
         split[0] = (Filter) split[0].accept(visitor, null);
         split[1] = (Filter) split[1].accept(visitor, null);

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/DataAccessMappingFeatureIterator.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/DataAccessMappingFeatureIterator.java
@@ -1579,10 +1579,6 @@ public class DataAccessMappingFeatureIterator extends AbstractMappingFeatureIter
 
             Collection collection = (Collection) property.getValue();
 
-            if (this.getClientProperties(property).containsKey(XLINK_HREF_NAME)) {
-                return true;
-            }
-
             List<Property> values = new ArrayList<>();
             for (Object o : collection) {
                 if (o instanceof Property) {
@@ -1602,6 +1598,9 @@ public class DataAccessMappingFeatureIterator extends AbstractMappingFeatureIter
                 }
             }
             property.setValue(values);
+            if (this.getClientProperties(property).containsKey(XLINK_HREF_NAME)) {
+                return true;
+            }
         } else if (property.getName().equals(ComplexFeatureConstants.FEATURE_CHAINING_LINK_NAME)) {
             // ignore fake attribute FEATURE_LINK
             result = false;


### PR DESCRIPTION
This pr fixes two bugs linked with the usage of a JDBCMultipleValue directive in an AppSchema AttributeMapping:
1. ClientProperty name with xlink:href not encoded when targetValue is left void;
2. ambiguous sql statement when ClientProperty is placed after JDBCMultipleValue and is mapped to a column name equal to the column name of a different table. 
Jira tickets
https://osgeo-org.atlassian.net/browse/GEOT-6854
https://osgeo-org.atlassian.net/browse/GEOT-6855


Related gs pr with integration tests here https://github.com/geoserver/geoserver/pull/4910


# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.
