### PR TITLE
GeoPkg: use correct value for constraint_type when writing a range constraint

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgSchemaExtension.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgSchemaExtension.java
@@ -269,7 +269,7 @@ public class GeoPkgSchemaExtension extends GeoPkgExtension {
             NumberRange range = rangeConstraint.getRange();
             try (PreparedStatement ps = cx.prepareStatement(sql)) {
                 ps.setString(1, constraintName);
-                ps.setString(2, "glob");
+                ps.setString(2, "range");
                 ps.setString(3, null);
                 ps.setDouble(4, range.getMinimum());
                 ps.setBoolean(5, range.isMinIncluded());


### PR DESCRIPTION
Writing a range constraint currently wrongly uses the 'glob' constraint_type. Found only by code review when cross-checking with new GDAL capabilities in https://github.com/OSGeo/gdal/pull/3638 . It doesn't look Geotools has unit test for range constraints currently (and sorry that would be a bit of my scope to write one :-))

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [ ] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.