### PR TITLE
[GEOT-6896] Add support for GML 3.2 namespace to gml-geometry-streaming

### DIFF
--- a/modules/unsupported/gml-geometry-streaming/src/main/java/org/geotools/gml/stream/GML.java
+++ b/modules/unsupported/gml-geometry-streaming/src/main/java/org/geotools/gml/stream/GML.java
@@ -15,44 +15,43 @@
 
 package org.geotools.gml.stream;
 
-import javax.xml.namespace.QName;
-
 /** Names of GML elements parseable with XmlStreamGeometryReader. */
 public class GML {
     private GML() {}
 
     public static final String NAMESPACE = "http://www.opengis.net/gml";
+    public static final String NAMESPACE_3_2 = "http://www.opengis.net/gml/3.2";
 
-    public static final QName Arc = new QName(NAMESPACE, "Arc");
-    public static final QName CompositeCurve = new QName(NAMESPACE, "CompositeCurve");
-    public static final QName coord = new QName(NAMESPACE, "coord");
-    public static final QName coordinates = new QName(NAMESPACE, "coordinates");
-    public static final QName Curve = new QName(NAMESPACE, "Curve");
-    public static final QName curveMember = new QName(NAMESPACE, "curveMember");
-    public static final QName exterior = new QName(NAMESPACE, "exterior");
-    public static final QName innerBoundaryIs = new QName(NAMESPACE, "innerBoundaryIs");
-    public static final QName interior = new QName(NAMESPACE, "interior");
-    public static final QName LinearRing = new QName(NAMESPACE, "LinearRing");
-    public static final QName LineString = new QName(NAMESPACE, "LineString");
-    public static final QName lineStringMember = new QName(NAMESPACE, "lineStringMember");
-    public static final QName LineStringSegment = new QName(NAMESPACE, "LineStringSegment");
-    public static final QName MultiCurve = new QName(NAMESPACE, "MultiCurve");
-    public static final QName MultiLineString = new QName(NAMESPACE, "MultiLineString");
-    public static final QName MultiPoint = new QName(NAMESPACE, "MultiPoint");
-    public static final QName MultiPolygon = new QName(NAMESPACE, "MultiPolygon");
-    public static final QName MultiSurface = new QName(NAMESPACE, "MultiSurface");
-    public static final QName OrientableCurve = new QName(NAMESPACE, "OrientableCurve");
-    public static final QName outerBoundaryIs = new QName(NAMESPACE, "outerBoundaryIs");
-    public static final QName Point = new QName(NAMESPACE, "Point");
-    public static final QName pointMember = new QName(NAMESPACE, "pointMember");
-    public static final QName pointMembers = new QName(NAMESPACE, "pointMembers");
-    public static final QName Polygon = new QName(NAMESPACE, "Polygon");
-    public static final QName polygonMember = new QName(NAMESPACE, "polygonMember");
-    public static final QName pos = new QName(NAMESPACE, "pos");
-    public static final QName posList = new QName(NAMESPACE, "posList");
-    public static final QName Ring = new QName(NAMESPACE, "Ring");
-    public static final QName segments = new QName(NAMESPACE, "segments");
-    public static final QName srsName = new QName(NAMESPACE, "srsName");
-    public static final QName surfaceMember = new QName(NAMESPACE, "surfaceMember");
-    public static final QName surfaceMembers = new QName(NAMESPACE, "surfaceMembers");
+    public static final String Arc = "Arc";
+    public static final String CompositeCurve = "CompositeCurve";
+    public static final String coord = "coord";
+    public static final String coordinates = "coordinates";
+    public static final String Curve = "Curve";
+    public static final String curveMember = "curveMember";
+    public static final String exterior = "exterior";
+    public static final String innerBoundaryIs = "innerBoundaryIs";
+    public static final String interior = "interior";
+    public static final String LinearRing = "LinearRing";
+    public static final String LineString = "LineString";
+    public static final String lineStringMember = "lineStringMember";
+    public static final String LineStringSegment = "LineStringSegment";
+    public static final String MultiCurve = "MultiCurve";
+    public static final String MultiLineString = "MultiLineString";
+    public static final String MultiPoint = "MultiPoint";
+    public static final String MultiPolygon = "MultiPolygon";
+    public static final String MultiSurface = "MultiSurface";
+    public static final String OrientableCurve = "OrientableCurve";
+    public static final String outerBoundaryIs = "outerBoundaryIs";
+    public static final String Point = "Point";
+    public static final String pointMember = "pointMember";
+    public static final String pointMembers = "pointMembers";
+    public static final String Polygon = "Polygon";
+    public static final String polygonMember = "polygonMember";
+    public static final String pos = "pos";
+    public static final String posList = "posList";
+    public static final String Ring = "Ring";
+    public static final String segments = "segments";
+    public static final String srsName = "srsName";
+    public static final String surfaceMember = "surfaceMember";
+    public static final String surfaceMembers = "surfaceMembers";
 }

--- a/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderTest.java
+++ b/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderTest.java
@@ -58,7 +58,9 @@ public class XmlStreamGeometryReaderTest {
         r.nextTag();
         Exception exception =
                 assertThrows(IllegalStateException.class, geometryReader::readGeometry);
-        assertEquals(exception.getMessage(), "Unrecognized geometry element unknown");
+        assertEquals(
+                "Expected a geometry element in the GML namespace but found \"unknown\"",
+                exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-6896](https://badgen.net/badge/JIRA/GEOT-6896/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6896) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Supports elements in the `http://www.opengis.net/gml/3.2` namespace without any other changes to the parsing of the `http://www.opengis.net/gml` namespace. Based on OGC document "[OGC 07-061: Revision Notes for OpenGIS® Implementation Specification: Geographic information - Geography Markup Language Version 3.2.1](https://portal.opengeospatial.org/files/?artifact_id=26765)" I conclude that is the only difference between these versions related to the parsing of geometry elements relevant for this parser.

Tests also compare some geometries to the XSD GML 3.2 parser in addition to the standard XSD GML 3 parser.

Additionally some small warnings from IDEA have feen fixed.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.