### PR TITLE
[Backport 25.x] [GEOT-6894] WMTS fails when initial url contains query parameters 

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
@@ -94,7 +94,7 @@ public class WMTSTileService extends TileService {
     private Map<String, Object> extrainfo = new HashMap<>();
 
     /**
-     * create a service directly with out parsing the capabilties again.
+     * create a service directly with out parsing the capabilities again.
      *
      * @param templateURL - where to ask for tiles
      * @param type - KVP or REST
@@ -112,7 +112,7 @@ public class WMTSTileService extends TileService {
     }
 
     /**
-     * create a service directly with out parsing the capabilties again.
+     * create a service directly with out parsing the capabilities again.
      *
      * @param templateURL - where to ask for tiles
      * @param type - KVP or REST

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -322,24 +322,22 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     @Override
     public URL getFinalURL() {
-        String requestUrl = onlineResource.toString();
         if (WMTSServiceType.REST.equals(type)) {
-            requestUrl = layer.getTemplate(format);
-            if (requestUrl == null) {
-                if (LOGGER.isLoggable(Level.INFO))
-                    LOGGER.info("Template URL not available for format  " + format);
+            if (layer.getTemplate(format) == null) {
+                LOGGER.info("Template URL not available for format  " + format);
                 type = WMTSServiceType.KVP;
-                requestUrl = onlineResource.toString();
+                return onlineResource;
+            } else {
+                try {
+                    return new URL(layer.getTemplate(format));
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(
+                            "URL for GetTile specified within capabilities is wrong.", e);
+                }
             }
+        } else {
+            return super.getFinalURL();
         }
-        URL ret = null;
-        try {
-            ret = new URL(requestUrl);
-        } catch (MalformedURLException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        return ret;
     }
 
     private TileMatrixSet selectMatrixSet() throws ServiceException, RuntimeException {

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/ESRIWMTSServerOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/ESRIWMTSServerOnlineTest.java
@@ -82,7 +82,7 @@ public class ESRIWMTSServerOnlineTest extends OnlineTestCase {
         request.setCRS(DefaultGeographicCRS.WGS84);
         Set<Tile> tiles = request.getTiles();
         for (Tile tile : tiles) {
-            assertTrue(tile.getUrl().toString().contains("style=default"));
+            assertTrue(tile.getUrl().toString().toLowerCase().contains("style=default"));
         }
     }
 }

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/OrdnanceSurveyOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/OrdnanceSurveyOnlineTest.java
@@ -1,0 +1,89 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.ows.wmts.online;
+
+import java.net.URL;
+import java.util.Properties;
+import java.util.logging.Logger;
+import org.geotools.ows.wmts.WebMapTileServer;
+import org.geotools.ows.wmts.model.WMTSServiceType;
+import org.geotools.ows.wmts.request.GetTileRequest;
+import org.geotools.test.OnlineTestCase;
+import org.geotools.util.logging.Logging;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests to check the WMTS capabilities of Ordnance Survey services
+ *
+ * @author Roar Brænden
+ */
+public class OrdnanceSurveyOnlineTest extends OnlineTestCase {
+
+    private String wmtsUrl;
+
+    private String key;
+
+    private static Logger LOGGER = Logging.getLogger(OrdnanceSurveyOnlineTest.class);
+
+    @Override
+    protected String getFixtureId() {
+        return "os-uk-wmts";
+    }
+
+    @Override
+    protected Properties createExampleFixture() {
+        Properties example = new Properties();
+        example.put(
+                "key", "<< You should sign up for a API key at https://osdatahub.os.uk/plans >>");
+        example.put("wmts_url", "https://api.os.uk/maps/raster/v1/wmts");
+
+        return example;
+    }
+
+    @Override
+    protected void setUpInternal() throws Exception {
+        wmtsUrl = fixture.getProperty("wmts_url");
+        key = fixture.getProperty("key");
+    }
+
+    @Test
+    public void testWMTSCapabilities() throws Exception {
+        URL lowerCaseUrl = new URL(wmtsUrl + "?key=" + key);
+        Assert.assertEquals(
+                "Get capabilities with lowercase key",
+                WMTSServiceType.KVP,
+                new WebMapTileServer(lowerCaseUrl).getType());
+
+        URL upperCaseUrl = new URL(wmtsUrl + "?KEY=" + key);
+        Assert.assertEquals(
+                "Get capabilities with uppercase key",
+                WMTSServiceType.KVP,
+                new WebMapTileServer(upperCaseUrl).getType());
+    }
+
+    @Test
+    public void testWMTSTileRequestShouldKeepKey() throws Exception {
+        WebMapTileServer tileServer = new WebMapTileServer(new URL(wmtsUrl + "?key=" + key));
+        GetTileRequest tileRequest = tileServer.createGetTileRequest();
+        URL finalUrl = tileRequest.getFinalURL();
+        LOGGER.fine("GetTile finalUrl: " + finalUrl.toString());
+        String query = finalUrl.getQuery();
+
+        Assert.assertTrue("Query contains key=", query.contains("key="));
+    }
+}

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/WMTSTransparentTileOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/WMTSTransparentTileOnlineTest.java
@@ -90,9 +90,6 @@ public class WMTSTransparentTileOnlineTest extends OnlineTestCase {
 
         MapContent map = new SingleLayerMapContent(layer);
 
-        GTRenderer renderer = new StreamingRenderer();
-        renderer.setMapContent(map);
-
         ReferencedEnvelope mapBounds = service.getBounds();
         double heightToWidth = mapBounds.getSpan(1) / mapBounds.getSpan(0);
         int imageWidth = 600;
@@ -111,6 +108,8 @@ public class WMTSTransparentTileOnlineTest extends OnlineTestCase {
         gr.fill(imageBounds);
 
         // render tiles
+        GTRenderer renderer = new StreamingRenderer();
+        renderer.setMapContent(map);
         renderer.paint(gr, imageBounds, mapBounds);
 
         // get first pixel


### PR DESCRIPTION
[![GEOT-6894](https://badgen.net/badge/JIRA/GEOT-6894/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6894) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backporting to 25.x

* [GEOT-6894] WMTS fails when initial url contains query parameters

* Fixed the failing tests

* Fixed the formatting

* Using variable separator instead of skipFirst

* Fixed formatting


# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [X] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.