### PR TITLE
[GEOT-6880] Rendering process fails if vendor option sortByGroup is used (25.x)

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/ZGroupLayer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/ZGroupLayer.java
@@ -192,14 +192,16 @@ class ZGroupLayer extends Layer {
                 // but we'd have to delay opening the MarkFeatureIterator to recognize the
                 // situation
                 int maxFeatures = SortedFeatureReader.getMaxFeaturesInMemory(layer.getQuery());
-                try (MarkFeatureIterator fi =
-                        MarkFeatureIterator.create(features, maxFeatures, cancellationListener)) {
-                    if (fi.hasNext()) {
-                        @SuppressWarnings("PMD.CloseResource") // returned
-                        ZGroupLayerPainter painter =
-                                new ZGroupLayerPainter(fi, lfts, renderer, layerId);
-                        painters.add(painter);
-                    }
+
+                @SuppressWarnings("PMD.CloseResource")
+                // iterator will be closed after drawing when painter is closed
+                MarkFeatureIterator fi =
+                        MarkFeatureIterator.create(features, maxFeatures, cancellationListener);
+                if (fi.hasNext()) {
+                    @SuppressWarnings("PMD.CloseResource") // returned
+                    ZGroupLayerPainter painter =
+                            new ZGroupLayerPainter(fi, lfts, renderer, layerId);
+                    painters.add(painter);
                 }
             }
 

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/ZOrderTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/ZOrderTest.java
@@ -26,6 +26,8 @@ import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.geotools.data.property.PropertyDataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
@@ -37,13 +39,18 @@ import org.geotools.renderer.RenderListener;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.Style;
 import org.geotools.test.TestData;
+import org.geotools.util.factory.Hints;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.opengis.feature.simple.SimpleFeature;
 
 /**
  * Z-order rendering test making use of FeatureTypeStyle sortBy to refine query used for styling.
  */
+@RunWith(Parameterized.class)
 public class ZOrderTest {
     private static final long TIME = 40000;
 
@@ -57,6 +64,15 @@ public class ZOrderTest {
 
     SimpleFeatureSource zbuildings;
 
+    @Parameterized.Parameters
+    public static Collection<Integer> maxMemorySortValues() {
+        return Arrays.asList(new Integer[] {1000, 2});
+    }
+
+    public ZOrderTest(Integer maxMemorySort) {
+        Hints.putSystemDefault(Hints.MAX_MEMORY_SORT, maxMemorySort);
+    }
+
     @Before
     public void setUp() throws Exception {
         File property = new File(TestData.getResource(this, "zorder/zsquares.properties").toURI());
@@ -68,7 +84,11 @@ public class ZOrderTest {
         bounds.expandBy(0.2, 0.2);
 
         // System.setProperty("org.geotools.test.interactive", "true");
+    }
 
+    @After
+    public void tearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.MAX_MEMORY_SORT);
     }
 
     @Test


### PR DESCRIPTION
backport of bugreport

Fix rendering error in case the rendered dataset size is over 1000 features and uses SLD xml element sld:VendorOption sortBy.
Unit tests extended to test with both MarkFeatureIterator implementations (memory and disk) by setting max memory sort limit to default value and low to use DiskMarkFeatureIterator during rendering ZOrder testing.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [ ] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.
