### PR TITLE
Deadlock on concurrent WFS at start

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/XSD.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/XSD.java
@@ -183,8 +183,10 @@ public abstract class XSD {
         if (schema == null) {
             synchronized (this) {
                 if (schema == null) {
-                    LOGGER.fine("building schema for schema: " + getNamespaceURI());
-                    schema = buildSchema();
+                    synchronized (Schemas.class) {
+                        LOGGER.fine("building schema for schema: " + getNamespaceURI());
+                        schema = buildSchema();
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-10132

Simultaneous requests after geoserver starts, creates some deadlocks on getSchemas().