### PR TITLE
[Backport-25.x][GEOT-6891]: GeoTiffWriter writing on ImageOutputStream wrapped within an OutputStream

### DIFF
--- a/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffWriter.java
+++ b/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffWriter.java
@@ -19,6 +19,7 @@ package org.geotools.gce.geotiff;
 import it.geosolutions.imageio.plugins.tiff.TIFFImageWriteParam;
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFImageMetadata;
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFImageWriter;
+import it.geosolutions.io.output.adapter.OutputStreamAdapter;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.image.RenderedImage;
@@ -118,9 +119,12 @@ public class GeoTiffWriter extends AbstractGridCoverageWriter implements GridCov
             }
 
         } else if (destination instanceof OutputStream) {
-
-            this.outStream = ImageIOExt.createImageOutputStream(null, destination);
-
+            if (destination instanceof OutputStreamAdapter) {
+                this.outStream = ((OutputStreamAdapter) destination).getWrappedStream();
+                this.destination = outStream;
+            } else {
+                this.outStream = ImageIOExt.createImageOutputStream(null, destination);
+            }
         } else if (destination instanceof ImageOutputStream)
             this.outStream = (ImageOutputStream) destination;
         else throw new IllegalArgumentException("The provided destination canno be used!");

--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
     <test.forkMode>once</test.forkMode>
     <test.args></test.args>
     <src.output>${basedir}/target</src.output>
-    <imageio.ext.version>1.3.6</imageio.ext.version>
+    <imageio.ext.version>1.3.9</imageio.ext.version>
     <jts.version>1.18.1</jts.version>
     <jaiext.version>1.1.20</jaiext.version>
     <netcdf.version>4.6.15</netcdf.version>


### PR DESCRIPTION
[![GEOT-6891](https://badgen.net/badge/JIRA/GEOT-6891/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6891) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backporting [GEOT-6891] to 25.x