### PR TITLE
[24.x backport][GEOT-6848] Vendor options in RasterSymbolizer are not parsed (#3404)

### DIFF
--- a/modules/extension/xsd/xsd-sld/src/main/java/org/geotools/sld/bindings/SLDRasterSymbolizerBinding.java
+++ b/modules/extension/xsd/xsd-sld/src/main/java/org/geotools/sld/bindings/SLDRasterSymbolizerBinding.java
@@ -16,7 +16,9 @@
  */
 package org.geotools.sld.bindings;
 
+import java.util.List;
 import javax.xml.namespace.QName;
+import org.geotools.sld.CssParameter;
 import org.geotools.styling.ChannelSelection;
 import org.geotools.styling.ColorMap;
 import org.geotools.styling.ContrastEnhancement;
@@ -167,6 +169,12 @@ public class SLDRasterSymbolizerBinding extends AbstractComplexBinding {
         if (node.hasChild("ImageOutline")) {
             ImageOutline imageOutput = (ImageOutline) node.getChildValue("ImageOutline");
             rs.setImageOutline(imageOutput.getSymbolizer());
+        }
+
+        // &lt;xsd:element ref="sld:VendorOption" minOccurs="0" maxOccurs="unbounded"/&gt;
+        for (CssParameter param : (List<CssParameter>) node.getChildValues(CssParameter.class)) {
+            rs.getOptions()
+                    .put(param.getName(), param.getExpression().evaluate(null, String.class));
         }
 
         return rs;

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/bindings/SLDMockData.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/bindings/SLDMockData.java
@@ -317,7 +317,13 @@ public class SLDMockData {
         contrastEnhancement(document, rasterSymbolizer);
         shadedRelief(document, rasterSymbolizer);
         imageOutline(document, rasterSymbolizer);
+        return rasterSymbolizer;
+    }
 
+    static Element rasterSymbolizerWithVendorOptions(Document document, Node parent) {
+        Element rasterSymbolizer = rasterSymbolizer(document, parent);
+        vendorOption(document, rasterSymbolizer, "name", "value");
+        vendorOption(document, rasterSymbolizer, "name2", "value2");
         return rasterSymbolizer;
     }
 

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/bindings/SLDRasterSymbolizerBindingTest.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/bindings/SLDRasterSymbolizerBindingTest.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.sld.bindings;
 
+import java.util.Map;
 import org.geotools.styling.RasterSymbolizer;
 
 public class SLDRasterSymbolizerBindingTest extends SLDTestSupport {
@@ -36,5 +37,24 @@ public class SLDRasterSymbolizerBindingTest extends SLDTestSupport {
         assertNotNull(rs.getOverlap());
         assertNotNull(rs.getGeometryPropertyName());
         assertNotNull(rs.getShadedRelief());
+    }
+
+    public void testWithVendorOptions() throws Exception {
+        SLDMockData.rasterSymbolizerWithVendorOptions(document, document);
+
+        RasterSymbolizer rs = (RasterSymbolizer) parse();
+        assertNotNull(rs);
+        assertNotNull(rs.getChannelSelection());
+        assertNotNull(rs.getColorMap());
+        assertNotNull(rs.getContrastEnhancement());
+        assertNotNull(rs.getImageOutline());
+        assertNotNull(rs.getOpacity());
+        assertNotNull(rs.getOverlap());
+        assertNotNull(rs.getGeometryPropertyName());
+        assertNotNull(rs.getShadedRelief());
+        Map<String, String> options = rs.getOptions();
+        assertEquals(2, options.size());
+        assertEquals("value", options.get("name"));
+        assertEquals("value2", options.get("name2"));
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -1316,6 +1316,8 @@ public class SLDParser {
                 symbol.setShadedRelief(parseShadedRelief(child));
             } else if (childName.equalsIgnoreCase(imageOutlineString)) {
                 symbol.setImageOutline(parseLineSymbolizer(child));
+            } else if (childName.equalsIgnoreCase(VendorOptionString)) {
+                parseVendorOption(symbol.getOptions(), child);
             }
         }
 

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -41,6 +41,7 @@ import org.geotools.styling.ExternalGraphic;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.Mark;
 import org.geotools.styling.PointSymbolizer;
+import org.geotools.styling.RasterSymbolizer;
 import org.geotools.styling.ResourceLocator;
 import org.geotools.styling.Rule;
 import org.geotools.styling.Stroke;
@@ -370,6 +371,34 @@ public class SLDParserTest {
                     + "					   <VendorOption name=\"NullVendor\"/>  \n"
                     + "					   <VendorOption name=\"OkVendor\">TEST_OK</VendorOption>  \n"
                     + "                </PointSymbolizer>\n"
+                    + "            </Rule>\n"
+                    + "        </FeatureTypeStyle>\n"
+                    + "    </UserStyle>\n"
+                    + "</StyledLayerDescriptor>";
+
+    static String SLD_RASTER_SYMBOLIZER_WITH_VENDOR_OPTIONS =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                    + "<StyledLayerDescriptor version=\"1.0.0\" \n"
+                    + "        xsi:schemaLocation=\"http://www.opengis.net/sld StyledLayerDescriptor.xsd\" \n"
+                    + "        xmlns=\"http://www.opengis.net/sld\" xmlns:ogc=\"http://www.opengis.net/ogc\" \n"
+                    + "        xmlns:xlink=\"http://www.w3.org/1999/xlink\" \n"
+                    + "        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n"
+                    + "    <UserStyle>\n"
+                    + "        <Name>Default Styler</Name>\n"
+                    + "        <Title>Default Styler</Title>\n"
+                    + "        <Abstract></Abstract>\n"
+                    + "        <FeatureTypeStyle>\n"
+                    + "            <Rule>\n"
+                    + "                <RasterSymbolizer>\n"
+                    + "                    <ColorMap>\n"
+                    + "                     <ColorMapEntry color=\"#FF0000\" quantity=\"0\" />\n"
+                    + "                     <ColorMapEntry color=\"#FFFFFF\" quantity=\"100\"/>\n"
+                    + "                     <ColorMapEntry color=\"#00FF00\" quantity=\"2000\"/>\n"
+                    + "                     <ColorMapEntry color=\"#0000FF\" quantity=\"5000\"/>\n"
+                    + "                    </ColorMap>\n"
+                    + "					   <VendorOption name=\"FirstVendorOption\">FIRST_VENDOR_OPTION</VendorOption>\n"
+                    + "					   <VendorOption name=\"SecondVendorOption\">SECOND_VENDOR_OPTION</VendorOption>\n"
+                    + "                </RasterSymbolizer>\n"
                     + "            </Rule>\n"
                     + "        </FeatureTypeStyle>\n"
                     + "    </UserStyle>\n"
@@ -796,6 +825,26 @@ public class SLDParserTest {
 
         assertEquals(1, ps.getOptions().size());
         assertTrue(ps.getOptions().containsKey(OK_KEY));
+    }
+
+    @Test
+    public void testVendorOptionsInRasterSymbolizer() throws Exception {
+        // tests that VendorOptions placed under a RasterSymbolizer
+        // are correctly parsed
+        SLDParser parser =
+                new SLDParser(styleFactory, input(SLD_RASTER_SYMBOLIZER_WITH_VENDOR_OPTIONS));
+        Style[] styles = parser.readXML();
+        List<FeatureTypeStyle> fts = styles[0].featureTypeStyles();
+        List<Rule> rules = fts.get(0).rules();
+        List<Symbolizer> symbolizers = rules.get(0).symbolizers();
+
+        RasterSymbolizer ps = (RasterSymbolizer) symbolizers.get(0);
+
+        assertEquals(2, ps.getOptions().size());
+        assertTrue(ps.getOptions().containsKey("FirstVendorOption"));
+        assertTrue(ps.getOptions().containsKey("SecondVendorOption"));
+        assertEquals("FIRST_VENDOR_OPTION", ps.getOptions().get("FirstVendorOption"));
+        assertEquals("SECOND_VENDOR_OPTION", ps.getOptions().get("SecondVendorOption"));
     }
 
     void assertStyles(Style[] styles) {


### PR DESCRIPTION
Jira ticket https://osgeo-org.atlassian.net/browse/GEOT-6848

* [GEOT-6848] Vendor options in RasterSymbolizer are not parsed

* review feedback applied

<Include a few sentences describing the overall goals for this Pull Request>

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.
