### PR TITLE
[GEOT-6899] Resource (CPU/Heap) starvation building shapefile spatial index

### DIFF
--- a/modules/plugin/shapefile/pom.xml
+++ b/modules/plugin/shapefile/pom.xml
@@ -153,6 +153,11 @@
       <artifactId>commons-io</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapeFileIndexer.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapeFileIndexer.java
@@ -128,14 +128,12 @@ class ShapeFileIndexer implements FileWriter {
     }
 
     /**
-     * Index the shapefile denoted by setShapeFileName(String fileName) If when a thread starts,
-     * another thread is indexing the same file, this thread will wait that the first thread ends
-     * indexing; in this case <b>zero</b> is reurned as result of the indexing process.
+     * Indexes the shapefile denoted by setShapeFileName(String fileName).
      *
      * @param verbose enable/disable printing of dots every 500 indexed records
-     * @return The number of indexed records (or zero)
+     * @return The number of indexed records
      */
-    public int index(boolean verbose, ProgressListener listener)
+    public int index(boolean verbose, /*unused*/ ProgressListener listener)
             throws MalformedURLException, IOException, TreeException, StoreException,
                     LockTimeoutException {
 

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/IndexManagerTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/IndexManagerTest.java
@@ -1,0 +1,220 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.shapefile;
+
+import static org.geotools.data.shapefile.files.ShpFileType.QIX;
+import static org.geotools.data.shapefile.files.ShpFileType.SHP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.geotools.data.shapefile.files.ShpFiles;
+import org.geotools.feature.NameImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IndexManagerTest extends TestCaseSupport {
+
+    private ShapefileDataStore mockDataStore;
+    private ShpFiles shpFiles;
+
+    @Before
+    public void setUp() throws IOException {
+        File statesShp = copyShapefiles(STATE_POP);
+        shpFiles = new ShpFiles(statesShp);
+
+        mockDataStore = mock(ShapefileDataStore.class);
+        when(mockDataStore.getTypeName()).thenReturn(new NameImpl("statepop"));
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        shpFiles.dispose();
+    }
+
+    @Test
+    public void testCreateSpatialIndex() throws Exception {
+        deleteQixFile();
+        IndexManager indexManager = new IndexManager(shpFiles, mockDataStore);
+
+        assertFalse(shpFiles.exists(QIX));
+        final boolean force = false;
+        assertTrue(indexManager.createSpatialIndex(force));
+        assertTrue(shpFiles.exists(QIX));
+        assertFalse(indexManager.createSpatialIndex(force));
+    }
+
+    @Test
+    public void testCreateSpatialIndex_force() throws Exception {
+        deleteQixFile();
+        IndexManager indexManager = new IndexManager(shpFiles, mockDataStore);
+
+        final boolean force = true;
+        assertTrue(indexManager.createSpatialIndex(force));
+
+        File file = null;
+        try {
+            file = shpFiles.acquireReadFile(QIX, indexManager.writer);
+            assertNotNull(file);
+        } finally {
+            shpFiles.unlockRead(file, indexManager.writer);
+        }
+
+        final long maxWaitNanos = TimeUnit.NANOSECONDS.convert(30, TimeUnit.SECONDS);
+        final long initial = System.nanoTime();
+        long now = initial;
+
+        final long currentLastModified = file.lastModified();
+        while (file.lastModified() == currentLastModified && (now - initial) < maxWaitNanos) {
+            assertTrue(indexManager.createSpatialIndex(force));
+            assertTrue(shpFiles.exists(QIX));
+        }
+        assertTrue(file.lastModified() > currentLastModified);
+    }
+
+    @Test
+    public void testCreateSpatialIndex_stale_index_rebuilds() throws Exception {
+        IndexManager indexManager = new IndexManager(shpFiles, mockDataStore);
+        if (!shpFiles.exists(QIX)) {
+            assertTrue(indexManager.createSpatialIndex(true));
+        }
+
+        File shpFile = null;
+        File indexFile = null;
+        try {
+            shpFile = shpFiles.acquireReadFile(SHP, indexManager.writer);
+            indexFile = shpFiles.acquireReadFile(QIX, indexManager.writer);
+            assertTrue(indexFile.exists());
+        } finally {
+            shpFiles.unlockRead(indexFile, indexManager.writer);
+            shpFiles.unlockRead(shpFile, indexManager.writer);
+        }
+
+        // make the file stale (i.e. older than the .shp)
+        indexFile.setLastModified(shpFile.lastModified() - 100_000);
+        final long lastModified = indexFile.lastModified();
+
+        final boolean force = false;
+        assertTrue("stale index should force rebuild", indexManager.createSpatialIndex(force));
+        assertTrue(shpFiles.exists(QIX));
+
+        assertTrue(indexFile.lastModified() > lastModified);
+
+        assertFalse("index is not stale anymore", indexManager.createSpatialIndex(force));
+    }
+
+    @Test(timeout = 30_000) // timeout at 30s to fail in case of deadlock, too slow build server
+    public void testCreateSpatialIndex_Concurrency_runs_once() throws Exception {
+        deleteQixFile();
+        IndexManager indexManager = new IndexManager(shpFiles, mockDataStore);
+
+        final int threadCount = Math.min(8, 2 * Runtime.getRuntime().availableProcessors());
+        final int taskCount = 2 * threadCount;
+        final boolean force = false;
+        List<Boolean> builds =
+                buildSpatialIndexConcurrently(indexManager, threadCount, taskCount, force);
+
+        long buildCount = builds.stream().filter(Boolean::booleanValue).count();
+
+        String msg =
+                String.format(
+                        "Expected only 1 true result from %d concurrent createSpatialIndex calls",
+                        taskCount);
+        assertEquals(msg, 1, buildCount);
+    }
+
+    @Test(timeout = 30_000) // timeout at 30s to fail in case of deadlock, too slow build server
+    public void testCreateSpatialIndex_Concurrency_with_force_run_sequentially() throws Exception {
+        deleteQixFile();
+        final AtomicInteger concurrentBuilds = new AtomicInteger();
+        final AtomicInteger maxConcurrentBuilds = new AtomicInteger();
+        IndexManager indexManager =
+                new IndexManager(shpFiles, mockDataStore) {
+                    @Override
+                    protected void doCreateSpatialIndex() throws Exception {
+                        int concurrency = concurrentBuilds.incrementAndGet();
+                        super.doCreateSpatialIndex();
+                        concurrentBuilds.decrementAndGet();
+                        maxConcurrentBuilds.set(Math.max(maxConcurrentBuilds.get(), concurrency));
+                    }
+                };
+
+        final int threadCount = Math.min(8, 2 * Runtime.getRuntime().availableProcessors());
+        final int taskCount = 2 * threadCount;
+        final boolean force = true;
+        List<Boolean> builds =
+                buildSpatialIndexConcurrently(indexManager, threadCount, taskCount, force);
+
+        long buildCount = builds.stream().filter(Boolean::booleanValue).count();
+
+        String msg =
+                String.format(
+                        "Expected only %d true results from %d concurrent createSpatialIndex calls with force == true",
+                        taskCount, taskCount);
+        assertEquals(msg, taskCount, buildCount);
+        assertEquals(1, maxConcurrentBuilds.get());
+    }
+
+    private List<Boolean> buildSpatialIndexConcurrently(
+            IndexManager indexManager,
+            final int threadCount,
+            final int taskCount,
+            final boolean force)
+            throws Exception {
+
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Callable<Boolean>> tasks = new ArrayList<>();
+        for (int i = 0; i < taskCount; i++) {
+            tasks.add(() -> indexManager.createSpatialIndex(force));
+        }
+        List<Future<Boolean>> results;
+        try {
+            results = executor.invokeAll(tasks);
+        } finally {
+            executor.shutdownNow();
+        }
+        List<Boolean> retCodes = new ArrayList<>();
+        for (Future<Boolean> f : results) {
+            retCodes.add(f.get());
+        }
+        return retCodes;
+    }
+
+    private void deleteQixFile() throws Exception {
+        if (shpFiles.exists(QIX)) {
+            File path = new File(new URL(shpFiles.get(QIX)).toURI());
+            assertTrue(path.delete());
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-6899](https://badgen.net/badge/JIRA/GEOT-6899/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6899) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Shapefile quadtree index building is triggered on each calling thread,
eventually exhausting available CPU/Memory resources.

Acquire a write lock on the QIX file before building the quad-tree, and
check for stale-ness right after acquiring the lock, to avoid building
the same quad-tree concurrently and/or unnecessarily.

Before:
![image](https://user-images.githubusercontent.com/207423/119744415-5f4ebc00-be62-11eb-8943-7f4dca209980.png)

After:

![image](https://user-images.githubusercontent.com/207423/119744393-50680980-be62-11eb-8f9d-dd3788f9d3bf.png)

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.