### PR TITLE
[GEOT-6916] "WGS 84 / UPS South (N,E)" is rendered with flipped axis

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.referencing;
 
+import static org.geotools.referencing.cs.DefaultCoordinateSystemAxis.EASTING;
+import static org.geotools.referencing.cs.DefaultCoordinateSystemAxis.NORTHING;
+
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.HashSet;
@@ -2286,6 +2289,18 @@ public final class CRS {
             } else {
                 return AxisOrder.NORTH_EAST;
             }
+        }
+
+        // if the AxisOrder does not help, try with the axis abbreviations (for polar
+        // stereographics)
+        String labelFirst = cs.getAxis(0).getAbbreviation();
+        String labelSecond = cs.getAxis(1).getAbbreviation();
+        if (labelFirst.equals(NORTHING.getAbbreviation())
+                && labelSecond.equals(EASTING.getAbbreviation())) {
+            return AxisOrder.NORTH_EAST;
+        } else if (labelFirst.equals(EASTING.getAbbreviation())
+                && labelSecond.equals(NORTHING.getAbbreviation())) {
+            return AxisOrder.EAST_NORTH;
         }
 
         return AxisOrder.INAPPLICABLE;

--- a/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/HSQLCRSTest.java
+++ b/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/HSQLCRSTest.java
@@ -57,4 +57,18 @@ public class HSQLCRSTest extends AbstractCRSTest {
         DirectPosition2D position2Dres = new DirectPosition2D();
         mathTransform.transform(position2D, position2Dres);
     }
+
+    @Test
+    public void testSouthPolarEastNorth() throws Exception {
+        // force NE while decoding
+        CoordinateReferenceSystem crsEN = CRS.decode("EPSG:32761", true);
+        assertEquals(CRS.AxisOrder.EAST_NORTH, CRS.getAxisOrder(crsEN));
+    }
+
+    @Test
+    public void testSouthPolarNorthEast() throws Exception {
+        // leave native axis order, it should be recognized as north/east
+        CoordinateReferenceSystem crsNE = CRS.decode("EPSG:32761", false);
+        assertEquals(CRS.AxisOrder.NORTH_EAST, CRS.getAxisOrder(crsNE));
+    }
 }


### PR DESCRIPTION
[![GEOT-6916](https://badgen.net/badge/JIRA/GEOT-6916/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6916) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.