### PR TITLE
[GEOT-6900] Shapefile quadtree build performance improvements

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapeFileIndexer.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapeFileIndexer.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2002-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2002-2021, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -16,6 +16,8 @@
  */
 package org.geotools.data.shapefile;
 
+import static org.geotools.data.shapefile.ShapefileIndexerBoundsHelper.createBoundsReader;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geotools.data.shapefile.ShapefileIndexerBoundsHelper.BoundsReader;
 import org.geotools.data.shapefile.files.FileWriter;
 import org.geotools.data.shapefile.files.ShpFileType;
 import org.geotools.data.shapefile.files.ShpFiles;
@@ -56,7 +59,7 @@ import org.opengis.util.ProgressListener;
 class ShapeFileIndexer implements FileWriter {
     private static final Logger LOGGER = Logging.getLogger(ShapeFileIndexer.class);
 
-    private int max = -1;
+    private int maxDepth = -1;
     private int leafSize = 16;
 
     private String byteOrder;
@@ -148,25 +151,8 @@ class ShapeFileIndexer implements FileWriter {
         // Temporary file for building...
         StorageFile storage = shpFiles.getStorageFile(ShpFileType.QIX);
         File treeFile = storage.getFile();
-
-        if (max == -1) {
-            try (ShapefileReader reader =
-                    new ShapefileReader(shpFiles, true, false, new GeometryFactory())) {
-
-                // compute a reasonable index max depth, considering a fully developed
-                // 10 levels one already contains 200k index nodes, good for indexing up
-                // to 3M features without consuming too much memory
-                int features = reader.getCount(0);
-                max = 1;
-                int nodes = 1;
-                while (nodes * leafSize < features) {
-                    max++;
-                    nodes *= 4;
-                }
-                if (max < 10) {
-                    max = 10;
-                }
-            }
+        if (maxDepth == -1) {
+            maxDepth = computeMaxDepth();
         }
 
         try (ShapefileReader reader =
@@ -181,69 +167,106 @@ class ShapeFileIndexer implements FileWriter {
         return cnt;
     }
 
+    /**
+     * Compute a reasonable index max depth, considering a fully developed 10 levels one already
+     * contains 200k index nodes, good for indexing up to 3M features without consuming too much
+     * memory
+     */
+    private int computeMaxDepth() throws IOException {
+        int maxDepth;
+        try (ShapefileReader reader =
+                new ShapefileReader(shpFiles, true, false, new GeometryFactory())) {
+            int features = reader.getCount(0);
+            maxDepth = 1;
+            int nodes = 1;
+            while (nodes * leafSize < features) {
+                maxDepth++;
+                nodes *= 4;
+            }
+            if (maxDepth < 10) {
+                maxDepth = 10;
+            }
+            return maxDepth;
+        }
+    }
+
     private int buildQuadTree(ShapefileReader reader, File file, boolean verbose)
             throws IOException, StoreException {
         LOGGER.fine(
                 "Building quadtree spatial index with depth "
-                        + max
+                        + maxDepth
                         + " for file "
                         + file.getAbsolutePath());
 
-        byte order = 0;
+        final byte fileByteOrder = resolveStorageByteOrder();
 
-        if ((this.byteOrder == null) || this.byteOrder.equalsIgnoreCase("NM")) {
-            order = IndexHeader.NEW_MSB_ORDER;
-        } else if (this.byteOrder.equalsIgnoreCase("NL")) {
-            order = IndexHeader.NEW_LSB_ORDER;
-        } else {
-            throw new StoreException(
-                    "Asked byte order '" + this.byteOrder + "' must be 'NL' or 'NM'!");
-        }
-
-        IndexFile shpIndex = new IndexFile(shpFiles, false);
         int cnt = 0;
-        int numRecs = shpIndex.getRecordCount();
-        ShapefileHeader header = reader.getHeader();
-        Envelope bounds = new Envelope(header.minX(), header.maxX(), header.minY(), header.maxY());
 
-        try (QuadTree tree = new QuadTree(numRecs, max, bounds, shpIndex)) {
-            Record rec = null;
-
+        try (IndexFile shpIndex = new IndexFile(shpFiles, false);
+                // strategy to speed up optimizeTree()
+                BoundsReader boundsHelper = createBoundsReader(reader, shpIndex);
+                QuadTree tree =
+                        new QuadTree(
+                                shpIndex.getRecordCount(), maxDepth, getBounds(reader), shpIndex)) {
+            Envelope env = new Envelope();
             while (reader.hasNext()) {
-                rec = reader.nextRecord();
-                tree.insert(cnt++, new Envelope(rec.minX, rec.maxX, rec.minY, rec.maxY));
+                Record rec = reader.nextRecord();
+                env.init(rec.minX, rec.maxX, rec.minY, rec.maxY);
+                int recno = cnt++;
+                tree.insert(recno, env);
+                boundsHelper.insert(recno, env);
 
-                if (verbose && ((cnt % 1000) == 0)) {
+                if (verbose && ((cnt % 1_000) == 0)) {
                     System.out.print('.');
                 }
-                if (cnt % 100000 == 0) System.out.print('\n');
+                if (cnt % 100_000 == 0) System.out.print('\n');
             }
-            if (verbose) System.out.println("done");
-            FileSystemIndexStore store = new FileSystemIndexStore(file, order);
+            if (verbose) System.out.println("done building quadtree");
 
-            if (leafSize > 0) {
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.fine("Optimizing the tree (this might take some time)");
-                }
-                optimizeTree(tree, tree.getRoot(), 0, reader, shpIndex);
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.fine("Tree optimized");
-                }
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("Optimizing the tree (this might take some time)");
+            }
+            if (verbose) System.out.println("Optimizing the tree (this might take some time)");
+            optimizeTree(tree, tree.getRoot(), 0, boundsHelper);
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("Tree optimized");
             }
 
             if (LOGGER.isLoggable(Level.FINE)) {
                 printStats(tree);
             }
+            if (verbose) System.out.println("Storing the tree...");
+            FileSystemIndexStore store = new FileSystemIndexStore(file, fileByteOrder);
             store.store(tree);
+            if (verbose) System.out.println("done");
         }
         return cnt;
     }
 
-    private Node optimizeTree(
-            QuadTree tree, Node node, int level, ShapefileReader reader, IndexFile index)
+    private Envelope getBounds(ShapefileReader reader) {
+        ShapefileHeader header = reader.getHeader();
+        Envelope bounds = new Envelope(header.minX(), header.maxX(), header.minY(), header.maxY());
+        return bounds;
+    }
+
+    private byte resolveStorageByteOrder() throws StoreException {
+        if ((this.byteOrder == null) || this.byteOrder.equalsIgnoreCase("NM")) {
+            return IndexHeader.NEW_MSB_ORDER;
+        }
+        if (this.byteOrder.equalsIgnoreCase("NL")) {
+            return IndexHeader.NEW_LSB_ORDER;
+        }
+        throw new StoreException("Asked byte order '" + this.byteOrder + "' must be 'NL' or 'NM'!");
+    }
+
+    private Node optimizeTree(QuadTree tree, Node node, int level, BoundsReader reader)
             throws StoreException, IOException {
         // recurse, with a check to avoid too deep recursion due to odd data that has a
-        if (node.getNumShapeIds() > leafSize && node.getNumSubNodes() == 0 && level < max * 2) {
+        final boolean isLeafNode = node.getNumSubNodes() == 0;
+        final boolean isOverFlown = node.getNumShapeIds() > leafSize;
+        final int hardMaxDepth = maxDepth * 2;
+        final boolean canBeSplit = level < hardMaxDepth;
+        if (isLeafNode && isOverFlown && canBeSplit) {
             // ok, we need to split this baby further
             int[] shapeIds = node.getShapesId();
             int numShapesId = node.getNumShapeIds();
@@ -257,13 +280,11 @@ class ShapeFileIndexer implements FileWriter {
                 nodes *= 4;
             }
 
+            Envelope env = new Envelope();
             for (int i = 0; i < numShapesId; i++) {
-                final int shapeId = shapeIds[i];
-                int offset = index.getOffsetInBytes(shapeId);
-                reader.goTo(offset);
-                Record rec = reader.nextRecord();
-                Envelope env = new Envelope(rec.minX, rec.maxX, rec.minY, rec.maxY);
-                tree.insert(node, shapeId, env, extraLevels);
+                final int recNumber = shapeIds[i];
+                reader.read(recNumber, env);
+                tree.insert(node, recNumber, env, extraLevels);
             }
         }
 
@@ -272,7 +293,7 @@ class ShapeFileIndexer implements FileWriter {
 
         // recurse
         for (int i = 0; i < node.getNumSubNodes(); i++) {
-            optimizeTree(tree, node.getSubNode(i), level + 1, reader, index);
+            optimizeTree(tree, node.getSubNode(i), level + 1, reader);
         }
 
         // prune empty subnodes
@@ -301,12 +322,8 @@ class ShapeFileIndexer implements FileWriter {
             Envelope bounds = new Envelope();
             if (node.getNumShapeIds() > 0) {
                 int[] shapeIds = node.getShapesId();
-                for (final int shapeId : shapeIds) {
-                    int offset = index.getOffsetInBytes(shapeId);
-                    reader.goTo(offset);
-                    Record rec = reader.nextRecord();
-                    Envelope env = new Envelope(rec.minX, rec.maxX, rec.minY, rec.maxY);
-                    bounds.expandToInclude(env);
+                for (final int recNumber : shapeIds) {
+                    reader.expandEnvelope(recNumber, bounds);
                 }
             }
             if (node.getNumSubNodes() > 0) {
@@ -369,7 +386,7 @@ class ShapeFileIndexer implements FileWriter {
 
     /** For quad tree this is the max depth. I don't know what it is for RTree */
     public void setMax(int i) {
-        max = i;
+        maxDepth = i;
     }
 
     /** @param shpFiles */
@@ -392,6 +409,9 @@ class ShapeFileIndexer implements FileWriter {
     }
 
     public void setLeafSize(int leafSize) {
+        if (leafSize < 1) {
+            throw new IllegalArgumentException("Maximum node leaf size must be a positive integer");
+        }
         this.leafSize = leafSize;
     }
 }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileIndexerBoundsHelper.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileIndexerBoundsHelper.java
@@ -1,0 +1,332 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.shapefile;
+
+import static org.geotools.data.shapefile.shp.ShapeType.POINT;
+import static org.geotools.data.shapefile.shp.ShapeType.POINTM;
+import static org.geotools.data.shapefile.shp.ShapeType.POINTZ;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.DoubleBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geotools.data.shapefile.index.quadtree.QuadTree;
+import org.geotools.data.shapefile.shp.IndexFile;
+import org.geotools.data.shapefile.shp.ShapeType;
+import org.geotools.data.shapefile.shp.ShapefileReader;
+import org.geotools.data.shapefile.shp.ShapefileReader.Record;
+import org.geotools.util.NIOUtilities;
+import org.geotools.util.logging.Logging;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.index.quadtree.Quadtree;
+
+/**
+ * Utility class to assist {@link ShapeFileIndexer} in speeding up the {@link QuadTree} optimization
+ * phase through a {@link BoundsReader strategy object} that provides quick access to each shapefile
+ * record envelope, potentially avoiding an immense amount of random disk I/O calls through {@link
+ * ShapefileReader}, as the quad tree internal nodes get split/shrank.
+ *
+ * <p>Since the {@link QuadTree} leaf nodes hold only the shapefile record ids, and not their
+ * bounds, the tree layout optimization phase may incur into too much random disk reads on the
+ * {@code .shp} file.
+ *
+ * <p>The strategy object {@link #create provided} is meant to avoid that to the extent possible.
+ *
+ * <p>To a given point, record bounds will be stored in heap memory (up to 1MiB, accounting for 32K
+ * records, or 64K records if it's a points shapefile).
+ *
+ * <p>For a bigger number of {@link IndexFile#getRecordCount() shapefile records}, the strategy is
+ * to store the bounds in a temporary file (named {@code GeoTools_shp_qix_bounds_<random
+ * number>.tmp} under {@code java.io.tmpdir}), which is memory mapped and deleted at {@link
+ * BoundsReader#close()}. This leverages the Operating System's native paging, and due to the
+ * reduced size of the bounds file compared to the actual {@code.shp} and avoiding the parsing
+ * performed by {@link ShapefileReader#nextRecord()}, results in dramatically less random I/O and
+ * computing.
+ *
+ * <p>Note, however, that if there's not enough temporary space in the file system where the {@code
+ * java.io.tmpdir} directory resides, a fall back strategy that reads directly from the {@link
+ * ShapefileReader} will be used. This should be a very edge case though, since with a bounds record
+ * size of 32 bytes, the required temporary storage is 30.1MiB per million features.
+ */
+class ShapefileIndexerBoundsHelper {
+
+    private static final Logger LOGGER = Logging.getLogger(ShapefileIndexerBoundsHelper.class);
+
+    /**
+     * A record count threshold past which bounds storage falls back to a temporary file.
+     *
+     * <p>Set to the equivalent of 1MB of heap memory, accounting for 32768 records (for a 32 byte
+     * serialized envelope size), or 65536 records if the shapefile geometry type is POINT (using 16
+     * bytes per envelope).
+     */
+    private static final int FALLBACK_TO_FILE_REC_COUNT_THRESHOLD = (1024 * 1024) / 32;
+
+    /**
+     * Returns a bounds reader strategy following the logic explained at the class' javadocs.
+     *
+     * @param reader the shapefile reader used to build the QuadTree
+     * @param shpIndex provided shapefile record count, and file offsets if necesasry
+     * @return a reader optimized to quickly store and serve the shapefile records bounds, may fall
+     *     back to random disk I/O on the {@code .shp} itself through {@link ShapefileReader}.
+     */
+    static BoundsReader createBoundsReader(final ShapefileReader reader, final IndexFile shpIndex) {
+        final int numRecs = shpIndex.getRecordCount();
+        final ShapeType shapeType = reader.getHeader().getShapeType();
+        final boolean pointBounds =
+                shapeType == POINT || shapeType == POINTM || shapeType == POINTZ;
+        final int fileRecCountThreshold =
+                (pointBounds ? 2 : 1) * FALLBACK_TO_FILE_REC_COUNT_THRESHOLD;
+
+        if (numRecs <= fileRecCountThreshold) {
+            return new HeapBoundsReader(numRecs, pointBounds);
+        }
+        try {
+            return new FileBoundsReader(numRecs, pointBounds);
+        } catch (IOException e) {
+            LOGGER.log(
+                    Level.INFO,
+                    "Unable to create a temporary file backed bounds reader, falling back to slower ShapefileReader random access",
+                    e);
+            return new ShapefileReaderBoundsReader(reader, shpIndex);
+        }
+    }
+
+    /**
+     * Strategy to save the {@code .shp} records bounds while building the {@link QuadTree} and
+     * quickly access them when optimizing its layout.
+     *
+     * <p>While building the in memory {@link Quadtree}, the {@link ShapefileReader} is traversed
+     * sequentially. At that point, {@link #insert(int, Envelope)} should be called with each
+     * record's index and bounds, for this strategy object to save the bounds in its internal
+     * storage.
+     *
+     * <p>While optimizing the {@link QuadTree} layout, {@link #read(int, Envelope)} and {@link
+     * #expandEnvelope(int, Envelope)} provided quick access to each record bounds.
+     *
+     * <p>Finally, {@link #close()} must be called to release any internal resources being used.
+     */
+    static interface BoundsReader extends Closeable {
+
+        /** Records the bounds of the given shapefile record to be read after. */
+        void insert(int recNumber, Envelope env);
+
+        /**
+         * Initializes the provided envelope to the bounds of the requested shapefile record {@code
+         * recNumber}.
+         */
+        void read(int recNumber, Envelope env) throws IOException;
+
+        /**
+         * Expands the provided envelope to cover the bounds of the shapefile record {@code
+         * recNumber}.
+         */
+        void expandEnvelope(int recNumber, Envelope env) throws IOException;
+
+        /**
+         * Releases the underlying bounds storage and any other resource being used to such effect.
+         */
+        @Override
+        default void close() throws IOException {}
+    }
+
+    /**
+     * A fallback strategy to use {@link ShapefileReader}'s random access to records through (e.g.
+     * {@link ShapefileReader#recordAt(int)}).
+     *
+     * <p>Note {@link #insert(int, Envelope)} is a no-op operation, {@link #read} and {@link
+     * #expand} will incur into random disk reads as they position on the {@code .shp} record index
+     * and read them to obtain each record bounds.
+     */
+    private static class ShapefileReaderBoundsReader implements BoundsReader {
+
+        private ShapefileReader reader;
+        private IndexFile shpIndex;
+
+        ShapefileReaderBoundsReader(ShapefileReader reader, IndexFile shpIndex) {
+            this.reader = reader;
+            this.shpIndex = shpIndex;
+        }
+
+        @Override
+        public void insert(int recno, Envelope env) {
+            // no-op, bounds reading is performed directly against the .shp
+        }
+
+        @Override
+        public void read(int recNumber, Envelope env) throws IOException {
+            int offset = shpIndex.getOffsetInBytes(recNumber);
+            reader.goTo(offset);
+            Record rec = reader.nextRecord();
+            env.init(rec.minX, rec.maxX, rec.minY, rec.maxY);
+        }
+
+        @Override
+        public void expandEnvelope(int recNumber, Envelope env) throws IOException {
+            int offset = shpIndex.getOffsetInBytes(recNumber);
+            reader.goTo(offset);
+            Record rec = reader.nextRecord();
+            env.expandToInclude(rec.minX, rec.minY);
+            env.expandToInclude(rec.maxX, rec.maxY);
+        }
+    }
+
+    /**
+     * Stores record bounds in a {@link DoubleBuffer}, in {@code minx,miny[,maxx,maxy]} order; point
+     * bounds are stored as a single ordinate pair.
+     */
+    private static class BufferBoundsReader implements BoundsReader {
+
+        protected DoubleBuffer buff;
+        private final boolean pointBounds;
+        private final int ordinatesPerRec;
+
+        BufferBoundsReader(DoubleBuffer buff, boolean pointBounds) {
+            this.buff = buff;
+            this.pointBounds = pointBounds;
+            this.ordinatesPerRec = pointBounds ? 2 : 4;
+        }
+
+        private int offsetOf(int recNumber) {
+            return ordinatesPerRec * recNumber;
+        }
+
+        @Override
+        public void close() {
+            buff = null;
+        }
+
+        @Override
+        public void insert(int recno, Envelope env) {
+            final int offset = offsetOf(recno);
+            buff.put(offset, env.getMinX());
+            buff.put(offset + 1, env.getMinY());
+            if (!pointBounds) {
+                buff.put(offset + 2, env.getMaxX());
+                buff.put(offset + 3, env.getMaxY());
+            }
+        }
+
+        @Override
+        public void read(int recNumber, Envelope env) throws IOException {
+            buff.position(offsetOf(recNumber));
+            double minx = buff.get();
+            double miny = buff.get();
+            if (pointBounds) {
+                env.init(minx, minx, miny, miny);
+            } else {
+                double maxx = buff.get();
+                double maxy = buff.get();
+                env.init(minx, maxx, miny, maxy);
+            }
+        }
+
+        @Override
+        public void expandEnvelope(int recNumber, Envelope env) throws IOException {
+            buff.position(offsetOf(recNumber));
+            env.expandToInclude(buff.get(), buff.get());
+            if (!pointBounds) {
+                env.expandToInclude(buff.get(), buff.get());
+            }
+        }
+    }
+
+    /** Uses a heap memory backed {@link DoubleBuffer} */
+    private static class HeapBoundsReader extends BufferBoundsReader {
+        HeapBoundsReader(int recCount, boolean pointBounds) {
+            super(DoubleBuffer.allocate((pointBounds ? 2 : 4) * recCount), pointBounds);
+        }
+    }
+
+    /**
+     * Uses a memory mapped temporary file as the source for the {@link DoubleBuffer} where to store
+     * the record bounds.
+     *
+     * <p>{@link #close()} releases the memory mapped byte buffer and deletes the temporary file.
+     */
+    private static class FileBoundsReader implements BoundsReader {
+
+        private static final String TMP_FILE_NAME_PREFIX = "GeoTools_shp_qix_bounds_";
+        private final BufferBoundsReader reader;
+        private final Path path;
+        private final RandomAccessFile file;
+        private final MappedByteBuffer mappedBuffer;
+
+        FileBoundsReader(final int recCount, final boolean isPoint) throws IOException {
+            final int fileSize = recCount * Double.BYTES * (isPoint ? 2 : 4);
+            path = Files.createTempFile(TMP_FILE_NAME_PREFIX, ".tmp");
+            try {
+                checkAvailableSpace(path, fileSize);
+                file = new RandomAccessFile(path.toFile(), "rw");
+                mappedBuffer = file.getChannel().map(MapMode.READ_WRITE, 0L, fileSize);
+                reader = new BufferBoundsReader(mappedBuffer.asDoubleBuffer(), isPoint);
+            } catch (IOException | RuntimeException e) {
+                Files.delete(path);
+                throw e;
+            }
+        }
+
+        @Override
+        public void close() {
+            reader.close();
+            NIOUtilities.clean(mappedBuffer, true);
+            try {
+                file.close();
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Error closing temporary file " + path, e);
+            }
+            try {
+                Files.delete(path);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Error deleting temporary file " + path, e);
+            }
+        }
+
+        @Override
+        public void insert(int recno, Envelope env) {
+            reader.insert(recno, env);
+        }
+
+        @Override
+        public void read(int recNumber, Envelope env) throws IOException {
+            reader.read(recNumber, env);
+        }
+
+        @Override
+        public void expandEnvelope(int recNumber, Envelope env) throws IOException {
+            reader.expandEnvelope(recNumber, env);
+        }
+
+        private void checkAvailableSpace(final Path path, final int fileSize) throws IOException {
+            final FileStore fileStore = Files.getFileStore(path);
+            final long usableSpace = fileStore.getUsableSpace();
+            if (usableSpace < fileSize) {
+                throw new FileSystemException(
+                        String.format(
+                                "Not enough disk space. Required %,d bytes, available: %,d ",
+                                fileSize, usableSpace));
+            }
+        }
+    }
+}

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/QuadTree.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/QuadTree.java
@@ -112,12 +112,13 @@ public class QuadTree implements Closeable {
      * @param recno The record number
      * @param bounds The bounding box
      */
-    public void insert(int recno, Envelope bounds) throws StoreException {
+    public void insert(final int recno, final Envelope bounds) throws StoreException {
         this.insert(this.root, recno, bounds, this.maxDepth);
     }
 
     /** Inserts a shape record id in the quadtree */
-    public void insert(Node node, int recno, Envelope bounds, int maxDepth) throws StoreException {
+    public void insert(Node node, final int recno, final Envelope recBounds, final int maxDepth)
+            throws StoreException {
 
         if (maxDepth > 1 && node.getNumSubNodes() > 0) {
             /*
@@ -127,8 +128,8 @@ public class QuadTree implements Closeable {
             Node subNode = null;
             for (int i = 0; i < node.getNumSubNodes(); i++) {
                 subNode = node.getSubNode(i);
-                if (subNode.getBounds().contains(bounds)) {
-                    this.insert(subNode, recno, bounds, maxDepth - 1);
+                if (subNode.getBounds().contains(recBounds)) {
+                    this.insert(subNode, recno, recBounds, maxDepth - 1);
                     return;
                 }
             }
@@ -152,19 +153,19 @@ public class QuadTree implements Closeable {
             Envelope quad4 = tmp[1];
 
             Node subnode = null;
-            if (quad1.contains(bounds)) {
+            if (quad1.contains(recBounds)) {
                 subnode = new Node(quad1);
-            } else if (quad2.contains(bounds)) {
+            } else if (quad2.contains(recBounds)) {
                 subnode = new Node(quad2);
-            } else if (quad3.contains(bounds)) {
+            } else if (quad3.contains(recBounds)) {
                 subnode = new Node(quad3);
-            } else if (quad4.contains(bounds)) {
+            } else if (quad4.contains(recBounds)) {
                 subnode = new Node(quad4);
             }
 
             if (subnode != null) {
                 node.addSubNode(subnode);
-                this.insert(subnode, recno, bounds, maxDepth - 1);
+                this.insert(subnode, recno, recBounds, maxDepth - 1);
                 return;
             }
         }

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapeFileIndexerStressTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapeFileIndexerStressTest.java
@@ -1,0 +1,170 @@
+package org.geotools.data.shapefile;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Transaction;
+import org.geotools.data.shapefile.files.ShpFiles;
+import org.geotools.data.shapefile.index.LockTimeoutException;
+import org.geotools.data.shapefile.index.TreeException;
+import org.geotools.data.shapefile.index.quadtree.StoreException;
+import org.geotools.data.util.NullProgressListener;
+import org.geotools.feature.SchemaException;
+import org.geotools.util.logging.Logging;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.util.Stopwatch;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+@RunWith(Parameterized.class)
+@SuppressWarnings("PMD.SystemPrintln")
+public class ShapeFileIndexerStressTest {
+
+    private static final Logger LOGGER = Logging.getLogger(ShapeFileIndexerStressTest.class);
+
+    private static final GeometryFactory GF = new GeometryFactory();
+
+    @Parameters
+    public static Integer[] featureCount() {
+        return new Integer[] {1_000, 10_000, 100_000, 1_000_000, 10_000_000};
+    }
+
+    @Parameter(value = 0)
+    public int featureCount;
+
+    private ShapefileDataStore dataStore;
+
+    public @Rule TemporaryFolder tmpDir = new TemporaryFolder();
+
+    private File file;
+
+    private static List<Stats> STATS = new ArrayList<>();
+
+    static class Stats {
+        int featureCount;
+        long ellapsed;
+
+        public static void printHeader() {
+            System.out.println("|# Features|Index build time|");
+            System.out.println("|----------|----------------|");
+        }
+
+        @Override
+        public String toString() {
+            return String.format("|%,d|%s|", featureCount, Stopwatch.getTimeString(ellapsed));
+        }
+    }
+
+    @Before
+    public void setUp() throws SchemaException, IOException {
+        final String typeName = getClass().getSimpleName() + "_" + featureCount + ".shp";
+        file = new File(tmpDir.getRoot(), typeName);
+        URL url = file.toURI().toURL();
+
+        dataStore = new ShapefileDataStore(url);
+        dataStore.setIndexCreationEnabled(false);
+        SimpleFeatureType featureType =
+                DataUtilities.createType(typeName, "id:0,the_geom:LineString");
+        dataStore.createSchema(featureType);
+        LOGGER.info(String.format("Setting up %,d features shapefile %s...", featureCount, file));
+        addFeatures(dataStore, featureType, featureCount);
+        LOGGER.info(
+                String.format(
+                        "%,d features shapefile %s, %,d bytes...",
+                        featureCount, file, file.length()));
+    }
+
+    @After
+    public void tearDown() {
+        dataStore.dispose();
+        Stats.printHeader();
+        for (Stats s : STATS) {
+            System.out.println(s);
+        }
+    }
+
+    private void addFeatures(ShapefileDataStore store, SimpleFeatureType type, final int count)
+            throws IOException {
+        FeatureWriter<SimpleFeatureType, SimpleFeature> writer =
+                store.getFeatureWriterAppend(Transaction.AUTO_COMMIT);
+        try {
+            int recno = 0;
+            int zlevel = 1;
+            while (recno <= count) {
+                double width = 360D / zlevel;
+                double height = 180D / zlevel;
+                for (double minx = -180d; minx < 180d; minx += width) {
+                    for (double miny = -90d; miny < 90d; miny += height) {
+                        double maxx = minx + width;
+                        double maxy = miny + height;
+                        addFeature(recno++, count, writer, minx, miny, minx, maxy);
+                        addFeature(recno++, count, writer, minx, maxy, maxx, maxy);
+                        addFeature(recno++, count, writer, maxx, maxy, maxx, miny);
+                        addFeature(recno++, count, writer, maxx, miny, minx, miny);
+                    }
+                }
+                ++zlevel;
+            }
+        } finally {
+            writer.close();
+        }
+    }
+
+    private void addFeature(
+            int recno,
+            int maxCount,
+            FeatureWriter<SimpleFeatureType, SimpleFeature> writer,
+            double minx,
+            double miny,
+            double maxx,
+            double maxy)
+            throws IOException {
+        if (recno < maxCount) {
+            SimpleFeature f = writer.next();
+            f.setAttribute("id", recno);
+            LineString geom = buildLineString(minx, miny, maxx, maxy);
+            f.setAttribute("the_geom", geom);
+            writer.write();
+        }
+    }
+
+    private LineString buildLineString(double x1, double y1, double x2, double y2) {
+        CoordinateSequence coords = GF.getCoordinateSequenceFactory().create(2, 2);
+        coords.setOrdinate(0, 0, x1);
+        coords.setOrdinate(0, 1, y1);
+        coords.setOrdinate(1, 0, x2);
+        coords.setOrdinate(1, 1, y2);
+        return GF.createLineString(coords);
+    }
+
+    @Test
+    public void testIndex()
+            throws TreeException, StoreException, IOException, LockTimeoutException {
+        ShapeFileIndexer indexer = new ShapeFileIndexer();
+        indexer.setShapeFileName(new ShpFiles(file));
+        Stopwatch sw = new Stopwatch();
+        indexer.index(true, new NullProgressListener());
+        sw.stop();
+        long ellapsedMillis = sw.getTime();
+        Stats s = new Stats();
+        s.featureCount = featureCount;
+        s.ellapsed = ellapsedMillis;
+        STATS.add(s);
+    }
+}

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapeFileIndexerStressTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapeFileIndexerStressTest.java
@@ -101,9 +101,8 @@ public class ShapeFileIndexerStressTest {
 
     private void addFeatures(ShapefileDataStore store, SimpleFeatureType type, final int count)
             throws IOException {
-        FeatureWriter<SimpleFeatureType, SimpleFeature> writer =
-                store.getFeatureWriterAppend(Transaction.AUTO_COMMIT);
-        try {
+        try (FeatureWriter<SimpleFeatureType, SimpleFeature> writer =
+                store.getFeatureWriterAppend(Transaction.AUTO_COMMIT)) {
             int recno = 0;
             int zlevel = 1;
             while (recno <= count) {
@@ -121,8 +120,6 @@ public class ShapeFileIndexerStressTest {
                 }
                 ++zlevel;
             }
-        } finally {
-            writer.close();
         }
     }
 


### PR DESCRIPTION
[![GEOT-6900](https://badgen.net/badge/JIRA/GEOT-6900/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6900) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Use a strategy object (`BoundsReader`) to assist `ShapeFileIndexer` in speeding up the 
`QuadTree` optimization  phase, providing quick access to each shapefile
 record envelope, potentially avoiding an immense amount of random disk I/O calls through
`ShapefileReader`, as the quad tree internal nodes get split/shrank.

Since the `QuadTree` leaf nodes hold only the shapefile record ids, and not their
 bounds, the tree layout optimization phase may incur into too much random disk reads on the
`.shp` file, which has a bigger impact the bigger the shapefile is, especially related to the size of the
geometries more than the number of records itself.

The `BoundsReader` strategy object is meant to avoid that to the extent possible.

To a given point, record bounds will be stored in heap memory (up to 1MiB, accounting for 32K
 records, or 64K records if it's a points shapefile).

For a bigger number of shapefile records, the strategy is
 to store the bounds in a temporary file (named 
 `GeoTools_shp_qix_bounds_<random number>.tmp`  under `${java.io.tmpdir}`), 
 which is memory mapped and deleted at `BoundsReader.close()`. This leverages the Operating 
 System's native paging, and due to the reduced size of the bounds file compared to the actual 
 `.shp` and avoiding the parsing performed by `ShapefileReader.nextRecord()`, results in 
 dramatically less random I/O and computing.

Note, however, that if there's not enough temporary space in the file system where the 
`java.io.tmpdir` directory resides, a fall back strategy that reads directly from the 
`ShapefileReader` will be used. This should be a very edge case though, since with a bounds record
 size of 32 bytes, the required temporary storage is 30.1MiB per million features.

## Index build time

The polygon test dataset that was used is attached to [GEOT-6900](https://osgeo-org.atlassian.net/browse/GEOT-6900).

Running `ShapefileIndexer` on it from `main` at 0adffaf3278ca8ff7f6e653b33749620f6cbf59c, prints:
```
341769 features indexed in 193826ms.
```
The same execution with this patch prints:
```
341769 features indexed in 920ms.
```
and produces the exact same results.

The new `ShapefileIndexerStressTest.java` test, ran against the above-mentioned baseline and this patch, results in:

|# Features| Baseline | This patch |
|------------------|----------------| ----------------|
|1,000            | 15 ms| 16 ms|
|10,000         | 41 ms| 24 ms|
|100,000       | 204 ms| 106 ms|
|1,000,000   | 1821 ms| 600 ms|
|10,000,000| 21994 s| 5720 ms|

This shows that the impact of the improvement is proportional to the number of records, but more importantly to the complexity/size of the data itself. Since the test data produced by the stress test is very simple, with 10M records we get only a 4x improvement, but with 300K complex polygons the improvement is 2 orders of magnitude.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.