### PR TITLE
[25.x backport] [GEOT-6874] Add support for count distinct aggregations in gt-jdbc

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -71,6 +71,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.visitor.CountVisitor;
 import org.geotools.feature.visitor.GroupByVisitor;
 import org.geotools.feature.visitor.LimitingVisitor;
+import org.geotools.feature.visitor.UniqueCountVisitor;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.JoinInfo.JoinPart;
@@ -3977,10 +3978,11 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
         } else if (queryLimitOffset) {
             applyLimitOffset(sql, query.getStartIndex(), query.getMaxFeatures());
         }
-
+        boolean isUniqueCount = visitor instanceof UniqueCountVisitor;
         // if the limits were in query or there is a group by with complex expressions
+        // or there is a UniqueCountVisitor
         // we need to roll what was built so far in a sub-query
-        if (queryLimitOffset || groupByComplexExpressions) {
+        if (queryLimitOffset || groupByComplexExpressions || isUniqueCount) {
             StringBuffer sql2 = new StringBuffer("SELECT ");
             try {
                 if (groupByExpressions != null && !groupByExpressions.isEmpty()) {
@@ -4000,15 +4002,12 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
                 throw new RuntimeException("Failed to encode group by expressions", e);
             }
             FilterToSQL filterToSQL = getFilterToSQL(featureType);
-            if (groupByComplexExpressions) {
-                if ("count".equals(function)) {
-                    sql2.append("count(*)");
-                } else {
-                    sql2.append(function).append("(").append("gt_agg_src").append(")");
-                }
-            } else {
-                encodeFunction(function, expr, sql2, filterToSQL);
-            }
+            boolean countQuery =
+                    isUniqueCount || (groupByComplexExpressions && "count".equals(function));
+            if (countQuery) sql2.append("count(*)");
+            else if (groupByComplexExpressions)
+                sql2.append(function).append("(").append("gt_agg_src").append(")");
+            else encodeFunction(function, expr, sql2, filterToSQL);
             toSQL.add(filterToSQL);
             sql2.append(" AS gt_result_");
             sql2.append(" FROM (");

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCAggregateFunctionOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCAggregateFunctionOnlineTest.java
@@ -34,6 +34,7 @@ import org.geotools.feature.visitor.NearestVisitor;
 import org.geotools.feature.visitor.StandardDeviationVisitor;
 import org.geotools.feature.visitor.SumAreaVisitor;
 import org.geotools.feature.visitor.SumVisitor;
+import org.geotools.feature.visitor.UniqueCountVisitor;
 import org.geotools.feature.visitor.UniqueVisitor;
 import org.geotools.filter.IllegalFilterException;
 import org.geotools.filter.SortByImpl;
@@ -606,5 +607,42 @@ public abstract class JDBCAggregateFunctionOnlineTest extends JDBCTestSupport {
 
         assertFalse(visited);
         assertEquals(0.55, v.getResult().toDouble(), 0.01);
+    }
+
+    public void testUniqueCount() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+        PropertyName p = ff.property(aname("stringProperty"));
+
+        UniqueVisitor v = new UniqueCountVisitor(p);
+        dataStore.getFeatureSource(tname("ft1")).accepts(Query.ALL, v, null);
+        int result = v.getResult().toInt();
+        assertEquals(0, v.getUnique().size());
+        assertEquals(3, result);
+    }
+
+    public void testUniqueCountWithFilter() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+        PropertyName p = ff.property(aname("stringProperty"));
+
+        UniqueCountVisitor v = new UniqueCountVisitor(p);
+        Filter f = ff.greater(ff.property(aname("doubleProperty")), ff.literal(1));
+        Query q = new Query(tname("ft1"), f);
+        dataStore.getFeatureSource(tname("ft1")).accepts(q, v, null);
+        assertFalse(visited);
+        Set result = v.getUnique();
+        assertEquals(0, result.size());
+        assertEquals(2, v.getResult().toInt());
+    }
+
+    public void testUniqueCountWithLimit() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+        PropertyName p = ff.property(aname("stringProperty"));
+
+        UniqueVisitor v = new UniqueCountVisitor(p);
+        v.setMaxFeatures(2);
+        dataStore.getFeatureSource(tname("ft1")).accepts(Query.ALL, v, null);
+        int result = v.getResult().toInt();
+        assertEquals(0, v.getUnique().size());
+        assertEquals(2, result);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/UniqueCountVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/UniqueCountVisitor.java
@@ -1,0 +1,66 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.feature.visitor;
+
+import java.util.Set;
+import org.geotools.filter.IllegalFilterException;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.expression.Expression;
+
+/**
+ * Determines the number of unique features in the collection on the basis of the specified feature
+ * attribute.
+ */
+public class UniqueCountVisitor extends UniqueVisitor {
+
+    Integer count = null;
+
+    public UniqueCountVisitor(String attributeTypeName) {
+        super(attributeTypeName);
+    }
+
+    public UniqueCountVisitor(int attributeTypeIndex, SimpleFeatureType type)
+            throws IllegalFilterException {
+        super(attributeTypeIndex, type);
+    }
+
+    public UniqueCountVisitor(String attrName, SimpleFeatureType type)
+            throws IllegalFilterException {
+        super(attrName, type);
+    }
+
+    public UniqueCountVisitor(Expression expr) {
+        super(expr);
+    }
+
+    public void setValue(Integer count) {
+        this.count = count;
+    }
+
+    @Override
+    public CalcResult getResult() {
+        Set uniqueValues = getUnique();
+        Integer result;
+        if (count == null) {
+            if (uniqueValues.isEmpty()) return CalcResult.NULL_RESULT;
+            else result = uniqueValues.size();
+        } else {
+            result = count;
+        }
+        return new CountVisitor.CountResult(result);
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/feature/visitor/UniqueCountVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/visitor/UniqueCountVisitorTest.java
@@ -1,0 +1,127 @@
+package org.geotools.feature.visitor;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.geotools.data.DataUtilities;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.locationtech.jts.io.WKTReader;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
+
+public class UniqueCountVisitorTest {
+
+    private static WKTReader wktParser = new WKTReader();
+
+    private static SimpleFeatureType uniqueValuesCountTestType;
+    private static FeatureCollection featureCollection;
+    static FilterFactory ff = CommonFactoryFinder.getFilterFactory2();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // the building feature type that will be used during the tests
+        uniqueValuesCountTestType =
+                DataUtilities.createType(
+                        "uniqueValuesCount",
+                        "id:Integer,aStringValue:String," + "aDoubleValue:Double,geo:Geometry");
+        // the building features that will be used during the tests
+        SimpleFeature[] simpleFeatures = {
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {1, "A", 50.0, wktParser.read("POINT(-5 -5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {2, "B", 10.0, wktParser.read("POINT(-5 -5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {3, "C", 20.0, wktParser.read("POINT(-5 -5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {4, "D", 30.0, wktParser.read("POINT(5 5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {5, "E", 60.0, wktParser.read("POINT(5 5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {6, "E", 10.0, wktParser.read("POINT(5 5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {7, "D", 500.0, wktParser.read("POINT(-5 5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {8, "C", 150.0, wktParser.read("POINT(-5 5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {9, "C", 20.0, wktParser.read("POINT(5 -5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {10, "C", 30.0, wktParser.read("POINT(5 -5)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {11, "A", 500.0, wktParser.read("POINT(0 0)")},
+                    null),
+            SimpleFeatureBuilder.build(
+                    uniqueValuesCountTestType,
+                    new Object[] {12, "F", 500.0, wktParser.read("POINT(0 0)")},
+                    null),
+        };
+        // creating the bulding featrue collection
+        featureCollection = DataUtilities.collection(simpleFeatures);
+    }
+
+    @Test
+    public void testUniqueCountVisitor() throws IOException {
+        UniqueCountVisitor uniqueCountVisitor = new UniqueCountVisitor("aStringValue");
+        featureCollection.accepts(uniqueCountVisitor, null);
+        int count = uniqueCountVisitor.getResult().toInt();
+        assertEquals(6, count);
+    }
+
+    @Test
+    public void testUniqueCountVisitor2() throws IOException {
+        UniqueCountVisitor uniqueCountVisitor = new UniqueCountVisitor("aDoubleValue");
+        featureCollection.accepts(uniqueCountVisitor, null);
+        int count = uniqueCountVisitor.getResult().toInt();
+        assertEquals(7, count);
+    }
+
+    @Test
+    public void testUniqueCountVisitorWithFilter() throws IOException {
+        UniqueCountVisitor uniqueCountVisitor = new UniqueCountVisitor("aStringValue");
+        Filter f =
+                ff.or(
+                        ff.equals(ff.property("aStringValue"), ff.literal("A")),
+                        ff.equals(ff.property("aStringValue"), ff.literal("B")));
+        featureCollection.subCollection(f).accepts(uniqueCountVisitor, null);
+        int count = uniqueCountVisitor.getResult().toInt();
+        assertEquals(2, count);
+    }
+
+    @Test
+    public void testUniqueCountVisitorWithFilter2() throws IOException {
+        UniqueCountVisitor uniqueCountVisitor = new UniqueCountVisitor("aDoubleValue");
+        Filter f =
+                ff.or(
+                        ff.equals(ff.property("aDoubleValue"), ff.literal(500d)),
+                        ff.equals(ff.property("aDoubleValue"), ff.literal(20d)));
+        featureCollection.subCollection(f).accepts(uniqueCountVisitor, null);
+        int count = uniqueCountVisitor.getResult().toInt();
+        assertEquals(2, count);
+    }
+}


### PR DESCRIPTION
early backport request [here](https://sourceforge.net/p/geotools/mailman/message/37271370/)
jira ticket https://osgeo-org.atlassian.net/browse/GEOT-6874?searchSessionId=5bc8449d-6233-45c8-adb6-83320063fa83&searchObjectId=53789&searchContainerId=10001&searchContentType=issue
# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.
