### PR TITLE
[GEOT-6949] CropCoverage should retain the ROI information (25.x backport)

### DIFF
--- a/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/CropCoverage.java
+++ b/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/CropCoverage.java
@@ -22,9 +22,11 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.processing.CoverageProcessor;
 import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.image.ImageWorker;
 import org.geotools.process.factory.DescribeParameter;
 import org.geotools.process.factory.DescribeProcess;
 import org.geotools.process.factory.DescribeResult;
+import org.geotools.util.factory.Hints;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.opengis.parameter.ParameterValueGroup;
@@ -79,6 +81,10 @@ public class CropCoverage implements RasterProcess {
         param.parameter("Envelope").setValue(bounds);
         param.parameter("ROI").setValue(roi);
 
-        return (GridCoverage2D) PROCESSOR.doOperation(param);
+        Hints hints = null;
+        if (new ImageWorker(coverage.getRenderedImage()).getNoData() == null)
+            hints = new Hints(ImageWorker.FORCE_MOSAIC_ROI_PROPERTY, true);
+
+        return (GridCoverage2D) PROCESSOR.doOperation(param, hints);
     }
 }

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/CropCoverageTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/CropCoverageTest.java
@@ -1,0 +1,91 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.process.raster;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.awt.Image;
+import java.awt.image.RenderedImage;
+import java.io.File;
+import java.io.IOException;
+import javax.media.jai.ROI;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.coverage.grid.io.GridFormatFinder;
+import org.geotools.image.jai.Registry;
+import org.geotools.test.TestData;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.WKTReader;
+import org.opengis.coverage.grid.GridCoverageReader;
+
+public class CropCoverageTest {
+
+    private static GridCoverage2D gray;
+    private static GridCoverage2D current;
+
+    @BeforeClass
+    public static void readCoverages() throws Exception {
+        // read a simple 1 band gray image, no ROI, no NODATA
+        // Disable medialib
+        System.setProperty("com.sun.media.jai.disableMediaLib", "true");
+        // Disable bandmerge and mosaic native operation
+        Registry.setNativeAccelerationAllowed("BandMerge", false);
+        Registry.setNativeAccelerationAllowed("Mosaic", false);
+        // First file selection
+        gray = readCoverage(TestData.file(CropCoverageTest.class, "sample.tif"));
+        current = readCoverage(TestData.file(CropCoverageTest.class, "current.tif"));
+    }
+
+    private static GridCoverage2D readCoverage(File input) throws IOException {
+        AbstractGridFormat format = GridFormatFinder.findFormat(input);
+        // Get a reader for the selected format
+        GridCoverageReader reader = format.getReader(input);
+        try {
+            // Read the simple gray image
+            return (GridCoverage2D) reader.read(null);
+            // Reader disposal
+        } finally {
+            reader.dispose();
+        }
+    }
+
+    @Test
+    public void testROI() throws Exception {
+        CropCoverage cc = new CropCoverage();
+        // a small triangle
+        Geometry roi =
+                new WKTReader().read("POLYGON((8.91 47.10, 8.92 47.10, 8.92 47.11, 8.91 47.10))");
+        GridCoverage2D result = cc.execute(gray, roi, null);
+        RenderedImage ri = result.getRenderedImage();
+        assertThat(ri.getProperty("ROI"), instanceOf(ROI.class));
+    }
+
+    @Test
+    public void testNoData() throws Exception {
+        CropCoverage cc = new CropCoverage();
+        // a small triangle
+        Geometry roi = new WKTReader().read("POLYGON((0 0, 16 0, 16 16, 0 0))");
+        GridCoverage2D result = cc.execute(current, roi, null);
+        RenderedImage ri = result.getRenderedImage();
+        // there is NODATA, no need for a ROI too
+        assertEquals(Image.UndefinedProperty, ri.getProperty("ROI"));
+    }
+}


### PR DESCRIPTION
[![GEOT-6949](https://badgen.net/badge/JIRA/GEOT-6949/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6949) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->