### PR TITLE
[GEOT-6906] WFS DescribeFeatureType doesn't account for outputFormats defined globally

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -665,12 +665,7 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
         return ftypeCrss;
     }
 
-    /**
-     * Returns parameters defined in OperationsMetadata
-     *
-     * @param parameterName
-     * @return
-     */
+    /** Returns parameters defined in OperationsMetadata */
     @SuppressWarnings("unchecked")
     private Set<String> findParameters(final String parameterName) {
         final OperationsMetadataType operationsMetadata = capabilities.getOperationsMetadata();
@@ -678,11 +673,11 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
         List<DomainType> parameters = operationsMetadata.getParameter();
         for (DomainType parameter : parameters) {
             if (parameterName.equals(parameter.getName())) {
-                Set<String> outputFormats = new HashSet<>();
+                Set<String> foundValues = new HashSet<>();
                 for (ValueType value : (List<ValueType>) parameter.getAllowedValues().getValue()) {
-                    outputFormats.add(value.getValue());
+                    foundValues.add(value.getValue());
                 }
-                return outputFormats;
+                return foundValues;
             }
         }
         return Collections.emptySet();
@@ -698,12 +693,12 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
             String paramName = param.getName();
 
             if (parameterName.equals(paramName)) {
-                Set<String> outputFormats = new HashSet<>();
+                Set<String> foundValues = new HashSet<>();
 
                 for (ValueType value : (List<ValueType>) param.getAllowedValues().getValue()) {
-                    outputFormats.add(value.getValue());
+                    foundValues.add(value.getValue());
                 }
-                return outputFormats;
+                return foundValues;
             }
         }
         return Collections.emptySet();

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -561,6 +561,9 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
         final OperationType operationMetadata = getOperationMetadata(operation);
 
         Set<String> serverSupportedFormats = findParameters(operationMetadata, parameterName);
+        if (serverSupportedFormats.isEmpty()) {
+            serverSupportedFormats = findParameters(parameterName);
+        }
         return serverSupportedFormats;
     }
 
@@ -662,10 +665,32 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
         return ftypeCrss;
     }
 
+    /**
+     * Returns parameters defined in OperationsMetadata
+     *
+     * @param parameterName
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    private Set<String> findParameters(final String parameterName) {
+        final OperationsMetadataType operationsMetadata = capabilities.getOperationsMetadata();
+
+        List<DomainType> parameters = operationsMetadata.getParameter();
+        for (DomainType parameter : parameters) {
+            if (parameterName.equals(parameter.getName())) {
+                Set<String> outputFormats = new HashSet<>();
+                for (ValueType value : (List<ValueType>) parameter.getAllowedValues().getValue()) {
+                    outputFormats.add(value.getValue());
+                }
+                return outputFormats;
+            }
+        }
+        return Collections.emptySet();
+    }
+
     @SuppressWarnings("unchecked")
     protected Set<String> findParameters(
             final OperationType operationMetadata, final String parameterName) {
-        Set<String> outputFormats = new HashSet<>();
 
         List<DomainType> parameters = operationMetadata.getParameter();
         for (DomainType param : parameters) {
@@ -673,13 +698,15 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
             String paramName = param.getName();
 
             if (parameterName.equals(paramName)) {
+                Set<String> outputFormats = new HashSet<>();
 
                 for (ValueType value : (List<ValueType>) param.getAllowedValues().getValue()) {
                     outputFormats.add(value.getValue());
                 }
+                return outputFormats;
             }
         }
-        return outputFormats;
+        return Collections.emptySet();
     }
 
     protected AbstractTransactionActionType createInsert(Wfs20Factory factory, Insert elem)

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/WFSTestData.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/WFSTestData.java
@@ -53,7 +53,7 @@ public class WFSTestData {
          * @param featureTypeName the name as stated in the capabilities
          * @param crs the default feature type CRS as stated in the capabilities
          */
-        TestDataType(
+        public TestDataType(
                 final String folder,
                 final QName qName,
                 final String featureTypeName,

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/AbstractWfsDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/AbstractWfsDataStoreOnlineTest.java
@@ -51,7 +51,6 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.CRS.AxisOrder;
 import org.geotools.util.logging.Logging;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -465,12 +464,6 @@ public abstract class AbstractWfsDataStoreOnlineTest {
         */
     }
 
-    /**
-     * There must be a better way to check for axis flipping than counting all features.
-     *
-     * @throws Exception
-     */
-    @Ignore
     @Test
     public void testDataStoreHandlesAxisFlipping() throws Exception {
         if (Boolean.FALSE.equals(serviceAvailable)) {

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/AbstractWfsDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/AbstractWfsDataStoreOnlineTest.java
@@ -18,7 +18,6 @@
 package org.geotools.data.wfs.online;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -318,7 +317,6 @@ public abstract class AbstractWfsDataStoreOnlineTest {
             SimpleFeature next = iterator.next();
             assertNotNull(next);
             assertNotNull(next.getDefaultGeometry());
-            assertFalse(iterator.hasNext());
         }
     }
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/AbstractWfsDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/AbstractWfsDataStoreOnlineTest.java
@@ -332,6 +332,29 @@ public abstract class AbstractWfsDataStoreOnlineTest {
         List<String> typeNames = Arrays.asList(types);
         assertTrue(typeNames.contains(testType.FEATURETYPENAME));
 
+        for (String typeName : types) {
+            SimpleFeatureType type = wfs.getSchema(typeName);
+            type.getTypeName();
+            type.getName().getNamespaceURI();
+
+            SimpleFeatureSource source = wfs.getFeatureSource(typeName);
+            source.getBounds();
+
+            SimpleFeatureCollection features = source.getFeatures();
+            features.getBounds();
+            features.getSchema();
+
+            Query query = new Query(typeName, Filter.INCLUDE, 20, Query.ALL_NAMES, "work already");
+            features = source.getFeatures(query);
+            features.size();
+
+            try (SimpleFeatureIterator iterator = features.features()) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        }
+
         SimpleFeatureType schema = wfs.getSchema(testType.FEATURETYPENAME);
         assertNotNull(schema);
         GeometryDescriptor geometryDescriptor = schema.getGeometryDescriptor();

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
@@ -49,7 +49,8 @@ public class KartverketStedsnavnDataStoreOnlineTest extends AbstractWfsDataStore
 
     static final Id fidFilter = ff.id(Collections.singleton(ff.featureId("404676")));
 
-    static final Filter spatialFilter = null;
+    static final Filter spatialFilter =
+            ff.bbox(defaultGeometryName, 68.0, 17.0, 69.0, 18.0, "urn:ogc:def:crs:EPSG::4258");
 
     public KartverketStedsnavnDataStoreOnlineTest() {
         super(

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import javax.xml.namespace.QName;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.WFSTestData.TestDataType;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.locationtech.jts.geom.Polygon;
 import org.opengis.filter.Filter;
 import org.opengis.filter.Id;
@@ -65,5 +67,12 @@ public class KartverketStedsnavnDataStoreOnlineTest extends AbstractWfsDataStore
     protected void setUpParameters(final Map<String, Serializable> params) {
         super.setUpParameters(params);
         params.put(WFSDataStoreFactory.USE_HTTP_CONNECTION_POOLING.key, "False");
+    }
+    
+    @Override
+    @Test
+    @Ignore
+    public void testDataStoreHandlesAxisFlipping() {
+        // disabled, not implemented for 2.0.0
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
@@ -1,0 +1,69 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.wfs.online;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import org.geotools.data.wfs.WFSDataStoreFactory;
+import org.geotools.data.wfs.WFSTestData.TestDataType;
+import org.locationtech.jts.geom.Polygon;
+import org.opengis.filter.Filter;
+import org.opengis.filter.Id;
+
+/** @author Roar Brænden */
+public class KartverketStedsnavnDataStoreOnlineTest extends AbstractWfsDataStoreOnlineTest {
+
+    static final String SERVER_URL =
+            "https://wfs.geonorge.no/skwms1/wfs.stedsnavn?request=GetCapabilities&service=WFS";
+
+    static final TestDataType KARTVERKET_STEDSNAVN =
+            new TestDataType(
+                    "KartverketNo",
+                    new QName(
+                            "http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115",
+                            "sted"),
+                    "app_Sted",
+                    "urn:ogc:def:crs:EPSG::4258");
+
+    static final String defaultGeometryName = "område";
+
+    static final Class<?> geometryType = Polygon.class;
+
+    static final Id fidFilter = ff.id(Collections.singleton(ff.featureId("404676")));
+
+    static final Filter spatialFilter = null;
+
+    public KartverketStedsnavnDataStoreOnlineTest() {
+        super(
+                SERVER_URL,
+                KARTVERKET_STEDSNAVN,
+                defaultGeometryName,
+                geometryType,
+                -1,
+                fidFilter,
+                spatialFilter,
+                WFSDataStoreFactory.AXIS_ORDER_COMPLIANT);
+    }
+
+    @Override
+    protected void setUpParameters(final Map<String, Serializable> params) {
+        super.setUpParameters(params);
+        params.put(WFSDataStoreFactory.USE_HTTP_CONNECTION_POOLING.key, "False");
+    }
+}

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
@@ -68,7 +68,7 @@ public class KartverketStedsnavnDataStoreOnlineTest extends AbstractWfsDataStore
         super.setUpParameters(params);
         params.put(WFSDataStoreFactory.USE_HTTP_CONNECTION_POOLING.key, "False");
     }
-    
+
     @Override
     @Test
     @Ignore

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
@@ -16,17 +16,25 @@
  */
 package org.geotools.data.wfs.online;
 
+import java.io.IOException;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import javax.xml.namespace.QName;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.WFSTestData.TestDataType;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.locationtech.jts.geom.Polygon;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.filter.Filter;
 import org.opengis.filter.Id;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /** @author Roar Brænden */
 public class KartverketStedsnavnDataStoreOnlineTest extends AbstractWfsDataStoreOnlineTest {
@@ -68,6 +76,27 @@ public class KartverketStedsnavnDataStoreOnlineTest extends AbstractWfsDataStore
     protected void setUpParameters(final Map<String, Serializable> params) {
         super.setUpParameters(params);
         params.put(WFSDataStoreFactory.USE_HTTP_CONNECTION_POOLING.key, "False");
+    }
+
+    @Override
+    @Test
+    public void testTypes() throws IOException, NoSuchElementException {
+        if (Boolean.FALSE.equals(serviceAvailable)) {
+            return;
+        }
+
+        String[] types = wfs.getTypeNames();
+        List<String> typeNames = Arrays.asList(types);
+        Assert.assertTrue(typeNames.contains(testType.FEATURETYPENAME));
+
+        SimpleFeatureType schema = wfs.getSchema(testType.FEATURETYPENAME);
+        Assert.assertNotNull(schema);
+        GeometryDescriptor geometryDescriptor = schema.getGeometryDescriptor();
+        Assert.assertNotNull(geometryDescriptor);
+        Assert.assertEquals(defaultGeometryName, geometryDescriptor.getLocalName());
+        Assert.assertEquals(geometryType, geometryDescriptor.getType().getBinding());
+        CoordinateReferenceSystem crs = geometryDescriptor.getCoordinateReferenceSystem();
+        Assert.assertNotNull(crs);
     }
 
     @Override

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
@@ -110,7 +110,7 @@ public class WFSOnlineTestSupport {
             assertNotNull(next);
             int j = 1;
             while (reader.hasNext()) {
-            	assertTrue("Query maxFeatures isn't respected.", j <= 5);
+                assertTrue("Query maxFeatures isn't respected.", j <= 5);
                 reader.next();
                 j++;
             }
@@ -154,7 +154,7 @@ public class WFSOnlineTestSupport {
             fid = feature.getID();
             int j = 1;
             while (fr.hasNext()) {
-            	assertTrue("Query maxFeatures isn't respected.", j <= 5);
+                assertTrue("Query maxFeatures isn't respected.", j <= 5);
                 fr.next();
                 j++;
             }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
@@ -108,7 +108,7 @@ public class WFSOnlineTestSupport {
             SimpleFeature next = reader.next();
             assertNotNull(next);
             int j = 1;
-            while (reader.hasNext()) {
+            while (j < 6 && reader.hasNext()) {
                 reader.next();
                 j++;
             }
@@ -152,7 +152,7 @@ public class WFSOnlineTestSupport {
             assertNotNull("must have 1 feature ", feature);
             fid = feature.getID();
             int j = 1;
-            while (fr.hasNext()) {
+            while (j < 6 && fr.hasNext()) {
                 fr.next();
                 j++;
             }
@@ -167,7 +167,7 @@ public class WFSOnlineTestSupport {
                 wfs.getFeatureReader(query, Transaction.AUTO_COMMIT)) {
             assertNotNull("FeatureType was null", ft);
             int j = 0;
-            while (fr.hasNext()) {
+            while (j < 2 && fr.hasNext()) {
                 assertEquals(fid, fr.next().getID());
                 j++;
             }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
@@ -18,6 +18,7 @@
 package org.geotools.data.wfs.online;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -108,11 +109,11 @@ public class WFSOnlineTestSupport {
             SimpleFeature next = reader.next();
             assertNotNull(next);
             int j = 1;
-            while (j < 6 && reader.hasNext()) {
+            while (reader.hasNext()) {
+            	assertTrue("Query maxFeatures isn't respected.", j <= 5);
                 reader.next();
                 j++;
             }
-            assertTrue("Query maxFeatures is respected.", j <= 5);
         }
     }
 
@@ -152,11 +153,11 @@ public class WFSOnlineTestSupport {
             assertNotNull("must have 1 feature ", feature);
             fid = feature.getID();
             int j = 1;
-            while (j < 6 && fr.hasNext()) {
+            while (fr.hasNext()) {
+            	assertTrue("Query maxFeatures isn't respected.", j <= 5);
                 fr.next();
                 j++;
             }
-            assertTrue("Query maxFeatures is respected.", j <= 5);
         }
 
         // test fid filter
@@ -166,12 +167,9 @@ public class WFSOnlineTestSupport {
         try (FeatureReader<SimpleFeatureType, SimpleFeature> fr =
                 wfs.getFeatureReader(query, Transaction.AUTO_COMMIT)) {
             assertNotNull("FeatureType was null", ft);
-            int j = 0;
-            while (j < 2 && fr.hasNext()) {
-                assertEquals(fid, fr.next().getID());
-                j++;
-            }
-            assertEquals(1, j);
+            assertTrue("Query should return one feature.", fr.hasNext());
+            assertEquals(fid, fr.next().getID());
+            assertFalse("Query should only return one feature.", fr.hasNext());
         }
     }
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
@@ -107,6 +107,12 @@ public class WFSOnlineTestSupport {
 
             SimpleFeature next = reader.next();
             assertNotNull(next);
+            int j = 1;
+            while (reader.hasNext()) {
+                reader.next();
+                j++;
+            }
+            assertTrue("Query maxFeatures is respected.", j <= 5);
         }
     }
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/WFSOnlineTestSupport.java
@@ -145,6 +145,12 @@ public class WFSOnlineTestSupport {
             }
             assertNotNull("must have 1 feature ", feature);
             fid = feature.getID();
+            int j = 1;
+            while (fr.hasNext()) {
+                fr.next();
+                j++;
+            }
+            assertTrue("Query maxFeatures is respected.", j <= 5);
         }
 
         // test fid filter

--- a/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/DescribeFeatureType_sted.xsd
+++ b/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/DescribeFeatureType_sted.xsd
@@ -1,0 +1,14570 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:app="http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115"
+	xmlns:gml="http://www.opengis.net/gml/3.2"
+	xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+	elementFormDefault="qualified"
+	targetNamespace="http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115"
+	version="20181115">
+
+	<annotation>
+
+		<documentation>spesifikasjonen omfatter de vanlig brukte stedsnavn som
+			inngår i Sentralt stedsnavnregister - SSR2</documentation>
+
+	</annotation>
+
+	<import
+		namespace="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+		schemaLocation="http://shapechange.net/resources/schema/ShapeChangeAppinfo.xsd" />
+
+	<import namespace="http://www.opengis.net/gml/3.2"
+		schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+
+	<!--XML Schema document created by ShapeChange - http://shapechange.net/ -->
+
+	<element abstract="true" name="Fellesegenskaper"
+		substitutionGroup="gml:AbstractFeature"
+		type="app:FellesegenskaperType">
+
+		<annotation>
+
+			<documentation>abstrakt objekttype som bærer sentrale egenskaper som
+				er anbefalt for bruk i produktspesifikasjoner.
+
+				Merknad: Disse egenskapene skal derfor ikke modelleres inn i
+				fagområdemodeller.
+			</documentation>
+
+		</annotation>
+
+	</element>
+
+	<complexType abstract="true" name="FellesegenskaperType">
+
+		<complexContent>
+
+			<extension base="gml:AbstractFeatureType">
+
+				<sequence>
+
+					<element name="identifikasjon"
+						type="app:IdentifikasjonPropertyType">
+
+						<annotation>
+
+							<documentation>unik identifikasjon av et objekt</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">IDENT</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element name="oppdateringsdato" type="dateTime">
+
+						<annotation>
+
+							<documentation>dato for siste endring på objektetdataene
+
+								Merknad:
+								Oppdateringsdato kan være forskjellig fra Datafangsdato ved at data som er
+								registrert kan bufres en kortere eller lengre periode før disse
+								legges inn i datasystemet (databasen).
+							</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">OPPDATERINGSDATO</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element name="datauttaksdato" type="dateTime">
+
+						<annotation>
+
+							<documentation>dato for uttak fra en database
+
+								Merknad:
+								Skiller seg fra Kopidato ved at en ikke skiller på om det er uttak fra
+								en originaldatabase eller en kopidatabase.
+							</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">DATAUTTAKSDATO</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+				</sequence>
+
+			</extension>
+
+		</complexContent>
+
+	</complexType>
+
+	<complexType name="FellesegenskaperPropertyType">
+
+		<sequence minOccurs="0">
+
+			<element ref="app:Fellesegenskaper" />
+
+		</sequence>
+
+		<attributeGroup ref="gml:AssociationAttributeGroup" />
+
+		<attributeGroup ref="gml:OwnershipAttributeGroup" />
+
+	</complexType>
+
+	<simpleType name="FylkesnummerType">
+
+		<annotation>
+
+			<documentation>nummerering av fylker i henhold til Statistisk
+				sentralbyrå sin offisielle liste
+
+				Merknad:
+				Det presiseres at fylkesnummer alltid skal ha 2 sifre, dvs. eventuelt
+				med ledende null. Fylkesnummer benyttes for kopling mot en rekke
+				andre registre som også benytter 2 sifre.
+			</documentation>
+
+			<appinfo>
+
+				<taggedValue
+					xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+					tag="SOSI_navn">FYLKESNR</taggedValue>
+
+			</appinfo>
+
+		</annotation>
+
+		<union
+			memberTypes="app:FylkesnummerEnumerationType app:FylkesnummerOtherType" />
+
+	</simpleType>
+
+	<simpleType name="FylkesnummerEnumerationType">
+
+		<annotation>
+
+			<documentation>nummerering av fylker i henhold til Statistisk
+				sentralbyrå sin offisielle liste
+
+				Merknad:
+				Det presiseres at fylkesnummer alltid skal ha 2 sifre, dvs. eventuelt
+				med ledende null. Fylkesnummer benyttes for kopling mot en rekke
+				andre registre som også benytter 2 sifre.
+			</documentation>
+
+			<appinfo>
+
+				<taggedValue
+					xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+					tag="SOSI_navn">FYLKESNR</taggedValue>
+
+			</appinfo>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="01">
+
+				<annotation>
+
+					<documentation>Østfold (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="30">
+
+				<annotation>
+
+					<documentation>Viken</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="02">
+
+				<annotation>
+
+					<documentation>Akershus (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="03">
+
+				<annotation>
+
+					<documentation>Oslo</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="04">
+
+				<annotation>
+
+					<documentation>Hedmark (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="34">
+
+				<annotation>
+
+					<documentation>Innlandet</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="05">
+
+				<annotation>
+
+					<documentation>Oppland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="06">
+
+				<annotation>
+
+					<documentation>Buskerud (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="07">
+
+				<annotation>
+
+					<documentation>Vestfold (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="38">
+
+				<annotation>
+
+					<documentation>Telemark og Vestfold</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="08">
+
+				<annotation>
+
+					<documentation>Telemark (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="09">
+
+				<annotation>
+
+					<documentation>Aust-Agder (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="42">
+
+				<annotation>
+
+					<documentation>Agder</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="10">
+
+				<annotation>
+
+					<documentation>Vest-Agder (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="11">
+
+				<annotation>
+
+					<documentation>Rogaland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="12">
+
+				<annotation>
+
+					<documentation>Hordaland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="46">
+
+				<annotation>
+
+					<documentation>Vestland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="13">
+
+				<annotation>
+
+					<documentation>Bergen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="14">
+
+				<annotation>
+
+					<documentation>Sogn og Fjordane (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="15">
+
+				<annotation>
+
+					<documentation>Møre og Romsdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="16">
+
+				<annotation>
+
+					<documentation>Sør-Trøndelag (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="17">
+
+				<annotation>
+
+					<documentation>Nord-Trøndelag (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="18">
+
+				<annotation>
+
+					<documentation>Nordland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="19">
+
+				<annotation>
+
+					<documentation>Troms - Romsa (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="54">
+
+				<annotation>
+
+					<documentation>Troms og Finnmark</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="20">
+
+				<annotation>
+
+					<documentation>Finnmark - Finnmárku (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="21">
+
+				<annotation>
+
+					<documentation>Svalbard</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="22">
+
+				<annotation>
+
+					<documentation>Jan Mayen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="23">
+
+				<annotation>
+
+					<documentation>Kontinentalsokkelen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="50">
+
+				<annotation>
+
+					<documentation>Trøndelag</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="FylkesnummerOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<element name="Identifikasjon"
+		substitutionGroup="gml:AbstractObject" type="app:IdentifikasjonType">
+
+		<annotation>
+
+			<documentation>Identification: Unik identifikasjon av et objekt i et
+				datasett, forvaltet av den ansvarlige produsent/forvalter, og kan
+				benyttes av eksterne applikasjoner som stabil referanse til
+				objektet.
+
+				Merknad 1: Denne objektidentifikasjonen må ikke forveksles med en tematisk
+				objektidentifikasjon, slik som f.eks bygningsnummer.
+
+				Merknad 2: Denne unike identifikatoren vil ikke endres i løpet av objektets
+				levetid, og ikke gjenbrukes i andre objekt.
+			</documentation>
+
+			<appinfo>
+
+				<taggedValue
+					xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+					tag="SOSI_navn">IDENT</taggedValue>
+
+			</appinfo>
+
+		</annotation>
+
+	</element>
+
+	<complexType name="IdentifikasjonType">
+
+		<sequence>
+
+			<element name="lokalId" type="string">
+
+				<annotation>
+
+					<documentation>localId: lokal identifikator av et objekt
+
+						Merknad: Det er dataleverendørens ansvar å sørge for at den lokale
+						identifikatoren er unik innenfor navnerommet.
+					</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">LOKALID</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="navnerom" type="string">
+
+				<annotation>
+
+					<documentation>namespace: navnerom som unikt identifiserer
+						datakilden til et objekt, anbefales å være en http-URI
+
+						Eksempel: http://data.geonorge.no/SentraltStedsnavnsregister/1.0
+
+						Merknad : Verdien for nanverom vil eies av den dataprodusent som har
+						ansvar for de unike identifikatorene og må være registrert i
+						data.geonorge.no eller data.norge.no
+					</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">NAVNEROM</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="versjonId" type="string">
+
+				<annotation>
+
+					<documentation>versionId: identifikasjon av en spesiell versjon av
+						et geografisk objekt (instans)</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">VERSJONID</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+		</sequence>
+
+	</complexType>
+
+	<complexType name="IdentifikasjonPropertyType">
+
+		<sequence>
+
+			<element ref="app:Identifikasjon" />
+
+		</sequence>
+
+	</complexType>
+
+	<element name="Kommune" substitutionGroup="gml:AbstractObject"
+		type="app:KommuneType">
+
+		<annotation>
+
+			<documentation>Selvstendig objekt som kan pekes til fra flere steder,
+				og skal vise kommunen(e) det registrerte stedet er i. Denne skal
+				ikke brukes for navnetypen "Kommune".</documentation>
+
+		</annotation>
+
+	</element>
+
+	<complexType name="KommuneType">
+
+		<sequence>
+
+			<element name="kommunenummer" type="app:KommunenummerType">
+
+				<annotation>
+
+					<documentation>Kommunenummer er nummer for å identifisere
+						kommunerer og er et firesifret nummer (eks.: 0101) som er unikt
+						for hver kommune i Norge</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="kommunenavn" type="string">
+
+				<annotation>
+
+					<documentation>Navnet på kommunen, navnet vises på flere språk
+						dersom kommunen er flerspråklig.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">KOMMUNENAVN</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="fylkesnummer" type="app:FylkesnummerType">
+
+				<annotation>
+
+					<documentation>Fylkesnummer er definerte identifikasjonskoder for
+						norske fylker og to territorier (Svalbard og Jan Mayen)
+					</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">FYLKESNR</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="fylkesnavn" type="string">
+
+				<annotation>
+
+					<documentation>Navnet på fylket, navnet vises på flere språk med
+						riktig rekkefølge på spårkene dersom fylket er flerspråklig.
+					</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">FYLKESNAVN</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+		</sequence>
+
+	</complexType>
+
+	<complexType name="KommunePropertyType">
+
+		<sequence>
+
+			<element ref="app:Kommune" />
+
+		</sequence>
+
+	</complexType>
+
+	<simpleType name="KommunenummerType">
+
+		<annotation>
+
+			<documentation>nummerering av kommuner i henhold til Statistisk
+				sentralbyrå sin offisielle liste samt et utvalg av utgåtte numre
+
+				Merknad: Det presiseres at kommune alltid skal ha 4 sifre, dvs.
+				eventuelt med ledende null. Kommune benyttes for kopling mot en
+				rekke andre registre som også benytter 4 sifre.
+			</documentation>
+
+			<appinfo>
+
+				<taggedValue
+					xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+					tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+
+			</appinfo>
+
+		</annotation>
+
+		<union
+			memberTypes="app:KommunenummerEnumerationType app:KommunenummerOtherType" />
+
+	</simpleType>
+
+	<simpleType name="KommunenummerEnumerationType">
+
+		<annotation>
+
+			<documentation>nummerering av kommuner i henhold til Statistisk
+				sentralbyrå sin offisielle liste samt et utvalg av utgåtte numre
+
+				Merknad: Det presiseres at kommune alltid skal ha 4 sifre, dvs.
+				eventuelt med ledende null. Kommune benyttes for kopling mot en
+				rekke andre registre som også benytter 4 sifre.
+			</documentation>
+
+			<appinfo>
+
+				<taggedValue
+					xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+					tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+
+			</appinfo>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="0101">
+
+				<annotation>
+
+					<documentation>Halden (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3001">
+
+				<annotation>
+
+					<documentation>Halden</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0102">
+
+				<annotation>
+
+					<documentation>Sarpsborg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0103">
+
+				<annotation>
+
+					<documentation>Fredrikstad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0104">
+
+				<annotation>
+
+					<documentation>Moss (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3002">
+
+				<annotation>
+
+					<documentation>Moss</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0105">
+
+				<annotation>
+
+					<documentation>Sarpsborg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3003">
+
+				<annotation>
+
+					<documentation>Sarpsborg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0106">
+
+				<annotation>
+
+					<documentation>Fredrikstad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3004">
+
+				<annotation>
+
+					<documentation>Fredrikstad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0111">
+
+				<annotation>
+
+					<documentation>Hvaler (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3011">
+
+				<annotation>
+
+					<documentation>Hvaler</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0113">
+
+				<annotation>
+
+					<documentation>Borge (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0114">
+
+				<annotation>
+
+					<documentation>Varteig (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0115">
+
+				<annotation>
+
+					<documentation>Skjeberg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0118">
+
+				<annotation>
+
+					<documentation>Aremark (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3012">
+
+				<annotation>
+
+					<documentation>Aremark</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0119">
+
+				<annotation>
+
+					<documentation>Marker (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3013">
+
+				<annotation>
+
+					<documentation>Marker</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0121">
+
+				<annotation>
+
+					<documentation>Rømskog (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3026">
+
+				<annotation>
+
+					<documentation>Aurskog-Høland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0122">
+
+				<annotation>
+
+					<documentation>Trøgstad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3014">
+
+				<annotation>
+
+					<documentation>Indre Østfold</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0123">
+
+				<annotation>
+
+					<documentation>Spydeberg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0124">
+
+				<annotation>
+
+					<documentation>Askim (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0125">
+
+				<annotation>
+
+					<documentation>Eidsberg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0127">
+
+				<annotation>
+
+					<documentation>Skiptvet (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3015">
+
+				<annotation>
+
+					<documentation>Skiptvet</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0128">
+
+				<annotation>
+
+					<documentation>Rakkestad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3016">
+
+				<annotation>
+
+					<documentation>Rakkestad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0130">
+
+				<annotation>
+
+					<documentation>Tune (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0131">
+
+				<annotation>
+
+					<documentation>Rolvsøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0133">
+
+				<annotation>
+
+					<documentation>Kråkerøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0134">
+
+				<annotation>
+
+					<documentation>Onsøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0135">
+
+				<annotation>
+
+					<documentation>Råde (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3017">
+
+				<annotation>
+
+					<documentation>Råde</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0136">
+
+				<annotation>
+
+					<documentation>Rygge (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0137">
+
+				<annotation>
+
+					<documentation>Våler i Østfold (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3018">
+
+				<annotation>
+
+					<documentation>Våler</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0138">
+
+				<annotation>
+
+					<documentation>Hobøl (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0211">
+
+				<annotation>
+
+					<documentation>Vestby (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3019">
+
+				<annotation>
+
+					<documentation>Vestby</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0213">
+
+				<annotation>
+
+					<documentation>Ski (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3020">
+
+				<annotation>
+
+					<documentation>Nordre Follo</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0214">
+
+				<annotation>
+
+					<documentation>Ås (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3021">
+
+				<annotation>
+
+					<documentation>Ås</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0215">
+
+				<annotation>
+
+					<documentation>Frogn (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3022">
+
+				<annotation>
+
+					<documentation>Frogn</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0216">
+
+				<annotation>
+
+					<documentation>Nesodden (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3023">
+
+				<annotation>
+
+					<documentation>Nesodden</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0217">
+
+				<annotation>
+
+					<documentation>Oppegård (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0219">
+
+				<annotation>
+
+					<documentation>Bærum (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3024">
+
+				<annotation>
+
+					<documentation>Bærum</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0220">
+
+				<annotation>
+
+					<documentation>Asker (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3025">
+
+				<annotation>
+
+					<documentation>Asker</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0221">
+
+				<annotation>
+
+					<documentation>Aurskog-Høland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0226">
+
+				<annotation>
+
+					<documentation>Sørum (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3030">
+
+				<annotation>
+
+					<documentation>Lillestrøm</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0227">
+
+				<annotation>
+
+					<documentation>Fet (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0228">
+
+				<annotation>
+
+					<documentation>Rælingen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3027">
+
+				<annotation>
+
+					<documentation>Rælingen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0229">
+
+				<annotation>
+
+					<documentation>Enebakk (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3028">
+
+				<annotation>
+
+					<documentation>Enebakk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0230">
+
+				<annotation>
+
+					<documentation>Lørenskog (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3029">
+
+				<annotation>
+
+					<documentation>Lørenskog</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0231">
+
+				<annotation>
+
+					<documentation>Skedsmo (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0233">
+
+				<annotation>
+
+					<documentation>Nittedal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3031">
+
+				<annotation>
+
+					<documentation>Nittedal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0234">
+
+				<annotation>
+
+					<documentation>Gjerdrum (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3032">
+
+				<annotation>
+
+					<documentation>Gjerdrum</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0235">
+
+				<annotation>
+
+					<documentation>Ullensaker (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3033">
+
+				<annotation>
+
+					<documentation>Ullensaker</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0236">
+
+				<annotation>
+
+					<documentation>Nes i Akershus (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3034">
+
+				<annotation>
+
+					<documentation>Nes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0237">
+
+				<annotation>
+
+					<documentation>Eidsvoll (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3035">
+
+				<annotation>
+
+					<documentation>Eidsvoll</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0238">
+
+				<annotation>
+
+					<documentation>Nannestad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3036">
+
+				<annotation>
+
+					<documentation>Nannestad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0239">
+
+				<annotation>
+
+					<documentation>Hurdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3037">
+
+				<annotation>
+
+					<documentation>Hurdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0301">
+
+				<annotation>
+
+					<documentation>Oslo</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0401">
+
+				<annotation>
+
+					<documentation>Hamar (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0402">
+
+				<annotation>
+
+					<documentation>Kongsvinger (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3401">
+
+				<annotation>
+
+					<documentation>Kongsvinger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0403">
+
+				<annotation>
+
+					<documentation>Hamar (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3403">
+
+				<annotation>
+
+					<documentation>Hamar</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0412">
+
+				<annotation>
+
+					<documentation>Ringsaker (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3411">
+
+				<annotation>
+
+					<documentation>Ringsaker</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0414">
+
+				<annotation>
+
+					<documentation>Vang (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0415">
+
+				<annotation>
+
+					<documentation>Løten (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3412">
+
+				<annotation>
+
+					<documentation>Løten</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0417">
+
+				<annotation>
+
+					<documentation>Stange (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3413">
+
+				<annotation>
+
+					<documentation>Stange</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0418">
+
+				<annotation>
+
+					<documentation>Nord-Odal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3414">
+
+				<annotation>
+
+					<documentation>Nord-Odal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0419">
+
+				<annotation>
+
+					<documentation>Sør-Odal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3415">
+
+				<annotation>
+
+					<documentation>Sør-Odal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0420">
+
+				<annotation>
+
+					<documentation>Eidskog (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3416">
+
+				<annotation>
+
+					<documentation>Eidskog</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0423">
+
+				<annotation>
+
+					<documentation>Grue (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3417">
+
+				<annotation>
+
+					<documentation>Grue</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0425">
+
+				<annotation>
+
+					<documentation>Åsnes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3418">
+
+				<annotation>
+
+					<documentation>Åsnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0426">
+
+				<annotation>
+
+					<documentation>Våler i Hedmark (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3419">
+
+				<annotation>
+
+					<documentation>Våler</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0427">
+
+				<annotation>
+
+					<documentation>Elverum (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3420">
+
+				<annotation>
+
+					<documentation>Elverum</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0428">
+
+				<annotation>
+
+					<documentation>Trysil (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3421">
+
+				<annotation>
+
+					<documentation>Trysil</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0429">
+
+				<annotation>
+
+					<documentation>Åmot (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3422">
+
+				<annotation>
+
+					<documentation>Åmot</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0430">
+
+				<annotation>
+
+					<documentation>Stor-Elvdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3423">
+
+				<annotation>
+
+					<documentation>Stor-Elvdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0432">
+
+				<annotation>
+
+					<documentation>Rendalen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3424">
+
+				<annotation>
+
+					<documentation>Rendalen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0434">
+
+				<annotation>
+
+					<documentation>Engerdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3425">
+
+				<annotation>
+
+					<documentation>Engerdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0436">
+
+				<annotation>
+
+					<documentation>Tolga (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3426">
+
+				<annotation>
+
+					<documentation>Tolga</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0437">
+
+				<annotation>
+
+					<documentation>Tynset (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3427">
+
+				<annotation>
+
+					<documentation>Tynset</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0438">
+
+				<annotation>
+
+					<documentation>Alvdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3428">
+
+				<annotation>
+
+					<documentation>Alvdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0439">
+
+				<annotation>
+
+					<documentation>Folldal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3429">
+
+				<annotation>
+
+					<documentation>Folldal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0441">
+
+				<annotation>
+
+					<documentation>Os i Hedmark (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3430">
+
+				<annotation>
+
+					<documentation>Os</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0501">
+
+				<annotation>
+
+					<documentation>Lillehammer (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3405">
+
+				<annotation>
+
+					<documentation>Lillehammer</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0502">
+
+				<annotation>
+
+					<documentation>Gjøvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3407">
+
+				<annotation>
+
+					<documentation>Gjøvik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0511">
+
+				<annotation>
+
+					<documentation>Dovre (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3431">
+
+				<annotation>
+
+					<documentation>Dovre</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0512">
+
+				<annotation>
+
+					<documentation>Lesja (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3432">
+
+				<annotation>
+
+					<documentation>Lesja</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0513">
+
+				<annotation>
+
+					<documentation>Skjåk (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3433">
+
+				<annotation>
+
+					<documentation>Skjåk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0514">
+
+				<annotation>
+
+					<documentation>Lom (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3434">
+
+				<annotation>
+
+					<documentation>Lom</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0515">
+
+				<annotation>
+
+					<documentation>Vågå (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3435">
+
+				<annotation>
+
+					<documentation>Vågå</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0516">
+
+				<annotation>
+
+					<documentation>Nord-Fron (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3436">
+
+				<annotation>
+
+					<documentation>Nord-Fron</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0517">
+
+				<annotation>
+
+					<documentation>Sel (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3437">
+
+				<annotation>
+
+					<documentation>Sel</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0519">
+
+				<annotation>
+
+					<documentation>Sør-Fron (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3438">
+
+				<annotation>
+
+					<documentation>Sør-Fron</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0520">
+
+				<annotation>
+
+					<documentation>Ringebu (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3439">
+
+				<annotation>
+
+					<documentation>Ringebu</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0521">
+
+				<annotation>
+
+					<documentation>Øyer (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3440">
+
+				<annotation>
+
+					<documentation>Øyer</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0522">
+
+				<annotation>
+
+					<documentation>Gausdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3441">
+
+				<annotation>
+
+					<documentation>Gausdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0528">
+
+				<annotation>
+
+					<documentation>Østre Toten (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3442">
+
+				<annotation>
+
+					<documentation>Østre Toten</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0529">
+
+				<annotation>
+
+					<documentation>Vestre Toten (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3443">
+
+				<annotation>
+
+					<documentation>Vestre Toten</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0532">
+
+				<annotation>
+
+					<documentation>Jevnaker (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3053">
+
+				<annotation>
+
+					<documentation>Jevnaker</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0533">
+
+				<annotation>
+
+					<documentation>Lunner (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3054">
+
+				<annotation>
+
+					<documentation>Lunner</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0534">
+
+				<annotation>
+
+					<documentation>Gran (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3446">
+
+				<annotation>
+
+					<documentation>Gran</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0536">
+
+				<annotation>
+
+					<documentation>Søndre Land (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3447">
+
+				<annotation>
+
+					<documentation>Søndre Land</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0538">
+
+				<annotation>
+
+					<documentation>Nordre Land (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3448">
+
+				<annotation>
+
+					<documentation>Nordre Land</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0540">
+
+				<annotation>
+
+					<documentation>Sør-Aurdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3449">
+
+				<annotation>
+
+					<documentation>Sør-Aurdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0541">
+
+				<annotation>
+
+					<documentation>Etnedal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3450">
+
+				<annotation>
+
+					<documentation>Etnedal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0542">
+
+				<annotation>
+
+					<documentation>Nord-Aurdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3451">
+
+				<annotation>
+
+					<documentation>Nord-Aurdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0543">
+
+				<annotation>
+
+					<documentation>Vestre Slidre (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3452">
+
+				<annotation>
+
+					<documentation>Vestre Slidre</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0544">
+
+				<annotation>
+
+					<documentation>Øystre Slidre (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3453">
+
+				<annotation>
+
+					<documentation>Øystre Slidre</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0545">
+
+				<annotation>
+
+					<documentation>Vang (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3454">
+
+				<annotation>
+
+					<documentation>Vang</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0602">
+
+				<annotation>
+
+					<documentation>Drammen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3005">
+
+				<annotation>
+
+					<documentation>Drammen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0604">
+
+				<annotation>
+
+					<documentation>Kongsberg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3006">
+
+				<annotation>
+
+					<documentation>Kongsberg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0605">
+
+				<annotation>
+
+					<documentation>Ringerike (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3007">
+
+				<annotation>
+
+					<documentation>Ringerike</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0612">
+
+				<annotation>
+
+					<documentation>Hole (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3038">
+
+				<annotation>
+
+					<documentation>Hole</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0615">
+
+				<annotation>
+
+					<documentation>Flå (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3039">
+
+				<annotation>
+
+					<documentation>Flå</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0616">
+
+				<annotation>
+
+					<documentation>Nes i Buskerud (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3040">
+
+				<annotation>
+
+					<documentation>Nes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0617">
+
+				<annotation>
+
+					<documentation>Gol (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3041">
+
+				<annotation>
+
+					<documentation>Gol</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0618">
+
+				<annotation>
+
+					<documentation>Hemsedal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3042">
+
+				<annotation>
+
+					<documentation>Hemsedal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0619">
+
+				<annotation>
+
+					<documentation>Ål (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3043">
+
+				<annotation>
+
+					<documentation>Ål</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0620">
+
+				<annotation>
+
+					<documentation>Hol (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3044">
+
+				<annotation>
+
+					<documentation>Hol</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0621">
+
+				<annotation>
+
+					<documentation>Sigdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3045">
+
+				<annotation>
+
+					<documentation>Sigdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0622">
+
+				<annotation>
+
+					<documentation>Krødsherad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3046">
+
+				<annotation>
+
+					<documentation>Krødsherad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0623">
+
+				<annotation>
+
+					<documentation>Modum (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3047">
+
+				<annotation>
+
+					<documentation>Modum</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0624">
+
+				<annotation>
+
+					<documentation>Øvre Eiker (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3048">
+
+				<annotation>
+
+					<documentation>Øvre Eiker</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0625">
+
+				<annotation>
+
+					<documentation>Nedre Eiker (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0626">
+
+				<annotation>
+
+					<documentation>Lier (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3049">
+
+				<annotation>
+
+					<documentation>Lier</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0627">
+
+				<annotation>
+
+					<documentation>Røyken (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0628">
+
+				<annotation>
+
+					<documentation>Hurum (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0631">
+
+				<annotation>
+
+					<documentation>Flesberg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3050">
+
+				<annotation>
+
+					<documentation>Flesberg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0632">
+
+				<annotation>
+
+					<documentation>Rollag (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3051">
+
+				<annotation>
+
+					<documentation>Rollag</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0633">
+
+				<annotation>
+
+					<documentation>Nore og Uvdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3052">
+
+				<annotation>
+
+					<documentation>Nore og Uvdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0701">
+
+				<annotation>
+
+					<documentation>Horten (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3801">
+
+				<annotation>
+
+					<documentation>Horten</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0702">
+
+				<annotation>
+
+					<documentation>Holmestrand (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0703">
+
+				<annotation>
+
+					<documentation>Horten (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0704">
+
+				<annotation>
+
+					<documentation>Tønsberg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3803">
+
+				<annotation>
+
+					<documentation>Tønsberg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0705">
+
+				<annotation>
+
+					<documentation>Tønsberg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0706">
+
+				<annotation>
+
+					<documentation>Sandefjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0707">
+
+				<annotation>
+
+					<documentation>Larvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0708">
+
+				<annotation>
+
+					<documentation>Stavern (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0709">
+
+				<annotation>
+
+					<documentation>Larvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0710">
+
+				<annotation>
+
+					<documentation>Sandefjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3804">
+
+				<annotation>
+
+					<documentation>Sandefjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0711">
+
+				<annotation>
+
+					<documentation>Svelvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0713">
+
+				<annotation>
+
+					<documentation>Sande i Vestfold (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3802">
+
+				<annotation>
+
+					<documentation>Holmestrand</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0714">
+
+				<annotation>
+
+					<documentation>Hof (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0716">
+
+				<annotation>
+
+					<documentation>Re (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0717">
+
+				<annotation>
+
+					<documentation>Borre (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0718">
+
+				<annotation>
+
+					<documentation>Ramnes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0719">
+
+				<annotation>
+
+					<documentation>Andebu (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0720">
+
+				<annotation>
+
+					<documentation>Stokke (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0721">
+
+				<annotation>
+
+					<documentation>Sem (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0722">
+
+				<annotation>
+
+					<documentation>Nøtterøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0723">
+
+				<annotation>
+
+					<documentation>Tjøme (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0725">
+
+				<annotation>
+
+					<documentation>Tjølling (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0726">
+
+				<annotation>
+
+					<documentation>Brunlanes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0727">
+
+				<annotation>
+
+					<documentation>Hedrum (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0728">
+
+				<annotation>
+
+					<documentation>Lardal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0805">
+
+				<annotation>
+
+					<documentation>Porsgrunn (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3806">
+
+				<annotation>
+
+					<documentation>Porsgrunn</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0806">
+
+				<annotation>
+
+					<documentation>Skien (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3807">
+
+				<annotation>
+
+					<documentation>Skien</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0807">
+
+				<annotation>
+
+					<documentation>Notodden (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3808">
+
+				<annotation>
+
+					<documentation>Notodden</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0811">
+
+				<annotation>
+
+					<documentation>Siljan (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3812">
+
+				<annotation>
+
+					<documentation>Siljan</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0814">
+
+				<annotation>
+
+					<documentation>Bamble (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3813">
+
+				<annotation>
+
+					<documentation>Bamble</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0815">
+
+				<annotation>
+
+					<documentation>Kragerø (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3814">
+
+				<annotation>
+
+					<documentation>Kragerø</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0817">
+
+				<annotation>
+
+					<documentation>Drangedal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3815">
+
+				<annotation>
+
+					<documentation>Drangedal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0819">
+
+				<annotation>
+
+					<documentation>Nome (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3816">
+
+				<annotation>
+
+					<documentation>Nome</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0821">
+
+				<annotation>
+
+					<documentation>Bø i Telemark (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3817">
+
+				<annotation>
+
+					<documentation>Midt-Telemark</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0822">
+
+				<annotation>
+
+					<documentation>Sauherad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0826">
+
+				<annotation>
+
+					<documentation>Tinn (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3818">
+
+				<annotation>
+
+					<documentation>Tinn</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0827">
+
+				<annotation>
+
+					<documentation>Hjartdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3819">
+
+				<annotation>
+
+					<documentation>Hjartdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0828">
+
+				<annotation>
+
+					<documentation>Seljord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3820">
+
+				<annotation>
+
+					<documentation>Seljord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0829">
+
+				<annotation>
+
+					<documentation>Kviteseid (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3821">
+
+				<annotation>
+
+					<documentation>Kviteseid</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0830">
+
+				<annotation>
+
+					<documentation>Nissedal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3822">
+
+				<annotation>
+
+					<documentation>Nissedal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0831">
+
+				<annotation>
+
+					<documentation>Fyresdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3823">
+
+				<annotation>
+
+					<documentation>Fyresdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0833">
+
+				<annotation>
+
+					<documentation>Tokke (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3824">
+
+				<annotation>
+
+					<documentation>Tokke</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0834">
+
+				<annotation>
+
+					<documentation>Vinje (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3825">
+
+				<annotation>
+
+					<documentation>Vinje</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0901">
+
+				<annotation>
+
+					<documentation>Risør (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4201">
+
+				<annotation>
+
+					<documentation>Risør</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0903">
+
+				<annotation>
+
+					<documentation>Arendal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0904">
+
+				<annotation>
+
+					<documentation>Grimstad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4202">
+
+				<annotation>
+
+					<documentation>Grimstad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0906">
+
+				<annotation>
+
+					<documentation>Arendal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4203">
+
+				<annotation>
+
+					<documentation>Arendal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0911">
+
+				<annotation>
+
+					<documentation>Gjerstad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4211">
+
+				<annotation>
+
+					<documentation>Gjerstad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0912">
+
+				<annotation>
+
+					<documentation>Vegårshei (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4212">
+
+				<annotation>
+
+					<documentation>Vegårshei</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0914">
+
+				<annotation>
+
+					<documentation>Tvedestrand (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4213">
+
+				<annotation>
+
+					<documentation>Tvedestrand</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0918">
+
+				<annotation>
+
+					<documentation>Moland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0919">
+
+				<annotation>
+
+					<documentation>Froland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4214">
+
+				<annotation>
+
+					<documentation>Froland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0920">
+
+				<annotation>
+
+					<documentation>Øyestad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0921">
+
+				<annotation>
+
+					<documentation>Tromøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0922">
+
+				<annotation>
+
+					<documentation>Hisøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0926">
+
+				<annotation>
+
+					<documentation>Lillesand (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4215">
+
+				<annotation>
+
+					<documentation>Lillesand</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0928">
+
+				<annotation>
+
+					<documentation>Birkenes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4216">
+
+				<annotation>
+
+					<documentation>Birkenes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0929">
+
+				<annotation>
+
+					<documentation>Åmli (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4217">
+
+				<annotation>
+
+					<documentation>Åmli</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0935">
+
+				<annotation>
+
+					<documentation>Iveland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4218">
+
+				<annotation>
+
+					<documentation>Iveland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0937">
+
+				<annotation>
+
+					<documentation>Evje og Hornnes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4219">
+
+				<annotation>
+
+					<documentation>Evje og Hornnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0938">
+
+				<annotation>
+
+					<documentation>Bygland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4220">
+
+				<annotation>
+
+					<documentation>Bygland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0940">
+
+				<annotation>
+
+					<documentation>Valle (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4221">
+
+				<annotation>
+
+					<documentation>Valle</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0941">
+
+				<annotation>
+
+					<documentation>Bykle (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4222">
+
+				<annotation>
+
+					<documentation>Bykle</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1001">
+
+				<annotation>
+
+					<documentation>Kristiansand (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4204">
+
+				<annotation>
+
+					<documentation>Kristiansand</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1002">
+
+				<annotation>
+
+					<documentation>Mandal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4205">
+
+				<annotation>
+
+					<documentation>Lindesnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1003">
+
+				<annotation>
+
+					<documentation>Farsund (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4206">
+
+				<annotation>
+
+					<documentation>Farsund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1004">
+
+				<annotation>
+
+					<documentation>Flekkefjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4207">
+
+				<annotation>
+
+					<documentation>Flekkefjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1014">
+
+				<annotation>
+
+					<documentation>Vennesla (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4223">
+
+				<annotation>
+
+					<documentation>Vennesla</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1017">
+
+				<annotation>
+
+					<documentation>Songdalen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1018">
+
+				<annotation>
+
+					<documentation>Søgne (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1021">
+
+				<annotation>
+
+					<documentation>Marnardal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1026">
+
+				<annotation>
+
+					<documentation>Åseral (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4224">
+
+				<annotation>
+
+					<documentation>Åseral</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1027">
+
+				<annotation>
+
+					<documentation>Audnedal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4225">
+
+				<annotation>
+
+					<documentation>Lyngdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1029">
+
+				<annotation>
+
+					<documentation>Lindesnes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1032">
+
+				<annotation>
+
+					<documentation>Lyngdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1034">
+
+				<annotation>
+
+					<documentation>Hægebostad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4226">
+
+				<annotation>
+
+					<documentation>Hægebostad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1037">
+
+				<annotation>
+
+					<documentation>Kvinesdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4227">
+
+				<annotation>
+
+					<documentation>Kvinesdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1046">
+
+				<annotation>
+
+					<documentation>Sirdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4228">
+
+				<annotation>
+
+					<documentation>Sirdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1101">
+
+				<annotation>
+
+					<documentation>Eigersund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1102">
+
+				<annotation>
+
+					<documentation>Sandnes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1108">
+
+				<annotation>
+
+					<documentation>Sandnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1103">
+
+				<annotation>
+
+					<documentation>Stavanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1106">
+
+				<annotation>
+
+					<documentation>Haugesund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1111">
+
+				<annotation>
+
+					<documentation>Sokndal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1112">
+
+				<annotation>
+
+					<documentation>Lund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1114">
+
+				<annotation>
+
+					<documentation>Bjerkreim</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1119">
+
+				<annotation>
+
+					<documentation>Hå</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1120">
+
+				<annotation>
+
+					<documentation>Klepp</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1121">
+
+				<annotation>
+
+					<documentation>Time</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1122">
+
+				<annotation>
+
+					<documentation>Gjesdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1124">
+
+				<annotation>
+
+					<documentation>Sola</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1127">
+
+				<annotation>
+
+					<documentation>Randaberg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1129">
+
+				<annotation>
+
+					<documentation>Forsand (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1130">
+
+				<annotation>
+
+					<documentation>Strand</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1133">
+
+				<annotation>
+
+					<documentation>Hjelmeland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1134">
+
+				<annotation>
+
+					<documentation>Suldal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1135">
+
+				<annotation>
+
+					<documentation>Sauda</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1141">
+
+				<annotation>
+
+					<documentation>Finnøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1103">
+
+				<annotation>
+
+					<documentation>Stavanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1142">
+
+				<annotation>
+
+					<documentation>Rennesøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1144">
+
+				<annotation>
+
+					<documentation>Kvitsøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1145">
+
+				<annotation>
+
+					<documentation>Bokn</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1146">
+
+				<annotation>
+
+					<documentation>Tysvær</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1149">
+
+				<annotation>
+
+					<documentation>Karmøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1151">
+
+				<annotation>
+
+					<documentation>Utsira</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1154">
+
+				<annotation>
+
+					<documentation>Vindafjord ((utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1159">
+
+				<annotation>
+
+					<documentation>Ølen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1160">
+
+				<annotation>
+
+					<documentation>Vindafjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1201">
+
+				<annotation>
+
+					<documentation>Bergen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4601">
+
+				<annotation>
+
+					<documentation>Bergen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1211">
+
+				<annotation>
+
+					<documentation>Etne (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4611">
+
+				<annotation>
+
+					<documentation>Etne</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1214">
+
+				<annotation>
+
+					<documentation>Ølen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1216">
+
+				<annotation>
+
+					<documentation>Sveio (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4612">
+
+				<annotation>
+
+					<documentation>Sveio</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1219">
+
+				<annotation>
+
+					<documentation>Bømlo (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4613">
+
+				<annotation>
+
+					<documentation>Bømlo</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1221">
+
+				<annotation>
+
+					<documentation>Stord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4614">
+
+				<annotation>
+
+					<documentation>Stord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1222">
+
+				<annotation>
+
+					<documentation>Fitjar (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4615">
+
+				<annotation>
+
+					<documentation>Fitjar</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1223">
+
+				<annotation>
+
+					<documentation>Tysnes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4616">
+
+				<annotation>
+
+					<documentation>Tysnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1224">
+
+				<annotation>
+
+					<documentation>Kvinnherad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4617">
+
+				<annotation>
+
+					<documentation>Kvinnherad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1227">
+
+				<annotation>
+
+					<documentation>Jondal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4618">
+
+				<annotation>
+
+					<documentation>Ullensvang</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1228">
+
+				<annotation>
+
+					<documentation>Odda (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1231">
+
+				<annotation>
+
+					<documentation>Ullensvang (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1232">
+
+				<annotation>
+
+					<documentation>Eidfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4619">
+
+				<annotation>
+
+					<documentation>Eidfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1233">
+
+				<annotation>
+
+					<documentation>Ulvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4620">
+
+				<annotation>
+
+					<documentation>Ulvik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1234">
+
+				<annotation>
+
+					<documentation>Granvin (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4621">
+
+				<annotation>
+
+					<documentation>Voss</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1235">
+
+				<annotation>
+
+					<documentation>Voss (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1238">
+
+				<annotation>
+
+					<documentation>Kvam (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4622">
+
+				<annotation>
+
+					<documentation>Kvam</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1241">
+
+				<annotation>
+
+					<documentation>Fusa (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4624">
+
+				<annotation>
+
+					<documentation>Bjørnafjorden</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1242">
+
+				<annotation>
+
+					<documentation>Samnanger (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4623">
+
+				<annotation>
+
+					<documentation>Samnanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1243">
+
+				<annotation>
+
+					<documentation>Os i Hordaland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1244">
+
+				<annotation>
+
+					<documentation>Austevoll (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4625">
+
+				<annotation>
+
+					<documentation>Austevoll</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1245">
+
+				<annotation>
+
+					<documentation>Sund (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4626">
+
+				<annotation>
+
+					<documentation>Øygarden</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1246">
+
+				<annotation>
+
+					<documentation>Fjell (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1247">
+
+				<annotation>
+
+					<documentation>Askøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4627">
+
+				<annotation>
+
+					<documentation>Askøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1251">
+
+				<annotation>
+
+					<documentation>Vaksdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4628">
+
+				<annotation>
+
+					<documentation>Vaksdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1252">
+
+				<annotation>
+
+					<documentation>Modalen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4629">
+
+				<annotation>
+
+					<documentation>Modalen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1253">
+
+				<annotation>
+
+					<documentation>Osterøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4630">
+
+				<annotation>
+
+					<documentation>Osterøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1256">
+
+				<annotation>
+
+					<documentation>Meland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4631">
+
+				<annotation>
+
+					<documentation>Alver</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1259">
+
+				<annotation>
+
+					<documentation>Øygarden (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1260">
+
+				<annotation>
+
+					<documentation>Radøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1263">
+
+				<annotation>
+
+					<documentation>Lindås (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1264">
+
+				<annotation>
+
+					<documentation>Austrheim (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4632">
+
+				<annotation>
+
+					<documentation>Austrheim</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1265">
+
+				<annotation>
+
+					<documentation>Fedje (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4633">
+
+				<annotation>
+
+					<documentation>Fedje</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1266">
+
+				<annotation>
+
+					<documentation>Masfjorden (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4634">
+
+				<annotation>
+
+					<documentation>Masfjorden</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1401">
+
+				<annotation>
+
+					<documentation>Flora (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4602">
+
+				<annotation>
+
+					<documentation>Kinn</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1411">
+
+				<annotation>
+
+					<documentation>Gulen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4635">
+
+				<annotation>
+
+					<documentation>Gulen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1412">
+
+				<annotation>
+
+					<documentation>Solund (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4636">
+
+				<annotation>
+
+					<documentation>Solund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1413">
+
+				<annotation>
+
+					<documentation>Hyllestad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4637">
+
+				<annotation>
+
+					<documentation>Hyllestad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1416">
+
+				<annotation>
+
+					<documentation>Høyanger (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4638">
+
+				<annotation>
+
+					<documentation>Høyanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1417">
+
+				<annotation>
+
+					<documentation>Vik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4639">
+
+				<annotation>
+
+					<documentation>Vik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1418">
+
+				<annotation>
+
+					<documentation>Balestrand (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4640">
+
+				<annotation>
+
+					<documentation>Sogndal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1419">
+
+				<annotation>
+
+					<documentation>Leikanger (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1420">
+
+				<annotation>
+
+					<documentation>Sogndal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1421">
+
+				<annotation>
+
+					<documentation>Aurland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4641">
+
+				<annotation>
+
+					<documentation>Aurland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1422">
+
+				<annotation>
+
+					<documentation>Lærdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4642">
+
+				<annotation>
+
+					<documentation>Lærdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1424">
+
+				<annotation>
+
+					<documentation>Årdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4643">
+
+				<annotation>
+
+					<documentation>Årdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1426">
+
+				<annotation>
+
+					<documentation>Luster (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4644">
+
+				<annotation>
+
+					<documentation>Luster</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1428">
+
+				<annotation>
+
+					<documentation>Askvoll (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4645">
+
+				<annotation>
+
+					<documentation>Askvoll</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1429">
+
+				<annotation>
+
+					<documentation>Fjaler (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4646">
+
+				<annotation>
+
+					<documentation>Fjaler</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1430">
+
+				<annotation>
+
+					<documentation>Gaular (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4647">
+
+				<annotation>
+
+					<documentation>Sunnfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1431">
+
+				<annotation>
+
+					<documentation>Jølster (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1432">
+
+				<annotation>
+
+					<documentation>Førde (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1433">
+
+				<annotation>
+
+					<documentation>Naustdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1438">
+
+				<annotation>
+
+					<documentation>Bremanger (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4648">
+
+				<annotation>
+
+					<documentation>Bremanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1439">
+
+				<annotation>
+
+					<documentation>Vågsøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1441">
+
+				<annotation>
+
+					<documentation>Selje (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4649">
+
+				<annotation>
+
+					<documentation>Stad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1443">
+
+				<annotation>
+
+					<documentation>Eid (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1444">
+
+				<annotation>
+
+					<documentation>Hornindal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1577">
+
+				<annotation>
+
+					<documentation>Volda</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1445">
+
+				<annotation>
+
+					<documentation>Gloppen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4650">
+
+				<annotation>
+
+					<documentation>Gloppen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1449">
+
+				<annotation>
+
+					<documentation>Stryn (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="4651">
+
+				<annotation>
+
+					<documentation>Stryn</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1502">
+
+				<annotation>
+
+					<documentation>Molde (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1506">
+
+				<annotation>
+
+					<documentation>Molde</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1504">
+
+				<annotation>
+
+					<documentation>Ålesund (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1507">
+
+				<annotation>
+
+					<documentation>Ålesund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1505">
+
+				<annotation>
+
+					<documentation>Kristiansund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1511">
+
+				<annotation>
+
+					<documentation>Vanylven</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1514">
+
+				<annotation>
+
+					<documentation>Sande i Møre og Romsdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1515">
+
+				<annotation>
+
+					<documentation>Herøy i Møre og Romsdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1516">
+
+				<annotation>
+
+					<documentation>Ulstein</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1517">
+
+				<annotation>
+
+					<documentation>Hareid</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1519">
+
+				<annotation>
+
+					<documentation>Volda (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1520">
+
+				<annotation>
+
+					<documentation>Ørsta</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1523">
+
+				<annotation>
+
+					<documentation>Ørskog (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1524">
+
+				<annotation>
+
+					<documentation>Norddal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1578">
+
+				<annotation>
+
+					<documentation>Fjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1525">
+
+				<annotation>
+
+					<documentation>Stranda</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1526">
+
+				<annotation>
+
+					<documentation>Stordal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1528">
+
+				<annotation>
+
+					<documentation>Sykkylven</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1529">
+
+				<annotation>
+
+					<documentation>Skodje (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1531">
+
+				<annotation>
+
+					<documentation>Sula</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1532">
+
+				<annotation>
+
+					<documentation>Giske</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1534">
+
+				<annotation>
+
+					<documentation>Haram (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1535">
+
+				<annotation>
+
+					<documentation>Vestnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1539">
+
+				<annotation>
+
+					<documentation>Rauma</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1543">
+
+				<annotation>
+
+					<documentation>Nesset (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1545">
+
+				<annotation>
+
+					<documentation>Midsund (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1546">
+
+				<annotation>
+
+					<documentation>Sandøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1547">
+
+				<annotation>
+
+					<documentation>Aukra</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1548">
+
+				<annotation>
+
+					<documentation>Fræna (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1579">
+
+				<annotation>
+
+					<documentation>Hustadvika</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1551">
+
+				<annotation>
+
+					<documentation>Eide (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1554">
+
+				<annotation>
+
+					<documentation>Averøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1557">
+
+				<annotation>
+
+					<documentation>Gjemnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1560">
+
+				<annotation>
+
+					<documentation>Tingvoll</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1563">
+
+				<annotation>
+
+					<documentation>Sunndal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1566">
+
+				<annotation>
+
+					<documentation>Surnadal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1567">
+
+				<annotation>
+
+					<documentation>Rindal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5061">
+
+				<annotation>
+
+					<documentation>Rindal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1569">
+
+				<annotation>
+
+					<documentation>Aure (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1571">
+
+				<annotation>
+
+					<documentation>Halsa (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5055">
+
+				<annotation>
+
+					<documentation>Heim</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1572">
+
+				<annotation>
+
+					<documentation>Tustna (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1573">
+
+				<annotation>
+
+					<documentation>Smøla</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1576">
+
+				<annotation>
+
+					<documentation>Aure</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1601">
+
+				<annotation>
+
+					<documentation>Trondheim (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1612">
+
+				<annotation>
+
+					<documentation>Hemne (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1613">
+
+				<annotation>
+
+					<documentation>Snillfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1617">
+
+				<annotation>
+
+					<documentation>Hitra (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1620">
+
+				<annotation>
+
+					<documentation>Frøya (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1621">
+
+				<annotation>
+
+					<documentation>Ørland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1622">
+
+				<annotation>
+
+					<documentation>Agdenes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1624">
+
+				<annotation>
+
+					<documentation>Rissa (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1627">
+
+				<annotation>
+
+					<documentation>Bjugn (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1630">
+
+				<annotation>
+
+					<documentation>Åfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1632">
+
+				<annotation>
+
+					<documentation>Roan (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1633">
+
+				<annotation>
+
+					<documentation>Osen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1634">
+
+				<annotation>
+
+					<documentation>Oppdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1635">
+
+				<annotation>
+
+					<documentation>Rennebu (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1636">
+
+				<annotation>
+
+					<documentation>Meldal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1638">
+
+				<annotation>
+
+					<documentation>Orkdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1640">
+
+				<annotation>
+
+					<documentation>Røros (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1644">
+
+				<annotation>
+
+					<documentation>Holtålen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1648">
+
+				<annotation>
+
+					<documentation>Midtre Gauldal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1653">
+
+				<annotation>
+
+					<documentation>Melhus (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1657">
+
+				<annotation>
+
+					<documentation>Skaun (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1662">
+
+				<annotation>
+
+					<documentation>Klæbu (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1663">
+
+				<annotation>
+
+					<documentation>Malvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1664">
+
+				<annotation>
+
+					<documentation>Selbu (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1665">
+
+				<annotation>
+
+					<documentation>Tydal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1702">
+
+				<annotation>
+
+					<documentation>Steinkjer (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1703">
+
+				<annotation>
+
+					<documentation>Namsos (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1711">
+
+				<annotation>
+
+					<documentation>Meråker (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1714">
+
+				<annotation>
+
+					<documentation>Stjørdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1717">
+
+				<annotation>
+
+					<documentation>Frosta (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1718">
+
+				<annotation>
+
+					<documentation>Leksvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1719">
+
+				<annotation>
+
+					<documentation>Levanger (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1721">
+
+				<annotation>
+
+					<documentation>Verdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1723">
+
+				<annotation>
+
+					<documentation>Mosvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1724">
+
+				<annotation>
+
+					<documentation>Verran (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1725">
+
+				<annotation>
+
+					<documentation>Namdalseid (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1729">
+
+				<annotation>
+
+					<documentation>Inderøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1736">
+
+				<annotation>
+
+					<documentation>Snåase – Snåsa (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1738">
+
+				<annotation>
+
+					<documentation>Lierne (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1739">
+
+				<annotation>
+
+					<documentation>Raarvihke – Røyrvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1740">
+
+				<annotation>
+
+					<documentation>Namsskogan (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1742">
+
+				<annotation>
+
+					<documentation>Grong (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1743">
+
+				<annotation>
+
+					<documentation>Høylandet (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1744">
+
+				<annotation>
+
+					<documentation>Overhalla (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1748">
+
+				<annotation>
+
+					<documentation>Fosnes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1749">
+
+				<annotation>
+
+					<documentation>Flatanger (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1750">
+
+				<annotation>
+
+					<documentation>Vikna (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1751">
+
+				<annotation>
+
+					<documentation>Nærøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1755">
+
+				<annotation>
+
+					<documentation>Leka (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1756">
+
+				<annotation>
+
+					<documentation>Inderøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1804">
+
+				<annotation>
+
+					<documentation>Bodø</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1805">
+
+				<annotation>
+
+					<documentation>Narvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1806">
+
+				<annotation>
+
+					<documentation>Narvik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1811">
+
+				<annotation>
+
+					<documentation>Bindal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1812">
+
+				<annotation>
+
+					<documentation>Sømna</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1813">
+
+				<annotation>
+
+					<documentation>Brønnøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1815">
+
+				<annotation>
+
+					<documentation>Vega</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1816">
+
+				<annotation>
+
+					<documentation>Vevelstad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1818">
+
+				<annotation>
+
+					<documentation>Herøy i Nordland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1820">
+
+				<annotation>
+
+					<documentation>Alstahaug</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1822">
+
+				<annotation>
+
+					<documentation>Leirfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1824">
+
+				<annotation>
+
+					<documentation>Vefsn</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1825">
+
+				<annotation>
+
+					<documentation>Grane</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1826">
+
+				<annotation>
+
+					<documentation>Hattfjelldal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1827">
+
+				<annotation>
+
+					<documentation>Dønna</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1828">
+
+				<annotation>
+
+					<documentation>Nesna</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1832">
+
+				<annotation>
+
+					<documentation>Hemnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1833">
+
+				<annotation>
+
+					<documentation>Rana</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1834">
+
+				<annotation>
+
+					<documentation>Lurøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1835">
+
+				<annotation>
+
+					<documentation>Træna</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1836">
+
+				<annotation>
+
+					<documentation>Rødøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1837">
+
+				<annotation>
+
+					<documentation>Meløy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1838">
+
+				<annotation>
+
+					<documentation>Gildeskål</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1839">
+
+				<annotation>
+
+					<documentation>Beiarn</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1840">
+
+				<annotation>
+
+					<documentation>Saltdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1841">
+
+				<annotation>
+
+					<documentation>Fauske – Fuossko</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1842">
+
+				<annotation>
+
+					<documentation>Skjerstad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1845">
+
+				<annotation>
+
+					<documentation>Sørfold</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1848">
+
+				<annotation>
+
+					<documentation>Steigen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1849">
+
+				<annotation>
+
+					<documentation>Hamarøy – Hábmer (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1875">
+
+				<annotation>
+
+					<documentation>Hamarøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1850">
+
+				<annotation>
+
+					<documentation>Divtasvuodna – Tysfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1851">
+
+				<annotation>
+
+					<documentation>Lødingen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1852">
+
+				<annotation>
+
+					<documentation>Tjeldsund (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5412">
+
+				<annotation>
+
+					<documentation>Tjeldsund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1853">
+
+				<annotation>
+
+					<documentation>Evenes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1854">
+
+				<annotation>
+
+					<documentation>Ballangen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1856">
+
+				<annotation>
+
+					<documentation>Røst</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1857">
+
+				<annotation>
+
+					<documentation>Værøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1859">
+
+				<annotation>
+
+					<documentation>Flakstad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1860">
+
+				<annotation>
+
+					<documentation>Vestvågøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1865">
+
+				<annotation>
+
+					<documentation>Vågan</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1866">
+
+				<annotation>
+
+					<documentation>Hadsel</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1867">
+
+				<annotation>
+
+					<documentation>Bø i Nordland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1868">
+
+				<annotation>
+
+					<documentation>Øksnes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1870">
+
+				<annotation>
+
+					<documentation>Sortland – Suortá</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1871">
+
+				<annotation>
+
+					<documentation>Andøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1874">
+
+				<annotation>
+
+					<documentation>Moskenes</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1901">
+
+				<annotation>
+
+					<documentation>Harstad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1902">
+
+				<annotation>
+
+					<documentation>Tromsø (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5401">
+
+				<annotation>
+
+					<documentation>Tromsø</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1903">
+
+				<annotation>
+
+					<documentation>Harstad – Hárstták (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5402">
+
+				<annotation>
+
+					<documentation>Harstad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1911">
+
+				<annotation>
+
+					<documentation>Kvæfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5411">
+
+				<annotation>
+
+					<documentation>Kvæfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1913">
+
+				<annotation>
+
+					<documentation>Skånland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1915">
+
+				<annotation>
+
+					<documentation>Bjarkøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1917">
+
+				<annotation>
+
+					<documentation>Ibestad (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5413">
+
+				<annotation>
+
+					<documentation>Ibestad</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1919">
+
+				<annotation>
+
+					<documentation>Gratangen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5414">
+
+				<annotation>
+
+					<documentation>Gratangen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1920">
+
+				<annotation>
+
+					<documentation>Loabák – Lavangen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5415">
+
+				<annotation>
+
+					<documentation>Lavangen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1922">
+
+				<annotation>
+
+					<documentation>Bardu (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5416">
+
+				<annotation>
+
+					<documentation>Bardu</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1923">
+
+				<annotation>
+
+					<documentation>Salangen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5417">
+
+				<annotation>
+
+					<documentation>Salangen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1924">
+
+				<annotation>
+
+					<documentation>Målselv (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5418">
+
+				<annotation>
+
+					<documentation>Målselv</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1925">
+
+				<annotation>
+
+					<documentation>Sørreisa (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5419">
+
+				<annotation>
+
+					<documentation>Sørreisa</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1926">
+
+				<annotation>
+
+					<documentation>Dyrøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5420">
+
+				<annotation>
+
+					<documentation>Dyrøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1927">
+
+				<annotation>
+
+					<documentation>Tranøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5421">
+
+				<annotation>
+
+					<documentation>Senja</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1928">
+
+				<annotation>
+
+					<documentation>Torsken (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1929">
+
+				<annotation>
+
+					<documentation>Berg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1931">
+
+				<annotation>
+
+					<documentation>Lenvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1933">
+
+				<annotation>
+
+					<documentation>Balsfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5422">
+
+				<annotation>
+
+					<documentation>Balsfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1936">
+
+				<annotation>
+
+					<documentation>Karlsøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5423">
+
+				<annotation>
+
+					<documentation>Karlsøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1938">
+
+				<annotation>
+
+					<documentation>Lyngen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5424">
+
+				<annotation>
+
+					<documentation>Lyngen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1939">
+
+				<annotation>
+
+					<documentation>Storfjord – Omasvuotna – Omasvuono (utgått)
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5425">
+
+				<annotation>
+
+					<documentation>Storfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1940">
+
+				<annotation>
+
+					<documentation>Gáivuotna – Kåfjord – Kaivuono (utgått)
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5426">
+
+				<annotation>
+
+					<documentation>Kåfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1941">
+
+				<annotation>
+
+					<documentation>Skjervøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5427">
+
+				<annotation>
+
+					<documentation>Skjervøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1942">
+
+				<annotation>
+
+					<documentation>Nordreisa (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5428">
+
+				<annotation>
+
+					<documentation>Nordreisa</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="1943">
+
+				<annotation>
+
+					<documentation>Kvænangen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5429">
+
+				<annotation>
+
+					<documentation>Kvænangen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2001">
+
+				<annotation>
+
+					<documentation>Hammerfest (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2002">
+
+				<annotation>
+
+					<documentation>Vardø (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5404">
+
+				<annotation>
+
+					<documentation>Vardø</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2003">
+
+				<annotation>
+
+					<documentation>Vadsø (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5405">
+
+				<annotation>
+
+					<documentation>Vadsø</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2004">
+
+				<annotation>
+
+					<documentation>Hammerfest (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5406">
+
+				<annotation>
+
+					<documentation>Hammerfest</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2011">
+
+				<annotation>
+
+					<documentation>Guovdageaidnu – Kautokeino (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5430">
+
+				<annotation>
+
+					<documentation>Kautokeino</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2012">
+
+				<annotation>
+
+					<documentation>Alta (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5403">
+
+				<annotation>
+
+					<documentation>Alta</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2014">
+
+				<annotation>
+
+					<documentation>Loppa (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5432">
+
+				<annotation>
+
+					<documentation>Loppa</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2015">
+
+				<annotation>
+
+					<documentation>Hasvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5433">
+
+				<annotation>
+
+					<documentation>Hasvik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2016">
+
+				<annotation>
+
+					<documentation>Sørøysund (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2017">
+
+				<annotation>
+
+					<documentation>Kvalsund (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2018">
+
+				<annotation>
+
+					<documentation>Måsøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5434">
+
+				<annotation>
+
+					<documentation>Måsøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2019">
+
+				<annotation>
+
+					<documentation>Nordkapp (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5435">
+
+				<annotation>
+
+					<documentation>Nordkapp</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2020">
+
+				<annotation>
+
+					<documentation>Porsanger – Porsá?gu – Porsanki (utgått)
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5436">
+
+				<annotation>
+
+					<documentation>Porsanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2021">
+
+				<annotation>
+
+					<documentation>Kárášjohka – Karasjok (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5437">
+
+				<annotation>
+
+					<documentation>Karasjok</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2022">
+
+				<annotation>
+
+					<documentation>Lebesby (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5438">
+
+				<annotation>
+
+					<documentation>Lebesby</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2023">
+
+				<annotation>
+
+					<documentation>Gamvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5439">
+
+				<annotation>
+
+					<documentation>Gamvik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2024">
+
+				<annotation>
+
+					<documentation>Berlevåg (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5440">
+
+				<annotation>
+
+					<documentation>Berlevåg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2025">
+
+				<annotation>
+
+					<documentation>Deatnu – Tana (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5441">
+
+				<annotation>
+
+					<documentation>Tana</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2027">
+
+				<annotation>
+
+					<documentation>Unjárga – Nesseby (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5442">
+
+				<annotation>
+
+					<documentation>Nesseby</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2028">
+
+				<annotation>
+
+					<documentation>Båtsfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5443">
+
+				<annotation>
+
+					<documentation>Båtsfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2030">
+
+				<annotation>
+
+					<documentation>Sør-Varanger (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5444">
+
+				<annotation>
+
+					<documentation>Sør-Varanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2111">
+
+				<annotation>
+
+					<documentation>Spitsbergen (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2100">
+
+				<annotation>
+
+					<documentation>Svalbard</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2121">
+
+				<annotation>
+
+					<documentation>Bjørnøya (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2131">
+
+				<annotation>
+
+					<documentation>Hopen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2211">
+
+				<annotation>
+
+					<documentation>Jan Mayen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2311">
+
+				<annotation>
+
+					<documentation>Sokkelen sør for 62 grader Nord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="2321">
+
+				<annotation>
+
+					<documentation>Sokkelen nord for 62 grader Nord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5001">
+
+				<annotation>
+
+					<documentation>Trondheim</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5004">
+
+				<annotation>
+
+					<documentation>Steinkjer (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5006">
+
+				<annotation>
+
+					<documentation>Steinkjer</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5005">
+
+				<annotation>
+
+					<documentation>Namsos (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5007">
+
+				<annotation>
+
+					<documentation>Namsos</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5011">
+
+				<annotation>
+
+					<documentation>Hemne (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5012">
+
+				<annotation>
+
+					<documentation>Snillfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5059">
+
+				<annotation>
+
+					<documentation>Orkland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5013">
+
+				<annotation>
+
+					<documentation>Hitra (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5056">
+
+				<annotation>
+
+					<documentation>Hitra</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5014">
+
+				<annotation>
+
+					<documentation>Frøya</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5015">
+
+				<annotation>
+
+					<documentation>Ørland (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5057">
+
+				<annotation>
+
+					<documentation>Ørland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5016">
+
+				<annotation>
+
+					<documentation>Agdenes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5017">
+
+				<annotation>
+
+					<documentation>Bjugn (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5018">
+
+				<annotation>
+
+					<documentation>Åfjord (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5058">
+
+				<annotation>
+
+					<documentation>Åfjord</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5019">
+
+				<annotation>
+
+					<documentation>Roan (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5020">
+
+				<annotation>
+
+					<documentation>Osen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5021">
+
+				<annotation>
+
+					<documentation>Oppdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5022">
+
+				<annotation>
+
+					<documentation>Rennebu</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5023">
+
+				<annotation>
+
+					<documentation>Meldal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5024">
+
+				<annotation>
+
+					<documentation>Orkdal (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5025">
+
+				<annotation>
+
+					<documentation>Røros</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5026">
+
+				<annotation>
+
+					<documentation>Holtålen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5027">
+
+				<annotation>
+
+					<documentation>Midtre Gauldal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5028">
+
+				<annotation>
+
+					<documentation>Melhus</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5029">
+
+				<annotation>
+
+					<documentation>Skaun</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5030">
+
+				<annotation>
+
+					<documentation>Klæbu (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5001">
+
+				<annotation>
+
+					<documentation>Trondheim</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5031">
+
+				<annotation>
+
+					<documentation>Malvik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5032">
+
+				<annotation>
+
+					<documentation>Selbu</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5033">
+
+				<annotation>
+
+					<documentation>Tydal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5034">
+
+				<annotation>
+
+					<documentation>Meråker</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5035">
+
+				<annotation>
+
+					<documentation>Stjørdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5036">
+
+				<annotation>
+
+					<documentation>Frosta</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5037">
+
+				<annotation>
+
+					<documentation>Levanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5038">
+
+				<annotation>
+
+					<documentation>Verdal</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5039">
+
+				<annotation>
+
+					<documentation>Verran (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5040">
+
+				<annotation>
+
+					<documentation>Namdalseid (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5041">
+
+				<annotation>
+
+					<documentation>Snåase – Snåsa</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5042">
+
+				<annotation>
+
+					<documentation>Lierne</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5043">
+
+				<annotation>
+
+					<documentation>Raarvihke – Røyrvik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5044">
+
+				<annotation>
+
+					<documentation>Namsskogan</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5045">
+
+				<annotation>
+
+					<documentation>Grong</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5046">
+
+				<annotation>
+
+					<documentation>Høylandet</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5047">
+
+				<annotation>
+
+					<documentation>Overhalla</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5048">
+
+				<annotation>
+
+					<documentation>Frosnes (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5049">
+
+				<annotation>
+
+					<documentation>Flatanger</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5050">
+
+				<annotation>
+
+					<documentation>Vikna (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5060">
+
+				<annotation>
+
+					<documentation>Nærøysund</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5051">
+
+				<annotation>
+
+					<documentation>Nærøy (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5052">
+
+				<annotation>
+
+					<documentation>Leka</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5053">
+
+				<annotation>
+
+					<documentation>Inderøy</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="5054">
+
+				<annotation>
+
+					<documentation>Indre Fosen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0712">
+
+				<annotation>
+
+					<documentation>Larvik (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3805">
+
+				<annotation>
+
+					<documentation>Larvik</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0715">
+
+				<annotation>
+
+					<documentation>Holmestrand (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="0729">
+
+				<annotation>
+
+					<documentation>Færder (utgått)</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="3811">
+
+				<annotation>
+
+					<documentation>Færder</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="KommunenummerOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="LandKodeType">
+
+		<annotation>
+
+			<documentation>Landkoder, subsett av&lt;b> ISO 3166-1 alpha-2&lt;/b>
+				som kun inneholder de landkodene som vi har bruk for for å
+				konvertere SSR til SSR 2.0. Etter produksjonsetting utvides
+				kodelista ved behov.
+
+				Merk: XZ - "Internasjonalt farvann" og ZZ "Uspesifisert" er
+				brukerdefinerte koder (tillatt etter ISO-beskrivelsen). Det vil si
+				at koden ikke har noen bestemt betydning i ISO-kodelista, og vår
+				kodeliste må være tilgjengelig for at eksterne parter kan tolke vår
+				bruk av kodeverdiene.
+			</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:LandKodeEnumerationType app:LandKodeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="LandKodeEnumerationType">
+
+		<annotation>
+
+			<documentation>Landkoder, subsett av&lt;b> ISO 3166-1 alpha-2&lt;/b>
+				som kun inneholder de landkodene som vi har bruk for for å
+				konvertere SSR til SSR 2.0. Etter produksjonsetting utvides
+				kodelista ved behov.
+
+				Merk: XZ - "Internasjonalt farvann" og ZZ "Uspesifisert" er
+				brukerdefinerte koder (tillatt etter ISO-beskrivelsen). Det vil si
+				at koden ikke har noen bestemt betydning i ISO-kodelista, og vår
+				kodeliste må være tilgjengelig for at eksterne parter kan tolke vår
+				bruk av kodeverdiene.
+			</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="Norge">
+
+				<annotation>
+
+					<documentation>Norge</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Danmark">
+
+				<annotation>
+
+					<documentation>Danmark</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Sverige">
+
+				<annotation>
+
+					<documentation>Sverige</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Finland">
+
+				<annotation>
+
+					<documentation>Finland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Island">
+
+				<annotation>
+
+					<documentation>Island</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Grønland">
+
+				<annotation>
+
+					<documentation>Grønland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Russland">
+
+				<annotation>
+
+					<documentation>Russland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Storbritannia">
+
+				<annotation>
+
+					<documentation>Storbritannia</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Tyskland">
+
+				<annotation>
+
+					<documentation>Tyskland</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Svalbard_og_Jan_Mayen">
+
+				<annotation>
+
+					<documentation>Svalbard og Jan Mayen</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="Færøyene">
+
+				<annotation>
+
+					<documentation>Færøyene</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="internasjonaltFarvann">
+
+				<annotation>
+
+					<documentation>Brukerdefinert</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="uspesifisert">
+
+				<annotation>
+
+					<documentation>Brukerdefinert</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="LandKodeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavneobjektgruppeType">
+
+		<annotation>
+
+			<documentation>Gruppeinndelingen av navneobjekttypene</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:NavneobjektgruppeEnumerationType app:NavneobjektgruppeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="NavneobjektgruppeEnumerationType">
+
+		<annotation>
+
+			<documentation>Gruppeinndelingen av navneobjekttypene</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="terrengområder">
+
+				<annotation>
+
+					<documentation>Terrengområder: Samlegruppe for objekttyper som
+						beskriver terrengoverflate over større områder.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="høyder">
+
+				<annotation>
+
+					<documentation>Høyder: Samlegruppe for objekttyper som er høyere
+						enn andre objektyper i samme område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="senkninger">
+
+				<annotation>
+
+					<documentation>Senkninger: Samlegruppe for objekttyper som er
+						senket ned i forhold til andre objekttyper i samme område.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="flater">
+
+				<annotation>
+
+					<documentation>Flater: Samlegruppe for objekttyper som flate
+						terrengområder.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skråninger">
+
+				<annotation>
+
+					<documentation>Skråninger: Samlegruppe for objekttyper som
+						beskriver hellende terreng.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="terrengdetaljer">
+
+				<annotation>
+
+					<documentation>Terrengdetaljer: Samlegruppe for objekttyper som
+						beskriver spesielle terrengdetaljer.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bartFjell">
+
+				<annotation>
+
+					<documentation>Bart fjell: Samlegruppe for objekttyper som
+						beskriver overflater av bart fjell.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="løsmasseavsetninger">
+
+				<annotation>
+
+					<documentation>Løsmasseavsetninger: Samlegruppe for objekttyper som
+						beskriver avsetting av løse masser.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vegetasjon">
+
+				<annotation>
+
+					<documentation>Vegetasjon: Samlegruppe for objekttyper som
+						beskriver vegetasjonen.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="våtmark">
+
+				<annotation>
+
+					<documentation>Våtmark: Samlegruppe for objekttyper som beskriver
+						våt/fuktig mark.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="dyrkamark">
+
+				<annotation>
+
+					<documentation>Dyrkamark: Samlegruppe for objekttyper som beskriver
+						ulike typer dyrket mark.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="isOgPermafrost">
+
+				<annotation>
+
+					<documentation>Is og permafrost: Samlegruppe for objekttyper som er
+						fryst.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="uttakOgDeponi">
+
+				<annotation>
+
+					<documentation>Uttak og deponi: Samlegruppe for objekttyper av
+						menneskeskapte uttak eller fyllinger.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stilleståendeVann">
+
+				<annotation>
+
+					<documentation>Stillestående vann: Samlegruppe for objekttyper av
+						ferskvann som ser ut til å stå stille.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ferskvannskontur">
+
+				<annotation>
+
+					<documentation>Ferskvannskontur: Samlegruppe for objekttyper som
+						beskriver omrisset av objekter med ferskvann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grunnerIFerskvann">
+
+				<annotation>
+
+					<documentation>Grunner i ferskvann: Samlegruppe for objekttyper
+						under vannflaten som stikker høyere opp enn resten av området, men
+						ikke vesentlig over vannflaten.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="rennendeVann">
+
+				<annotation>
+
+					<documentation>Rennende vann: Samlegruppe for objekttyper som
+						beskriver rennenede ferskvann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="detaljerIFerskvann">
+
+				<annotation>
+
+					<documentation>Detaljer i ferskvann: Samlegruppe for objekttyper
+						som beskriver detaljer i ferskvann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="farvann">
+
+				<annotation>
+
+					<documentation>Farvann: Samlegruppe for objekttyper som beskriver
+						større områder av sjø.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kystkontur">
+
+				<annotation>
+
+					<documentation>Kystkontur: Samlegruppe for objekttyper som
+						beskriver grensa mellom sjø og tørt land.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grunnerISjø">
+
+				<annotation>
+
+					<documentation>Grunner i sjø: Samlegruppe for objekttyper under
+						havflaten som stikker høyere opp enn resten av området, men ikke
+						vesentlig over vannflaten.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sjøbunn">
+
+				<annotation>
+
+					<documentation>Sjøbunn: Samlegruppe for objekttyper som beskriver
+						sjøbunnen.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="detaljISjø">
+
+				<annotation>
+
+					<documentation>Detalj i sjø: Samlegruppe for objekttyper som
+						beskriver detaljer i sjøen.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bebyggelsesområder">
+
+				<annotation>
+
+					<documentation>Bebyggelsesområder: Samlegruppe for objekttyper som
+						beskriver områder med flere bygninger samlet innenfor et begrenset
+						område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="gardsbebyggelse">
+
+				<annotation>
+
+					<documentation>Gardsbebyggelse: Samlegruppe for objekttyper som
+						beskriver områder med samling av bebyggelse som hovedsakelig er
+						knyttet til landbruk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bolighus">
+
+				<annotation>
+
+					<documentation>Bolighus: Samlegruppe for objekttyper som beskriver
+						enkeltbygninger til boligformål som er bebodd midlertidig eller
+						permanent.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="næring">
+
+				<annotation>
+
+					<documentation>Næring: Samlegruppe for objekttyper som beskriver
+						enkeltbygninger til næringsformål.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="institusjoner">
+
+				<annotation>
+
+					<documentation>Institusjoner: Samlegruppe for objekttyper som
+						beskriver enkeltbygninger eller mindre samlinger av bygninger av
+						institusjonell karakter.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fritidsanlegg">
+
+				<annotation>
+
+					<documentation>Fritidsanlegg: Samlegruppe for objekttyper som
+						beskriver bygningsmessige og naturlige anlegg for rekreasjon og
+						fritidsaktiviteter.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="veg">
+
+				<annotation>
+
+					<documentation>Veg: Samlegruppe for objekttyper som beskriver
+						objekter som brukes til ferdsel, både motorisert og til fots.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bane">
+
+				<annotation>
+
+					<documentation>Bane: Samlegruppe for objekttyper som beskriver
+						funksjoner knyttet til skinnegående kjøretøy.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="luftfart">
+
+				<annotation>
+
+					<documentation>Luftfart: Samlegruppe for objekttyper som beskriver
+						anlegg hvor luftfartøy lander og tar av.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sjøfart">
+
+				<annotation>
+
+					<documentation>Sjøfart: Samlegruppe for objekttyper som beskriver
+						anlegg som har tilknytning til sjøfart.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="navigasjon">
+
+				<annotation>
+
+					<documentation>Navigasjon: Samlegruppe for objekttyper som
+						beskriver navigasjonshjelpemidler for skipsfart.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="samferdselsanlegg">
+
+				<annotation>
+
+					<documentation>Samferdselsanlegg: Samlegruppe for objekttyper som
+						beskriver anlegg som brukes i forbindelse med transport, både for
+						kjøretøy og til fots.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="energi">
+
+				<annotation>
+
+					<documentation>Energi: Samlegruppe for objekttyper som beskriver
+						anlegg for energi produksjon og transport.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kommunikasjon">
+
+				<annotation>
+
+					<documentation>Kommunikasjon: Samlegruppe for objekttyper som
+						beskriver anlegg for radiokommunikasjon.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="administrativeIndelinger">
+
+				<annotation>
+
+					<documentation>Administrative indelinger: Samlegruppe for
+						objekttyper som beskriver alle typer administrative inndelinger.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="verne-OgBruksområder">
+
+				<annotation>
+
+					<documentation>Verne- og bruksområder: Samlegruppe for objekttyper
+						som regulerer vern og bruksrettigheter.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kulturminner">
+
+				<annotation>
+
+					<documentation>Kulturminner: Samlegruppe for objekttyper som er
+						vernet som kulturminner.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kulturinstitusjoner">
+
+				<annotation>
+
+					<documentation>Kulturinstitusjoner: Samlegruppe for objekttyper som
+						beskriver institusjoner for kulturell aktivitet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavneobjektgruppeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavneobjekthovedgruppeType">
+
+		<annotation>
+
+			<documentation>Hovedgruppeinndelingen av navneobjekttyper.
+			</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:NavneobjekthovedgruppeEnumerationType app:NavneobjekthovedgruppeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="NavneobjekthovedgruppeEnumerationType">
+
+		<annotation>
+
+			<documentation>Hovedgruppeinndelingen av navneobjekttyper.
+			</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="terreng">
+
+				<annotation>
+
+					<documentation>Terreng: Alle grupper som beskriver
+						terrengformasjoner.
+						Tilsvarer Inspire temaet "landform".
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="markslag">
+
+				<annotation>
+
+					<documentation>Markslag: Alle grupper som er relevante under
+						hovedgruppe Markslag. Tilsvarer Inspire temaet "landcover".
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ferskvann">
+
+				<annotation>
+
+					<documentation>Ferskvann: Alle grupper som er relevante under
+						hovedgruppe Ferskvann. Under Inspire temaet "hydrography" som vi
+						har delt i to.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sjø">
+
+				<annotation>
+
+					<documentation>Sjø: Alle grupper som er relevante under hovedgruppe
+						Sjø. Under Inspire temaet "hydrography" som vi har delt i to.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bebyggelse">
+
+				<annotation>
+
+					<documentation>Bebyggelse: Alle grupper som er relevante under
+						hovedgruppe bebyggelse. Tilsvarer Inspire temaet "building" og
+						"populatedPlace".</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="infrastruktur">
+
+				<annotation>
+
+					<documentation>Infrastruktur: Alle grupper som er relevante under
+						hovedgruppe infrastruktur. Tilsvarer Inspire temaet
+						"transportNetwork".</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="offentligAdministrasjon">
+
+				<annotation>
+
+					<documentation>Offentlig administrasjon: Alle grupper som er
+						relevante under hovedgruppe offentlig administrasjon. Tilsvarer
+						Inspire temaet "administrativUnit".</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kultur">
+
+				<annotation>
+
+					<documentation>Kultur: Alle grupper som er relevante under
+						hovedgruppe Kultur.
+						Tilsvarer Inspire temaet "protctedSite".
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavneobjekthovedgruppeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavneobjekttypeType">
+
+		<annotation>
+
+			<documentation>Navneobjekttypene som stedsnavn er delt inn i.
+			</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:NavneobjekttypeEnumerationType app:NavneobjekttypeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="NavneobjekttypeEnumerationType">
+
+		<annotation>
+
+			<documentation>Navneobjekttypene som stedsnavn er delt inn i.
+			</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="eiendomsteig">
+
+				<annotation>
+
+					<documentation>eiendomsteig</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="våtmarksområde">
+
+				<annotation>
+
+					<documentation>våtmarksområde</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="busstasjon">
+
+				<annotation>
+
+					<documentation>busstasjon</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vannstandsmåler">
+
+				<annotation>
+
+					<documentation>vannstandsmåler</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="friluftsområde">
+
+				<annotation>
+
+					<documentation>friluftsområde</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sjømerkeMedIndirekteBelysning">
+
+				<annotation>
+
+					<documentation>sjømerkeMedIndirekteBelysning</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="reinbeitedistrikt">
+
+				<annotation>
+
+					<documentation>reinbeitedistrikt</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="boinstitusjon">
+
+				<annotation>
+
+					<documentation>boinstitusjon</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="egg">
+
+				<annotation>
+
+					<documentation>egg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellvegg">
+
+				<annotation>
+
+					<documentation>fjellvegg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="delAvVann">
+
+				<annotation>
+
+					<documentation>delAvVann</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="jernbanebru">
+
+				<annotation>
+
+					<documentation>jernbanebru</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="jernbanetunnel">
+
+				<annotation>
+
+					<documentation>jernbanetunnel</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="helikopterlandingsplass">
+
+				<annotation>
+
+					<documentation>helikopterlandingsplass</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kulturMessehall">
+
+				<annotation>
+
+					<documentation>kulturMessehall</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="overbygg">
+
+				<annotation>
+
+					<documentation>overbygg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="mindreBrukonstruksjon">
+
+				<annotation>
+
+					<documentation>mindreBrukonstruksjon</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stølsSetereiendom">
+
+				<annotation>
+
+					<documentation>stølsSetereiendom</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tuft">
+
+				<annotation>
+
+					<documentation>tuft</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vannverk">
+
+				<annotation>
+
+					<documentation>vannverk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="hammar">
+
+				<annotation>
+
+					<documentation>hammar</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellovergang">
+
+				<annotation>
+
+					<documentation>fjellovergang</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sva">
+
+				<annotation>
+
+					<documentation>sva</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="administrativBydel">
+
+				<annotation>
+
+					<documentation>Administrativ bydel: Offisielt navn på
+						bydelsforvaltningen i et angitt område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="adressenavn">
+
+				<annotation>
+
+					<documentation>Adressenavn: Offisielt adressenavn, veg-/gatenavn
+						eller områdenavn, jf. § 2 bokstav e i matrikkelforskriften.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="adressetilleggsnavn">
+
+				<annotation>
+
+					<documentation>Adressetilleggsnavn: Et stedsnavn som er en del av
+						den offisielle (veg-)adressen, jf. § 54 i matrikkelforskriften;
+						vanligvis bruksnavn eller sjeldnere bygnings-/institusjonsnavn.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="allmenning">
+
+				<annotation>
+
+					<documentation>Allmenning: Område hvor rettighetene er regulert og
+						fordelt på flere.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="alpinanlegg">
+
+				<annotation>
+
+					<documentation>Alpinanlegg: Anlegg for slalåm, utfor, snøbrett osv.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ankringsplass">
+
+				<annotation>
+
+					<documentation>Ankringsplass: Opplagsplass for store fartøy.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="annenAdministrativInndeling">
+
+				<annotation>
+
+					<documentation>Annen administrativ inndeling: Andre administrative
+						inndelinger som ikke tilhører øvrige navneobjekttyper.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="annenBygningForReligionsutøvelse">
+
+				<annotation>
+
+					<documentation>Annen bygning for religionsutøvelse: Synagoge,
+						moské, frikirke, menighetshus, kloster, gravkapell, bårehus,
+						krematorium.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="annenIndustri-OgLagerbygning">
+
+				<annotation>
+
+					<documentation>Annen industri- og lagerbygning: Mindre industri- og
+						produksjonsbedrift eller lager.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="annenKulturdetalj">
+
+				<annotation>
+
+					<documentation>Annen kulturdetalj: Alle andre typer kulturdetaljer,
+						f.eks. lekeplass, utkikkstårn, fiskeplass, og lignende.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="annenTerrengdetalj">
+
+				<annotation>
+
+					<documentation>Annen terrengdetalj: Små detaljer som ikke dekkes av
+						andre navneobjekttyper innenfor kategorien.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="annenVanndetalj">
+
+				<annotation>
+
+					<documentation>Annen vanndetalj: Andre navngitte forhold i
+						ferskvann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="badeplass">
+
+				<annotation>
+
+					<documentation>Badeplass: Offentlig eller privat badeplass.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bakke">
+
+				<annotation>
+
+					<documentation>Bakke: Terrengskråning, særlig om siden av en ås
+						eller haug.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bakkeVeg">
+
+				<annotation>
+
+					<documentation>Bakke (Veg): Allment kjent bakke på alle typer veger
+						og gater.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bakkeISjø">
+
+				<annotation>
+
+					<documentation>Bakke i sjø: Skrånende sjøbunn.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bakketoppISjø">
+
+				<annotation>
+
+					<documentation>Bakketopp i sjø: Undersjøisk knaus, kolle eller
+						haug.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="banestrekning">
+
+				<annotation>
+
+					<documentation>Banestrekning: Jernbanestrekning, tunnelbane eller
+						trikkelinje/-strekning.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="banke">
+
+				<annotation>
+
+					<documentation>Banke: Flatt, større undervannsområde.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bankeISjø">
+
+				<annotation>
+
+					<documentation>Banke i sjø: Større grunt område i sjøen med dypere
+						vann omkring; fiskegrunn.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="barnehage">
+
+				<annotation>
+
+					<documentation>Barnehage: Offentlig og privat barnehage.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bassengISjø">
+
+				<annotation>
+
+					<documentation>Basseng i sjø: Vid, undersjøisk dal.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bekk">
+
+				<annotation>
+
+					<documentation>Bekk: Rennende vann i naturlig vannvei, vanligvis
+						smalere enn 3 meter.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="berg">
+
+				<annotation>
+
+					<documentation>Berg: Markert eller avrunda høyde med stein,
+						steinmasse (med eller uten vegetasjon).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bergverk">
+
+				<annotation>
+
+					<documentation>Bergverk: Gruve, skjerp og mineraluttak i dagen
+						eller under jorda.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="boligblokk">
+
+				<annotation>
+
+					<documentation>Boligblokk: Stort (bolig)hus av mur, betong med over
+						fire boliger som har felles trapp(er) eller heis(er).
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="boligfelt">
+
+				<annotation>
+
+					<documentation>Boligfelt: Regulert boligområde.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bomstasjon">
+
+				<annotation>
+
+					<documentation>Bomstasjon: Større bomanlegg på offentlig veg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="borettslag">
+
+				<annotation>
+
+					<documentation>Borettslag: Bofellesskap i blokk eller
+						flerbebyggelse.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="botn">
+
+				<annotation>
+
+					<documentation>Botn: Innerste del av en dal; rundaktig, bratt dal
+						eller uthulning i fjellet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bru">
+
+				<annotation>
+
+					<documentation>Bru: Både på veg og jernbane.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bruk">
+
+				<annotation>
+
+					<documentation>Bruk: Navn på (landbruks)eiendom med ett eller flere
+						bruksnummer under ett gardsnummer, jf. lov om stadnamn §§ 2 og 8.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="brygge">
+
+				<annotation>
+
+					<documentation>Brygge: Mindre, fastbygd bryggeanlegg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="busstopp">
+
+				<annotation>
+
+					<documentation>Busstopp: Stoppested for rutegående vegtrafikk.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="by">
+
+				<annotation>
+
+					<documentation>By: Tettbygd sted som er større og (til dels)
+						innehar viktigere funksjoner enn andre tettbygde steder /
+						tettsteder.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bydel">
+
+				<annotation>
+
+					<documentation>Bydel: Kulturmessig del av by.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="bygdelagBygd">
+
+				<annotation>
+
+					<documentation>Bygdelag (bygd): Stort, uregulert gards- og
+						boligområde.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="byggForJordbrukFiskeOgFangst">
+
+				<annotation>
+
+					<documentation>Bygg for jordbruk, fiske og fangst: Til
+						primærnæring, f.eks. naust, uthus, sommerfjøs eller gamme.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="båe">
+
+				<annotation>
+
+					<documentation>Båe: Fjell eller stein under vannflaten.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="båeISjø">
+
+				<annotation>
+
+					<documentation>Båe i sjø: Spiss grunne; blindskjær som sjøen bryter
+						over.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="båke">
+
+				<annotation>
+
+					<documentation>Båke: Fast sjømerke. Sprinkelverk bygget i tre eller
+						metall.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="campingplass">
+
+				<annotation>
+
+					<documentation>Campingplass: Alle typer, med/uten campinghytter,
+						campingvogner og telt.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="dal">
+
+				<annotation>
+
+					<documentation>Dal: Mellomstor eller liten dal.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="dalføre">
+
+				<annotation>
+
+					<documentation>Dalføre: Stor dal med sidedaler.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="dam">
+
+				<annotation>
+
+					<documentation>Dam: Vann bak oppbygd hindring, oftest i en elv, for
+						å få jevn vannføring til fløting, til kraftverk eller for å hindre
+						skadeflom.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="delAvInnsjø">
+
+				<annotation>
+
+					<documentation>Del av innsjø: Mindre del av innsjø.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="eggISjø">
+
+				<annotation>
+
+					<documentation>Egg i sjø: Undersjøisk kant mot havdyp.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="eid">
+
+				<annotation>
+
+					<documentation>Eid: Lavt eller smalt parti mellom to vannkanter
+						(elv eller vann).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="eidISjø">
+
+				<annotation>
+
+					<documentation>Eid i sjø: Landstripe med sjø på begge sider som
+						binder sammen to landområder.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="eiendom">
+
+				<annotation>
+
+					<documentation>Eiendom: Navn på eiendom som ikke er bruksnavn, ev.
+						felles stedsnavn for flere eiendommer.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="elv">
+
+				<annotation>
+
+					<documentation>Elv: Rennende vann i naturlig vannvei, vanligvis
+						bredere enn 3 meter.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="elvemel">
+
+				<annotation>
+
+					<documentation>Elvemel: Bratt sand-/grusskråning langs elv eller
+						vann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="elvesving">
+
+				<annotation>
+
+					<documentation>Elvesving: Naturlig sving i elv eller bekk.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="eneboligMindreBoligbygg">
+
+				<annotation>
+
+					<documentation>Enebolig/mindre boligbygg: Navn på mindre eiendom
+						for fast bosetting. Hovedsakelig eiendom hvor eier kan bestemme
+						skrivemåten (jf. § 8 i lov om stadnamn og § 54 i
+						matrikkelforskriften). Kan også omfatte eget navn på bygg, eller
+						våningshus/gardsbruk som ikke er gitt eget matrikkelnummer.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="eng">
+
+				<annotation>
+
+					<documentation>Eng: Kultivert slåtte-/gressmark.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fabrikk">
+
+				<annotation>
+
+					<documentation>Fabrikk: Større industrivirksomhet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="farledSkipslei">
+
+				<annotation>
+
+					<documentation>Farled/skipslei: Allment kjent
+						seglingslei/farvannsområde med dybdeforhold passende for skip av
+						en viss størrelse.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fengsel">
+
+				<annotation>
+
+					<documentation>Fengsel: Bygning der arresterte eller dømte personer
+						soner straff.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ferjekai">
+
+				<annotation>
+
+					<documentation>Ferjekai: Ferjekai i fast regulert ferjesamband.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ferjestrekning">
+
+				<annotation>
+
+					<documentation>Ferjestrekning: Ferjesamband som inngår i områdets
+						samferdselsnett.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fiskeplassISjø">
+
+				<annotation>
+
+					<documentation>Fiskeplass i sjø: Navngitt fiskested; fiskemed.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjell">
+
+				<annotation>
+
+					<documentation>Fjell: Høyereliggende område (over tregrensa) med
+						stein og sva og lite vegetasjon som reiser seg over landskapet
+						omkring (med høye berg og nuter).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellIDagen">
+
+				<annotation>
+
+					<documentation>Fjell i dagen: Lite/ingen vegetasjon; sva, svaberg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellheis">
+
+				<annotation>
+
+					<documentation>Fjellheis: Gondolbane og trallebane for frakt av
+						folk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellkant">
+
+				<annotation>
+
+					<documentation>Fjellkant: Aksel, skulder, nese og bryn.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellkjedeISjø">
+
+				<annotation>
+
+					<documentation>Fjellkjede i sjø: Lengre, sammenhengende undersjøisk
+						fjellformasjon.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellområde">
+
+				<annotation>
+
+					<documentation>Fjellområde: Større område med fjell og
+						fjellandskap.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellside">
+
+				<annotation>
+
+					<documentation>Fjellside: Åpent, skrånende terreng i fjellet.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjelltoppISjø">
+
+				<annotation>
+
+					<documentation>Fjelltopp i sjø: Undersjøisk fjelltopp.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjord">
+
+				<annotation>
+
+					<documentation>Fjord: Arm av havet inn i fastlandet.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjordmunning">
+
+				<annotation>
+
+					<documentation>Fjordmunning: Område ytterst i en fjord.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="flyplass">
+
+				<annotation>
+
+					<documentation>Flyplass: Offentlig godkjent, avgrenset område med
+						start- og landingsplass for fly.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fløtningsanlegg">
+
+				<annotation>
+
+					<documentation>Fløtningsanlegg: Kunstig fløtningsanlegg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fonn">
+
+				<annotation>
+
+					<documentation>Fonn: Liten snø- eller isflate som vanligvis ikke
+						smelter om sommeren.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fornøyelsespark">
+
+				<annotation>
+
+					<documentation>Fornøyelsespark: Store, regulerte anlegg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="forretningsbygg">
+
+				<annotation>
+
+					<documentation>Forretningsbygg: Bygning for kontor-, salg- og
+						servicevirksomhet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="forsamlingshusKulturhus">
+
+				<annotation>
+
+					<documentation>Forsamlingshus/kulturhus: Teater, kino, samfunnshus,
+						grendehus o.l.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="forskningsstasjon">
+
+				<annotation>
+
+					<documentation>Forskningsstasjon: Bemannet forskningsstasjon eller
+						meteorologisk stasjon med bygningsmasse.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="foss">
+
+				<annotation>
+
+					<documentation>Foss: Vann i tilnærmet fritt fall.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fritidsbolig">
+
+				<annotation>
+
+					<documentation>Fritidsbolig: Eget navn på hytter og hus som ikke er
+						ment for fast bosetting.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fylke">
+
+				<annotation>
+
+					<documentation>Fylke: Offisielt navn.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fyllplass">
+
+				<annotation>
+
+					<documentation>Fyllplass: Plass for deponering av masse som stein,
+						jord og søppel.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fyrlykt">
+
+				<annotation>
+
+					<documentation>Fyrlykt: Linse og lyskilde anbrakt i hus eller
+						liknende. Ikke flytende.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fyrstasjon">
+
+				<annotation>
+
+					<documentation>Fyrstasjon: Automatisk og ubemannet. Et fast anlegg
+						hvor linse og lyskilde er anbrakt i hus, tårn eller spesielt bygg.
+						Ikke flytende.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="gammelBosettingsplass">
+
+				<annotation>
+
+					<documentation>Gammel bosettingsplass: Nedlagt bruk, seter, boplass
+						hvor bygningen(e) er borte eller bare tuftene er tilbake.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="garasjeHangarbygg">
+
+				<annotation>
+
+					<documentation>Garasje/hangarbygg: Trikkestall, bussgarasje,
+						flyhangar eller lokomotivstall.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="gard">
+
+				<annotation>
+
+					<documentation>Gard: Felles navn for et helt gardsnummer (jf. § 8 i
+						lov om stadnamn).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="gass-OljefeltISjø">
+
+				<annotation>
+
+					<documentation>Gass-/oljefelt i sjø: Navngitt gass- eller oljefelt
+						i havet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="geologiskStruktur">
+
+				<annotation>
+
+					<documentation>Geologisk struktur: Navngitt struktur/formasjon i
+						berggrunnen.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="gjerde">
+
+				<annotation>
+
+					<documentation>Gjerde: Oppsatt stengsel, vern, skille mellom
+						jordstykker, eiendommer eller beiteområder.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="gravplass">
+
+				<annotation>
+
+					<documentation>Gravplass: Alle typer gravlunder, gravplasser.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grend">
+
+				<annotation>
+
+					<documentation>Grend: Mindre uregulert gards-, seter- og
+						boligområde.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grensemerke">
+
+				<annotation>
+
+					<documentation>Grensemerke: Offisielt grensemerke: Varde, tre,
+						stein, bolt, kors o.l.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grind">
+
+				<annotation>
+
+					<documentation>Grind: Port i gjerde.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grotte">
+
+				<annotation>
+
+					<documentation>Grotte: Naturlig fjellgrotte.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grunne">
+
+				<annotation>
+
+					<documentation>Grunne: Lite område under vann som hever seg fra
+						området rundt.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grunneISjø">
+
+				<annotation>
+
+					<documentation>Grunne i sjø: Markant forhøyning av havbunnen.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grunnkrets">
+
+				<annotation>
+
+					<documentation>Grunnkrets: Offisielt navn på grunnkrets.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="gruppeAvTjern">
+
+				<annotation>
+
+					<documentation>Gruppe av tjern: To eller flere små tjern.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="gruppeAvVann">
+
+				<annotation>
+
+					<documentation>Gruppe av vann: To eller flere vann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grustakSteinbrudd">
+
+				<annotation>
+
+					<documentation>Grustak/steinbrudd: Uttaksplass/-område for sand,
+						grus, pukk, skifer eller stein.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grøft">
+
+				<annotation>
+
+					<documentation>Grøft: Rennende vann i oppgravd vannvei, f.eks.
+						dreneringsgrøft i myr.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="halvøy">
+
+				<annotation>
+
+					<documentation>Halvøy: Større nes i ferskvann med smalt eid mot
+						fastland.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="halvøyISjø">
+
+				<annotation>
+
+					<documentation>Halvøy i sjø: Større nes med smalt eid mot fastland.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="haug">
+
+				<annotation>
+
+					<documentation>Haug: Liten, markant forhøynet terrengform.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="havdyp">
+
+				<annotation>
+
+					<documentation>Havdyp: Stort, dypt område i havet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="havn">
+
+				<annotation>
+
+					<documentation>Havn: Sted der fartøy laster, losser eller søker ly
+						for vær og sjø.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="havnehage">
+
+				<annotation>
+
+					<documentation>Havnehage: Inngjerdet beitemark.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="havområde">
+
+				<annotation>
+
+					<documentation>Havområde: Del av et hav.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="havstrøm">
+
+				<annotation>
+
+					<documentation>Havstrøm: Kontinuerlig bevegelse av vann (i havet)
+						på grunn av klimatiske forhold eller tidevann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="hei">
+
+				<annotation>
+
+					<documentation>Hei: Berglendt, høyere beliggende område med
+						beitemark.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="heller">
+
+				<annotation>
+
+					<documentation>Heller: Utoverhengende bergvegg eller berghule.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="helseinstitusjon">
+
+				<annotation>
+
+					<documentation>Helseinstitusjon: Aldershjem, rekreasjonshjem og
+						lignende.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="historiskBosetting">
+
+				<annotation>
+
+					<documentation>Historisk bosetting: Ubebodd eller forlatt bosetting
+						med bestående bygningsmasse eller ruiner.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="holdeplass">
+
+				<annotation>
+
+					<documentation>Holdeplass: Ubetjent stoppested for jernbane,
+						tunnelbane og/eller trikk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="holme">
+
+				<annotation>
+
+					<documentation>Holme: Liten øy i ferskvann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="holmeISjø">
+
+				<annotation>
+
+					<documentation>Holme i sjø: Liten øy.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="holmegruppeISjø">
+
+				<annotation>
+
+					<documentation>Holmegruppe i sjø: To eller flere små øyer.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="hotell">
+
+				<annotation>
+
+					<documentation>Hotell: Større, offentlig godkjent overnattingssted.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="hylle">
+
+				<annotation>
+
+					<documentation>Hylle: Flatt, tilnærmet vannrett område i fjellside.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="hylleISjø">
+
+				<annotation>
+
+					<documentation>Hylle i sjø: Undersjøisk benk; klippeavsats, kant,
+						fremspring, avsats.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="hyttefelt">
+
+				<annotation>
+
+					<documentation>Hyttefelt: Offentlig eller privat hyttefelt.
+						Regulert område med høy utnyttelsesgrad.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="høl">
+
+				<annotation>
+
+					<documentation>Høl: Dyp elvebunn under foss eller etter et stryk.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="høyde">
+
+				<annotation>
+
+					<documentation>Høyde: Høyereliggende terrengform, mindre omfattende
+						enn ås og større enn haug.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="idrettsanlegg">
+
+				<annotation>
+
+					<documentation>Idrettsanlegg: Alle typer utendørsanlegg for idrett.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="idrettshall">
+
+				<annotation>
+
+					<documentation>Idrettshall: Alle typer innendørsanlegg, f.eks.
+						ishall, svømmehall, idrettshall og ridehall.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="industriområde">
+
+				<annotation>
+
+					<documentation>Industriområde: Større, sammenhengende område til
+						industri- og næringsformål.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="innsjø">
+
+				<annotation>
+
+					<documentation>Innsjø: Stort vann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="isbre">
+
+				<annotation>
+
+					<documentation>Isbre: Større sammenhengende snø- eller isområde som
+						ikke smelter i løpet av sommeren.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="iskuppel">
+
+				<annotation>
+
+					<documentation>Iskuppel: Konveks ismasse av en viss tykkelse i
+						større bre eller innlandsis.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="jernstang">
+
+				<annotation>
+
+					<documentation>Jernstang: Fast sjømerke av typen jernstang eller
+						jernsøyle.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="jorde">
+
+				<annotation>
+
+					<documentation>Jorde: Kultivert dyrkningsmark.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="juv">
+
+				<annotation>
+
+					<documentation>Juv: Kløftlignende dal eller canyon.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kabel">
+
+				<annotation>
+
+					<documentation>Kabel: Alle typer kabler i sjø eller i ferskvann.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kai">
+
+				<annotation>
+
+					<documentation>Kai: Større, fastbygd bryggeanlegg.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kanal">
+
+				<annotation>
+
+					<documentation>Kanal: Kunstig eller naturlig vannvei eller
+						gjennomseiling.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kilde">
+
+				<annotation>
+
+					<documentation>Kilde: Oppkomme, olle, kildeutspring, osv.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kirke">
+
+				<annotation>
+
+					<documentation>Kirke: Kirke, kapell, arbeidskirke o.l.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="klakkISjø">
+
+				<annotation>
+
+					<documentation>Klakk i sjø: Fjellknatt på sjøbunnen.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="klopp">
+
+				<annotation>
+
+					<documentation>Klopp: Liten gangbru av stokker og/eller stein over
+						bekker og elver, i myr eller i fjæra.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kommune">
+
+				<annotation>
+
+					<documentation>Kommune: Offisielt navn.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kontinentalsokkel">
+
+				<annotation>
+
+					<documentation>Kontinentalsokkel: Område med grunt hav rundt
+						kontinentene. Ofte brukt om et lands økonomiske interessesone til
+						sjøs.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="korallrev">
+
+				<annotation>
+
+					<documentation>Korallrev: Rev som er dannet av koraller.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kraftgateRørgate">
+
+				<annotation>
+
+					<documentation>Kraftgate (rørgate): Store tilførselsrør for
+						kraftanlegg.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kraftledning">
+
+				<annotation>
+
+					<documentation>Kraftledning: Stor strømoverføringsledning.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kraftstasjon">
+
+				<annotation>
+
+					<documentation>Kraftstasjon: Alle typer / alle størrelser til
+						energiproduksjon (f.eks. el. og varme).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="krater">
+
+				<annotation>
+
+					<documentation>Krater: Skål- eller traktformet senkning i
+						jordoverflaten forårsaket av vulkansk aktivitet eller av
+						meteorittnedslag.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="landingsplass">
+
+				<annotation>
+
+					<documentation>Landingsplass: Landingsplass for helikopter og/eller
+						privatfly.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="landskapsområde">
+
+				<annotation>
+
+					<documentation>Landskapsområde: Område der drag i landskapet,
+						naturforhold, arealbruk og bosetting er samlende og skiller seg
+						fra tilgrensende områder.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="lanterne">
+
+				<annotation>
+
+					<documentation>Lanterne: En innretning hvor linsen med eller uten
+						beskyttelsesglass utgjør en del av den bærende del av
+						konstruksjonen. Ikke flytende.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="li">
+
+				<annotation>
+
+					<documentation>Li: Skrånende terreng.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="lon">
+
+				<annotation>
+
+					<documentation>Lon: Utbuktning i elv eller bekk der vannet renner
+						stille.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="lysbøye">
+
+				<annotation>
+
+					<documentation>Lysbøye: Flytende innretning for farvannsmerking med
+						en lanterne som lyskilde.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="matrikkeladressenavn">
+
+				<annotation>
+
+					<documentation>Matrikkeladressenavn: Et stedsnavn som inngår i den
+						offiselle adressen ved matrikkeladresser, jf. § 55 tredje ledd i
+						matrikkelforskriften.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="melkeplass">
+
+				<annotation>
+
+					<documentation>Melkeplass: Seterplass uten hus (ev. med enkelt
+						skur) brukt til melking av husdyr.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="militærtByggAnlegg">
+
+				<annotation>
+
+					<documentation>Militært bygg/anlegg: Militærleir.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="mo">
+
+				<annotation>
+
+					<documentation>Mo: Større, flatt landområde (ofte skogkledd).
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="molo">
+
+				<annotation>
+
+					<documentation>Molo: Fast byggverk, utstikkende voll i sjøen.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="moreneryggISjø">
+
+				<annotation>
+
+					<documentation>Morenerygg i sjø: Marin israndavsetning.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="museumGalleriBibliotek">
+
+				<annotation>
+
+					<documentation>Museum/galleri/bibliotek: Alle typer museum, galleri
+						og bibliotek.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="myr">
+
+				<annotation>
+
+					<documentation>Myr: Alle typer fra åpen gressmyr til våt moldjord
+						dekket med kjerr.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="nasjon">
+
+				<annotation>
+
+					<documentation>Nasjon: Offisielt navn på selvstendig stat eller
+						land.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="navnegard">
+
+				<annotation>
+
+					<documentation>Navnegard: Opprinnelig navn fra før garden ble
+						oppdelt i gards- og bruksenheter. Navnegardens utbredelse kan
+						omfatte flere enn ett gardsnummer.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="nes">
+
+				<annotation>
+
+					<documentation>Nes: Landområde stikkende ut i ferskvann.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="nesISjø">
+
+				<annotation>
+
+					<documentation>Nes i sjø: Landområde stikkende ut i sjø.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="nesVedElver">
+
+				<annotation>
+
+					<documentation>Nes ved elver: Landet mellom to møtende elver.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="offersted">
+
+				<annotation>
+
+					<documentation>Offersted: Alle typer offersted.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="oljeinstallasjon">
+
+				<annotation>
+
+					<documentation>Oljeinstallasjon: Stasjonær olje- og
+						gassinstallasjon (fast eller flytende).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="oppdrettsanlegg">
+
+				<annotation>
+
+					<documentation>Oppdrettsanlegg: Anlegg for foring og stell av
+						husdyr til de kan settes i produksjon eller slaktes; oppforing av
+						fisk (og andre sjødyr) i fangenskap.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="os">
+
+				<annotation>
+
+					<documentation>Os: Innløp eller utløp av elv eller bekk i
+						innsjø/vann/tjern eller sjø (saltvann).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="overett">
+
+				<annotation>
+
+					<documentation>Overett: To sjømerker, med eller uten lys, som, når
+						de peiles på linje, viser kurs for gjennomseiling.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="park">
+
+				<annotation>
+
+					<documentation>Park: Kultivert grøntområde i by/tettsted.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="parkeringsplass">
+
+				<annotation>
+
+					<documentation>Parkeringsplass: Tomt (eller bygning) for parkering
+						av biler.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="pensjonat">
+
+				<annotation>
+
+					<documentation>Pensjonat: Mindre, offentlig godkjent
+						overnattingssted.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="platåISjø">
+
+				<annotation>
+
+					<documentation>Platå i sjø: Stor, flat forhøyning som skiller seg
+						fra havbunnen omkring.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="poststed">
+
+				<annotation>
+
+					<documentation>Poststed: Offisielt poststed/postnummerområde.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="pytt">
+
+				<annotation>
+
+					<documentation>Pytt: Lite vannhull (mindre enn tjern).
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="rasISjø">
+
+				<annotation>
+
+					<documentation>Ras i sjø: Undersjøisk rasområde med stein, jord,
+						sand eller leire.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="rasteplass">
+
+				<annotation>
+
+					<documentation>Rasteplass: Rasteplass definert og lagt til rette av
+						Statens vegvesen eller annen offentlig myndighet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="renneKløftISjø">
+
+				<annotation>
+
+					<documentation>Renne/Kløft i sjø: Undersjøisk dal, kanal, senkning,
+						ravine, fure, spor, rille o.l.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="revISjø">
+
+				<annotation>
+
+					<documentation>Rev i sjø: Grunne, banke av stein/fjell (som
+						strekker seg ut fra en kyst).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="rygg">
+
+				<annotation>
+
+					<documentation>Rygg: Langstrakt terrengform.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ryggISjø">
+
+				<annotation>
+
+					<documentation>Rygg i sjø: Undersjøisk ås, åskam eller fjellrygg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="rørledning">
+
+				<annotation>
+
+					<documentation>Rørledning: Alle typer rørledninger: Olje, gass,
+						vann o.l.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="rådhus">
+
+				<annotation>
+
+					<documentation>Rådhus: Administrasjonssenteret i den administrative
+						enheten, f.eks. stat, fylke, kommune.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sadelISjø">
+
+				<annotation>
+
+					<documentation>Sadel i sjø: Undersjøisk skar mellom to høyere
+						topper/rygger.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sand">
+
+				<annotation>
+
+					<documentation>Sand: Finkornede avsetninger (sand og/eller grus).
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="senkning">
+
+				<annotation>
+
+					<documentation>Senkning: Flat forsenkning, dalsenkning.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="serveringssted">
+
+				<annotation>
+
+					<documentation>Serveringssted: Serveringssted uten overnatting.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="seterStøl">
+
+				<annotation>
+
+					<documentation>Seter/støl: Enklere landbruksbebyggelse med hus. Kan
+						ha periodisk fast bosetting, vanligvis sommerstid.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="setervoll">
+
+				<annotation>
+
+					<documentation>Setervoll: Ryddet, gressbevokst område på seter uten
+						hus.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="severdighet">
+
+				<annotation>
+
+					<documentation>Severdighet: Minnesmerke, arkeologiske funn o.l.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sjødetalj">
+
+				<annotation>
+
+					<documentation>Sjødetalj: Detalj som ikke dekkes av andre
+						sjø-navneobjekttyper.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sjøvarde">
+
+				<annotation>
+
+					<documentation>Sjømerke: Varde av stein eller betong primært for
+						navigering til sjøs.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sjøstykke">
+
+				<annotation>
+
+					<documentation>Sjøstykke: Stykke av sjøen utanfor land, vanligvis
+						innaskjærs eller i kystnære farvann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skar">
+
+				<annotation>
+
+					<documentation>Skar: Markant senkning i fjell eller berg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skiheis">
+
+				<annotation>
+
+					<documentation>Skiheis: Skitrekk og stolheis i skianlegg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skjær">
+
+				<annotation>
+
+					<documentation>Skjær: Fjell eller stein i vannflaten.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skjærISjø">
+
+				<annotation>
+
+					<documentation>Skjær i sjø: Bergrunn nær eller rett over
+						vannflaten.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skog">
+
+				<annotation>
+
+					<documentation>Skog: Alle typer fra stor barskog til og med
+						vierkratt i Finnmark.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skogholt">
+
+				<annotation>
+
+					<documentation>Skogholt: Mindre samling av trær.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skogområde">
+
+				<annotation>
+
+					<documentation>Skogområde: Større område med skog og mark.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skole">
+
+				<annotation>
+
+					<documentation>Skole: Offentlig og privat skole.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skolekrets">
+
+				<annotation>
+
+					<documentation>Skolekrets: Skolekrets definert av kommunen.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skredområde">
+
+				<annotation>
+
+					<documentation>Skredområde: Område der det går eller har gått
+						skred.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skytebane">
+
+				<annotation>
+
+					<documentation>Skytebane: Bane for øvelse el. konkurranse i
+						skyting.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skytefelt">
+
+				<annotation>
+
+					<documentation>Skytefelt: Militært sprengingsfelt, bombe- og
+						skytefelt, både på land og sjø.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="slette">
+
+				<annotation>
+
+					<documentation>Slette: Åpent, flatt område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sluse">
+
+				<annotation>
+
+					<documentation>Sluse: Kunstig løfteanretning for båter i vassdrag.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="småbåthavn">
+
+				<annotation>
+
+					<documentation>Småbåthavn: Regulert havneanlegg for småbåter.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sokkelISjø">
+
+				<annotation>
+
+					<documentation>Sokkel i sjø: Undersjøisk fjellfot.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sokn">
+
+				<annotation>
+
+					<documentation>Sokn: Kirkesokn i Den norske kirke.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="soneinndelingTilHavs">
+
+				<annotation>
+
+					<documentation>Soneinndeling til havs: Fiskerisone, havrettssone og
+						lignende.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stake">
+
+				<annotation>
+
+					<documentation>Stake: Flytende sjømerke. Ofte kalt bøyestake,
+						stakebøye, kubbestake.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stasjon">
+
+				<annotation>
+
+					<documentation>Stasjon: Stoppested for jernbane, tunnelbane
+						og/eller trikk. Som regel betjent.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="statistiskTettsted">
+
+				<annotation>
+
+					<documentation>Statistisk tettsted: Tettsted etter Statistisk
+						sentralbyrås klassifisering som brukes for å lage statistikk over
+						befolkning og tettsteder.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stein">
+
+				<annotation>
+
+					<documentation>Stein: Frittliggende steinblokk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sti">
+
+				<annotation>
+
+					<documentation>Sti: Stistrekning, råk, slepe (gammel drifteveg),
+						reindriftsveg.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="strand">
+
+				<annotation>
+
+					<documentation>Strand: Sand-, grus- eller steindekket område i
+						vannkanten ved elv eller vann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="strandISjø">
+
+				<annotation>
+
+					<documentation>Strand i sjø: Sand-, grus- eller steindekket område
+						i sjøkanten.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stryk">
+
+				<annotation>
+
+					<documentation>Stryk: Del av elv, bekk der vannet går i stryk (og
+						skiller seg tydelig fra resten av elva/bekken).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stup">
+
+				<annotation>
+
+					<documentation>Stup: Loddrett, svært bratt berg.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stø">
+
+				<annotation>
+
+					<documentation>Stø: Båtplass i vannkanten uten naust.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sund">
+
+				<annotation>
+
+					<documentation>Sund: Innsnevret område i vann eller vassdrag.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sundISjø">
+
+				<annotation>
+
+					<documentation>Sund i sjø: Innsnevret område mellom øyer eller
+						fastland.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sykehus">
+
+				<annotation>
+
+					<documentation>Sykehus: Offentlig og privat sykehus.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="søkk">
+
+				<annotation>
+
+					<documentation>Søkk: Mindre markant, begrenset fordypning.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="søkkISjø">
+
+				<annotation>
+
+					<documentation>Søkk i sjø: Stor eller liten grop på sjøbunnen.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="taubane">
+
+				<annotation>
+
+					<documentation>Taubane: Heis til frakt av gods/høy, ikke
+						persontrafikk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tettbebyggelse">
+
+				<annotation>
+
+					<documentation>Tettbebyggelse: Bebygd område uten sentrumskarakter.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tettsted">
+
+				<annotation>
+
+					<documentation>Tettsted: Mindre, bymessig bebygd område med
+						sentrumskarakter.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tettsteddel">
+
+				<annotation>
+
+					<documentation>Tettsteddel: Kulturmessig del av tettsted.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tjern">
+
+				<annotation>
+
+					<documentation>Tjern: Lite vann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="topp">
+
+				<annotation>
+
+					<documentation>Topp: Tind, markant topp på fjell, berg, ås osv.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="torg">
+
+				<annotation>
+
+					<documentation>Torg: Stor, åpen plass i en by.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="torvtak">
+
+				<annotation>
+
+					<documentation>Torvtak: Sted for uttak av myrtorv, brenntorv eller
+						veksttorv.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="traktorveg">
+
+				<annotation>
+
+					<documentation>Traktorveg: Driftsveg anlagt for traktorbruk. Ikke
+						fremkommelig med vanlig personbil.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tunnel">
+
+				<annotation>
+
+					<documentation>Tunnel: Vanlig tunnel, rasoverbygg eller undergang.
+						Både på veg og jernbane.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="turisthytte">
+
+				<annotation>
+
+					<documentation>Turisthytte: Overnattingssted utenfor tettbygd
+						område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tV-Radio-EllerMobiltelefontårn">
+
+				<annotation>
+
+					<documentation>TV-/radio- eller mobiltelefontårn: Alle typer
+						bakkebasert telekommunikasjon.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tømmervelte">
+
+				<annotation>
+
+					<documentation>Tømmervelte: Midlertidig lagringsplass for tømmer.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="undersjøiskVegg">
+
+				<annotation>
+
+					<documentation>Undersjøisk vegg: Fjellside i havet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="universitetHøgskole">
+
+				<annotation>
+
+					<documentation>Universitet/høgskole: Offentlig og privat høgskole
+						og universitet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ur">
+
+				<annotation>
+
+					<documentation>Ur: Steinområde, steinrøys.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="utmark">
+
+				<annotation>
+
+					<documentation>Utmark: Beitemark i skog og mark vekk fra garden (og
+						innmarka).</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="utsiktspunkt">
+
+				<annotation>
+
+					<documentation>Utsiktspunkt: Både fra tårn og på bakken.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="utstikker">
+
+				<annotation>
+
+					<documentation>Utstikker: Flytende bryggeanlegg.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vad">
+
+				<annotation>
+
+					<documentation>Vad: Vadested, vanligvis der en stistrekning krysser
+						elv, bekk eller vann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vaktstasjonBeredsskapsbygning">
+
+				<annotation>
+
+					<documentation>Vaktstasjon/beredsskapsbygning: Bygning for
+						politi/brann/los/toll/ambulanse/fly- og skipsovervåkning.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="valgkrets">
+
+				<annotation>
+
+					<documentation>Valgkrets: Valgkrets definert av kommunen.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vann">
+
+				<annotation>
+
+					<documentation>Vann: Middels stort vann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="varde">
+
+				<annotation>
+
+					<documentation>Varde: (Som oftest) oppstablet stein som skal
+						markere sti, grensemerke, trigonometrisk punkt o.l.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vegbom">
+
+				<annotation>
+
+					<documentation>Vegbom: Mindre bomanlegg på privat veg.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vegkryss">
+
+				<annotation>
+
+					<documentation>Vegkryss: Allment kjent vegkryss i alle typer veger
+						og gater.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vegstrekning">
+
+				<annotation>
+
+					<documentation>Vegstrekning: Navn på vegstrekning som ikke
+						nødvendigvis har et formelt vedtak, og ikke er det samme som
+						adressenavnet. Det kan være f.eks. fjelloverganger,
+						turistrekninger og ringveger rundt en by.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vegsving">
+
+				<annotation>
+
+					<documentation>Vegsving: Allment kjent sving på alle typer veger og
+						gater.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="verneområde">
+
+				<annotation>
+
+					<documentation>Verneområde: Et område med spesiell natur- og/eller
+						kulturverdi som er formelt vedtatt vernet etter offentlig
+						regelverk. Alle typer, både på sjø og land.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vidde">
+
+				<annotation>
+
+					<documentation>Vidde: Høyereliggende (fjell)område med lite
+						høydevariasjoner innenfor området, som regel over tregrensa.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vik">
+
+				<annotation>
+
+					<documentation>Vik: Kil eller bukt i vann eller vassdrag.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vikISjø">
+
+				<annotation>
+
+					<documentation>Vik i sjø: Kil, bukt.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vulkanISjø">
+
+				<annotation>
+
+					<documentation>Vulkan i sjø: Vulkan eller slamvulkan på havbunnen.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vågISjø">
+
+				<annotation>
+
+					<documentation>Våg i sjø: Fjordarm, større vik.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="øy">
+
+				<annotation>
+
+					<documentation>Øy: Tørt landområde i ferskvann atskilt fra
+						fastlandet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="øyISjø">
+
+				<annotation>
+
+					<documentation>Øy i sjø: Tørt landområde atskilt fra fastlandet.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="øygruppe">
+
+				<annotation>
+
+					<documentation>Øygruppe: To eller flere øyer i ferskvann.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="øygruppeISjø">
+
+				<annotation>
+
+					<documentation>Øygruppe i sjø: To eller flere øyer.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="øyr">
+
+				<annotation>
+
+					<documentation>Øyr: Sand-/grusområde i elvemunning, elvedelta både
+						mot innsjø/vann og saltvann.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ås">
+
+				<annotation>
+
+					<documentation>Ås: Langstrakt høydedrag.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="eiendomsteig">
+
+				<annotation>
+
+					<documentation>eiendomsteig</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="våtmarksområde">
+
+				<annotation>
+
+					<documentation>våtmarksområde</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="busstasjon">
+
+				<annotation>
+
+					<documentation>busstasjon</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vannstandsmåler">
+
+				<annotation>
+
+					<documentation>vannstandsmåler</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="friluftsområde">
+
+				<annotation>
+
+					<documentation>friluftsområde</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sjømerkeMedIndirekteBelysning">
+
+				<annotation>
+
+					<documentation>sjømerkeMedIndirekteBelysning</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="reinbeitedistrikt">
+
+				<annotation>
+
+					<documentation>reinbeitedistrikt</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="boinstitusjon">
+
+				<annotation>
+
+					<documentation>boinstitusjon</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="egg">
+
+				<annotation>
+
+					<documentation>egg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellvegg">
+
+				<annotation>
+
+					<documentation>fjellvegg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="delAvVann">
+
+				<annotation>
+
+					<documentation>delAvVann</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="jernbanebru">
+
+				<annotation>
+
+					<documentation>jernbanebru</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="jernbanetunnel">
+
+				<annotation>
+
+					<documentation>jernbanetunnel</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="helikopterlandingsplass">
+
+				<annotation>
+
+					<documentation>helikopterlandingsplass</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kulturMessehall">
+
+				<annotation>
+
+					<documentation>kulturMessehall</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="overbygg">
+
+				<annotation>
+
+					<documentation>overbygg</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="mindreBrukonstruksjon">
+
+				<annotation>
+
+					<documentation>mindreBrukonstruksjon</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="stølsSetereiendom">
+
+				<annotation>
+
+					<documentation>stølsSetereiendom</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tuft">
+
+				<annotation>
+
+					<documentation>tuft</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vannverk">
+
+				<annotation>
+
+					<documentation>vannverk</documentation>
+
+				</annotation>
+
+			</enumeration>
+			<enumeration value="hammar">
+
+				<annotation>
+
+					<documentation>hammar</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fjellovergang">
+
+				<annotation>
+
+					<documentation>fjellovergang</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sva">
+
+				<annotation>
+
+					<documentation>sva</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavneobjekttypeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavnesakstatusKodeType">
+
+		<annotation>
+
+			<documentation>Saksgang/statuser finnes i modellen "Diagrammer" i
+				Perforce (stedsnavnDok/trunk/diagrammer)</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:NavnesakstatusKodeEnumerationType app:NavnesakstatusKodeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="NavnesakstatusKodeEnumerationType">
+
+		<annotation>
+
+			<documentation>Saksgang/statuser finnes i modellen "Diagrammer" i
+				Perforce (stedsnavnDok/trunk/diagrammer)</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="forenkletVedtak">
+
+				<annotation>
+
+					<documentation>Skrivemåten av stedsnavnet er vedtatt fordi den har
+						vedtak eller er godkjent i en annen funksjon.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="iverksattVedtak">
+
+				<annotation>
+
+					<documentation>Skrivemåten av stedsnavnet er bestemt ved vedtak.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="klagenemda">
+
+				<annotation>
+
+					<documentation>Hvis vedtaksmyndigheten står ved sitt valg av
+						skrivemåte i klagesaken blir saken sendt videre til klagenemnda.
+						De kan (men trenger ikke) innhente høringsuttalelser fra
+						Språkrådet, Sametinget og departement.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="klageIverksattVedtakIkkeTrukketTilbake">
+
+				<annotation>
+
+					<documentation>Det er kommet inn klage på vedtak for stedsnavnet,
+						der vedtaket er iverksatt. Det er ikke fremsatt ønske om at
+						vedtaket trekkes tilbake i klageperioden, eller slikt ønske er
+						ikke tatt til følge av vedtaksmyndigheten.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="klageVedtakTrukketTilbake">
+
+				<annotation>
+
+					<documentation>Det er kommet inn klage på vedtak for stedsnavnet,
+						der vedtaket er iverksatt. Det er fremsatt ønske om at vedtaket
+						trekkes tilbake i klageperioden, og ønsket er tatt til følge av
+						vedtaksmyndigheten.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skalIkkeBehandlesEtterLoven">
+
+				<annotation>
+
+					<documentation>Registrering av stedsnavn som ikke skal behandles
+						etter lov om stadnamn, der det altså ikke kan reises navnesak og
+						følgelig navnesakstatus ikke er relevant.
+
+						Stedsnavnets skrivemåter registreres med status Privat eller Internasjonal.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="navnBestemtAvNavnemyndighet">
+
+				<annotation>
+
+					<documentation>Registrering av stedsnavn som er bestemt av
+						navnemyndighet, f.eks. kommunen ved behandling etter
+						matrikkelloven. Ikke alle navnetyper kan behandles på denne måten,
+						det mest aktuelle er adressenavn.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="navnesakReist">
+
+				<annotation>
+
+					<documentation>Det er reist navnesak for stedsnavnet etter lov om
+						stadnamn, herunder navnesak reist på bakgrunn av klage på
+						normering av stedsnavn etter samlevedtak.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="samlevedtak">
+
+				<annotation>
+
+					<documentation>Stedsnavnet har blitt normert i et samlevedtak, jf.
+						forskrift om skrivemåten av stadnamn § 8, femte ledd.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="samlevedtakTrukketTilbake">
+
+				<annotation>
+
+					<documentation>Samlevedtak kreves trukket tilbake i forbindelse med
+						at navnesak reises for stedsnavnet på bakgrunn av klage på
+						normering av stedsnavn etter samlevedtak.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="ubehandlet">
+
+				<annotation>
+
+					<documentation>Stedsnavn som det ikke har vært gjennom noen form
+						for saksgang.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vedtakIverksettingUtsatt">
+
+				<annotation>
+
+					<documentation>Det er gjort vedtak for stedsnavnet etter lov om
+						stadnamn, men iverksetting av vedtaket er utsatt til klagefristen
+						er ute, jf. forskrift om skrivemåten av stadnamn § 12.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavnesakstatusKodeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavnestatuskodeType">
+
+		<annotation>
+
+			<documentation>Kodene angir et hierarki stedsnavna i mellom, som sier
+				noe om hvilket som blir brukt mest, like mye eller ikke er i bruk
+				lengre.</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:NavnestatuskodeEnumerationType app:NavnestatuskodeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="NavnestatuskodeEnumerationType">
+
+		<annotation>
+
+			<documentation>Kodene angir et hierarki stedsnavna i mellom, som sier
+				noe om hvilket som blir brukt mest, like mye eller ikke er i bruk
+				lengre.</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="hovednavn">
+
+				<annotation>
+
+					<documentation>Verdien betyr at stedsnavnet er i større bruk enn
+						andre navn for samme sted innenfor en språkform.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sidenavn">
+
+				<annotation>
+
+					<documentation>Brukes der det ikke kan fastslås at ett av to eller
+						flere forskjellige navn har større bruksverdi enn andre.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="undernavn">
+
+				<annotation>
+
+					<documentation>Brukes der ett av to forskjellige navn har mindre
+						bruksverdi enn det andre stedsnavnet, som vurderes som
+						hovednavnet.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="historisk">
+
+				<annotation>
+
+					<documentation>Brukes der stedsnavnet ikke er i bruk lenger og
+						dermed ikke er aktuell å vurdere i en navnesak.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="feilført">
+
+				<annotation>
+
+					<documentation>Brukes der stedsnavnet har vært registrert på feil
+						sted.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="NavnestatuskodeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<element name="Skrivemåte"
+		substitutionGroup="gml:AbstractObject" type="app:SkrivemåteType">
+
+		<annotation>
+
+			<documentation>Her registreres en skrivemåte av stedsnavnet med
+				opplysninger om status (godkjent/avslått/samlevedtak), anbefaling
+				til offentlig bruk, løse tillegg, osv...</documentation>
+
+		</annotation>
+
+	</element>
+
+	<complexType name="SkrivemåteType">
+
+		<sequence>
+
+			<element name="komplettskrivemåte" type="string">
+
+				<annotation>
+
+					<documentation>langform av alle skrivemåter avledet fra vanligste
+						kasus for variasjonstillegg, kjernenavn og funksjonstillegg og med
+						korrekt innbyrdes rekkefølge beskrevet i egenskapen rekkefølge.
+					</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">KOMPLETTSKRIVEMÅTE</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="skrivemåtestatus"
+				type="app:SkrivemåtestatusKodeType">
+
+				<annotation>
+
+					<documentation>henter gjeldende status (godkjent, vedtak, privat
+						osv.) og prioritering for skrivemåten fra datatypen.
+					</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">SKRIVEMÅTESTATUS</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="statusdato" type="date">
+
+				<annotation>
+
+					<documentation>hentes fra "fraDato" på Skrivemåtestatushistorikk.
+						En gyldighetsdato som forteller når en status startet, f.eks.
+						datoen for et vedtak.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">STATUSDATO</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="skrivemåtenummer" type="integer">
+
+				<annotation>
+
+					<documentation>stedsnummer, stedsnavnsnummer og skrivemåtenummer
+						skal sammen utgjøre en såkalt tematisk id som brukes av
+						registerførere som opplslagsnummer. Identifikatoren ligner litt på
+						Gnr/Bnr/Fnr.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">SKRIVEMÅTENUMMER</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+		</sequence>
+
+	</complexType>
+
+	<complexType name="SkrivemåtePropertyType">
+
+		<sequence>
+
+			<element ref="app:Skrivemåte" />
+
+		</sequence>
+
+	</complexType>
+
+	<simpleType name="SkrivemåtestatusKodeType">
+
+		<annotation>
+
+			<documentation>skrivemåtestatus</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:SkrivemåtestatusKodeEnumerationType app:SkrivemåtestatusKodeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="SkrivemåtestatusKodeEnumerationType">
+
+		<annotation>
+
+			<documentation>skrivemåtestatus</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="godkjent">
+
+				<annotation>
+
+					<documentation>Dokumentert skrivemåte fra før 01.07.1991 fra
+						offentlig utgitte kart eller dokument (matrikkel, offentlig
+						brevveksling osv.).
+
+						Gjelder også ved forenklet saksgang når primærfunksjonen er godkjent.
+
+						Stedsnavnet kan brukes i offentlig sammenheng.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="historisk">
+
+				<annotation>
+
+					<documentation>Historisk skrivemåte som ikke lenger er aktuell.
+
+						Stedsnavnet skal ikke brukes i offentlig sammenheng.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="internasjonal">
+
+				<annotation>
+
+					<documentation>Brukes i områder utenfor der lov om stadnamn
+						gjelder, og språk/språkform kan være så ymse.
+
+						Stedsnavnet kan brukes i offentlig sammenheng.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="privat">
+
+				<annotation>
+
+					<documentation>Navn på private objekter som hoteller, hytter,
+						bedrifter. Utenfor
+						&lt;i>lov om stadnamn&lt;/i>, eier av lokaliteten er ikke offentlig organ
+						etter lovens §1 tredje ledd.
+
+						Stedsnavnet kan brukes i offentlig sammenheng.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vedtatt">
+
+				<annotation>
+
+					<documentation>Skrivemåte som er vedtatt etter Lov om stadnamn.
+
+						Gjelder også ved forenklet saksgang når primærfunksjonen er
+						vedtatt.
+
+						Stedsnavnet skal alltid brukes i offentlig sammenheng.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="vedtattNavneledd">
+
+				<annotation>
+
+					<documentation>Godkjent skrivemåte med navneledd (ikke hele navnet)
+						som er vedtatt gjennom samlevedtak.
+
+						Ved etterregistrering av godkjent skrivemåte der det finnes
+						samlevedtak, skal skrivemåten ha statusen Godkjent og deretter
+						VedtattNavneledd dersom skrivemåten er i tråd med samlevedtaket.
+
+						Stedsnavnet kan brukes i offentlig sammenheng.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="uvurdert">
+
+				<annotation>
+
+					<documentation>Alle skrivemåter som ikke har vært til behandling
+						som navnesak etter lov om stadnamn, og som heller ikke kan
+						defineres som godkjente.
+
+						Stedsnavnet skal ikke brukes i offentlig sammenheng.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="foreslått">
+
+				<annotation>
+
+					<documentation>Skrivemåte som er til behandling i navnesak etter
+						lov om stadnamn, og som ikke kan defineres som godkjent.
+
+						Skal ikke brukes i offentlig sammenheng.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="SkrivemåtestatusKodeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="Sortering1KodeType">
+
+		<annotation>
+
+			<documentation>Kode for sortering av viktighet av stedsnavn, brukes
+				til å vurdere om stedsnavnet skal vises i ulike målestokker og ved
+				konflikt under visning. Alle store bokstaver fra og med A til og med
+				N, A er minst viktig og N er viktigst. N er navn på land store hav
+				osv, mens A er på terrengdetaljer.</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:Sortering1KodeEnumerationType app:Sortering1KodeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="Sortering1KodeEnumerationType">
+
+		<annotation>
+
+			<documentation>Kode for sortering av viktighet av stedsnavn, brukes
+				til å vurdere om stedsnavnet skal vises i ulike målestokker og ved
+				konflikt under visning. Alle store bokstaver fra og med A til og med
+				N, A er minst viktig og N er viktigst. N er navn på land store hav
+				osv, mens A er på terrengdetaljer.</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="viktighetA">
+
+				<annotation>
+
+					<documentation>Minst viktige objekt tegnes til slutt vanligvis i
+						små målestokker.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetB">
+
+				<annotation>
+
+					<documentation>Viktigere enn A</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetC">
+
+				<annotation>
+
+					<documentation>Viktigere enn A og B</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetD">
+
+				<annotation>
+
+					<documentation>Viktigere enn C men mindre viktig enn E
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetE">
+
+				<annotation>
+
+					<documentation>Viktigere enn D men mindre viktig enn F
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetF">
+
+				<annotation>
+
+					<documentation>Viktigere enn E men mindre viktig enn G
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetG">
+
+				<annotation>
+
+					<documentation>Viktigere enn F men mindre viktig enn H
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetH">
+
+				<annotation>
+
+					<documentation>Viktigere enn G men mindre viktig enn I
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetI">
+
+				<annotation>
+
+					<documentation>Viktigere enn H men mindre viktig enn J
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetJ">
+
+				<annotation>
+
+					<documentation>Viktigere enn I men mindre viktig enn K
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetK">
+
+				<annotation>
+
+					<documentation>Viktigere enn J men mindre viktig enn L
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetL">
+
+				<annotation>
+
+					<documentation>Viktigere enn K men mindre viktig enn M
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetM">
+
+				<annotation>
+
+					<documentation>Viktigere enn L men mindre viktig enn N
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="viktighetN">
+
+				<annotation>
+
+					<documentation>Høyest prioritet, de viktigste navnene, tegnes
+						vanligvis fra små målestokker.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="Sortering1KodeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="SpråkKodeType">
+
+		<annotation>
+
+			<documentation>Subsett av ISO 639-3 som inneholder trebokstavs-koder
+				de språkene som trengs for å konvertere innholdet fra SSR.
+				Kodelisten kan utvides ved behov etter produksjonssetting.
+			</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:SpråkKodeEnumerationType app:SpråkKodeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="SpråkKodeEnumerationType">
+
+		<annotation>
+
+			<documentation>Subsett av ISO 639-3 som inneholder trebokstavs-koder
+				de språkene som trengs for å konvertere innholdet fra SSR.
+				Kodelisten kan utvides ved behov etter produksjonssetting.
+			</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration value="dansk">
+
+				<annotation>
+
+					<documentation>Dansk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="tysk">
+
+				<annotation>
+
+					<documentation>Tysk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="engelsk">
+
+				<annotation>
+
+					<documentation>Engelsk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="færøysk">
+
+				<annotation>
+
+					<documentation>Færøysk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="finsk">
+
+				<annotation>
+
+					<documentation>Finsk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="kvensk">
+
+				<annotation>
+
+					<documentation>Kvensk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="fransk">
+
+				<annotation>
+
+					<documentation>Fransk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="irsk">
+
+				<annotation>
+
+					<documentation>Irsk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="islandsk">
+
+				<annotation>
+
+					<documentation>Islandsk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="grønlandsk">
+
+				<annotation>
+
+					<documentation>Grønlandsk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="lulesamisk">
+
+				<annotation>
+
+					<documentation>Lulesamisk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="nederlandsk">
+
+				<annotation>
+
+					<documentation>Nederlandsk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="nordsamisk">
+
+				<annotation>
+
+					<documentation>Nordsamisk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="norsk">
+
+				<annotation>
+
+					<documentation>Norsk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="russisk">
+
+				<annotation>
+
+					<documentation>Russisk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="svensk">
+
+				<annotation>
+
+					<documentation>Svensk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="sørsamisk">
+
+				<annotation>
+
+					<documentation>Sørsamisk</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration value="skoltesamisk" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="SpråkKodeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="SpråkprioriteringKodeType">
+
+		<annotation>
+
+			<documentation>Kodeliste som angir visningsrekkefølgen til stedsnavn
+				på forskjellig språk.
+
+				&lt;b>Det er de første fem verdiene i kodene (de norske språkene) som
+				varierer mellom kodene&lt;/b>, ellers er det lik (alfabetisk i
+				forhold til ISO-kodeverdien) rekkefølge på språkene som ikke er
+				aktuelle for behandling etter lov om stadnamn.</documentation>
+
+		</annotation>
+
+		<union
+			memberTypes="app:SpråkprioriteringKodeEnumerationType app:SpråkprioriteringKodeOtherType" />
+
+	</simpleType>
+
+	<simpleType name="SpråkprioriteringKodeEnumerationType">
+
+		<annotation>
+
+			<documentation>Kodeliste som angir visningsrekkefølgen til stedsnavn
+				på forskjellig språk.
+
+				&lt;b>Det er de første fem verdiene i kodene (de norske språkene) som
+				varierer mellom kodene&lt;/b>, ellers er det lik (alfabetisk i
+				forhold til ISO-kodeverdien) rekkefølge på språkene som ikke er
+				aktuelle for behandling etter lov om stadnamn.</documentation>
+
+		</annotation>
+
+		<restriction base="string">
+
+			<enumeration
+				value="lulesamisk-nordsamisk-skoltesamisk-sørsamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, lulesamisk
+						område der nordsamisk kan forekomme.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="lulesamisk-sørsamisk-nordsamisk-skoltesamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, lulesamisk
+						område der sørsamisk kan forekomme.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="nordsamisk-skoltesamisk-lulesamisk-sørsamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, nordsamisk
+						område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-lulesamisk-nordsamisk-skoltesamisk-sørsamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltingsområde, lulesamisk område
+						der nordsamisk kan forekomme sammen med lulesamisk.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-lulesamisk-sørsamisk-nordsamisk-skoltesamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltingsområde, lulesamisk område
+						der sørdsamisk kan forekomme sammen med lulesamisk.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-nordsamisk-skoltesamisk-lulesamisk-sørsamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltingsområde, nordsamisk område
+						der lulesamisk kan forekomme sammen med nordsamisk.
+
+						Denne brukes også for steder utenfor fastlandet.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-sørsamisk-lulesamisk-nordsamisk-skoltesamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltingsområde, sørsamisk område
+						der lulesamisk kan forekomme sammen med sørsamisk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="sørsamisk-lulesamisk-nordsamisk-skoltesamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, sørdsamisk
+						område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="kvensk-nordsamisk-skoltesamisk-lulesamisk-sørsamisk-norsk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, dersom kvensk
+						skal prioriteres over nordsamisk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="kvensk-norsk-nordsamisk-skoltesamisk-lulesamisk-sørsamisk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltningsområde dersom kvensk skal
+						prioriteres over norsk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-skoltesamisk-nordsamisk-lulesamisk-sørsamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltningsområde dersom
+						skoltesamisk skal prioriteres over norsk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="skoltesamisk-nordsamisk-lulesamisk-sørsamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i skoltesamisk forvaltningsområde dersom
+						skoltesamisk skal prioriteres over nordsamisk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="kvensk-skoltesamisk-nordsamisk-lulesamisk-sørsamisk-norsk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde dersom kvensk
+						skal prioriteres over skoltesamisk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="kvensk-norsk-skoltesamisk-nordsamisk-lulesamisk-sørsamisk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltningsområde dersom kvensk skal
+						prioriteres over norsk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-nordsamisk-lulesamisk-sørsamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltingsområde, nordsamisk område
+						der lulesamisk kan forekomme sammen med nordsamisk.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-lulesamisk-nordsamisk-sørsamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltingsområde, lulesamisk område
+						der nordsamisk kan forekomme sammen med lulesamisk.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-lulesamisk-sørsamisk-nordsamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltingsområde, lulesamisk område
+						der sørdsamisk kan forekomme sammen med lulesamisk.
+					</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="norsk-sørsamisk-lulesamisk-nordsamisk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltingsområde, sørsamisk område
+						der lulesamisk kan forekomme sammen med sørsamisk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="nordsamisk-lulesamisk-sørsamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, nordsamisk
+						område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="lulesamisk-nordsamisk-sørsamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, lulesamisk
+						område der nordsamisk kan forekomme.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="lulesamisk-sørsamisk-nordsamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, lulesamisk
+						område der sørsamisk kan forekomme.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="sørsamisk-lulesamisk-nordsamisk-norsk-kvensk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, sørdsamisk
+						område.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="kvensk-nordsamisk-lulesamisk-sørsamisk-norsk">
+
+				<annotation>
+
+					<documentation>Brukes i samisk forvaltningsområde, dersom kvensk
+						skal prioriteres over samisk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+			<enumeration
+				value="kvensk-norsk-nordsamisk-lulesamisk-sørsamisk">
+
+				<annotation>
+
+					<documentation>Brukes i norsk forvaltningsområde dersom kvensk skal
+						prioriteres over norsk.</documentation>
+
+				</annotation>
+
+			</enumeration>
+
+		</restriction>
+
+	</simpleType>
+
+	<simpleType name="SpråkprioriteringKodeOtherType">
+
+		<restriction base="string">
+
+			<pattern value="other: \w{2,}" />
+
+		</restriction>
+
+	</simpleType>
+
+	<element name="Sted" substitutionGroup="app:Fellesegenskaper"
+		type="app:StedType">
+
+		<annotation>
+
+			<documentation>Sted inneholder all egenskapene som er felles for de
+				ulike stedsnavnene (og deres skrivemåter) for en lokalitet,
+				uavhengig av språk.
+
+				Med felles egenskaper menes posisjon, presentasjonsinformasjon, land,
+				kommune, matrikkelnummer, navnetype, osv.
+			</documentation>
+
+		</annotation>
+
+	</element>
+
+	<complexType name="StedType">
+
+		<complexContent>
+
+			<extension base="app:FellesegenskaperType">
+
+				<sequence>
+
+					<element minOccurs="0" name="område"
+						type="gml:SurfacePropertyType">
+
+						<annotation>
+
+							<documentation>extent: area over which an object extends
+							</documentation>
+
+						</annotation>
+
+					</element>
+
+					<element minOccurs="0" name="posisjon"
+						type="gml:PointPropertyType">
+
+						<annotation>
+
+							<documentation>centerline: location where the object exists
+							</documentation>
+
+						</annotation>
+
+					</element>
+
+					<element minOccurs="0" name="senterlinje"
+						type="gml:CurvePropertyType">
+
+						<annotation>
+
+							<documentation>centerline: cource follwed by the central part of
+								the object</documentation>
+
+						</annotation>
+
+					</element>
+
+					<element minOccurs="0" name="multipunkt"
+						type="gml:MultiPointPropertyType">
+
+						<annotation>
+
+							<documentation>geometritype som benyttes for å representere flere
+								objekter hvor egenskapene med unntak av geometrien er like
+							</documentation>
+
+						</annotation>
+
+					</element>
+
+					<element maxOccurs="unbounded" name="stedsnavn"
+						type="app:StedsnavnPropertyType">
+
+						<annotation>
+
+							<documentation>navn på stedet/området/objektet. Her angir
+								registerføreren hvilket språk (og eventuelt opphavsspråket),
+								alfabetkode (styres av systemet), navnestatus, vedtaksmyndighet,
+								primærfunksjon, osv.</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">STEDSNAVN</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element name="land" type="app:LandKodeType">
+
+						<annotation>
+
+							<documentation>Hvilke land steder ligger i.
+
+								Tobokstavers kodeliste, subsett av ISO 3166-1 alpha-2.
+							</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">LAND</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element name="navneobjekthovedgruppe"
+						type="app:NavneobjekthovedgruppeType">
+
+						<annotation>
+
+							<documentation>Hovedgruppene følger i hovedsak Inspire
+								"NamedPlaceTypeValue", men populatedPlace og building er samlet
+								under bebyggelse og hydrography er delt mellom sjø og ferskvann.
+							</documentation>
+
+							<appinfo>
+
+								<defaultCodeSpace
+									xmlns="http://www.opengis.net/gml/3.2">http://skjema.geonorge.no/SOSI/produktspesifikasjon/Stedsnavn/5.0/Navneobjekthovedgruppe
+								</defaultCodeSpace>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">NAVNEOBJEKTHOVEDGRUPPE</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element name="navneobjektgruppe"
+						type="app:NavneobjektgruppeType">
+
+						<annotation>
+
+							<documentation>Inndeling i kategorier under hver hovedgruppe.
+							</documentation>
+
+							<appinfo>
+
+								<defaultCodeSpace
+									xmlns="http://www.opengis.net/gml/3.2">http://skjema.geonorge.no/SOSI/produktspesifikasjon/Stedsnavn/5.0/Navneobjektgruppe
+								</defaultCodeSpace>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">NAVNEOBJEKTGRUPPE</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element name="navneobjekttype"
+						type="app:NavneobjekttypeType">
+
+						<annotation>
+
+							<documentation>Stedets navneobjekttype er en underinndeling av
+								navneobjektgruppene som igjen er inndeling av
+								navneobjekthovedgruppene.</documentation>
+
+							<appinfo>
+
+								<defaultCodeSpace
+									xmlns="http://www.opengis.net/gml/3.2">http://skjema.geonorge.no/SOSI/produktspesifikasjon/Stedsnavn/5.0/Navneobjekttype
+								</defaultCodeSpace>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">NAVNEOBJEKTTYPE</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element name="sortering" type="app:Sortering1KodeType">
+
+						<annotation>
+
+							<documentation>Sorteringsegenskapene skal benyttes til å angi
+								stedets viktighet i forskjellige målestokker (i forhold til
+								andre stedsnavn).</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">SORTERING</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element minOccurs="0" name="språkprioritering"
+						type="app:SpråkprioriteringKodeType">
+
+						<annotation>
+
+							<documentation>Angir rekkefølgen av navn på forskjellige språk
+								som skal vises på skilt og kart, jf. forskriften § 7 annet ledd.
+							</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">SPRÅKPRIORITERING</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element name="stedsnummer" type="integer">
+
+						<annotation>
+
+							<documentation>Stedsnummer, stedsnavnsnummer og skrivemåtenummer
+								skal sammen utgjøre en såkalt tematisk id som brukes av
+								registerførere som opplslagsnummer. Identifikatoren ligner litt
+								på Gnr/Bnr/Fnr.
+
+								&lt;b>Stedsnummeret&lt;/b> er et løpende nummer systemet gir stedet som en identifikator.
+								Stedsnummeret er unikt og kan ikke brukes om igjen.
+							</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">STEDSNUMMER</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+					<element maxOccurs="unbounded" minOccurs="0" name="kommune"
+						type="app:KommunePropertyType">
+
+						<annotation>
+
+							<documentation>Stedets kommunetilknytning avhenger av stedets
+								geografiske beligenhet og viser hvlke kommuner stedet ligger i.
+							</documentation>
+
+							<appinfo>
+
+								<taggedValue
+									xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+									tag="SOSI_navn">KOMMUNE</taggedValue>
+
+							</appinfo>
+
+						</annotation>
+
+					</element>
+
+				</sequence>
+
+			</extension>
+
+		</complexContent>
+
+	</complexType>
+
+	<complexType name="StedPropertyType">
+
+		<sequence minOccurs="0">
+
+			<element ref="app:Sted" />
+
+		</sequence>
+
+		<attributeGroup ref="gml:AssociationAttributeGroup" />
+
+		<attributeGroup ref="gml:OwnershipAttributeGroup" />
+
+	</complexType>
+
+	<element name="Stedsnavn"
+		substitutionGroup="gml:AbstractObject" type="app:StedsnavnType">
+
+		<annotation>
+
+			<documentation>Navn på stedet/området/objektet.
+
+				Her angir registerføreren hvilket språk (og eventuelt opphavsspråket),
+				alfabetkode (styres av systemet), navnestatus, vedtaksmyndighet,
+				primærfunksjon, osv...
+			</documentation>
+
+		</annotation>
+
+	</element>
+
+	<complexType name="StedsnavnType">
+
+		<sequence>
+
+			<element name="offentligBruk" type="boolean">
+
+				<annotation>
+
+					<documentation>om stedsnavnet har skrivemåtestatuser som gjør at
+						det kan godkjennes for offentlig bruk.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">OFFENTLIGBRUK</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="navnesakstatus"
+				type="app:NavnesakstatusKodeType">
+
+				<annotation>
+
+					<documentation>nåværende saksbehandlingsstatus for stedsnavnet og
+						de tilhørende skrivemåtene.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">NAVNESAKSTATUS</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="navnestatus" type="app:NavnestatuskodeType">
+
+				<annotation>
+
+					<documentation>Nåværende navnestatus (Hovednavn, sidenavn,
+						undernavn, feilført eller historisk).</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">NAVNESTATUS</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="navnesaksstatusdato" type="dateTime">
+
+				<annotation>
+
+					<documentation>Hentes fra fraDato på Skrivemåtestatushistorikk. En
+						gyldighetsdato som forteller når en status startet, f.eks. datoen
+						for et vedtak.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">NAVNESAKSSTATUSDATO</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="språk" type="app:SpråkKodeType">
+
+				<annotation>
+
+					<documentation>Angir hvilket språk stedsnavnet hører til, norsk,
+						kvensk, nordsamisk, lulesamisk, sørsamisk osv.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">SPRÅK</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element name="stedsnavnnummer" type="integer">
+
+				<annotation>
+
+					<documentation>Stedsnummer, stedsnavnsnummer og skrivemåtenummer
+						skal sammen utgjøre en såkalt tematisk id som brukes av
+						registerførere som opplslagsnummer. identifikatoren ligner litt på
+						Gnr/Bnr/Fnr.
+
+						&lt;b>Stedsnavnsnummer&lt;/b> er et løpende nummer (starter på 1) systemet gir stedsnavnet som
+						en identifikator. stedsnavnsnummeret er kun unikt under ett
+						stedsnummer og kan ikke brukes om igjen for dette stedet.
+					</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">STEDSNAVNNUMMER</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element maxOccurs="unbounded" name="skrivemåte"
+				type="app:SkrivemåtePropertyType">
+
+				<annotation>
+
+					<documentation>den skrivemåten av stedsnavnet som har en status som
+						gjør at den anbefales til offentlig bruk.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">SKRIVEMÅTE</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+			<element maxOccurs="unbounded" minOccurs="0"
+				name="annenSkrivemåte" type="app:SkrivemåtePropertyType">
+
+				<annotation>
+
+					<documentation>de andre skrivemåtene av stedsnavnet som ikke er
+						anbefalt for offentlig bruk.</documentation>
+
+					<appinfo>
+
+						<taggedValue
+							xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+							tag="SOSI_navn">ANNENSKRIVEMÅTE</taggedValue>
+
+					</appinfo>
+
+				</annotation>
+
+			</element>
+
+		</sequence>
+
+	</complexType>
+
+	<complexType name="StedsnavnPropertyType">
+
+		<sequence>
+
+			<element ref="app:Stedsnavn" />
+
+		</sequence>
+
+	</complexType>
+
+</schema>

--- a/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/GetCapabilities.xml
+++ b/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/GetCapabilities.xml
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WFS_Capabilities xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:ogc="http://www.opengis.net/ogc" xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd">
+  <ows:ServiceIdentification>
+    <ows:Title>stedsnavn</ows:Title>
+    <ows:Abstract>WFS service for stedsnavn</ows:Abstract>
+    <ows:ServiceType codeSpace="http://www.opengeospatial.org/">WFS</ows:ServiceType>
+    <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
+    <ows:ServiceTypeVersion>1.1.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <ows:ServiceProvider>
+    <ows:ProviderName>Norwegian Mapping Authority</ows:ProviderName>
+    <ows:ProviderSite xlink:href="http://www.kartverket.no" />
+    <ows:ServiceContact>
+      <ows:ContactInfo>
+        <ows:Phone />
+        <ows:OnlineResource xlink:href="http://www.kartverket.no" />
+      </ows:ContactInfo>
+      <ows:Role>PointOfContact</ows:Role>
+    </ows:ServiceContact>
+  </ows:ServiceProvider>
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetCapabilities">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+          <ows:Post xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+        </ows:HTTP>
+      </ows:DCP>
+      <ows:Parameter name="AcceptVersions">
+        <ows:AllowedValues>
+          <ows:Value>2.0.0</ows:Value>
+          <ows:Value>1.1.0</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+      <ows:Parameter name="AcceptFormats">
+        <ows:AllowedValues>
+          <ows:Value>text/xml</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+      <ows:Parameter name="Sections">
+        <ows:AllowedValues>
+          <ows:Value>ServiceIdentification</ows:Value>
+          <ows:Value>ServiceProvider</ows:Value>
+          <ows:Value>OperationsMetadata</ows:Value>
+          <ows:Value>FeatureTypeList</ows:Value>
+          <ows:Value>Filter_Capabilities</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+    </ows:Operation>
+    <ows:Operation name="DescribeFeatureType">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+          <ows:Post xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="ListStoredQueries">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+          <ows:Post xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="DescribeStoredQueries">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+          <ows:Post xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetFeature">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+          <ows:Post xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetPropertyValue">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+          <ows:Post xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="CreateStoredQuery">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+          <ows:Post xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+        </ows:HTTP>
+      </ows:DCP>
+      <ows:Parameter name="language">
+        <ows:AllowedValues>
+          <ows:Value>urn:ogc:def:queryLanguage:OGC-WFS::WFSQueryExpression</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+    </ows:Operation>
+    <ows:Operation name="DropStoredQuery">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+          <ows:Post xlink:href="https://wfs.geonorge.no/skwms1/wfs.stedsnavn?" />
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Parameter name="version">
+      <ows:AllowedValues>
+        <ows:Value>2.0.0</ows:Value>
+        <ows:Value>1.1.0</ows:Value>
+      </ows:AllowedValues>
+    </ows:Parameter>
+    <ows:Parameter name="srsName">
+      <ows:AllowedValues>
+        <ows:Value>urn:ogc:def:crs:EPSG::4258</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::25832</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::25833</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::25835</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::3035</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::3044</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::3045</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::3047</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::4326</ows:Value>
+        <ows:Value>EPSG:900913</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::3857</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::3575</ows:Value>
+        <ows:Value>urn:ogc:def:crs:EPSG::3034</ows:Value>
+      </ows:AllowedValues>
+    </ows:Parameter>
+    <ows:Parameter name="outputFormat">
+      <ows:AllowedValues>
+        <ows:Value>text/xml; subtype=gml/3.2.1</ows:Value>
+        <ows:Value>application/gml+xml; version=3.2</ows:Value>
+      </ows:AllowedValues>
+    </ows:Parameter>
+    <ows:Parameter name="resolve">
+      <ows:AllowedValues>
+        <ows:Value>none</ows:Value>
+        <ows:Value>local</ows:Value>
+        <ows:Value>remote</ows:Value>
+        <ows:Value>all</ows:Value>
+      </ows:AllowedValues>
+    </ows:Parameter>
+    <ows:Constraint name="ImplementsSimpleWFS">
+      <ows:NoValues />
+      <ows:DefaultValue>TRUE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsBasicWFS">
+      <ows:NoValues />
+      <ows:DefaultValue>TRUE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsTransactionalWFS">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsLockingWFS">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="KVPEncoding">
+      <ows:NoValues />
+      <ows:DefaultValue>TRUE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="XMLEncoding">
+      <ows:NoValues />
+      <ows:DefaultValue>TRUE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="SOAPEncoding">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsInheritance">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsRemoteResolve">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsResultPaging">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsStandardJoins">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsSpatialJoins">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsTemporalJoins">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ImplementsFeatureVersioning">
+      <ows:NoValues />
+      <ows:DefaultValue>FALSE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ManageStoredQueries">
+      <ows:NoValues />
+      <ows:DefaultValue>TRUE</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="ResolveLocalScope">
+      <ows:NoValues />
+      <ows:DefaultValue>*</ows:DefaultValue>
+    </ows:Constraint>
+    <ows:Constraint name="QueryExpressions">
+      <ows:AllowedValues>
+        <ows:Value>wfs:Query</ows:Value>
+        <ows:Value>wfs:StoredQuery</ows:Value>
+      </ows:AllowedValues>
+    </ows:Constraint>
+  </ows:OperationsMetadata>
+  <FeatureTypeList>
+    <FeatureType>
+      <Name xmlns:app="http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115">app:Sted</Name>
+      <Title>app:Sted</Title>
+      <DefaultCRS>urn:ogc:def:crs:EPSG::4258</DefaultCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::25832</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::25833</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::25835</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::3035</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::3044</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::3045</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::3047</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::4326</OtherCRS>
+      <OtherCRS>EPSG:900913</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::3857</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::3575</OtherCRS>
+      <OtherCRS>urn:ogc:def:crs:EPSG::3034</OtherCRS>
+      <OutputFormats>
+        <Format>text/xml; subtype=gml/3.2.1</Format>
+        <Format>application/gml+xml; version=3.2</Format>
+      </OutputFormats>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>6.034809 58.111523</ows:LowerCorner>
+        <ows:UpperCorner>30.528068 70.671561</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+    </FeatureType>
+  </FeatureTypeList>
+  <fes:Filter_Capabilities>
+    <fes:Conformance>
+      <fes:Constraint name="ImplementsQuery">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsAdHocQuery">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsFunctions">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsResourceId">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsMinStandardFilter">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsStandardFilter">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsMinSpatialFilter">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsSpatialFilter">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsMinTemporalFilter">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsTemporalFilter">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsVersionNav">
+        <ows:NoValues />
+        <ows:DefaultValue>FALSE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsSorting">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsExtendedOperators">
+        <ows:NoValues />
+        <ows:DefaultValue>FALSE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsMinimumXPath">
+        <ows:NoValues />
+        <ows:DefaultValue>TRUE</ows:DefaultValue>
+      </fes:Constraint>
+      <fes:Constraint name="ImplementsSchemaElementFunc">
+        <ows:NoValues />
+        <ows:DefaultValue>FALSE</ows:DefaultValue>
+      </fes:Constraint>
+    </fes:Conformance>
+    <fes:Id_Capabilities>
+      <fes:ResourceIdentifier name="fes:ResourceId" />
+    </fes:Id_Capabilities>
+    <fes:Scalar_Capabilities>
+      <fes:LogicalOperators />
+      <fes:ComparisonOperators>
+        <fes:ComparisonOperator name="PropertyIsEqualTo" />
+        <fes:ComparisonOperator name="PropertyIsNotEqualTo" />
+        <fes:ComparisonOperator name="PropertyIsLessThan" />
+        <fes:ComparisonOperator name="PropertyIsGreaterThan" />
+        <fes:ComparisonOperator name="PropertyIsLessThanOrEqualTo" />
+        <fes:ComparisonOperator name="PropertyIsGreaterThanOrEqualTo" />
+        <fes:ComparisonOperator name="PropertyIsLike" />
+        <fes:ComparisonOperator name="PropertyIsNull" />
+        <fes:ComparisonOperator name="PropertyIsNil" />
+        <fes:ComparisonOperator name="PropertyIsBetween" />
+      </fes:ComparisonOperators>
+    </fes:Scalar_Capabilities>
+    <fes:Spatial_Capabilities>
+      <fes:GeometryOperands xmlns:gml32="http://www.opengis.net/gml/3.2">
+        <fes:GeometryOperand name="gml:Box" />
+        <fes:GeometryOperand name="gml:Envelope" />
+        <fes:GeometryOperand name="gml:Point" />
+        <fes:GeometryOperand name="gml:LineString" />
+        <fes:GeometryOperand name="gml:Curve" />
+        <fes:GeometryOperand name="gml:Polygon" />
+        <fes:GeometryOperand name="gml:Surface" />
+        <fes:GeometryOperand name="gml:MultiPoint" />
+        <fes:GeometryOperand name="gml:MultiLineString" />
+        <fes:GeometryOperand name="gml:MultiCurve" />
+        <fes:GeometryOperand name="gml:MultiPolygon" />
+        <fes:GeometryOperand name="gml:MultiSurface" />
+        <fes:GeometryOperand name="gml:CompositeCurve" />
+        <fes:GeometryOperand name="gml:CompositeSurface" />
+        <fes:GeometryOperand name="gml32:Envelope" />
+        <fes:GeometryOperand name="gml32:Point" />
+        <fes:GeometryOperand name="gml32:LineString" />
+        <fes:GeometryOperand name="gml32:Curve" />
+        <fes:GeometryOperand name="gml32:Polygon" />
+        <fes:GeometryOperand name="gml32:Surface" />
+        <fes:GeometryOperand name="gml32:MultiPoint" />
+        <fes:GeometryOperand name="gml32:MultiLineString" />
+        <fes:GeometryOperand name="gml32:MultiCurve" />
+        <fes:GeometryOperand name="gml32:MultiPolygon" />
+        <fes:GeometryOperand name="gml32:MultiSurface" />
+        <fes:GeometryOperand name="gml32:CompositeCurve" />
+        <fes:GeometryOperand name="gml32:CompositeSurface" />
+      </fes:GeometryOperands>
+      <fes:SpatialOperators>
+        <fes:SpatialOperator name="BBOX" />
+        <fes:SpatialOperator name="Equals" />
+        <fes:SpatialOperator name="Disjoint" />
+        <fes:SpatialOperator name="Intersects" />
+        <fes:SpatialOperator name="Touches" />
+        <fes:SpatialOperator name="Crosses" />
+        <fes:SpatialOperator name="Within" />
+        <fes:SpatialOperator name="Contains" />
+        <fes:SpatialOperator name="Overlaps" />
+        <fes:SpatialOperator name="Beyond" />
+        <fes:SpatialOperator name="DWithin" />
+      </fes:SpatialOperators>
+    </fes:Spatial_Capabilities>
+    <fes:Temporal_Capabilities>
+      <fes:TemporalOperands xmlns:gml32="http://www.opengis.net/gml/3.2">
+        <fes:TemporalOperand name="gml:TimeInstant" />
+        <fes:TemporalOperand name="gml:TimePeriod" />
+        <fes:TemporalOperand name="gml32:TimeInstant" />
+        <fes:TemporalOperand name="gml32:TimePeriod" />
+      </fes:TemporalOperands>
+      <fes:TemporalOperators>
+        <fes:TemporalOperator name="After" />
+        <fes:TemporalOperator name="Before" />
+        <fes:TemporalOperator name="During" />
+        <fes:TemporalOperator name="TEquals" />
+      </fes:TemporalOperators>
+    </fes:Temporal_Capabilities>
+    <fes:Functions>
+      <fes:Function name="Area">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type>gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="Area">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="Centroid">
+        <fes:Returns>gml:Point</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type>gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="Centroid">
+        <fes:Returns xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:Point</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="env">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:anyType</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:string</fes:Type>
+          </fes:Argument>
+          <fes:Argument name="arg2">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:anyType</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="ExtraProp">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:anyType</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:string</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="GeometryFromWKT">
+        <fes:Returns>gml:_Geometry</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:string</fes:Type>
+          </fes:Argument>
+          <fes:Argument name="arg2">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:string</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="GeometryFromWKT">
+        <fes:Returns xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:string</fes:Type>
+          </fes:Argument>
+          <fes:Argument name="arg2">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:string</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="GetCurrentScale">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Returns>
+      </fes:Function>
+      <fes:Function name="IDiv">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:integer</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:integer</fes:Type>
+          </fes:Argument>
+          <fes:Argument name="arg2">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:integer</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IMod">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:integer</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:integer</fes:Type>
+          </fes:Argument>
+          <fes:Argument name="arg2">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:integer</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="InteriorPoint">
+        <fes:Returns>gml:Point</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type>gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="InteriorPoint">
+        <fes:Returns xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:Point</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsCurve">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type>gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsCurve">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsPoint">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type>gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsPoint">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsSurface">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type>gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="IsSurface">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:boolean</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="Length">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type>gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="Length">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="Lower">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:integer</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="MoveGeometry">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type>gml:_Geometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="MoveGeometry">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:gml32="http://www.opengis.net/gml/3.2">gml32:AbstractGeometry</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+      <fes:Function name="Upper">
+        <fes:Returns xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:integer</fes:Returns>
+        <fes:Arguments>
+          <fes:Argument name="arg1">
+            <fes:Type xmlns:xsd="http://www.w3.org/2001/XMLSchema">xsd:double</fes:Type>
+          </fes:Argument>
+        </fes:Arguments>
+      </fes:Function>
+    </fes:Functions>
+  </fes:Filter_Capabilities>
+</WFS_Capabilities>

--- a/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/GetFeature_sted.xml
+++ b/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/GetFeature_sted.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wfs:FeatureCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115 https://wfs.geonorge.no/skwms1/wfs.stedsnavn?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2" xmlns:wfs="http://www.opengis.net/wfs/2.0" timeStamp="2021-06-06T08:34:32Z" xmlns:gml="http://www.opengis.net/gml/3.2" numberMatched="unknown" numberReturned="0">
+  <!--NOTE: numberReturned attribute should be 'unknown' as well, but this would not validate against the current version of the WFS 2.0 schema (change upcoming). See change request (CR 144): https://portal.opengeospatial.org/files?artifact_id=43925.-->
+  <wfs:member>
+    <app:Sted xmlns:app="http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115" gml:id="1">
+      <app:identifikasjon>
+        <app:Identifikasjon>
+          <app:lokalId>1</app:lokalId>
+          <app:navnerom>http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115</app:navnerom>
+          <app:versjonId>20181115</app:versjonId>
+        </app:Identifikasjon>
+      </app:identifikasjon>
+      <app:oppdateringsdato>2020-02-14T23:13:20</app:oppdateringsdato>
+      <app:datauttaksdato>2021-06-04T02:04:54.330</app:datauttaksdato>
+      <app:posisjon>
+        <!--Inlined geometry '1_APP_POSISJON'-->
+        <gml:Point gml:id="1_APP_POSISJON" srsName="urn:ogc:def:crs:EPSG::4258">
+          <gml:pos>58.710778 7.397043</gml:pos>
+        </gml:Point>
+      </app:posisjon>
+      <app:stedsnavn>
+        <app:Stedsnavn>
+          <app:offentligBruk>true</app:offentligBruk>
+          <app:navnesakstatus>ubehandlet</app:navnesakstatus>
+          <app:navnestatus>hovednavn</app:navnestatus>
+          <app:navnesaksstatusdato>1991-07-01T00:00:00</app:navnesaksstatusdato>
+          <app:språk>norsk</app:språk>
+          <app:stedsnavnnummer>1</app:stedsnavnnummer>
+          <app:skrivemåte>
+            <app:Skrivemåte>
+              <app:komplettskrivemåte>Stornesodden</app:komplettskrivemåte>
+              <app:skrivemåtestatus>godkjent</app:skrivemåtestatus>
+              <app:statusdato>1991-07-01</app:statusdato>
+              <app:skrivemåtenummer>1</app:skrivemåtenummer>
+            </app:Skrivemåte>
+          </app:skrivemåte>
+        </app:Stedsnavn>
+      </app:stedsnavn>
+      <app:land>Norge</app:land>
+      <app:navneobjekthovedgruppe>ferskvann</app:navneobjekthovedgruppe>
+      <app:navneobjektgruppe>ferskvannskontur</app:navneobjektgruppe>
+      <app:navneobjekttype>nes</app:navneobjekttype>
+      <app:sortering>viktighetF</app:sortering>
+      <app:språkprioritering>norsk-sørsamisk-lulesamisk-nordsamisk-kvensk</app:språkprioritering>
+      <app:stedsnummer>1</app:stedsnummer>
+      <app:kommune>
+        <app:Kommune>
+          <app:kommunenummer>4224</app:kommunenummer>
+          <app:kommunenavn>Åseral</app:kommunenavn>
+          <app:fylkesnummer>42</app:fylkesnummer>
+          <app:fylkesnavn>Agder</app:fylkesnavn>
+        </app:Kommune>
+      </app:kommune>
+    </app:Sted>
+  </wfs:member>
+</wfs:FeatureCollection>


### PR DESCRIPTION
[![GEOT-6906](https://badgen.net/badge/JIRA/GEOT-6906/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6906) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… defined globally

As explained in JIRA StrictWFS_2_0_Strategy.getServerSupportedOutputFormats doesn't look for Parameter-elements within the element OperationsMetadata.

The rest of the PR is concerned with adopting AbstractWfsDataStoreOnelineTest for the WFS server with this capabilities problem. The main issues are that CRS should be COMPLIANT, and that a GetFeature request returning everything is massive.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [ ] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [X] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [X] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [X] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.