### PR TITLE
[GEOT-6893] Add support for gml:Curve with gml:Arc segments to gml-geometry-streaming

### DIFF
--- a/modules/unsupported/gml-geometry-streaming/pom.xml
+++ b/modules/unsupported/gml-geometry-streaming/pom.xml
@@ -19,5 +19,11 @@
       <artifactId>gt-main</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.geotools.xsd</groupId>
+      <artifactId>gt-xsd-gml3</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/modules/unsupported/gml-geometry-streaming/src/main/java/org/geotools/gml/stream/GML.java
+++ b/modules/unsupported/gml-geometry-streaming/src/main/java/org/geotools/gml/stream/GML.java
@@ -23,6 +23,7 @@ public class GML {
 
     public static final String NAMESPACE = "http://www.opengis.net/gml";
 
+    public static final QName Arc = new QName(NAMESPACE, "Arc");
     public static final QName CompositeCurve = new QName(NAMESPACE, "CompositeCurve");
     public static final QName coord = new QName(NAMESPACE, "coord");
     public static final QName coordinates = new QName(NAMESPACE, "coordinates");
@@ -34,6 +35,7 @@ public class GML {
     public static final QName LinearRing = new QName(NAMESPACE, "LinearRing");
     public static final QName LineString = new QName(NAMESPACE, "LineString");
     public static final QName lineStringMember = new QName(NAMESPACE, "lineStringMember");
+    public static final QName LineStringSegment = new QName(NAMESPACE, "LineStringSegment");
     public static final QName MultiCurve = new QName(NAMESPACE, "MultiCurve");
     public static final QName MultiLineString = new QName(NAMESPACE, "MultiLineString");
     public static final QName MultiPoint = new QName(NAMESPACE, "MultiPoint");
@@ -48,6 +50,8 @@ public class GML {
     public static final QName polygonMember = new QName(NAMESPACE, "polygonMember");
     public static final QName pos = new QName(NAMESPACE, "pos");
     public static final QName posList = new QName(NAMESPACE, "posList");
+    public static final QName Ring = new QName(NAMESPACE, "Ring");
+    public static final QName segments = new QName(NAMESPACE, "segments");
     public static final QName srsName = new QName(NAMESPACE, "srsName");
     public static final QName surfaceMember = new QName(NAMESPACE, "surfaceMember");
     public static final QName surfaceMembers = new QName(NAMESPACE, "surfaceMembers");

--- a/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderParameterizedTest.java
+++ b/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderParameterizedTest.java
@@ -23,14 +23,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import org.geotools.geometry.jts.CompoundCurve;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.MultiPoint;
@@ -38,6 +39,7 @@ import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.opengis.referencing.FactoryException;
+import org.xml.sax.SAXException;
 
 @RunWith(Parameterized.class)
 public class XmlStreamGeometryReaderParameterizedTest {
@@ -45,50 +47,76 @@ public class XmlStreamGeometryReaderParameterizedTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
-                    {"point.gml", Point.class, "POINT (25888.999 387917.524)"},
-                    {"point2.gml", Point.class, "POINT (1 0)"},
+                    {"point.gml", Point.class, "POINT (25888.999 387917.524)", false},
+                    {"point2.gml", Point.class, "POINT (1 0)", false},
                     {
                         "linestring.gml",
                         LineString.class,
-                        "LINESTRING (-1.28 -0.11, -0.63 0.38, -0.22 0.09, -0.45 -0.36)"
+                        "LINESTRING (-1.28 -0.11, -0.63 0.38, -0.22 0.09, -0.45 -0.36)",
+                        false
                     },
-                    {"polygon.gml", Polygon.class, "POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))"},
+                    {
+                        "curve.gml",
+                        CompoundCurve.class,
+                        "COMPOUNDCURVE ((66693.157 438945.144, 66699.93 438933.685), CIRCULARSTRING (66699.93 438933.685, 66709.032 438911.512, 66710.378 438885.271), (66710.378 438885.271, 66710.27 438879.854), CIRCULARSTRING (66710.27 438879.854, 66709.268 438869.136, 66706.634 438860.394), (66706.634 438860.394, 66704.527 438855.457))",
+                        true
+                    },
+                    {"polygon.gml", Polygon.class, "POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))", false},
                     {
                         "polygon2.gml",
                         Polygon.class,
-                        "POLYGON ((15 7, 16 -7, -4 -7, 1 5, -2 6, 6 10, 15 7), (3 -4, 11 -4, 13 4, 5 4, 3 -4))"
+                        "POLYGON ((15 7, 16 -7, -4 -7, 1 5, -2 6, 6 10, 15 7), (3 -4, 11 -4, 13 4, 5 4, 3 -4))",
+                        false
                     },
                     {
                         "polygon3.gml",
                         Polygon.class,
-                        "POLYGON ((15 7, 16 -7, -4 -7, 1 5, -2 6, 6 10, 15 7), (3 -4, 11 -4, 13 4, 5 4, 3 -4), (3 -6, 2 -2, 5 6, 14 5, 12 -6, 3 -6), (2 -5, 1 0, 4 6, 6 8, 5 9, 1 7, 2 5, 0 -2, 2 -5))"
+                        "POLYGON ((15 7, 16 -7, -4 -7, 1 5, -2 6, 6 10, 15 7), (3 -4, 11 -4, 13 4, 5 4, 3 -4), (3 -6, 2 -2, 5 6, 14 5, 12 -6, 3 -6), (2 -5, 1 0, 4 6, 6 8, 5 9, 1 7, 2 5, 0 -2, 2 -5))",
+                        false
                     },
                     {
                         "multipoint.gml",
                         MultiPoint.class,
-                        "MULTIPOINT ((-23 11), (-24 9), (-22 9), (-24 8))"
+                        "MULTIPOINT ((-23 11), (-24 9), (-22 9), (-24 8))",
+                        false
                     },
-                    {"multipoint2.gml", MultiPoint.class, "MULTIPOINT ((-23 11), (-24 9))"},
+                    {"multipoint2.gml", MultiPoint.class, "MULTIPOINT ((-23 11), (-24 9))", false},
                     {
                         "multilinestring.gml",
                         MultiLineString.class,
-                        "MULTILINESTRING ((-27 -5, -11 -5), (-20 1, -19 -12))"
+                        "MULTILINESTRING ((-27 -5, -11 -5), (-20 1, -19 -12))",
+                        false
                     },
                     {
                         "multipolygon.gml",
                         MultiPolygon.class,
-                        "MULTIPOLYGON (((-11 -4, -8 9, 14 5, 5 -11, -11 -4), (-4 2, -6 -3, 1 -5, -4 2)), ((-19 5, -18 -10, -27 -10, -19 5)))"
+                        "MULTIPOLYGON (((-11 -4, -8 9, 14 5, 5 -11, -11 -4), (-4 2, -6 -3, 1 -5, -4 2)), ((-19 5, -18 -10, -27 -10, -19 5)))",
+                        false
                     },
                     {
                         "multicurvez.gml",
                         org.geotools.geometry.jts.MultiCurve.class,
-                        "MULTILINESTRING ((1 2, 3 4))"
+                        "MULTILINESTRING ((1 2, 3 4))",
+                        false
                     },
                     {
                         "multisurface.gml",
                         MultiPolygon.class,
-                        "MULTIPOLYGON (((10.5 3.34, 100 123.456, 150 130, 10.5 3.34)))"
+                        "MULTIPOLYGON (((10.5 3.34, 100 123.456, 150 130, 10.5 3.34)))",
+                        false
                     },
+                    {
+                        "multisurface_curve.gml",
+                        MultiPolygon.class,
+                        "MULTIPOLYGON (((25879.87 387915.774, 25880.336 387915.199, 25882.811 387912.147, 25888.868 387914.246, 25889.543528940994 387914.4529627376, 25890.820713326168 387914.70701050723, 25891.589 387914.778, 25892.120131109885 387914.7921788484, 25893.419548893602 387914.70701050723, 25894.351 387914.539, 25894.42 387914.848, 25893.844 387914.977, 25893.904 387915.98, 25896.156 387916.778, 25894.031 387922.9, 25886.656 387920.34, 25884.603 387919.628, 25884.646 387919.521, 25879.87 387915.774)))",
+                        true
+                    },
+                    {
+                        "multisurface_curve2.gml",
+                        MultiPolygon.class,
+                        "MULTIPOLYGON (((20716.496 371544.559, 20714.348583453197 371544.4182508586, 20712.23790942651 371543.99841169117, 20710.20009251658 371543.30666606233, 20708.27000033573 371542.3548499315, 20706.4806572963 371541.15924913663, 20704.862679553786 371539.7403207388, 20703.443751155955 371538.1223429963, 20702.248150361098 371536.3329999569, 20701.296334230294 371534.402907776, 20700.604588601436 371532.3650908661, 20700.18474943402 371530.2544168394, 20700.044 371528.107, 20700.044000292604 371528.10699991375, 20700.18474943402 371525.9595829881, 20700.604588601436 371523.8489089614, 20701.296334230294 371521.8110920515, 20702.248150361098 371519.88099987066, 20703.443751155955 371518.0916568312, 20704.862679553786 371516.4736790887, 20706.4806572963 371515.0547506909, 20708.27000033573 371513.859149896, 20710.20009251658 371512.9073337652, 20712.23790942651 371512.21558813634, 20714.348583453197 371511.7957489689, 20716.496 371511.655, 20718.643416349958 371511.79574914, 20720.754090354505 371512.215588303, 20722.791907243056 371512.9073339246, 20724.721999403657 371513.8591500454, 20726.511342424317 371515.0547508277, 20728.12932014986 371516.47367921064, 20729.548248532803 371518.0916569362, 20730.74384931512 371519.88099995686, 20731.69566543594 371521.81109211745, 20732.38741105754 371523.848909006, 20732.80725022055 371525.9595830106, 20732.94799936049 371528.1069999137, 20732.948 371528.107, 20732.80725022055 371530.2544168168, 20732.38741105754 371532.3650908214, 20731.69566543594 371534.40290770994, 20730.74384931512 371536.33299987053, 20729.548248532803 371538.1223428912, 20728.12932014986 371539.74032061675, 20726.511342424317 371541.15924899967, 20724.721999403657 371542.354849782, 20722.791907243056 371543.3066659028, 20720.754090354505 371543.9984115244, 20718.643416349958 371544.4182506874, 20716.496 371544.559)))",
+                        true
+                    }
                 });
     }
 
@@ -98,15 +126,23 @@ public class XmlStreamGeometryReaderParameterizedTest {
 
     private String expectedWKT;
 
+    private boolean compareXSD;
+
     public XmlStreamGeometryReaderParameterizedTest(
-            String gmlResource, Class expectedGeometryClass, String expectedWKT) {
+            String gmlResource,
+            Class expectedGeometryClass,
+            String expectedWKT,
+            boolean compareXSD) {
         this.gmlResource = gmlResource;
         this.expectedGeometryClass = expectedGeometryClass;
         this.expectedWKT = expectedWKT;
+        this.compareXSD = compareXSD;
     }
 
     @Test
-    public void test() throws IOException, XMLStreamException, FactoryException {
+    public void test()
+            throws IOException, XMLStreamException, FactoryException, ParserConfigurationException,
+                    SAXException {
         try (InputStream input =
                 getClass()
                         .getClassLoader()
@@ -114,13 +150,29 @@ public class XmlStreamGeometryReaderParameterizedTest {
             XMLInputFactory f = XMLInputFactory.newInstance();
             f.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
             XMLStreamReader r = f.createXMLStreamReader(input);
-            XmlStreamGeometryReader geometryReader =
-                    new XmlStreamGeometryReader(r, new GeometryFactory());
+            XmlStreamGeometryReader geometryReader = new XmlStreamGeometryReader(r);
             r.nextTag();
             Geometry g = geometryReader.readGeometry();
             assertNotNull(g);
             assertEquals(expectedGeometryClass, g.getClass());
             assertEquals(expectedWKT, g.toString());
+
+            if (compareXSD) {
+                Geometry xsdGeometry = parseWithXSD();
+                // Compare via default WKT toString()
+                assertEquals(xsdGeometry.toString(), g.toString());
+            }
+        }
+    }
+
+    private Geometry parseWithXSD() throws IOException, ParserConfigurationException, SAXException {
+        try (InputStream input =
+                getClass()
+                        .getClassLoader()
+                        .getResourceAsStream("org/geotools/gml/stream/" + gmlResource)) {
+            org.geotools.xsd.Parser parser =
+                    new org.geotools.xsd.Parser(new org.geotools.gml3.GMLConfiguration());
+            return (Geometry) parser.parse(input);
         }
     }
 }

--- a/modules/unsupported/gml-geometry-streaming/src/test/resources/org/geotools/gml/stream/curve.gml
+++ b/modules/unsupported/gml-geometry-streaming/src/test/resources/org/geotools/gml/stream/curve.gml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<gml:Curve xmlns:gml="http://www.opengis.net/gml">
+    <gml:segments>
+        <gml:LineStringSegment>
+            <gml:posList srsDimension="2">66693.157 438945.144 66699.930 438933.685</gml:posList>
+        </gml:LineStringSegment>
+        <gml:Arc>
+            <gml:posList srsDimension="2">66699.930 438933.685 66709.032 438911.512 66710.378 438885.271</gml:posList>
+        </gml:Arc>
+        <gml:LineStringSegment>
+            <gml:posList srsDimension="2">66710.378 438885.271 66710.270 438879.854</gml:posList>
+        </gml:LineStringSegment>
+        <gml:Arc>
+            <gml:posList srsDimension="2">66710.270 438879.854 66709.268 438869.136 66706.634 438860.394</gml:posList>
+        </gml:Arc>
+        <gml:LineStringSegment>
+            <gml:posList srsDimension="2">66706.634 438860.394 66704.527 438855.457</gml:posList>
+        </gml:LineStringSegment>
+    </gml:segments>
+</gml:Curve>

--- a/modules/unsupported/gml-geometry-streaming/src/test/resources/org/geotools/gml/stream/multisurface_curve.gml
+++ b/modules/unsupported/gml-geometry-streaming/src/test/resources/org/geotools/gml/stream/multisurface_curve.gml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gml:MultiSurface xmlns:gml="http://www.opengis.net/gml">
+    <gml:surfaceMember>
+        <gml:Polygon>
+            <gml:exterior>
+                <gml:Ring>
+                    <gml:curveMember>
+                        <gml:Curve>
+                            <gml:segments>
+                                <gml:LineStringSegment>
+                                    <gml:posList srsDimension="2">25879.870 387915.774 25880.336
+                                        387915.199 25882.811 387912.147 25888.868 387914.246
+                                    </gml:posList>
+                                </gml:LineStringSegment>
+                                <gml:Arc>
+                                    <gml:posList srsDimension="2">25888.868 387914.246 25891.589
+                                        387914.778 25894.351 387914.539
+                                    </gml:posList>
+                                </gml:Arc>
+                                <gml:LineStringSegment>
+                                    <gml:posList srsDimension="2">25894.351 387914.539 25894.420
+                                        387914.848 25893.844 387914.977 25893.904 387915.980 25896.156
+                                        387916.778 25894.031 387922.900 25886.656 387920.340 25884.603
+                                        387919.628 25884.646 387919.521 25879.870 387915.774
+                                    </gml:posList>
+                                </gml:LineStringSegment>
+                            </gml:segments>
+                        </gml:Curve>
+                    </gml:curveMember>
+                </gml:Ring>
+            </gml:exterior>
+        </gml:Polygon>
+    </gml:surfaceMember>
+</gml:MultiSurface>

--- a/modules/unsupported/gml-geometry-streaming/src/test/resources/org/geotools/gml/stream/multisurface_curve2.gml
+++ b/modules/unsupported/gml-geometry-streaming/src/test/resources/org/geotools/gml/stream/multisurface_curve2.gml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gml:MultiSurface xmlns:gml="http://www.opengis.net/gml">
+    <gml:surfaceMember>
+        <gml:Polygon>
+            <gml:exterior>
+                <gml:Ring>
+                    <gml:curveMember>
+                        <gml:Curve>
+                            <gml:segments>
+                                <gml:Arc>
+                                    <gml:posList srsDimension="2">20716.496 371544.559 20700.044
+                                        371528.107 20716.496 371511.655
+                                    </gml:posList>
+                                </gml:Arc>
+                                <gml:Arc>
+                                    <gml:posList srsDimension="2">20716.496 371511.655 20732.948
+                                        371528.107 20716.496 371544.559
+                                    </gml:posList>
+                                </gml:Arc>
+                            </gml:segments>
+                        </gml:Curve>
+                    </gml:curveMember>
+                </gml:Ring>
+            </gml:exterior>
+        </gml:Polygon>
+    </gml:surfaceMember>
+</gml:MultiSurface>


### PR DESCRIPTION
[![GEOT-6893](https://badgen.net/badge/JIRA/GEOT-6893/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6893) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adds support for a `gml:Curve` with `gml:LineStringSegment` and `gml:Arc` segments (3 control points) to (unsupported) **gt-gml-geometry-streaming**. Supported in a top-level geometry element, in a `gml:MultiCurve` or in the `gml:exterior` and `gml:interior` of a `gml:MultiSurface` or `gml:Polygon`.

Also added a flag to the parametrized test whether the WKT of the parsed geometry should be compared with the WKT from a Geometry parsed from the same XML using the `gt-xsd-gml3` module. For some top-level elements `gt-xsd-gml3` returns an empty geometry which may be just my misunderstanding how that module works.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.