### PR TITLE
[GEOT-6920] Make it easier to specify which transformation to use when selecting a coordinate system transform

### DIFF
--- a/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/factory/epsg/hsql/OperationFactoryTest.java
+++ b/modules/plugin/epsg-hsql/src/test/java/org/geotools/referencing/factory/epsg/hsql/OperationFactoryTest.java
@@ -33,7 +33,6 @@ import org.geotools.referencing.ReferencingFactoryFinder;
 import org.geotools.referencing.operation.AbstractCoordinateOperation;
 import org.geotools.referencing.operation.AuthorityBackedFactory;
 import org.geotools.referencing.operation.BufferedCoordinateOperationFactory;
-import org.geotools.referencing.operation.DefaultConcatenatedOperation;
 import org.geotools.referencing.operation.TransformTestBase;
 import org.geotools.util.Classes;
 import org.geotools.util.factory.Hints;
@@ -491,7 +490,7 @@ public class OperationFactoryTest {
                 crsAuthFactory.createCoordinateReferenceSystem("EPSG:21036");
         CoordinateReferenceSystem targetCRS =
                 crsAuthFactory.createCoordinateReferenceSystem("EPSG:32736");
-        Map<String, DefaultConcatenatedOperation> transforms =
+        Map<String, AbstractCoordinateOperation> transforms =
                 CRS.getTransforms(sourceCRS, targetCRS);
         String[] expected = {"EPSG:3998", "EPSG:1284", "EPSG:1122", "EPSG:1285"};
         Set<String> keys = transforms.keySet();
@@ -518,7 +517,23 @@ public class OperationFactoryTest {
         assertEquals("Wrong number of transforms", expected2.length, keys.size());
         for (String code : expected2) {
             assertTrue("Expected key " + code + " not found", keys.contains(code));
-            DefaultConcatenatedOperation op = transforms.get(code);
+            AbstractCoordinateOperation op = transforms.get(code);
+            assertNotNull(op);
+            assertNotNull(op.getMathTransform());
+        }
+
+        CoordinateReferenceSystem gda94 = CRS.decode("epsg:4283");
+        CoordinateReferenceSystem gda2020 = CRS.decode("epsg:7844");
+
+        transforms = CRS.getTransforms(gda94, gda2020);
+
+        String[] expected3 = {"EPSG:8048", "EPSG:8447"};
+        keys = transforms.keySet();
+
+        assertEquals("Wrong number of transforms", expected3.length, keys.size());
+        for (String code : expected3) {
+            assertTrue("Expected key " + code + " not found", keys.contains(code));
+            AbstractCoordinateOperation op = transforms.get(code);
             assertNotNull(op);
             assertNotNull(op.getMathTransform());
         }


### PR DESCRIPTION
[![GEOT-6920](https://badgen.net/badge/JIRA/GEOT-6920/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6920) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

make find transforms find NTv2 too
# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [ ] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [ ] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [x] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.