### PR TITLE
[GEOT-6891]: GeoTiffWriter writing on ImageOutputStream wrapped within an OutputStream

### DIFF
--- a/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffWriter.java
+++ b/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffWriter.java
@@ -19,6 +19,7 @@ package org.geotools.gce.geotiff;
 import it.geosolutions.imageio.plugins.tiff.TIFFImageWriteParam;
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFImageMetadata;
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFImageWriter;
+import it.geosolutions.io.output.adapter.OutputStreamAdapter;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.image.RenderedImage;
@@ -118,9 +119,12 @@ public class GeoTiffWriter extends AbstractGridCoverageWriter implements GridCov
             }
 
         } else if (destination instanceof OutputStream) {
-
-            this.outStream = ImageIOExt.createImageOutputStream(null, destination);
-
+            if (destination instanceof OutputStreamAdapter) {
+                this.outStream = ((OutputStreamAdapter) destination).getWrappedStream();
+                this.destination = outStream;
+            } else {
+                this.outStream = ImageIOExt.createImageOutputStream(null, destination);
+            }
         } else if (destination instanceof ImageOutputStream)
             this.outStream = (ImageOutputStream) destination;
         else throw new IllegalArgumentException("The provided destination canno be used!");

--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
     <test.forkMode>once</test.forkMode>
     <test.args></test.args>
     <src.output>${basedir}/target</src.output>
-    <imageio.ext.version>1.3.6</imageio.ext.version>
+    <imageio.ext.version>1.3.9</imageio.ext.version>
     <jts.version>1.18.1</jts.version>
     <jaiext.version>1.1.20</jaiext.version>
     <netcdf.version>4.6.15</netcdf.version>


### PR DESCRIPTION
[![GEOT-6891](https://badgen.net/badge/JIRA/GEOT-6891/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6891) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://osgeo-org.atlassian.net/browse/GEOT-6891

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.