### PR TITLE
[GEOT-2972] Character set from CPG files - add "enable feature" switch

### DIFF
--- a/docs/user/welcome/upgrade.rst
+++ b/docs/user/welcome/upgrade.rst
@@ -34,7 +34,17 @@ GeoTools 26.x
 Shapefile
 ^^^^^^^^^
 
-If no explicit charset parameter passed to ``ShapefileDataStoreFactory``, it will now instruct created ``ShapefileDataStore`` to try to figure out DBF file charset from CPG file. If the store fails to read CPG it uses the default charset specified by ``ShapefileDataStoreFactory.DBFCHARSET`` constant, which is usual behavior.
+``ShapefileDataStore`` will autodetect DBF charset from CPG sidecar file, the feature now enabled by default. When this feature 
+enabled the following rules apply:
+
+* if no explicit charset parameter passed to ``ShapefileDataStoreFactory``, it will instruct created ``ShapefileDataStore``
+  to try and figure out DBF file charset from CPG file. In this case, CPG files must contain correct charset name, otherwise, 
+  these files should be removed, or updated properly. 
+* if the store fails to read CPG, it uses the default charset specified by ``ShapefileDataStoreFactory.DBFCHARSET`` constant, 
+  which is usual behavior.
+
+In case of trouble there is an ability to bring old behavior back by setting ``org.geotools.shapefile.enableCPG`` system property
+to "false". This turns autodetection off. The name of the property stored in ``ShapefileDataStoreFactory.ENABLE_CPG_SWITCH`` constant.
 
 GeoTools 25.x
 -------------

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStoreFactory.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStoreFactory.java
@@ -49,6 +49,11 @@ public class ShapefileDataStoreFactory implements FileDataStoreFactorySpi {
             new Param(
                     "url", URL.class, "url to a .shp file", true, null, new KVP(Param.EXT, "shp"));
 
+    /**
+     * This system property will enable "DBF charset autodetection from CPG sidecar file" feature.
+     */
+    public static final String ENABLE_CPG_SWITCH = "org.geotools.shapefile.enableCPG";
+
     /** Optional - uri of the FeatureType's namespace */
     public static final Param NAMESPACEP =
             new Param(
@@ -248,7 +253,9 @@ public class ShapefileDataStoreFactory implements FileDataStoreFactorySpi {
             store.setMemoryMapped(useMemoryMappedBuffer);
             store.setBufferCachingEnabled(cacheMemoryMaps);
             store.setCharset(dbfCharset);
-            if (!hasParam(DBFCHARSET, params)) {
+            // CPG sidecar file enabled by default
+            boolean enableCPG = Boolean.valueOf(System.getProperty(ENABLE_CPG_SWITCH, "true"));
+            if (enableCPG && !hasParam(DBFCHARSET, params)) {
                 store.setTryCPGFile(true);
             }
             store.setTimeZone(dbfTimeZone);

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileWithCpgTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileWithCpgTest.java
@@ -38,6 +38,7 @@ import org.geotools.data.Query;
 import org.geotools.data.Transaction;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.test.TestData;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
@@ -46,9 +47,19 @@ import org.opengis.filter.Filter;
 
 public class ShapefileWithCpgTest extends TestCaseSupport {
 
+    private String savedEnableCPGSwitch;
+
     @Before
     public void setUp() throws Exception {
         copyShapefiles(RUSSIAN);
+        enableCPGSwitch();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        restoreCPGSwitch();
+        super.tearDown();
     }
 
     @Test
@@ -227,6 +238,19 @@ public class ShapefileWithCpgTest extends TestCaseSupport {
             }
         } finally {
             dataStore.dispose();
+        }
+    }
+
+    private void enableCPGSwitch() {
+        savedEnableCPGSwitch = System.getProperty(ShapefileDataStoreFactory.ENABLE_CPG_SWITCH);
+        System.setProperty(ShapefileDataStoreFactory.ENABLE_CPG_SWITCH, "true");
+    }
+
+    private void restoreCPGSwitch() {
+        if (savedEnableCPGSwitch != null) {
+            System.setProperty(ShapefileDataStoreFactory.ENABLE_CPG_SWITCH, savedEnableCPGSwitch);
+        } else {
+            System.clearProperty(ShapefileDataStoreFactory.ENABLE_CPG_SWITCH);
         }
     }
 }


### PR DESCRIPTION
[![GEOT-2972](https://badgen.net/badge/JIRA/GEOT-2972/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-2972) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is enhancement of #3405 with regards of #3497. It adds the following:

- introduce system property that allows turn on/off charset autodetection from CPG file;
- the property set to "true" by default, turning autodetection on. Setting it to "false" brings old behavior back.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.