### PR TITLE
[GEOT-6947] Copy Constructor not adding null Locale

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/GrowableInternationalString.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/GrowableInternationalString.java
@@ -111,8 +111,7 @@ public class GrowableInternationalString extends AbstractInternationalString
                         : Stream.of(Locale.getAvailableLocales()).collect(Collectors.toSet());
         for (Locale locale : locales) {
             String value = internationalString.toString(locale);
-            if (value != null && locale != null && !value.equals(defaultValue))
-                localMap.put(locale, value);
+            if (value != null && !value.equals(defaultValue)) localMap.put(locale, value);
         }
         if (defaultValue != null) localMap.put(Locale.getDefault(), defaultValue);
     }
@@ -142,13 +141,11 @@ public class GrowableInternationalString extends AbstractInternationalString
                     }
             }
             String old = localMap.get(locale);
-            if (old != null) {
-                if (string.equals(old)) {
-                    return;
-                }
-                // TODO: provide a localized message "String value already set for locale ...".
-                throw new IllegalArgumentException();
+
+            if (string.equals(old)) {
+                return;
             }
+
             localMap.put(locale, string);
             defaultValue = null; // Will be recomputed when first needed.
         }

--- a/modules/library/metadata/src/main/java/org/geotools/util/GrowableInternationalString.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/GrowableInternationalString.java
@@ -142,8 +142,12 @@ public class GrowableInternationalString extends AbstractInternationalString
             }
             String old = localMap.get(locale);
 
-            if (string.equals(old)) {
-                return;
+            if (old != null) {
+                if (string.equals(old)) {
+                    return;
+                }
+                // TODO: provide a localized message "String value already set for locale ...".
+                throw new IllegalArgumentException();
             }
 
             localMap.put(locale, string);

--- a/modules/library/metadata/src/test/java/org/geotools/util/GrowableInternationalStringTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/GrowableInternationalStringTest.java
@@ -29,7 +29,7 @@ public class GrowableInternationalStringTest {
 
     @Test
     public void testEmptyLanguage() {
-               GrowableInternationalString toCopy = new GrowableInternationalString();
+        GrowableInternationalString toCopy = new GrowableInternationalString();
         toCopy.add(Locale.ENGLISH, "english text");
         toCopy.add(null, "default text");
         GrowableInternationalString newGrowable = new GrowableInternationalString(toCopy);

--- a/modules/library/metadata/src/test/java/org/geotools/util/GrowableInternationalStringTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/GrowableInternationalStringTest.java
@@ -26,4 +26,15 @@ public class GrowableInternationalStringTest {
         assertEquals("testo italiano", newGrowable.toString(Locale.ITALIAN));
         assertEquals("texte français", newGrowable.toString(Locale.FRENCH));
     }
+
+    @Test
+    public void testEmptyLanguage() {
+               GrowableInternationalString toCopy = new GrowableInternationalString();
+        toCopy.add(Locale.ENGLISH, "english text");
+        toCopy.add(null, "default text");
+        GrowableInternationalString newGrowable = new GrowableInternationalString(toCopy);
+        assertEquals(2, newGrowable.getLocales().size());
+        assertEquals("english text", newGrowable.toString(Locale.ENGLISH));
+        assertEquals("default text", newGrowable.toString(null));
+    }
 }


### PR DESCRIPTION
[![GEOT-6947](https://badgen.net/badge/JIRA/GEOT-6947/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6947) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This pull request adds the possibility to have a null value to copy constructor.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->