### PR TITLE
[GEOT-6887] Bring GeoJsonWriter/GeoJsonReader on par with gt-geojson

### DIFF
--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/DateParser.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/DateParser.java
@@ -1,0 +1,106 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.geojson;
+
+import static org.geotools.data.geojson.GeoJSONWriter.DEFAULT_TIME_ZONE;
+
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.time.FastDateFormat;
+import org.geotools.util.logging.Logging;
+
+/**
+ * A date parser that tries different formats for single dates, but not as loose as {@link
+ * org.geotools.util.DateTimeParser} (and does not support periods and list of times either). For
+ * reading GeoJSON, especially when guessing if a field is a date, we want some flexibility, without
+ * mis-guessing a date field.
+ */
+class DateParser {
+
+    static final Logger LOGGER = Logging.getLogger(DateParser.class);
+
+    static final List<FastDateFormat> DEFAULT_FAST_DATE_FORMATS =
+            Arrays.asList(
+                    FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSX", DEFAULT_TIME_ZONE),
+                    FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSS", DEFAULT_TIME_ZONE),
+                    FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssX", DEFAULT_TIME_ZONE),
+                    FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss", DEFAULT_TIME_ZONE),
+                    FastDateFormat.getInstance("yyyy-MM-ddX", DEFAULT_TIME_ZONE),
+                    FastDateFormat.getInstance("yyyy-MM-dd", DEFAULT_TIME_ZONE));
+
+    List<FastDateFormat> formats = DEFAULT_FAST_DATE_FORMATS;
+
+    /**
+     * Sets the Timezone used to format the date fields. <code>null</code> is a valid value, the JVM
+     * local timezone will be used in that case.
+     */
+    public void setTimeZone(TimeZone tz) {
+        this.formats =
+                formats.stream()
+                        .map(f -> FastDateFormat.getInstance(f.getPattern(), tz))
+                        .collect(Collectors.toList());
+    }
+
+    /** Returns the timezone used to format dates. Defaults to GMT. */
+    public TimeZone getTimeZone() {
+        return formats.get(0).getTimeZone();
+    }
+
+    /**
+     * Sets the date formats for time parsing
+     *
+     * @param pattern {@link java.text.SimpleDateFormat} compatible * pattern
+     */
+    public void setDatePattern(String... pattern) {
+        if (pattern == null || pattern.length == 0)
+            throw new IllegalArgumentException("Date patterns must be non null, and non empty");
+        this.formats =
+                Arrays.stream(pattern)
+                        .map(p -> FastDateFormat.getInstance(p, getTimeZone()))
+                        .collect(Collectors.toList());
+    }
+
+    /** Returns the date formatter pattern. Defaults to DEFAULT_DATE_FORMAT */
+    public String[] getDatePatterns() {
+        return this.formats.stream().map(f -> f.getPattern()).toArray(n -> new String[n]);
+    }
+
+    /**
+     * Tries out the various date patterns and returns the result, or returns null if none could
+     * parse the date
+     */
+    public Date parse(String text) {
+        for (FastDateFormat format : formats) {
+            try {
+                return format.parse(text);
+            } catch (ParseException e) {
+                if (LOGGER.isLoggable(Level.FINEST))
+                    LOGGER.log(
+                            Level.FINEST,
+                            "Failed to parse " + text + " using " + format.getPattern(),
+                            e);
+            }
+        }
+        return null;
+    }
+}

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -30,11 +30,13 @@ import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -77,8 +79,6 @@ public class GeoJSONReader implements AutoCloseable {
 
     private SimpleFeatureType schema;
 
-    SimpleFeatureTypeBuilder typeBuilder = null;
-
     private SimpleFeatureBuilder builder;
 
     private int nextID = 0;
@@ -91,6 +91,11 @@ public class GeoJSONReader implements AutoCloseable {
 
     private URL url;
 
+    private boolean guessingDates = true;
+
+    /** For reading be a bit more lenient regarding what we parse */
+    private DateParser dateParser = new DateParser();
+
     public GeoJSONReader(URL url) throws IOException {
         this.url = url;
         parser = factory.createParser(url);
@@ -99,6 +104,19 @@ public class GeoJSONReader implements AutoCloseable {
 
     public GeoJSONReader(InputStream is) throws IOException {
         parser = factory.createParser(is);
+    }
+
+    /**
+     * Returns true if the parser is trying to convert string formatted as dates into
+     * java.util.Date, false otherwise. Defaults to true.
+     */
+    public boolean isGuessingDates() {
+        return guessingDates;
+    }
+
+    /** Enables/Disables guessing strings formatted as dates into java.util.Date. */
+    public void setGuessingDates(boolean guessingDates) {
+        this.guessingDates = guessingDates;
     }
 
     public boolean isConnected() {
@@ -137,7 +155,6 @@ public class GeoJSONReader implements AutoCloseable {
      * @return
      */
     public static SimpleFeatureCollection parseFeatureCollection(String jsonString) {
-
         try (GeoJSONReader reader =
                 new GeoJSONReader(new ByteArrayInputStream(jsonString.getBytes()))) {
             SimpleFeatureCollection features = (SimpleFeatureCollection) reader.getFeatures();
@@ -194,7 +211,6 @@ public class GeoJSONReader implements AutoCloseable {
         }
         if (isSchemaChanged()) {
             // retype the features if the schema changes
-
             List<SimpleFeature> nFeatures = new ArrayList<>(features.size());
             for (SimpleFeature feature : features) {
                 if (feature.getFeatureType() != schema) {
@@ -284,13 +300,25 @@ public class GeoJSONReader implements AutoCloseable {
                         list.add(vc);
                     }
                     builder.set(n.getKey(), list);
-                } else if (binding.isAssignableFrom(Geometry.class)) {
+                } else if (Geometry.class.isAssignableFrom(binding)) {
                     GeometryParser<Geometry> gParser = new GenericGeometryParser(gFac);
                     Geometry g = gParser.geometryFromJson(n.getValue());
                     builder.set(n.getKey(), g);
+                } else if (Date.class.isAssignableFrom(binding)) {
+                    String text = n.getValue().asText();
+                    Date date = dateParser.parse(text);
+                    if (date != null) {
+                        builder.set(n.getKey(), date);
+                    } else {
+                        // will go through the Converter machinery which, depending on the
+                        // classpath, might try out a larger set of conversions, or end up
+                        // with a null value
+                        builder.set(n.getKey(), n.getValue().asText());
+                    }
+
                 } else {
                     LOGGER.warning("Unable to parse object of type " + binding);
-                    builder.set(n.getKey(), n.getValue().toString());
+                    builder.set(n.getKey(), n.getValue().asText());
                 }
             }
             JsonNode geom = node.get("geometry");
@@ -307,7 +335,7 @@ public class GeoJSONReader implements AutoCloseable {
     /** Create a simpleFeatureBuilder for the current schema + these new properties. */
     private SimpleFeatureBuilder getBuilder(JsonNode props) {
 
-        typeBuilder = new SimpleFeatureTypeBuilder();
+        SimpleFeatureTypeBuilder typeBuilder = new SimpleFeatureTypeBuilder();
         // GeoJSON is always WGS84
         typeBuilder.setCRS(DefaultGeographicCRS.WGS84);
         typeBuilder.setName(baseName);
@@ -355,6 +383,15 @@ public class GeoJSONReader implements AutoCloseable {
                 }
             } else if (value instanceof ArrayNode) {
                 typeBuilder.add(n.getKey(), List.class);
+            } else if (value instanceof TextNode && guessingDates) {
+                // it could be a date too
+                Date date = dateParser.parse(value.asText());
+                if (date != null) {
+                    typeBuilder.add(n.getKey(), Date.class);
+                } else {
+                    typeBuilder.defaultValue("");
+                    typeBuilder.add(n.getKey(), String.class);
+                }
             } else {
                 typeBuilder.defaultValue("");
                 typeBuilder.add(n.getKey(), String.class);

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
@@ -20,20 +20,31 @@ import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
+import com.fasterxml.jackson.databind.ser.SerializerFactory;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Array;
 import java.text.NumberFormat;
+import java.util.Collection;
+import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -56,6 +67,14 @@ import org.opengis.referencing.operation.TransformException;
  */
 public class GeoJSONWriter implements AutoCloseable {
     static Logger LOGGER = Logging.getLogger("org.geotools.data.geojson");
+
+    /** Date format (ISO 8601) */
+    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+    public static final TimeZone TIME_ZONE = TimeZone.getTimeZone("GMT");
+
+    public static final FastDateFormat dateFormatter =
+            FastDateFormat.getInstance(DATE_FORMAT, TIME_ZONE);
 
     private int maxDecimals = 4;
 
@@ -83,6 +102,7 @@ public class GeoJSONWriter implements AutoCloseable {
     private final JtsModule module;
     private NumberFormat formatter = NumberFormat.getNumberInstance(Locale.ENGLISH);
     private boolean notWritenBbox = true;
+    private boolean singleFeature = false;
 
     public GeoJSONWriter(OutputStream outputStream) throws IOException {
         // force the output CRS to be long, lat as required by spec
@@ -107,18 +127,20 @@ public class GeoJSONWriter implements AutoCloseable {
 
     /** @throws IOException */
     private void initialise() throws IOException {
-        generator.writeStartObject();
-        generator.writeStringField("type", "FeatureCollection");
-        if (bounds != null && isEncodeFeatureBounds()) {
-            /* If they have provided a bbox we can write it out at the top of the file,
-             * else we'll need to do it at the bottom.
-             */
-            writeBoundingEnvelope();
-            notWritenBbox = false;
+        if (!singleFeature) {
+            generator.writeStartObject();
+            generator.writeStringField("type", "FeatureCollection");
+            if (bounds != null && isEncodeFeatureBounds()) {
+                /* If they have provided a bbox we can write it out at the top of the file,
+                 * else we'll need to do it at the bottom.
+                 */
+                writeBoundingEnvelope();
+                notWritenBbox = false;
+            }
+            generator.writeFieldName("features");
+            generator.writeStartArray();
+            inArray = true;
         }
-        generator.writeFieldName("features");
-        generator.writeStartArray();
-        inArray = true;
         initalised = true;
     }
 
@@ -182,14 +204,8 @@ public class GeoJSONWriter implements AutoCloseable {
                 continue;
             }
             Class<?> binding = p.getType().getBinding();
-            if (binding == Integer.class) {
-                g.writeNumberField(name, (int) value);
-            } else if (binding == Double.class) {
-                g.writeNumberField(name, (double) value);
-            } else {
-                g.writeFieldName(name);
-                g.writeString(value.toString());
-            }
+            g.writeFieldName(name);
+            writeValue(g, value, binding);
         }
         g.writeEndObject();
 
@@ -215,6 +231,52 @@ public class GeoJSONWriter implements AutoCloseable {
         g.flush();
     }
 
+    private void writeValue(JsonGenerator g, Object value, Class<?> binding) throws IOException {
+        if (value == null) {
+            g.writeNull();
+            return;
+        }
+
+        if (binding == Integer.class) {
+            g.writeNumber((int) value);
+        } else if (binding == Double.class) {
+            g.writeNumber((double) value);
+        } else if (binding == Boolean.class) {
+            g.writeBoolean((boolean) value);
+        } else if (Date.class.isAssignableFrom(binding)) {
+            g.writeString(dateFormatter.format(value));
+        } else if (Object.class.isAssignableFrom(binding) && value instanceof JsonNode) {
+            ((JsonNode) value)
+                    .serialize(
+                            g,
+                            new DefaultSerializerProvider(
+                                    mapper.getSerializerProvider(),
+                                    mapper.getSerializationConfig(),
+                                    mapper.getSerializerFactory()) {
+                                @Override
+                                public DefaultSerializerProvider createInstance(
+                                        SerializationConfig config, SerializerFactory jsf) {
+                                    throw new UnsupportedOperationException();
+                                }
+                            });
+        } else if (binding.isArray()) {
+            g.writeStartArray();
+            int length = Array.getLength(value);
+            for (int i = 0; i < length; i++) {
+                writeValue(g, Array.get(value, i), binding.getComponentType());
+            }
+            g.writeEndArray();
+        } else if (Collection.class.isAssignableFrom(binding)) {
+            g.writeStartArray();
+            for (Object v : ((Collection) value)) {
+                writeValue(g, v, v == null ? null : v.getClass());
+            }
+            g.writeEndArray();
+        } else {
+            g.writeString(value.toString());
+        }
+    }
+
     private Geometry reprojectGeometry(SimpleFeature currentFeature) {
         Geometry defaultGeometry = (Geometry) currentFeature.getDefaultGeometry();
         CoordinateReferenceSystem inCRS =
@@ -225,7 +287,8 @@ public class GeoJSONWriter implements AutoCloseable {
         if (transform == null || inCRS != lastCRS) {
             lastCRS = inCRS;
             try {
-                transform = CRS.findMathTransform(inCRS, outCRS, true);
+                if (inCRS == null) transform = IdentityTransform.create(2);
+                else transform = CRS.findMathTransform(inCRS, outCRS, true);
             } catch (FactoryException e) {
                 throw new RuntimeException(e);
             }
@@ -362,6 +425,11 @@ public class GeoJSONWriter implements AutoCloseable {
      * @throws IOException
      */
     public void writeFeatureCollection(SimpleFeatureCollection features) throws IOException {
+        // the collection might be empty, but we still need the wrapper JSON
+        // for a collection to be generated
+        if (!initalised) {
+            initialise();
+        }
         try (SimpleFeatureIterator itr = features.features()) {
             while (itr.hasNext()) {
                 SimpleFeature feature = (SimpleFeature) itr.next();
@@ -372,5 +440,22 @@ public class GeoJSONWriter implements AutoCloseable {
 
     public void setBounds(ReferencedEnvelope bbox) {
         bounds = bbox;
+    }
+
+    public boolean isSingleFeature() {
+        return singleFeature;
+    }
+
+    public void setSingleFeature(boolean singleFeature) {
+        this.singleFeature = singleFeature;
+    }
+
+    public void setPrettyPrinting(boolean prettyPrint) {
+        if (prettyPrint) generator.setPrettyPrinter(new DefaultPrettyPrinter());
+        else generator.setPrettyPrinter(null);
+    }
+
+    public boolean isPrettyPrinting() {
+        return generator.getPrettyPrinter() != null;
     }
 }

--- a/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
+++ b/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
@@ -670,7 +670,12 @@ public class GeoJSONWriteTest {
                         + "  \"type\" : \"FeatureCollection\",\n" //
                         + "  \"features\" : [ ]\n" //
                         + "}";
-        assertEquals(expected, json);
+        assertEquals(normalizeLineEnds(expected), normalizeLineEnds(json));
+    }
+
+    /** Normalizes line ends to \n, allows for cross-platform string comparisons */
+    private String normalizeLineEnds(String s) {
+        return s.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     @Test
@@ -699,8 +704,9 @@ public class GeoJSONWriteTest {
         String json = writeSingleFeature(feature);
         JsonNode root = new ObjectMapper().readTree(json);
         String isoDatePattern =
-                "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})\\.(\\d{3})\\+(\\d{4})";
-        assertTrue(root.get("properties").get("date").textValue().matches(isoDatePattern));
+                "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})\\.(\\d{3})Z";
+        String date = root.get("properties").get("date").textValue();
+        assertTrue(date + " does not match ISO date", date.matches(isoDatePattern));
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-6887](https://badgen.net/badge/JIRA/GEOT-6887/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6887) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hi @ianturton I needed to read/parse complex objects as part of GeoJSON properties... since the old gt-geojson was not able to handle that anyways, I thought to add the functionality to gt-geojsondatastore instead.
But... in the process I had to bring it on par with the gt-geojson functionality, found a bunch of things that were not supported, and added them. See [the ticket](https://osgeo-org.atlassian.net/browse/GEOT-6887) for details.

It's not 100% finished, need to support dates on the read end too. But... what do you think?
For round tripping complex objects I kept them in the jacksons objects form.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.