### PR TITLE
[GEOT-6921][backport 25.x] GeoTools primary key finder always query t…

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/MetadataTablePrimaryKeyFinder.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/MetadataTablePrimaryKeyFinder.java
@@ -99,6 +99,7 @@ public class MetadataTablePrimaryKeyFinder extends PrimaryKeyFinder {
     public PrimaryKey getPrimaryKey(JDBCDataStore store, String schema, String table, Connection cx)
             throws SQLException {
         ResultSet rs = null;
+        ResultSet tablesRs = null;
         PreparedStatement st = null;
 
         String metadataSchema = getMetadataSchema(store);
@@ -112,18 +113,29 @@ public class MetadataTablePrimaryKeyFinder extends PrimaryKeyFinder {
                 synchronized (this) {
                     if (metadataTableExists == null) {
                         try {
+                            // This is a database-agnostic way to check if the table exists without
+                            // resulting in error messages. It also checks for case sensitivity.
+                            tablesRs =
+                                    cx.getMetaData()
+                                            .getTables(
+                                                    null,
+                                                    metadataSchema,
+                                                    "%",
+                                                    new String[] {"TABLE", "VIEW"});
 
-                            StringBuffer sb = new StringBuffer();
-                            sb.append("SELECT * FROM ");
-                            if (metadataSchema != null) {
-                                store.getSQLDialect().encodeSchemaName(metadataSchema, sb);
-                                sb.append(".");
+                            metadataTableExists = false;
+
+                            while (tablesRs.next()) {
+                                String tblName = tablesRs.getString(3);
+                                if (tblName.toLowerCase().equals(tableName.toLowerCase())) {
+                                    metadataTableExists = true;
+                                    break;
+                                }
                             }
-                            sb.append(tableName).append(" WHERE 1 = 0");
-                            st = cx.prepareStatement(sb.toString());
-                            rs = st.executeQuery();
-                            metadataTableExists = true;
+
                         } catch (Exception e) {
+                            LOGGER.log(Level.WARNING, "Error retrieving database metadata: ", e);
+
                             // clean up the transaction status in case we are in auto-commit mode
                             if (e instanceof SQLException && !cx.getAutoCommit()) {
                                 cx.rollback();
@@ -132,10 +144,18 @@ public class MetadataTablePrimaryKeyFinder extends PrimaryKeyFinder {
                         } finally {
                             store.closeSafe(rs);
                             store.closeSafe(st);
+                            store.closeSafe(tablesRs);
                         }
                     }
                 }
             }
+
+            LOGGER.log(
+                    Level.FINE,
+                    metadataTableExists
+                            ? "Metadata table " + tableName + " was found"
+                            : "Metadata table " + tableName + " was not found");
+
             if (!metadataTableExists) {
                 return null;
             }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCPrimaryKeyFinderViewOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCPrimaryKeyFinderViewOnlineTest.java
@@ -1,0 +1,22 @@
+package org.geotools.jdbc;
+
+@SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation") // not yet a JUnit4 test
+public abstract class JDBCPrimaryKeyFinderViewOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected abstract JDBCPrimaryKeyFinderViewTestSetup createTestSetup();
+
+    @Override
+    protected void connect() throws Exception {
+        super.connect();
+        if (setup.canResetSchema()) {
+            dataStore.setDatabaseSchema(null);
+        }
+    }
+
+    public void testSequencedPrimaryKey() throws Exception {
+        JDBCFeatureStore fs = (JDBCFeatureStore) dataStore.getFeatureSource(tname("seqtable"));
+        assertEquals(1, fs.getPrimaryKey().getColumns().size());
+        assertTrue(fs.getPrimaryKey().getColumns().get(0) instanceof SequencedPrimaryKeyColumn);
+    }
+}

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCPrimaryKeyFinderViewTestSetup.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCPrimaryKeyFinderViewTestSetup.java
@@ -1,0 +1,63 @@
+package org.geotools.jdbc;
+
+import java.sql.SQLException;
+
+public abstract class JDBCPrimaryKeyFinderViewTestSetup extends JDBCDelegatingTestSetup {
+
+    protected JDBCPrimaryKeyFinderViewTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected final void setUpData() throws Exception {
+        // kill all the data
+        try {
+            dropMetadataView();
+        } catch (SQLException e) {
+        }
+        try {
+            dropMetadataTable();
+        } catch (SQLException e) {
+        }
+        try {
+            dropSequencedPrimaryKeyTable();
+        } catch (SQLException e) {
+        }
+
+        // create all the data
+        createMetadataTable();
+        createSequencedPrimaryKeyTable();
+        createMetadataView();
+    }
+
+    /** Drops the metadata table */
+    protected abstract void dropMetadataTable() throws Exception;
+
+    /** Drops the metadata view */
+    protected abstract void dropMetadataView() throws Exception;
+
+    /** Drops the "seqtable" table. */
+    protected abstract void dropSequencedPrimaryKeyTable() throws Exception;
+
+    /**
+     * Creates the default geotools metadata table, empty.
+     *
+     * <p>The table is named "tbl_gt_pk_metadata". See {@link MetadataTablePrimaryKeyFinder} javadoc
+     * for the expected table structure
+     */
+    protected abstract void createMetadataTable() throws Exception;
+
+    /** Creates a view named 'gt_pk_metadata' which queries from 'tbl_gt_pk_metadata' */
+    protected abstract void createMetadataView() throws Exception;
+
+    /**
+     * Creates a table with a primary key column, a sequence name 'pksequence", and links the two
+     * using the primary key metadata table
+     *
+     * <p>seqtable( name:String; geom:Geometry; )
+     *
+     * <p>The table should be populated with the following data: "one" | NULL ; pkey = 1 "two" |
+     * NULL ; pkey = 2 "three" | NULL ; pkey = 3
+     */
+    protected abstract void createSequencedPrimaryKeyTable() throws Exception;
+}

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2PrimaryKeyFinderViewTest.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2PrimaryKeyFinderViewTest.java
@@ -1,0 +1,21 @@
+package org.geotools.data.h2;
+
+import java.util.Map;
+import org.geotools.jdbc.JDBCDataStoreFactory;
+import org.geotools.jdbc.JDBCPrimaryKeyFinderViewOnlineTest;
+import org.geotools.jdbc.JDBCPrimaryKeyFinderViewTestSetup;
+
+public class H2PrimaryKeyFinderViewTest extends JDBCPrimaryKeyFinderViewOnlineTest {
+
+    @Override
+    protected JDBCPrimaryKeyFinderViewTestSetup createTestSetup() {
+        return new H2PrimaryKeyFinderViewTestSetup();
+    }
+
+    @Override
+    protected Map<String, Object> createDataStoreFactoryParams() throws Exception {
+        Map<String, Object> params = super.createDataStoreFactoryParams();
+        params.put(JDBCDataStoreFactory.PK_METADATA_TABLE.key, "gt_pk_metadata");
+        return params;
+    }
+}

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2PrimaryKeyFinderViewTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2PrimaryKeyFinderViewTestSetup.java
@@ -1,0 +1,66 @@
+package org.geotools.data.h2;
+
+import org.geotools.jdbc.JDBCPrimaryKeyFinderViewTestSetup;
+
+public class H2PrimaryKeyFinderViewTestSetup extends JDBCPrimaryKeyFinderViewTestSetup {
+
+    protected H2PrimaryKeyFinderViewTestSetup() {
+        super(new H2TestSetup());
+    }
+
+    @Override
+    protected void createMetadataTable() throws Exception {
+        run(
+                "CREATE TABLE tbl_gt_pk_metadata ( "
+                        + "table_schema VARCHAR, "
+                        + "table_name VARCHAR NOT NULL, "
+                        + "pk_column VARCHAR NOT NULL, "
+                        + "pk_column_idx INTEGER, "
+                        + "pk_policy VARCHAR, "
+                        + "pk_sequence VARCHAR)");
+    }
+
+    @Override
+    protected void createMetadataView() throws Exception {
+        run("CREATE VIEW \"gt_pk_metadata\" AS SELECT * FROM tbl_gt_pk_metadata");
+    }
+
+    @Override
+    protected void createSequencedPrimaryKeyTable() throws Exception {
+        run(
+                "CREATE TABLE \"seqtable\" ( \"key\" int PRIMARY KEY, "
+                        + "\"name\" VARCHAR, \"geom\" GEOMETRY)");
+        run("CALL AddGeometryColumn(NULL, 'seqtable', 'geom', 4326, 'GEOMETRY', 2)");
+        run("CREATE SEQUENCE pksequence START WITH 1");
+
+        run(
+                "INSERT INTO \"seqtable\" (\"key\", \"name\",\"geom\" ) VALUES ("
+                        + "(SELECT NEXTVAL('pksequence')),'one',NULL)");
+        run(
+                "INSERT INTO \"seqtable\" (\"key\", \"name\",\"geom\" ) VALUES ("
+                        + "(SELECT NEXTVAL('pksequence')),'two',NULL)");
+        run(
+                "INSERT INTO \"seqtable\" (\"key\", \"name\",\"geom\" ) VALUES ("
+                        + "(SELECT NEXTVAL('pksequence')),'three',NULL)");
+
+        run(
+                "INSERT INTO tbl_gt_pk_metadata VALUES"
+                        + "(NULL, 'seqtable', 'key', 0, 'sequence', 'pksequence')");
+    }
+
+    @Override
+    protected void dropSequencedPrimaryKeyTable() throws Exception {
+        run("DROP TABLE \"seqtable\"");
+        run("DROP SEQUENCE pksequence");
+    }
+
+    @Override
+    protected void dropMetadataTable() throws Exception {
+        runSafe("DROP TABLE tbl_gt_pk_metadata");
+    }
+
+    @Override
+    protected void dropMetadataView() throws Exception {
+        runSafe("DROP VIEW \"gt_pk_metadata\"");
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisPrimaryKeyFinderViewOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisPrimaryKeyFinderViewOnlineTest.java
@@ -1,0 +1,21 @@
+package org.geotools.data.postgis;
+
+import java.util.Map;
+import org.geotools.jdbc.JDBCDataStoreFactory;
+import org.geotools.jdbc.JDBCPrimaryKeyFinderViewOnlineTest;
+import org.geotools.jdbc.JDBCPrimaryKeyFinderViewTestSetup;
+
+public class PostgisPrimaryKeyFinderViewOnlineTest extends JDBCPrimaryKeyFinderViewOnlineTest {
+
+    @Override
+    protected JDBCPrimaryKeyFinderViewTestSetup createTestSetup() {
+        return new PostgisPrimaryKeyFinderViewTestSetup();
+    }
+
+    @Override
+    protected Map<String, Object> createDataStoreFactoryParams() throws Exception {
+        Map<String, Object> params = super.createDataStoreFactoryParams();
+        params.put(JDBCDataStoreFactory.PK_METADATA_TABLE.key, "gt_pk_metadata");
+        return params;
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisPrimaryKeyFinderViewTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisPrimaryKeyFinderViewTestSetup.java
@@ -1,0 +1,67 @@
+package org.geotools.data.postgis;
+
+import org.geotools.jdbc.JDBCPrimaryKeyFinderViewTestSetup;
+
+public class PostgisPrimaryKeyFinderViewTestSetup extends JDBCPrimaryKeyFinderViewTestSetup {
+
+    protected PostgisPrimaryKeyFinderViewTestSetup() {
+        super(new PostGISTestSetup());
+    }
+
+    @Override
+    protected void dropMetadataTable() throws Exception {
+        runSafe("DROP TABLE gt_pk_metadata");
+        runSafe("DROP TABLE tbl_gt_pk_metadata");
+    }
+
+    @Override
+    protected void dropMetadataView() throws Exception {
+        runSafe("DROP VIEW gt_pk_metadata");
+    }
+
+    @Override
+    protected void dropSequencedPrimaryKeyTable() throws Exception {
+        runSafe("DROP TABLE \"seqtable\"");
+        runSafe("DROP SEQUENCE pksequence");
+    }
+
+    @Override
+    protected void createMetadataTable() throws Exception {
+        run(
+                "CREATE TABLE tbl_gt_pk_metadata ( "
+                        + "table_schema VARCHAR(32), "
+                        + "table_name VARCHAR(32) NOT NULL, "
+                        + "pk_column VARCHAR(32) NOT NULL, "
+                        + "pk_column_idx INTEGER, "
+                        + "pk_policy VARCHAR(32), "
+                        + "pk_sequence VARCHAR(64),"
+                        + "unique (table_schema, table_name, pk_column),"
+                        + "check (pk_policy in ('sequence', 'assigned', 'autoincrement')))");
+    }
+
+    @Override
+    protected void createMetadataView() throws Exception {
+        run("CREATE VIEW gt_pk_metadata AS SELECT * FROM tbl_gt_pk_metadata");
+    }
+
+    @Override
+    protected void createSequencedPrimaryKeyTable() throws Exception {
+        run("CREATE TABLE \"seqtable\" ( \"key\" integer PRIMARY KEY, " + "\"name\" VARCHAR(256))");
+        run("SELECT AddGeometryColumn('seqtable', 'geom', -1, 'GEOMETRY', 2)");
+        run("CREATE SEQUENCE pksequence START WITH 1");
+
+        run(
+                "INSERT INTO \"seqtable\" (\"key\", \"name\",\"geom\" ) VALUES ("
+                        + "(SELECT NEXTVAL('PKSEQUENCE')),'one',NULL)");
+        run(
+                "INSERT INTO \"seqtable\" (\"key\", \"name\",\"geom\" ) VALUES ("
+                        + "(SELECT NEXTVAL('PKSEQUENCE')),'two',NULL)");
+        run(
+                "INSERT INTO \"seqtable\" (\"key\", \"name\",\"geom\" ) VALUES ("
+                        + "(SELECT NEXTVAL('PKSEQUENCE')),'three',NULL)");
+
+        run(
+                "INSERT INTO tbl_gt_pk_metadata VALUES"
+                        + "(NULL, 'seqtable', 'key', 0, 'sequence', 'PKSEQUENCE')");
+    }
+}


### PR DESCRIPTION
[![GEOT-6921](https://badgen.net/badge/JIRA/GEOT-6921/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6921) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…he table gt_pk_metadata even if it doesn't exists

The previous code was blindly querying the GT_PK_METADATA table, thus resulting in error logs on the database side if the table did not exist. The new code looks at database metadata to check if the table GT_PK_METADATA exists.

# Checklist

Reviewing is a process done by project maintainers, **mostly on a volunteer basis** (thus limited in time). We need to keep the review overhead as small as possible, and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the `main` branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [x] The changes are not causing two modules to share the same Java packages (to avoid [Java 9+ split package](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed) issues)
- [x] The changes are not breaking the build in downstream projects using SNAPSHOT dependencies, GeoWebCache and GeoServer (there is an automatic PR check verifying this, check this when it turns green).

The following are required only for core and extension modules (they are welcomed, but not required, for unsupported modules):

- [x] There is an issue in [Jira](https://osgeo-org.atlassian.net/projects/GEOT) describing the bug/task/new feature (a notable exemptions is, changes not visible to end users). The ticket is for the GeoTools project, if the issue was found elsewhere it's a good practice to link to the origin ticket/issue.
- [x] The pull request contains changes related to a single objective. If multiple focuses cannot be avoided, each one is in its own commit and has a separate ticket describing it.
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message(s) must be in the form "[GEOT-XYZW] Title of the Jira ticket"
- [x] New unit tests have been added covering the changes
- [x] This PR passes all existing unit tests (test results will be reported by Continuous Integration after opening this PR)
- [x] This PR passes the [QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html) (QA checks results will be reported by Continuous Integration after opening this PR)
- [ ] Documentation has been updated accordingly.

Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.