### PR TITLE
[25.x backport][GEOT-6717] IndexOutOfBoundsException at CapabilitiesFilterSplitter.visit(Function,...)

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/CapabilitiesFilterSplitter.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/CapabilitiesFilterSplitter.java
@@ -905,33 +905,36 @@ public class CapabilitiesFilterSplitter implements FilterVisitor, ExpressionVisi
     }
 
     /** @see org.geotools.filter.FilterVisitor#visit(org.geotools.filter.FunctionExpression) */
-    public Object visit(Function expression, Object notUsed) {
-        if (!fcs.fullySupports(expression)) {
-            postStack.push(expression);
+    public Object visit(Function function, Object notUsed) {
+        if (!fcs.fullySupports(function)) {
+            postStack.push(function);
             return null;
         }
 
-        if (expression.getName() == null) {
-            postStack.push(expression);
+        if (function.getName() == null) {
+            postStack.push(function);
             return null;
         }
 
-        int i = postStack.size();
-        int j = preStack.size();
+        final int postSize = postStack.size();
+        final int preSize = preStack.size();
 
-        for (int k = 0; k < expression.getParameters().size(); k++) {
-            expression.getParameters().get(i).accept(this, null);
+        final List<Expression> parameters = function.getParameters();
+        for (Expression param : parameters) {
+            param.accept(this, null);
 
-            if (i < postStack.size()) {
-                while (j < preStack.size()) preStack.pop();
+            if (postSize < postStack.size()) {
+                while (preSize < preStack.size()) {
+                    preStack.pop();
+                }
                 postStack.pop();
-                postStack.push(expression);
+                postStack.push(function);
 
                 return null;
             }
         }
-        while (j < preStack.size()) preStack.pop();
-        preStack.push(expression);
+        while (preSize < preStack.size()) preStack.pop();
+        preStack.push(function);
         return null;
     }
 

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/CapabilitiesFilterSplitterFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/CapabilitiesFilterSplitterFunctionTest.java
@@ -17,10 +17,14 @@
 package org.geotools.filter.visitor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.opengis.filter.Filter.EXCLUDE;
+import static org.opengis.filter.Filter.INCLUDE;
 
 import java.util.Arrays;
 import org.geotools.filter.Capabilities;
 import org.geotools.filter.function.math.FilterFunction_abs;
+import org.geotools.filter.function.math.FilterFunction_max;
 import org.junit.Test;
 import org.opengis.filter.Filter;
 import org.opengis.filter.PropertyIsEqualTo;
@@ -89,5 +93,29 @@ public class CapabilitiesFilterSplitterFunctionTest
 
         assertEquals(filter1, visitor.getFilterPre());
         assertEquals(filter2, visitor.getFilterPost());
+    }
+
+    @Test
+    public void testFunctionParameters() throws Exception {
+
+        FilterFunction_max filterFunction_max = new FilterFunction_max();
+        filterFunction_max.setParameters(Arrays.asList(ff.property("name"), ff.literal(1.0)));
+        PropertyIsEqualTo filter1 = ff.equals(ff.property("name"), filterFunction_max);
+
+        Capabilities filterCapabilitiesMask = new Capabilities();
+        filterCapabilitiesMask.addAll(Capabilities.SIMPLE_COMPARISONS_OPENGIS);
+        filterCapabilitiesMask.addAll(Capabilities.LOGICAL_OPENGIS);
+        filterCapabilitiesMask.addName(filterFunction_max.getName());
+        visitor = newVisitor(filterCapabilitiesMask);
+
+        // pre-flight to ensure post stack size is bigger than params size at visit(Function,...)
+        assertFalse(filterCapabilitiesMask.supports(Filter.EXCLUDE));
+        // Produces "IndexOutOfBoundsException: Index: 3, Size: 2" as of GEOT-6717
+        Filter filter = ff.or(Arrays.asList(EXCLUDE, EXCLUDE, EXCLUDE, filter1));
+
+        filter.accept(visitor, null);
+
+        assertEquals(INCLUDE, visitor.getFilterPre());
+        assertEquals(filter, visitor.getFilterPost());
     }
 }


### PR DESCRIPTION
Backport of #3444 to `25.x`.

Fix for an `IndexOutOfBoundsException` thrown at
`CapabilitiesFilterSplitter.visit(Function,...)` when the post-stack
size is bigger than the number of function arguments.

---

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [ ] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.
