### PR TITLE
[GEOT-6898] Read only GeoPackages fail when using the new GPKG application id (24.x)

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
@@ -129,6 +129,10 @@ public class GeoPackage implements Closeable {
     // requirement 11, two generic SRID are to be considered
     protected static final int GENERIC_GEOGRAPHIC_SRID = 0;
     protected static final int GENERIC_PROJECTED_SRID = -1;
+    /** The application id for GeoPackage 1.2 onwards (GPKG) */
+    static final int GPKG_120_APPID = 0x47504B47;
+    /** The application id for GeoPackage 1.0 (GP10) */
+    static final int GPKG_100_APPID = 0x47503130;
 
     public static enum DataType {
         Feature("features"),
@@ -281,7 +285,8 @@ public class GeoPackage implements Closeable {
                 ResultSet rs = st.executeQuery("PRAGMA application_id")) {
             if (rs.next()) {
                 int applicationId = rs.getInt(1);
-                initialized = (0x47503130 == applicationId);
+                // support legacy application id (before 1.2) as well as newer one (from 1.2)
+                initialized = (GPKG_100_APPID == applicationId || GPKG_120_APPID == applicationId);
             }
         }
         if (!initialized) {
@@ -296,7 +301,7 @@ public class GeoPackage implements Closeable {
             runScript(METADATA_REFERENCE + ".sql", cx);
             runScript(DATA_COLUMN_CONSTRAINTS + ".sql", cx);
             addDefaultSpatialReferences(cx);
-            runSQL("PRAGMA application_id = 0x47503130;", cx);
+            runSQL("PRAGMA application_id = " + GPKG_120_APPID + ";", cx);
         }
     }
 

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -154,16 +154,12 @@ public class GeoPackageTest {
     }
 
     void assertApplicationId() throws Exception {
-        Connection cx = geopkg.getDataSource().getConnection();
-        Statement st = cx.createStatement();
-        try {
-            ResultSet rs = st.executeQuery("PRAGMA application_id;");
-            assertEquals(rs.getInt(1), 0x47503130);
+        try (Connection cx = geopkg.getDataSource().getConnection();
+                Statement st = cx.createStatement();
+                ResultSet rs = st.executeQuery("PRAGMA application_id;")) {
+            assertEquals(rs.getInt(1), GeoPackage.GPKG_120_APPID);
         } catch (Exception e) {
             fail(e.getMessage());
-        } finally {
-            st.close();
-            cx.close();
         }
     }
 


### PR DESCRIPTION
[![GEOT-6898](https://badgen.net/badge/JIRA/GEOT-6898/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6898) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

24.x backport of https://github.com/geotools/geotools/pull/3524

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [ ] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.