### PR TITLE
[GEOT-6885] RasterAsPointCollectionProcess hemisphere error with some projections

### DIFF
--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/RasterAsPointCollectionProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/RasterAsPointCollectionProcessTest.java
@@ -315,22 +315,9 @@ public class RasterAsPointCollectionProcessTest {
     }
 
     @Test
-    public void testCoverageInNorthEastCoordinates() throws Exception {
-        // Read the global coverage in LonLat coordinates
-        GeoTiffReader reader = new GeoTiffReader(TestData.file(this, "current.tif"));
-        GridCoverage2D myCoverage = reader.read(null);
-        reader.dispose();
-        // Crop the global coverage to the northern and southern hemispheres
-        CoordinateReferenceSystem crs = myCoverage.getCoordinateReferenceSystem();
-        ParameterValueGroup param = processor.getOperation("CoverageCrop").getParameters();
-        param.parameter("Source").setValue(myCoverage);
-        param.parameter("Envelope").setValue(new ReferencedEnvelope(-180, 180, 0, 90, crs));
-        GridCoverage2D coverage1 = (GridCoverage2D) processor.doOperation(param);
-        param = processor.getOperation("CoverageCrop").getParameters();
-        param.parameter("Source").setValue(myCoverage);
-        param.parameter("Envelope").setValue(new ReferencedEnvelope(-180, 180, -90, -1, crs));
-        GridCoverage2D coverage2 = (GridCoverage2D) processor.doOperation(param);
-        // Resample the coverages to LatLon coordinates
+    public void testCoverageInNorthEastCoordinatesNorthern() throws Exception {
+        // Load the test coverage cropped to the northern hemisphere and
+        // reprojected to LatLon coordinates
         String wkt =
                 "GEOGCS[\"WGS 84\","
                         + "DATUM[\"World Geodetic System 1984\","
@@ -341,83 +328,90 @@ public class RasterAsPointCollectionProcessTest {
                         + "AXIS[\"Geodetic latitude\", NORTH],"
                         + "AXIS[\"Geodetic longitude\", EAST],"
                         + "AUTHORITY[\"EPSG\",\"4326\"]]";
-        crs = CRS.parseWKT(wkt);
-        param = processor.getOperation("Resample").getParameters();
-        param.parameter("Source").setValue(coverage1);
-        param.parameter("CoordinateReferenceSystem").setValue(crs);
-        coverage1 = (GridCoverage2D) processor.doOperation(param);
-        param = processor.getOperation("Resample").getParameters();
-        param.parameter("Source").setValue(coverage2);
-        param.parameter("CoordinateReferenceSystem").setValue(crs);
-        coverage2 = (GridCoverage2D) processor.doOperation(param);
+        CoordinateReferenceSystem crs = CRS.parseWKT(wkt);
+        GridCoverage2D coverage = readCropAndResampleCoverage(-180, 180, 0, 90, crs);
         // Execution of the RasterAsPointCollectionProcess setting hemisphere
-        SimpleFeatureCollection collection1 = process.execute(coverage1, null, null, null, true);
-        SimpleFeatureCollection collection2 = process.execute(coverage2, null, null, null, true);
-        // Check if the points are exactly as the number of pixel number
-        int pixelNumber1 =
-                coverage1.getRenderedImage().getHeight() * coverage1.getRenderedImage().getWidth();
-        Assert.assertEquals(pixelNumber1, collection1.size());
-        int pixelNumber2 =
-                coverage2.getRenderedImage().getHeight() * coverage2.getRenderedImage().getWidth();
-        Assert.assertEquals(pixelNumber2, collection2.size());
-        // Check if each point is in the correct hemisphere
-        try (SimpleFeatureIterator it = collection1.features()) {
-            while (it.hasNext()) {
-                Assert.assertEquals(NORTH, it.next().getAttribute("emisphere"));
-            }
-        }
-        try (SimpleFeatureIterator it = collection2.features()) {
-            while (it.hasNext()) {
-                Assert.assertEquals(SOUTH, it.next().getAttribute("emisphere"));
-            }
-        }
+        SimpleFeatureCollection collection = process.execute(coverage, null, null, null, true);
+        // Check if each point is in the northern hemisphere
+        assertPointsInHemisphere(coverage, collection, NORTH);
     }
 
     @Test
-    public void testCoverageInPolarStereographicProjections() throws Exception {
+    public void testCoverageInNorthEastCoordinatesSouthern() throws Exception {
+        // Load the test coverage cropped to the southern hemisphere and
+        // reprojected to LatLon coordinates
+        String wkt =
+                "GEOGCS[\"WGS 84\","
+                        + "DATUM[\"World Geodetic System 1984\","
+                        + "SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]],"
+                        + "AUTHORITY[\"EPSG\",\"6326\"]],"
+                        + "PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]],"
+                        + "UNIT[\"degree\", 0.017453292519943295],"
+                        + "AXIS[\"Geodetic latitude\", NORTH],"
+                        + "AXIS[\"Geodetic longitude\", EAST],"
+                        + "AUTHORITY[\"EPSG\",\"4326\"]]";
+        CoordinateReferenceSystem crs = CRS.parseWKT(wkt);
+        GridCoverage2D coverage = readCropAndResampleCoverage(-180, 180, -90, -1, crs);
+        // Execution of the RasterAsPointCollectionProcess setting hemisphere
+        SimpleFeatureCollection collection = process.execute(coverage, null, null, null, true);
+        // Check if each point is in the southern hemisphere
+        assertPointsInHemisphere(coverage, collection, SOUTH);
+    }
+
+    @Test
+    public void testCoverageInPolarStereographicProjectionsNorthern() throws Exception {
+        // Load the test coverage cropped to the northern hemisphere polar stereographic
+        // projection area of validity and reprojected to the projection
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:5041");
+        GridCoverage2D coverage = readCropAndResampleCoverage(-180, 180, 60, 90, crs);
+        // Execution of the RasterAsPointCollectionProcess setting hemisphere
+        SimpleFeatureCollection collection = process.execute(coverage, null, null, null, true);
+        // Check if each point is in the northern hemisphere
+        assertPointsInHemisphere(coverage, collection, NORTH);
+    }
+
+    @Test
+    public void testCoverageInPolarStereographicProjectionsSouthern() throws Exception {
+        // Load the test coverage cropped to the southern hemisphere polar stereographic
+        // projection area of validity and reprojected to the projection
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:5042");
+        GridCoverage2D coverage = readCropAndResampleCoverage(-180, 180, -90, -60, crs);
+        // Execution of the RasterAsPointCollectionProcess setting hemisphere
+        SimpleFeatureCollection collection = process.execute(coverage, null, null, null, true);
+        // Check if each point is in the southern hemisphere
+        assertPointsInHemisphere(coverage, collection, SOUTH);
+    }
+
+    private GridCoverage2D readCropAndResampleCoverage(
+            double x1, double x2, double y1, double y2, CoordinateReferenceSystem outCRS)
+            throws IOException {
         // Read the global coverage in LonLat coordinates
         GeoTiffReader reader = new GeoTiffReader(TestData.file(this, "current.tif"));
-        GridCoverage2D myCoverage = reader.read(null);
+        GridCoverage2D coverage = reader.read(null);
         reader.dispose();
-        // Crop the global coverage to the northern and southern hemisphere
-        // polar stereographic projection areas of validity
-        CoordinateReferenceSystem crs = myCoverage.getCoordinateReferenceSystem();
+        // Crop the global coverage to the specified envelope
+        CoordinateReferenceSystem inCRS = coverage.getCoordinateReferenceSystem();
         ParameterValueGroup param = processor.getOperation("CoverageCrop").getParameters();
-        param.parameter("Source").setValue(myCoverage);
-        param.parameter("Envelope").setValue(new ReferencedEnvelope(-180, 180, 60, 90, crs));
-        GridCoverage2D coverage1 = (GridCoverage2D) processor.doOperation(param);
-        param = processor.getOperation("CoverageCrop").getParameters();
-        param.parameter("Source").setValue(myCoverage);
-        param.parameter("Envelope").setValue(new ReferencedEnvelope(-180, 180, -90, -60, crs));
-        GridCoverage2D coverage2 = (GridCoverage2D) processor.doOperation(param);
-        // Reproject the coverages to a polar stereographic projection
+        param.parameter("Source").setValue(coverage);
+        param.parameter("Envelope").setValue(new ReferencedEnvelope(x1, x2, y1, y2, inCRS));
+        // Resample the coverage to to the specified coordinate system
+        coverage = (GridCoverage2D) processor.doOperation(param);
         param = processor.getOperation("Resample").getParameters();
-        param.parameter("Source").setValue(coverage1);
-        param.parameter("CoordinateReferenceSystem").setValue(CRS.decode("EPSG:5041"));
-        coverage1 = (GridCoverage2D) processor.doOperation(param);
-        param = processor.getOperation("Resample").getParameters();
-        param.parameter("Source").setValue(coverage2);
-        param.parameter("CoordinateReferenceSystem").setValue(CRS.decode("EPSG:5042"));
-        coverage2 = (GridCoverage2D) processor.doOperation(param);
-        // Execution of the RasterAsPointCollectionProcess setting hemisphere
-        SimpleFeatureCollection collection1 = process.execute(coverage1, null, null, null, true);
-        SimpleFeatureCollection collection2 = process.execute(coverage2, null, null, null, true);
+        param.parameter("Source").setValue(coverage);
+        param.parameter("CoordinateReferenceSystem").setValue(outCRS);
+        return (GridCoverage2D) processor.doOperation(param);
+    }
+
+    private static void assertPointsInHemisphere(
+            GridCoverage2D coverage, SimpleFeatureCollection collection, String hemisphere) {
         // Check if the points are exactly as the number of pixel number
-        int pixelNumber1 =
-                coverage1.getRenderedImage().getHeight() * coverage1.getRenderedImage().getWidth();
-        Assert.assertEquals(pixelNumber1, collection1.size());
-        int pixelNumber2 =
-                coverage2.getRenderedImage().getHeight() * coverage2.getRenderedImage().getWidth();
-        Assert.assertEquals(pixelNumber2, collection2.size());
+        int pixelNumber =
+                coverage.getRenderedImage().getHeight() * coverage.getRenderedImage().getWidth();
+        Assert.assertEquals(pixelNumber, collection.size());
         // Check if each point is in the correct hemisphere
-        try (SimpleFeatureIterator it = collection1.features()) {
+        try (SimpleFeatureIterator it = collection.features()) {
             while (it.hasNext()) {
-                Assert.assertEquals(NORTH, it.next().getAttribute("emisphere"));
-            }
-        }
-        try (SimpleFeatureIterator it = collection2.features()) {
-            while (it.hasNext()) {
-                Assert.assertEquals(SOUTH, it.next().getAttribute("emisphere"));
+                Assert.assertEquals(hemisphere, it.next().getAttribute("emisphere"));
             }
         }
     }


### PR DESCRIPTION
[![GEOT-6885](https://badgen.net/badge/JIRA/GEOT-6885/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6885) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR changes RasterAsPointCollectionProcess to use the WGS84 Y coordinate to determine the hemisphere rather than the coordinate of the coverage CRS north axis.
https://osgeo-org.atlassian.net/browse/GEOT-6885

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [X] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [X] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [X] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [X] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.