### PR TITLE
[GEOT-6894] WMTS fails when initial url contains query parameters

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
@@ -179,7 +179,7 @@ class WMTSTile extends Tile {
         params.put("TileRow", tileIdentifier.getY());
 
         StringBuilder arguments = new StringBuilder();
-        String separator =  (!baseUrl.contains("?") ? "?" : "&"); 
+        String separator = (!baseUrl.contains("?") ? "?" : "&");
 
         for (String key : params.keySet()) {
             if (!lowerBaseUrl.contains(key.toLowerCase() + "=")) {

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
@@ -102,7 +102,7 @@ class WMTSTile extends Tile {
     public URL getUrl() {
         String baseUrl = getService().getTemplateURL();
         if (LOGGER.isLoggable(Level.FINE)) {
-        	LOGGER.fine("baseUrl in tile.getUrl is :" + baseUrl);
+            LOGGER.fine("baseUrl in tile.getUrl is :" + baseUrl);
         }
         TileIdentifier tileIdentifier = getTileIdentifier();
         WMTSServiceType type = getType();
@@ -164,8 +164,8 @@ class WMTSTile extends Tile {
     }
 
     private URL getKVPurl(String baseUrl, TileIdentifier tileIdentifier) throws RuntimeException {
-    	final String lowerBaseUrl = baseUrl.toLowerCase();
-    	
+        final String lowerBaseUrl = baseUrl.toLowerCase();
+
         HashMap<String, Object> params = new HashMap<>();
         params.put("service", "WMTS");
         params.put("version", "1.0.0");
@@ -187,20 +187,21 @@ class WMTSTile extends Tile {
             skipFirst = true;
         }
         for (String key : params.keySet()) {
-        	if (!lowerBaseUrl.contains(key.toLowerCase() + "=")) {
-	            Object val = params.get(key);
-	            try {
-	                if (val != null) {
-	                    arguments.append(skipFirst ? "" : "&")
-	                    		 .append(key)
-	                    		 .append("=")
-	                    		 .append(URLEncoder.encode(val.toString(), "UTF-8"));
-	                    skipFirst = false;
-	                }
-	            } catch (Exception e) {
-	                LOGGER.warning("Could not encode param '" + key + "' with value '" + val + "'");
-	            }
-        	}
+            if (!lowerBaseUrl.contains(key.toLowerCase() + "=")) {
+                Object val = params.get(key);
+                try {
+                    if (val != null) {
+                        arguments
+                                .append(skipFirst ? "" : "&")
+                                .append(key)
+                                .append("=")
+                                .append(URLEncoder.encode(val.toString(), "UTF-8"));
+                        skipFirst = false;
+                    }
+                } catch (Exception e) {
+                    LOGGER.warning("Could not encode param '" + key + "' with value '" + val + "'");
+                }
+            }
         }
 
         try {

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
@@ -101,7 +101,9 @@ class WMTSTile extends Tile {
     @Override
     public URL getUrl() {
         String baseUrl = getService().getTemplateURL();
-
+        if (LOGGER.isLoggable(Level.FINE)) {
+        	LOGGER.fine("baseUrl in tile.getUrl is :" + baseUrl);
+        }
         TileIdentifier tileIdentifier = getTileIdentifier();
         WMTSServiceType type = getType();
         if (null == type) {
@@ -162,11 +164,8 @@ class WMTSTile extends Tile {
     }
 
     private URL getKVPurl(String baseUrl, TileIdentifier tileIdentifier) throws RuntimeException {
-        // in theory it should end with ? but there may be other params that the
-        // server needs out of spec
-        if (!baseUrl.contains("?")) {
-            baseUrl += "?";
-        }
+    	final String lowerBaseUrl = baseUrl.toLowerCase();
+    	
         HashMap<String, Object> params = new HashMap<>();
         params.put("service", "WMTS");
         params.put("version", "1.0.0");
@@ -180,17 +179,28 @@ class WMTSTile extends Tile {
         params.put("TileRow", tileIdentifier.getY());
 
         StringBuilder arguments = new StringBuilder();
+        // in theory it should end with ? but there may be other params that the
+        // server needs out of spec
+        boolean skipFirst = false;
+        if (!baseUrl.contains("?")) {
+            arguments.append("?");
+            skipFirst = true;
+        }
         for (String key : params.keySet()) {
-            Object val = params.get(key);
-            try {
-                if (val != null) {
-                    arguments.append(key).append("=");
-                    arguments.append(URLEncoder.encode(val.toString(), "UTF-8"));
-                    arguments.append('&');
-                }
-            } catch (Exception e) {
-                LOGGER.warning("Could not encode param '" + key + "' with value '" + val + "'");
-            }
+        	if (!lowerBaseUrl.contains(key.toLowerCase() + "=")) {
+	            Object val = params.get(key);
+	            try {
+	                if (val != null) {
+	                    arguments.append(skipFirst ? "" : "&")
+	                    		 .append(key)
+	                    		 .append("=")
+	                    		 .append(URLEncoder.encode(val.toString(), "UTF-8"));
+	                    skipFirst = false;
+	                }
+	            } catch (Exception e) {
+	                LOGGER.warning("Could not encode param '" + key + "' with value '" + val + "'");
+	            }
+        	}
         }
 
         try {

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
@@ -179,24 +179,19 @@ class WMTSTile extends Tile {
         params.put("TileRow", tileIdentifier.getY());
 
         StringBuilder arguments = new StringBuilder();
-        // in theory it should end with ? but there may be other params that the
-        // server needs out of spec
-        boolean skipFirst = false;
-        if (!baseUrl.contains("?")) {
-            arguments.append("?");
-            skipFirst = true;
-        }
+        String separator =  (!baseUrl.contains("?") ? "?" : "&"); 
+
         for (String key : params.keySet()) {
             if (!lowerBaseUrl.contains(key.toLowerCase() + "=")) {
                 Object val = params.get(key);
                 try {
                     if (val != null) {
                         arguments
-                                .append(skipFirst ? "" : "&")
+                                .append(separator)
                                 .append(key)
                                 .append("=")
                                 .append(URLEncoder.encode(val.toString(), "UTF-8"));
-                        skipFirst = false;
+                        separator = "&";
                     }
                 } catch (Exception e) {
                     LOGGER.warning("Could not encode param '" + key + "' with value '" + val + "'");

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
@@ -94,7 +94,7 @@ public class WMTSTileService extends TileService {
     private Map<String, Object> extrainfo = new HashMap<>();
 
     /**
-     * create a service directly with out parsing the capabilties again.
+     * create a service directly with out parsing the capabilities again.
      *
      * @param templateURL - where to ask for tiles
      * @param type - KVP or REST
@@ -112,7 +112,7 @@ public class WMTSTileService extends TileService {
     }
 
     /**
-     * create a service directly with out parsing the capabilties again.
+     * create a service directly with out parsing the capabilities again.
      *
      * @param templateURL - where to ask for tiles
      * @param type - KVP or REST

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -330,20 +330,21 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     @Override
     public URL getFinalURL() {
-        if (WMTSServiceType.REST.equals(type)) { 
-        	if (layer.getTemplate(format) == null) {
+        if (WMTSServiceType.REST.equals(type)) {
+            if (layer.getTemplate(format) == null) {
                 LOGGER.info("Template URL not available for format  " + format);
                 type = WMTSServiceType.KVP;
                 return onlineResource;
-        	} else {
-        		try {
-					return new URL(layer.getTemplate(format));
-				} catch (MalformedURLException e) {
-					throw new RuntimeException("URL for GetTile specified within capabilities is wrong.", e);
-				}
-        	}
+            } else {
+                try {
+                    return new URL(layer.getTemplate(format));
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(
+                            "URL for GetTile specified within capabilities is wrong.", e);
+                }
+            }
         } else {
-        	return super.getFinalURL();
+            return super.getFinalURL();
         }
     }
 

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -19,6 +19,7 @@ package org.geotools.ows.wmts.request;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -329,12 +330,21 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     @Override
     public URL getFinalURL() {
-        if (WMTSServiceType.REST.equals(type) && layer.getTemplate(format) == null) {
-            LOGGER.info("Template URL not available for format  " + format);
-            type = WMTSServiceType.KVP;
-            return onlineResource;
+        if (WMTSServiceType.REST.equals(type)) { 
+        	if (layer.getTemplate(format) == null) {
+                LOGGER.info("Template URL not available for format  " + format);
+                type = WMTSServiceType.KVP;
+                return onlineResource;
+        	} else {
+        		try {
+					return new URL(layer.getTemplate(format));
+				} catch (MalformedURLException e) {
+					throw new RuntimeException("URL for GetTile specified within capabilities is wrong.", e);
+				}
+        	}
+        } else {
+        	return super.getFinalURL();
         }
-        return super.getFinalURL();
     }
 
     private TileMatrixSet selectMatrixSet() throws ServiceException, RuntimeException {

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -19,7 +19,6 @@ package org.geotools.ows.wmts.request;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -330,23 +329,12 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     @Override
     public URL getFinalURL() {
-        String requestUrl = onlineResource.toString();
-        if (WMTSServiceType.REST.equals(type)) {
-            requestUrl = layer.getTemplate(format);
-            if (requestUrl == null) {
-                if (LOGGER.isLoggable(Level.INFO))
-                    LOGGER.info("Template URL not available for format  " + format);
-                type = WMTSServiceType.KVP;
-                requestUrl = onlineResource.toString();
-            }
+        if (WMTSServiceType.REST.equals(type) && layer.getTemplate(format) == null) {
+            LOGGER.info("Template URL not available for format  " + format);
+            type = WMTSServiceType.KVP;
+            return onlineResource;
         }
-        URL ret = null;
-        try {
-            ret = new URL(requestUrl);
-        } catch (MalformedURLException e) {
-            LOGGER.log(Level.SEVERE, "", e);
-        }
-        return ret;
+        return super.getFinalURL();
     }
 
     private TileMatrixSet selectMatrixSet() throws ServiceException, RuntimeException {

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/ESRIWMTSServerOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/ESRIWMTSServerOnlineTest.java
@@ -82,7 +82,7 @@ public class ESRIWMTSServerOnlineTest extends OnlineTestCase {
         request.setCRS(DefaultGeographicCRS.WGS84);
         Set<Tile> tiles = request.getTiles();
         for (Tile tile : tiles) {
-            assertTrue(tile.getUrl().toString().contains("style=default"));
+            assertTrue(tile.getUrl().toString().toLowerCase().contains("style=default"));
         }
     }
 }

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/OrdnanceSurveyOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/OrdnanceSurveyOnlineTest.java
@@ -1,0 +1,89 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.ows.wmts.online;
+
+import java.net.URL;
+import java.util.Properties;
+import java.util.logging.Logger;
+import org.geotools.ows.wmts.WebMapTileServer;
+import org.geotools.ows.wmts.model.WMTSServiceType;
+import org.geotools.ows.wmts.request.GetTileRequest;
+import org.geotools.test.OnlineTestCase;
+import org.geotools.util.logging.Logging;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests to check the WMTS capabilities of Ordnance Survey services
+ *
+ * @author Roar Brænden
+ */
+public class OrdnanceSurveyOnlineTest extends OnlineTestCase {
+
+    private String wmtsUrl;
+
+    private String key;
+
+    private static Logger LOGGER = Logging.getLogger(OrdnanceSurveyOnlineTest.class);
+
+    @Override
+    protected String getFixtureId() {
+        return "os-uk-wmts";
+    }
+
+    @Override
+    protected Properties createExampleFixture() {
+        Properties example = new Properties();
+        example.put(
+                "key", "<< You should sign up for a API key at https://osdatahub.os.uk/plans >>");
+        example.put("wmts_url", "https://api.os.uk/maps/raster/v1/wmts");
+
+        return example;
+    }
+
+    @Override
+    protected void setUpInternal() throws Exception {
+        wmtsUrl = fixture.getProperty("wmts_url");
+        key = fixture.getProperty("key");
+    }
+
+    @Test
+    public void testWMTSCapabilities() throws Exception {
+        URL lowerCaseUrl = new URL(wmtsUrl + "?key=" + key);
+        Assert.assertEquals(
+                "Get capabilities with lowercase key",
+                WMTSServiceType.KVP,
+                new WebMapTileServer(lowerCaseUrl).getType());
+
+        URL upperCaseUrl = new URL(wmtsUrl + "?KEY=" + key);
+        Assert.assertEquals(
+                "Get capabilities with uppercase key",
+                WMTSServiceType.KVP,
+                new WebMapTileServer(upperCaseUrl).getType());
+    }
+
+    @Test
+    public void testWMTSTileRequestShouldKeepKey() throws Exception {
+        WebMapTileServer tileServer = new WebMapTileServer(new URL(wmtsUrl + "?key=" + key));
+        GetTileRequest tileRequest = tileServer.createGetTileRequest();
+        URL finalUrl = tileRequest.getFinalURL();
+        LOGGER.fine("GetTile finalUrl: " + finalUrl.toString());
+        String query = finalUrl.getQuery();
+
+        Assert.assertTrue("Query contains key=", query.contains("key="));
+    }
+}

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/WMTSTransparentTileOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/WMTSTransparentTileOnlineTest.java
@@ -90,9 +90,6 @@ public class WMTSTransparentTileOnlineTest extends OnlineTestCase {
 
         MapContent map = new SingleLayerMapContent(layer);
 
-        GTRenderer renderer = new StreamingRenderer();
-        renderer.setMapContent(map);
-
         ReferencedEnvelope mapBounds = service.getBounds();
         double heightToWidth = mapBounds.getSpan(1) / mapBounds.getSpan(0);
         int imageWidth = 600;
@@ -111,6 +108,8 @@ public class WMTSTransparentTileOnlineTest extends OnlineTestCase {
         gr.fill(imageBounds);
 
         // render tiles
+        GTRenderer renderer = new StreamingRenderer();
+        renderer.setMapContent(map);
         renderer.paint(gr, imageBounds, mapBounds);
 
         // get first pixel


### PR DESCRIPTION
[![GEOT-6894](https://badgen.net/badge/JIRA/GEOT-6894/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6894) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When a WMTS service are using its own special query parameters within the url, for instance as authentication. They were omitted when asking for getFinalURL. This had the consequence that a GetTile request failed with a 403.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [X] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.