### PR TITLE
[GEOT-6920] Make it easier to specify which transformation to use when selecting a coordinate system transform

### DIFF
--- a/docs/user/library/referencing/crs.rst
+++ b/docs/user/library/referencing/crs.rst
@@ -245,6 +245,60 @@ Transforming an ISO Geometry is more straight forward::
   CoordinateReferenceSystem targetCRS = CRS.decode("EPSG:23032");
   Geometry target = geometry.transform( targetCRS );
 
+It is possible that the EPSG database specifies a number of different datum transforms that provide different levels of accuracy in different areas of the projections use. GeoTools provides a method ``CRS.getTransforms`` that takes two CRS and returns a ``Map`` of possible transforms for that pair of CRS. The user can then inspect the transform to see it's potential accuracy and area of validity.::
+
+  CoordinateReferenceSystem sourceCRS =
+                crsAuthFactory.createCoordinateReferenceSystem("EPSG:21036");
+  CoordinateReferenceSystem targetCRS =
+                crsAuthFactory.createCoordinateReferenceSystem("EPSG:32736");
+  Map<String, DefaultConcatenatedOperation> transforms = CRS.getTransforms(sourceCRS, targetCRS);
+  double best = Double.POSITIVE_INFINITY;
+  MathTransform transform = null;
+  for(Entry<String, DefaultConcatenatedOperation> entry:transforms.entrySet()) {
+      double accuracy = entry.getValue().getAccuracy();
+      System.out.println(entry.getKey()+"\t"+accuracy);
+      if(best>accuracy) {
+          best=accuracy;
+          transform = entry.getValue().getMathTransform();
+      }
+  }
+  System.out.println("Best transform is "+transform);
+
+which gives::
+
+  EPSG:3998	35.0
+  EPSG:1285	15.0
+  EPSG:1284	6.0
+  EPSG:1122	35.0
+  Best transform is CONCAT_MT[INVERSE_MT[PARAM_MT["Transverse_Mercator",
+        PARAMETER["semi_major", 6378249.145],
+        PARAMETER["semi_minor", 6356514.8695497755],
+        PARAMETER["central_meridian", 33.0],
+        PARAMETER["latitude_of_origin", 0.0],
+        PARAMETER["scale_factor", 0.9996],
+        PARAMETER["false_easting", 500000.0],
+        PARAMETER["false_northing", 10000000.0]]],
+    PARAM_MT["Ellipsoid_To_Geocentric",
+      PARAMETER["dim", 2],
+      PARAMETER["semi_major", 6378249.145],
+      PARAMETER["semi_minor", 6356514.8695497755]],
+    PARAM_MT["Geocentric translations (geog2D domain)",
+      PARAMETER["dx", -157.0],
+      PARAMETER["dy", -2.0],
+      PARAMETER["dz", -299.0]],
+    PARAM_MT["Geocentric_To_Ellipsoid",
+      PARAMETER["dim", 2],
+      PARAMETER["semi_major", 6378137.0],
+      PARAMETER["semi_minor", 6356752.314245179]],
+    PARAM_MT["Transverse_Mercator",
+      PARAMETER["semi_major", 6378137.0],
+      PARAMETER["semi_minor", 6356752.314245179],
+      PARAMETER["central_meridian", 33.0],
+      PARAMETER["latitude_of_origin", 0.0],
+      PARAMETER["scale_factor", 0.9996],
+      PARAMETER["false_easting", 500000.0],
+      PARAMETER["false_northing", 10000000.0]]]
+
 Axis Order
 ^^^^^^^^^^
 

--- a/docs/user/library/referencing/crs.rst
+++ b/docs/user/library/referencing/crs.rst
@@ -299,6 +299,15 @@ which gives::
       PARAMETER["false_easting", 500000.0],
       PARAMETER["false_northing", 10000000.0]]]
 
+If you already know the code of the transform that you require you can fetch it directly by using::
+
+
+  CoordinateReferenceSystem sourceCRS =
+                crsAuthFactory.createCoordinateReferenceSystem("EPSG:21036");
+  CoordinateReferenceSystem targetCRS =
+                crsAuthFactory.createCoordinateReferenceSystem("EPSG:32736");
+  MathTransform transform = CRS.findMathTransform(sourceCRS, targetCRS, "EPSG:1285");
+
 Axis Order
 ^^^^^^^^^^
 

--- a/docs/user/library/referencing/transform.rst
+++ b/docs/user/library/referencing/transform.rst
@@ -197,7 +197,7 @@ Other Math Transform Parameters
 * ``dim`` - dimension of points (2 or 3)
 * ``dx`` - x shift (m)
 * ``dy`` - y shift (m)
-* dz - z shift (m)
+* ``dz`` - z shift (m)
 * ``src_semi_major`` - source equatorial radius (m)
 * ``src_semi_minor`` - source polar radius (m)
 * ``tgt_semi_major`` - target equatorial radius (m)

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
@@ -18,8 +18,10 @@ package org.geotools.referencing;
 
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -43,7 +45,9 @@ import org.geotools.referencing.cs.DefaultCoordinateSystemAxis;
 import org.geotools.referencing.cs.DefaultEllipsoidalCS;
 import org.geotools.referencing.factory.AbstractAuthorityFactory;
 import org.geotools.referencing.factory.IdentifiedObjectFinder;
+import org.geotools.referencing.operation.DefaultConcatenatedOperation;
 import org.geotools.referencing.operation.DefaultMathTransformFactory;
+import org.geotools.referencing.operation.DefaultTransformation;
 import org.geotools.referencing.operation.projection.AzimuthalEquidistant;
 import org.geotools.referencing.operation.projection.LambertAzimuthalEqualArea;
 import org.geotools.referencing.operation.projection.MapProjection;
@@ -102,6 +106,7 @@ import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.MathTransform2D;
 import org.opengis.referencing.operation.NoninvertibleTransformException;
 import org.opengis.referencing.operation.Projection;
+import org.opengis.referencing.operation.SingleOperation;
 import org.opengis.referencing.operation.TransformException;
 
 /**
@@ -205,9 +210,9 @@ public final class CRS {
     private CRS() {}
 
     //////////////////////////////////////////////////////////////
-    ////                                                      ////
-    ////        FACTORIES, CRS CREATION AND INSPECTION        ////
-    ////                                                      ////
+    //// ////
+    //// FACTORIES, CRS CREATION AND INSPECTION ////
+    //// ////
     //////////////////////////////////////////////////////////////
 
     /**
@@ -428,9 +433,8 @@ public final class CRS {
     public static CoordinateReferenceSystem decode(final String code)
             throws NoSuchAuthorityCodeException, FactoryException {
         /*
-         * Do not use Boolean.getBoolean(GeoTools.FORCE_LONGITUDE_FIRST_AXIS_ORDER).
-         * The boolean argument should be 'false', which means "use system default"
-         * (not "latitude first").
+         * Do not use Boolean.getBoolean(GeoTools.FORCE_LONGITUDE_FIRST_AXIS_ORDER). The boolean argument should be 'false', which means
+         * "use system default" (not "latitude first").
          */
         return decode(code, false);
     }
@@ -464,32 +468,27 @@ public final class CRS {
      *
      * <table border='1'>
      * <tr>
-     *   <th>This method argument</th>
-     *   <th>{@linkplain Hints#FORCE_LONGITUDE_FIRST_AXIS_ORDER Hint} value</th>
-     *   <th>Meaning</th>
+     * <th>This method argument</th>
+     * <th>{@linkplain Hints#FORCE_LONGITUDE_FIRST_AXIS_ORDER Hint} value</th>
+     * <th>Meaning</th>
      * </tr>
      * <tr>
-     *   <td>{@code true}</td>
-     *   <td>{@link Boolean#TRUE TRUE}</td>
-     *   <td>All coordinate reference systems are forced to
-     *       (<var>longitude</var>, <var>latitude</var>) axis order.</td>
+     * <td>{@code true}</td>
+     * <td>{@link Boolean#TRUE TRUE}</td>
+     * <td>All coordinate reference systems are forced to (<var>longitude</var>, <var>latitude</var>) axis order.</td>
      * </tr>
      * <tr>
-     *   <td>{@code false}</td>
-     *   <td>{@code null}</td>
-     *   <td>Coordinate reference systems may or may not be forced to
-     *       (<var>longitude</var>, <var>latitude</var>) axis order. The behavior depends on user
-     *       setting, for example the value of the <code>{@value
-     *       GeoTools#FORCE_LONGITUDE_FIRST_AXIS_ORDER}</code>
-     *       system property.</td>
+     * <td>{@code false}</td>
+     * <td>{@code null}</td>
+     * <td>Coordinate reference systems may or may not be forced to (<var>longitude</var>, <var>latitude</var>) axis order. The behavior depends on
+     * user setting, for example the value of the <code>{@value
+     *       GeoTools#FORCE_LONGITUDE_FIRST_AXIS_ORDER}</code> system property.</td>
      * </tr>
      * <tr>
-     *   <td></td>
-     *   <td>{@link Boolean#FALSE FALSE}</td>
-     *   <td>Forcing (<var>longitude</var>, <var>latitude</var>) axis order is not allowed,
-     *       no matter the value of the <code>{@value
-     *       GeoTools#FORCE_LONGITUDE_FIRST_AXIS_ORDER}</code>
-     *       system property.</td>
+     * <td></td>
+     * <td>{@link Boolean#FALSE FALSE}</td>
+     * <td>Forcing (<var>longitude</var>, <var>latitude</var>) axis order is not allowed, no matter the value of the <code>{@value
+     *       GeoTools#FORCE_LONGITUDE_FIRST_AXIS_ORDER}</code> system property.</td>
      * </tr>
      * </table>
      *
@@ -597,9 +596,8 @@ public final class CRS {
             }
         }
         /*
-         * If no envelope was found, uses the geographic bounding box as a fallback. We will
-         * need to transform it from WGS84 to the supplied CRS. This step was not required in
-         * the previous block because the later selected only envelopes in the right CRS.
+         * If no envelope was found, uses the geographic bounding box as a fallback. We will need to transform it from WGS84 to the supplied CRS. This
+         * step was not required in the previous block because the later selected only envelopes in the right CRS.
          */
         if (envelope == null) {
             final GeographicBoundingBox bounds = getGeographicBoundingBox(crs);
@@ -616,10 +614,8 @@ public final class CRS {
                                             bounds.getNorthBoundLatitude()
                                         });
                 /*
-                 * We do not assign WGS84 inconditionnaly to the geographic bounding box, because
-                 * it is not defined to be on a particular datum; it is only approximative bounds.
-                 * We try to get the GeographicCRS from the user-supplied CRS and fallback on WGS
-                 * 84 only if we found none.
+                 * We do not assign WGS84 inconditionnaly to the geographic bounding box, because it is not defined to be on a particular datum; it is
+                 * only approximative bounds. We try to get the GeographicCRS from the user-supplied CRS and fallback on WGS 84 only if we found none.
                  */
                 final SingleCRS targetCRS = getHorizontalCRS(crs);
                 final GeographicCRS sourceCRS = CRSUtilities.getStandardGeographicCRS2D(targetCRS);
@@ -628,19 +624,17 @@ public final class CRS {
                     envelope = transform(envelope, targetCRS);
                 } catch (TransformException exception) {
                     /*
-                     * The envelope is probably outside the range of validity for this CRS.
-                     * It should not occurs, since the envelope is supposed to describe the
-                     * CRS area of validity. Logs a warning and returns null, since it is a
-                     * legal return value according this method contract.
+                     * The envelope is probably outside the range of validity for this CRS. It should not occurs, since the envelope is supposed to
+                     * describe the CRS area of validity. Logs a warning and returns null, since it is a legal return value according this method
+                     * contract.
                      */
                     envelope = null;
                     unexpectedException("getEnvelope", exception);
                 }
                 /*
-                 * If transform(...) created a new envelope, its CRS is already targetCRS so it
-                 * doesn't matter if 'merged' is not anymore the right instance. If 'transform'
-                 * returned the envelope unchanged, the 'merged' reference still valid and we
-                 * want to ensure that it have the user-supplied CRS.
+                 * If transform(...) created a new envelope, its CRS is already targetCRS so it doesn't matter if 'merged' is not anymore the right
+                 * instance. If 'transform' returned the envelope unchanged, the 'merged' reference still valid and we want to ensure that it have the
+                 * user-supplied CRS.
                  */
                 merged.setCoordinateReferenceSystem(targetCRS);
             }
@@ -702,9 +696,8 @@ public final class CRS {
             final int dimension = cs.getDimension();
             if (dimension == 2) {
                 /*
-                 * For two-dimensional CRS, returns the CRS directly if it is either a
-                 * GeographicCRS, or any kind of derived CRS having a GeographicCRS as
-                 * its base.
+                 * For two-dimensional CRS, returns the CRS directly if it is either a GeographicCRS, or any kind of derived CRS having a
+                 * GeographicCRS as its base.
                  */
                 CoordinateReferenceSystem base = crs;
                 while (base instanceof GeneralDerivedCRS) {
@@ -720,9 +713,8 @@ public final class CRS {
                 }
             } else if (dimension >= 3 && crs instanceof GeographicCRS) {
                 /*
-                 * For three-dimensional Geographic CRS, extracts the axis having a direction
-                 * like "North", "North-East", "East", etc. If we find exactly two of them,
-                 * we can build a new GeographicCRS using them.
+                 * For three-dimensional Geographic CRS, extracts the axis having a direction like "North", "North-East", "East", etc. If we find
+                 * exactly two of them, we can build a new GeographicCRS using them.
                  */
                 CoordinateSystemAxis axis0 = null, axis1 = null;
                 int count = 0;
@@ -1044,6 +1036,7 @@ public final class CRS {
             return identifiers.iterator().next().toString();
         }
     }
+
     /**
      * Returns the <cite>Spatial Reference System</cite> identifier, or {@code null} if none.
      *
@@ -1073,6 +1066,7 @@ public final class CRS {
             return srsName;
         }
     }
+
     /**
      * Looks up an identifier for the specified object. This method searchs in registered factories
      * for an object {@linkplain #equalsIgnoreMetadata equals, ignoring metadata}, to the specified
@@ -1099,9 +1093,8 @@ public final class CRS {
     public static String lookupIdentifier(final IdentifiedObject object, final boolean fullScan)
             throws FactoryException {
         /*
-         * We perform the search using the 'xyFactory' because our implementation of
-         * IdentifiedObjectFinder should be able to inspect both the (x,y) and (y,x)
-         * axis order using this factory.
+         * We perform the search using the 'xyFactory' because our implementation of IdentifiedObjectFinder should be able to inspect both the (x,y)
+         * and (y,x) axis order using this factory.
          */
         final AbstractAuthorityFactory xyFactory =
                 (AbstractAuthorityFactory) getAuthorityFactory(true);
@@ -1192,9 +1185,9 @@ public final class CRS {
     }
 
     /////////////////////////////////////////////////
-    ////                                         ////
-    ////          COORDINATE OPERATIONS          ////
-    ////                                         ////
+    //// ////
+    //// COORDINATE OPERATIONS ////
+    //// ////
     /////////////////////////////////////////////////
 
     /**
@@ -1234,6 +1227,81 @@ public final class CRS {
             final CoordinateReferenceSystem sourceCRS, final CoordinateReferenceSystem targetCRS)
             throws FactoryException {
         return findMathTransform(sourceCRS, targetCRS, false);
+    }
+
+    /**
+     * Grab a transform between two Coordinate Reference Systems with the required transformation
+     * being used.
+     *
+     * <p>Sample use:
+     *
+     * <blockquote>
+     *
+     * <code>
+     * {@linkplain MathTransform} transform = CRS.findMathTransform(
+     * CRS.{@linkplain #decode decode}("EPSG:21036"),
+     * CRS.{@linkplain #decode decode}("EPSG:32736"), "EPSG:1285" );
+     * </blockquote></code>
+     *
+     * @param sourceCRS The source CRS.
+     * @param targetCRS The target CRS.
+     * @param transformation code - the transform operation desired.
+     * @return The math transform from {@code sourceCRS} to {@code targetCRS} using the {@code
+     *     transformCode} if it is found, otherwise the first transform found will be returned.
+     * @throws FactoryException If no math transform can be created for the specified source and
+     *     target CRS.
+     */
+    public static MathTransform findMathTransform(
+            CoordinateReferenceSystem sourceCRS,
+            CoordinateReferenceSystem targetCRS,
+            String transformCode)
+            throws FactoryException {
+        CoordinateOperationFactory fac = getCoordinateOperationFactory(false);
+
+        Map<String, MathTransform> transforms = getTransforms(sourceCRS, targetCRS);
+        MathTransform ret = null;
+        for (Entry<String, MathTransform> entry : transforms.entrySet()) {
+            System.out.println(entry.getKey() + " -> " + entry.getValue());
+            if (entry.getKey().equalsIgnoreCase(transformCode)) {
+                ret = entry.getValue();
+            }
+        }
+        if (ret == null) {
+            LOGGER.info("No transform matching " + transformCode + " can be found");
+            ret = CRS.findMathTransform(sourceCRS, targetCRS);
+        }
+
+        return ret;
+    }
+
+    /**
+     * List the available transforms from sourceCRS to targetCRS
+     *
+     * @param sourceCRS - the starting CRS
+     * @param targetCRS - the target CRS
+     * @return - a Map of transforms keyed by id code which can be used in <code>
+     *     {@linkplain #findMathTransform(CoordinateReferenceSystem, CoordinateReferenceSystem, String)}
+     * findMathTransform}(sourceCRS, targetCRS, transformCode)</code>
+     * @throws FactoryException
+     */
+    public static Map<String, MathTransform> getTransforms(
+            CoordinateReferenceSystem sourceCRS, CoordinateReferenceSystem targetCRS)
+            throws FactoryException {
+        Set<CoordinateOperation> ops =
+                getCoordinateOperationFactory(true).findOperations(sourceCRS, targetCRS);
+        Map<String, MathTransform> transforms = new HashMap<>();
+        for (CoordinateOperation op : ops) {
+            if (op instanceof DefaultConcatenatedOperation) {
+                for (SingleOperation opx : ((DefaultConcatenatedOperation) op).getOperations()) {
+                    if (opx.getClass().isAssignableFrom(DefaultTransformation.class)) {
+                        for (ReferenceIdentifier id : opx.getIdentifiers()) {
+                            transforms.put(id.toString(), op.getMathTransform());
+                        }
+                    }
+                }
+            }
+        }
+        return transforms;
     }
 
     /**
@@ -1353,11 +1421,9 @@ public final class CRS {
         }
         if (transform.isIdentity()) {
             /*
-             * Slight optimisation: Just copy the envelope. Note that we need to set the CRS
-             * to null because we don't know what the target CRS was supposed to be. Even if
-             * an identity transform often imply that the target CRS is the same one than the
-             * source CRS, it is not always the case. The metadata may be differents, or the
-             * transform may be a datum shift without Bursa-Wolf parameters, etc.
+             * Slight optimisation: Just copy the envelope. Note that we need to set the CRS to null because we don't know what the target CRS was
+             * supposed to be. Even if an identity transform often imply that the target CRS is the same one than the source CRS, it is not always the
+             * case. The metadata may be differents, or the transform may be a datum shift without Bursa-Wolf parameters, etc.
              */
             final GeneralEnvelope e = new GeneralEnvelope(envelope);
             e.setCoordinateReferenceSystem(null);
@@ -1383,8 +1449,8 @@ public final class CRS {
             targetPt = new GeneralDirectPosition(transform.getTargetDimensions());
         }
         /*
-         * Before to run the loops, we must initialize the coordinates to the minimal values.
-         * This coordinates will be updated in the 'switch' statement inside the 'while' loop.
+         * Before to run the loops, we must initialize the coordinates to the minimal values. This coordinates will be updated in the 'switch'
+         * statement inside the 'while' loop.
          */
         final GeneralDirectPosition sourcePt = new GeneralDirectPosition(sourceDim);
         for (int i = sourceDim; --i >= 0; ) {
@@ -1393,8 +1459,8 @@ public final class CRS {
         loop:
         while (true) {
             /*
-             * Transform a point and add the transformed point to the destination envelope.
-             * Note that the very last point to be projected must be the envelope center.
+             * Transform a point and add the transformed point to the destination envelope. Note that the very last point to be projected must be the
+             * envelope center.
              */
             if (targetPt != transform.transform(sourcePt, targetPt)) {
                 throw new UnsupportedImplementationException(transform.getClass());
@@ -1405,14 +1471,11 @@ public final class CRS {
                 transformed = new GeneralEnvelope(targetPt, targetPt);
             }
             /*
-             * Get the next point's coordinates.  The 'coordinateNumber' variable should
-             * be seen as a number in base 5 where the number of digits is equals to the
-             * number of dimensions. For example, a 4-D space would have numbers ranging
-             * from "0000" to "4444" (numbers in base 4). The digits are then translated
-             * into minimal, central or maximal ordinates. The outer loop stops when the
-             * counter roll back to "0000".  Note that 'targetPt' must keep the value of
-             * the last projected point, which must be the envelope center identified by
-             * "4444" in the 4-D case.
+             * Get the next point's coordinates. The 'coordinateNumber' variable should be seen as a number in base 5 where the number of digits is
+             * equals to the number of dimensions. For example, a 4-D space would have numbers ranging from "0000" to "4444" (numbers in base 4). The
+             * digits are then translated into minimal, central or maximal ordinates. The outer loop stops when the counter roll back to "0000". Note
+             * that 'targetPt' must keep the value of the last projected point, which must be the envelope center identified by "4444" in the 4-D
+             * case.
              */
             int n = ++coordinateNumber;
             for (int i = sourceDim; --i >= 0; ) {
@@ -1478,12 +1541,10 @@ public final class CRS {
         final GeneralDirectPosition centerPt = new GeneralDirectPosition(mt.getTargetDimensions());
         final GeneralEnvelope transformed = transform(mt, envelope, centerPt);
         /*
-         * If the source envelope crosses the expected range of valid coordinates, also projects
-         * the range bounds as a safety. Example: if the source envelope goes from 150 to 200°E,
-         * some map projections will interpret 200° as if it was -160°, and consequently produce
-         * an envelope which do not include the 180°W extremum. We will add those extremum points
-         * explicitly as a safety. It may leads to bigger than necessary target envelope, but the
-         * contract is to include at least the source envelope, not to returns the smallest one.
+         * If the source envelope crosses the expected range of valid coordinates, also projects the range bounds as a safety. Example: if the source
+         * envelope goes from 150 to 200°E, some map projections will interpret 200° as if it was -160°, and consequently produce an envelope which do
+         * not include the 180°W extremum. We will add those extremum points explicitly as a safety. It may leads to bigger than necessary target
+         * envelope, but the contract is to include at least the source envelope, not to returns the smallest one.
          */
         if (sourceCRS != null) {
             final CoordinateSystem cs = sourceCRS.getCoordinateSystem();
@@ -1526,8 +1587,7 @@ public final class CRS {
 
         // check the target CRSS
         /*
-         * Special case for polar stereographic, if the envelope contains the origin, then
-         * the whole set of longitudes should be included
+         * Special case for polar stereographic, if the envelope contains the origin, then the whole set of longitudes should be included
          */
         final CoordinateReferenceSystem targetCRS = operation.getTargetCRS();
         if (targetCRS == null) {
@@ -1649,36 +1709,28 @@ public final class CRS {
             return transformed;
         }
         /*
-         * Checks for singularity points. For example the south pole is a singularity point in
-         * geographic CRS because we reach the maximal value allowed on one particular geographic
-         * axis, namely latitude. This point is not a singularity in the stereographic projection,
-         * where axis extends toward infinity in all directions (mathematically) and south pole
-         * has nothing special apart being the origin (0,0).
+         * Checks for singularity points. For example the south pole is a singularity point in geographic CRS because we reach the maximal value
+         * allowed on one particular geographic axis, namely latitude. This point is not a singularity in the stereographic projection, where axis
+         * extends toward infinity in all directions (mathematically) and south pole has nothing special apart being the origin (0,0).
          *
          * Algorithm:
          *
-         * 1) Inspect the target axis, looking if there is any bounds. If bounds are found, get
-         *    the coordinates of singularity points and project them from target to source CRS.
+         * 1) Inspect the target axis, looking if there is any bounds. If bounds are found, get the coordinates of singularity points and project them
+         * from target to source CRS.
          *
-         *    Example: if the transformed envelope above is (80°S to 85°S, 10°W to 50°W), and if
-         *             target axis inspection reveal us that the latitude in target CRS is bounded
-         *             at 90°S, then project (90°S,30°W) to source CRS. Note that the longitude is
-         *             set to the the center of the envelope longitude range (more on this later).
+         * Example: if the transformed envelope above is (80°S to 85°S, 10°W to 50°W), and if target axis inspection reveal us that the latitude in
+         * target CRS is bounded at 90°S, then project (90°S,30°W) to source CRS. Note that the longitude is set to the the center of the envelope
+         * longitude range (more on this later).
          *
-         * 2) If the singularity point computed above is inside the source envelope, add that
-         *    point to the target (transformed) envelope.
+         * 2) If the singularity point computed above is inside the source envelope, add that point to the target (transformed) envelope.
          *
-         * Note: We could choose to project the (-180, -90), (180, -90), (-180, 90), (180, 90)
-         * points, or the (-180, centerY), (180, centerY), (centerX, -90), (centerX, 90) points
-         * where (centerX, centerY) are transformed from the source envelope center. It make
-         * no difference for polar projections because the longitude is irrelevant at pole, but
-         * may make a difference for the 180° longitude bounds.  Consider a Mercator projection
-         * where the transformed envelope is between 20°N and 40°N. If we try to project (-180,90),
-         * we will get a TransformException because the Mercator projection is not supported at
-         * pole. If we try to project (-180, 30) instead, we will get a valid point. If this point
-         * is inside the source envelope because the later overlaps the 180° longitude, then the
-         * transformed envelope will be expanded to the full (-180 to 180) range. This is quite
-         * large, but at least it is correct (while the envelope without expansion is not).
+         * Note: We could choose to project the (-180, -90), (180, -90), (-180, 90), (180, 90) points, or the (-180, centerY), (180, centerY),
+         * (centerX, -90), (centerX, 90) points where (centerX, centerY) are transformed from the source envelope center. It make no difference for
+         * polar projections because the longitude is irrelevant at pole, but may make a difference for the 180° longitude bounds. Consider a Mercator
+         * projection where the transformed envelope is between 20°N and 40°N. If we try to project (-180,90), we will get a TransformException
+         * because the Mercator projection is not supported at pole. If we try to project (-180, 30) instead, we will get a valid point. If this point
+         * is inside the source envelope because the later overlaps the 180° longitude, then the transformed envelope will be expanded to the full
+         * (-180 to 180) range. This is quite large, but at least it is correct (while the envelope without expansion is not).
          */
         DirectPosition sourcePt = null;
         DirectPosition targetPt = null;
@@ -1693,9 +1745,8 @@ public final class CRS {
                 final double extremum = testMax ? axis.getMaximumValue() : axis.getMinimumValue();
                 if (Double.isInfinite(extremum) || Double.isNaN(extremum)) {
                     /*
-                     * The axis is unbounded. It should always be the case when the target CRS is
-                     * a map projection, in which case this loop will finish soon and this method
-                     * will do nothing more (no object instantiated, no MathTransform inversed...)
+                     * The axis is unbounded. It should always be the case when the target CRS is a map projection, in which case this loop will
+                     * finish soon and this method will do nothing more (no object instantiated, no MathTransform inversed...)
                      */
                     continue;
                 }
@@ -1704,15 +1755,12 @@ public final class CRS {
                         mt = mt.inverse();
                     } catch (NoninvertibleTransformException exception) {
                         /*
-                         * If the transform is non invertible, this method can't do anything. This
-                         * is not a fatal error because the envelope has already be transformed by
-                         * the caller. We lost the check for singularity points performed by this
-                         * method, but it make no difference in the common case where the source
-                         * envelope didn't contains any of those points.
+                         * If the transform is non invertible, this method can't do anything. This is not a fatal error because the envelope has
+                         * already be transformed by the caller. We lost the check for singularity points performed by this method, but it make no
+                         * difference in the common case where the source envelope didn't contains any of those points.
                          *
-                         * Note that this exception is normal if target dimension is smaller than
-                         * source dimension, since the math transform can not reconstituate the
-                         * lost dimensions. So we don't log any warning in this case.
+                         * Note that this exception is normal if target dimension is smaller than source dimension, since the math transform can not
+                         * reconstituate the lost dimensions. So we don't log any warning in this case.
                          */
                         if (dimension >= mt.getSourceDimensions()) {
                             unexpectedException("transform", exception);
@@ -1729,9 +1777,8 @@ public final class CRS {
                     sourcePt = mt.transform(targetPt, sourcePt);
                 } catch (Exception e) {
                     /*
-                     * This exception may be normal. For example we are sure to get this exception
-                     * when trying to project the latitude extremums with a cylindrical Mercator
-                     * projection. Do not log any message and try the other points.
+                     * This exception may be normal. For example we are sure to get this exception when trying to project the latitude extremums with
+                     * a cylindrical Mercator projection. Do not log any message and try the other points.
                      */
                     continue;
                 }
@@ -2021,7 +2068,9 @@ public final class CRS {
      *
      * <p>
      *
-     * <pre>transform(transform, new GeneralEnvelope(envelope)).toRectangle2D()</pre>
+     * <pre>
+     * transform(transform, new GeneralEnvelope(envelope)).toRectangle2D()
+     * </pre>
      *
      * <p>Note that this method can not handle the case where the rectangle contains the North or
      * South pole, or when it cross the &plusmn;180° longitude, because {@linkplain MathTransform
@@ -2068,11 +2117,7 @@ public final class CRS {
         double ymax = Double.NEGATIVE_INFINITY;
         for (int i = 0; i <= 8; i++) {
             /*
-             *   (0)----(5)----(1)
-             *    |             |
-             *   (4)    (8)    (7)
-             *    |             |
-             *   (2)----(6)----(3)
+             * (0)----(5)----(1) | | (4) (8) (7) | | (2)----(6)----(3)
              *
              * (note: center must be last)
              */
@@ -2123,7 +2168,9 @@ public final class CRS {
      *
      * <p>
      *
-     * <pre>transform(operation, new GeneralEnvelope(envelope)).toRectangle2D()</pre>
+     * <pre>
+     * transform(operation, new GeneralEnvelope(envelope)).toRectangle2D()
+     * </pre>
      *
      * <p>This method can handle the case where the rectangle contains the North or South pole, or
      * when it cross the &plusmn;180° longitude.

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
@@ -209,12 +209,6 @@ public final class CRS {
     /** Do not allow instantiation of this class. */
     private CRS() {}
 
-    //////////////////////////////////////////////////////////////
-    //// ////
-    //// FACTORIES, CRS CREATION AND INSPECTION ////
-    //// ////
-    //////////////////////////////////////////////////////////////
-
     /**
      * Returns the CRS authority factory used by the {@link #decode(String,boolean) decode} methods.
      * This factory is {@linkplain org.geotools.referencing.factory.BufferedAuthorityFactory
@@ -1184,12 +1178,6 @@ public final class CRS {
         return null;
     }
 
-    /////////////////////////////////////////////////
-    //// ////
-    //// COORDINATE OPERATIONS ////
-    //// ////
-    /////////////////////////////////////////////////
-
     /**
      * Grab a transform between two Coordinate Reference Systems. This convenience method is a
      * shorthand for the following:
@@ -2116,7 +2104,9 @@ public final class CRS {
         double ymax = Double.NEGATIVE_INFINITY;
         for (int i = 0; i <= 8; i++) {
             /*
-             * (0)----(5)----(1) | | (4) (8) (7) | | (2)----(6)----(3)
+             *  | (0)----(5)----(1) |
+             *  | (4)    (8)    (7) |
+             *  | (2)----(6)----(3) |
              *
              * (note: center must be last)
              */

--- a/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/factory/epsg/hsql/OperationFactoryTest.java
+++ b/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/factory/epsg/hsql/OperationFactoryTest.java
@@ -16,6 +16,10 @@
  */
 package org.geotools.referencing.factory.epsg.hsql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +51,7 @@ import org.opengis.referencing.operation.Conversion;
 import org.opengis.referencing.operation.CoordinateOperation;
 import org.opengis.referencing.operation.CoordinateOperationFactory;
 import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
 import org.opengis.referencing.operation.Transformation;
 
 /**
@@ -128,8 +133,7 @@ public class OperationFactoryTest {
         Assert.assertEquals(1.0, AbstractCoordinateOperation.getAccuracy(operation), 1E-6);
         Assert.assertTrue(operation instanceof Transformation);
         /*
-         * Tests a transformation not backed directly by an authority factory.
-         * However, the inverse transform may exist in the authority factory.
+         * Tests a transformation not backed directly by an authority factory. However, the inverse transform may exist in the authority factory.
          */
         sourceCRS = crsAuthFactory.createCoordinateReferenceSystem("4326");
         targetCRS = crsAuthFactory.createCoordinateReferenceSystem("2995");
@@ -222,9 +226,9 @@ public class OperationFactoryTest {
         DirectPosition expected =
                 new DirectPosition2D(targetCRS, 214741.10238960697, 26957.60506898933);
 
-        // geoserver vecmath:  TransformedDirectPosition[214741.10238960697, 26957.60506898933]
-        // geoserver    ejml:  TransformedDirectPosition[214636.7447572897,  27218.077500249085]
-        // geotools     ejml:  TransformedDirectPosition[214636.7447572897,  27218.077500249085]
+        // geoserver vecmath: TransformedDirectPosition[214741.10238960697, 26957.60506898933]
+        // geoserver ejml: TransformedDirectPosition[214636.7447572897, 27218.077500249085]
+        // geotools ejml: TransformedDirectPosition[214636.7447572897, 27218.077500249085]
         Assert.assertEquals(expected.getOrdinate(0), arbitraryToInternal.getOrdinate(0), 1e-9);
         Assert.assertEquals(expected.getOrdinate(1), arbitraryToInternal.getOrdinate(1), 1e-9);
     }
@@ -443,5 +447,76 @@ public class OperationFactoryTest {
         // try reverse order
         operation = opFactory.createOperation(targetCRS, sourceCRS);
         assertOperation(operation, targetCRS, sourceCRS);
+    }
+
+    @Test
+    public void testGetSpecificTransform()
+            throws FactoryException, TransformException, ParseException {
+
+        CoordinateReferenceSystem sourceCRS =
+                crsAuthFactory.createCoordinateReferenceSystem("EPSG:21036");
+        CoordinateReferenceSystem targetCRS =
+                crsAuthFactory.createCoordinateReferenceSystem("EPSG:32736");
+
+        MathTransform crsTransform = CRS.findMathTransform(sourceCRS, targetCRS, "EPSG:1285");
+        // in an ideal world we would examine the transform to see what the TOWGS parameter is but
+        // that is locked away from us.
+        assertTrue(crsTransform.toString().contains("PARAMETER[\"dx\", -175.0]"));
+        assertTrue(crsTransform.toString().contains("PARAMETER[\"dy\", -23.0]"));
+        assertTrue(crsTransform.toString().contains("PARAMETER[\"dz\", -303.0]"));
+        DirectPosition input = new DirectPosition2D(sourceCRS, 790615.026, 9316007.421);
+        DirectPosition expected =
+                new DirectPosition2D(targetCRS, 790691.8117871293, 9315700.848637346);
+        DirectPosition output = new DirectPosition2D();
+        crsTransform.transform(input, output);
+        assertPointsEqual(expected, output);
+
+        sourceCRS = crsAuthFactory.createCoordinateReferenceSystem("EPSG:27700");
+        targetCRS = crsAuthFactory.createCoordinateReferenceSystem("EPSG:4258");
+        crsTransform = CRS.findMathTransform(sourceCRS, targetCRS, "EPSG:5339");
+        System.out.println(crsTransform);
+    }
+
+    @Test
+    public void testGetTransforms() throws FactoryException, TransformException, ParseException {
+
+        CoordinateReferenceSystem sourceCRS =
+                crsAuthFactory.createCoordinateReferenceSystem("EPSG:21036");
+        CoordinateReferenceSystem targetCRS =
+                crsAuthFactory.createCoordinateReferenceSystem("EPSG:32736");
+        Map<String, MathTransform> transforms = CRS.getTransforms(sourceCRS, targetCRS);
+        String[] expected = {"EPSG:3998", "EPSG:1284", "EPSG:1122", "EPSG:1285"};
+        Set<String> keys = transforms.keySet();
+        assertEquals("Wrong number of transforms", expected.length, keys.size());
+        for (String code : expected) {
+            assertTrue("Expected key " + code + " not found", keys.contains(code));
+        }
+
+        sourceCRS = crsAuthFactory.createCoordinateReferenceSystem("EPSG:27700");
+        targetCRS = crsAuthFactory.createCoordinateReferenceSystem("EPSG:4326");
+        transforms = CRS.getTransforms(sourceCRS, targetCRS);
+        String[] expected2 = {
+            "EPSG:1195",
+            "EPSG:1314",
+            "EPSG:5622",
+            "EPSG:1197",
+            "EPSG:1196",
+            "EPSG:1199",
+            "EPSG:1198"
+        };
+        keys = transforms.keySet();
+
+        assertEquals("Wrong number of transforms", expected2.length, keys.size());
+        for (String code : expected2) {
+            assertTrue("Expected key " + code + " not found", keys.contains(code));
+        }
+    }
+    /**
+     * @param expected
+     * @param output
+     */
+    private void assertPointsEqual(DirectPosition expected, DirectPosition output) {
+        Assert.assertEquals(expected.getOrdinate(0), output.getOrdinate(0), 1e-6);
+        Assert.assertEquals(expected.getOrdinate(1), output.getOrdinate(1), 1e-6);
     }
 }


### PR DESCRIPTION
[![GEOT-6920](https://badgen.net/badge/JIRA/GEOT-6920/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6920) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Add two new method to `CRS` to allow users to find possible transformations on a coordinate transformation and to request a transform using a specific one.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.