### PR TITLE
[GEOT-6962] GeoPkg: use correct value for constraint_type when writing a range constraint.

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgSchemaExtension.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgSchemaExtension.java
@@ -231,6 +231,12 @@ public class GeoPkgSchemaExtension extends GeoPkgExtension {
         }
     }
 
+    public void addConstraint(DataColumnConstraint constraint) throws SQLException {
+        try (Connection cx = geoPackage.connPool.getConnection()) {
+            addConstraint(cx, constraint);
+        }
+    }
+
     public void addConstraint(Connection cx, DataColumnConstraint constraint) throws SQLException {
         String constraintName = constraint.getName();
         String sql =

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgSchemaExtension.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgSchemaExtension.java
@@ -269,7 +269,7 @@ public class GeoPkgSchemaExtension extends GeoPkgExtension {
             NumberRange range = rangeConstraint.getRange();
             try (PreparedStatement ps = cx.prepareStatement(sql)) {
                 ps.setString(1, constraintName);
-                ps.setString(2, "glob");
+                ps.setString(2, "range");
                 ps.setString(3, null);
                 ps.setDouble(4, range.getMinimum());
                 ps.setBoolean(5, range.isMinIncluded());

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -76,6 +76,7 @@ import org.geotools.jdbc.util.SqlUtil;
 import org.geotools.parameter.Parameter;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.util.NumberRange;
 import org.geotools.util.URLs;
 import org.geotools.util.factory.Hints;
 import org.junit.After;
@@ -1019,10 +1020,7 @@ public class GeoPackageTest {
     @Test
     public void testMetadata() throws Exception {
         // create a geopacakge from a shapefile
-        ShapefileDataStore shp = new ShapefileDataStore(setUpShapefile());
-        FeatureEntry entry = new FeatureEntry();
-        geopkg.add(entry, shp.getFeatureSource(), null);
-        assertTableExists("bugsites");
+        createBugSites();
 
         // grab the metadata extension, check it's initially empty
         GeoPkgMetadataExtension ext = geopkg.getExtension(GeoPkgMetadataExtension.class);
@@ -1057,11 +1055,7 @@ public class GeoPackageTest {
 
     @Test
     public void testMetadataReferences() throws Exception {
-        // create a geopacakge from a shapefile
-        ShapefileDataStore shp = new ShapefileDataStore(setUpShapefile());
-        FeatureEntry entry = new FeatureEntry();
-        geopkg.add(entry, shp.getFeatureSource(), null);
-        assertTableExists("bugsites");
+        createBugSites();
 
         // grab the metadata extension and add a couple of metadata entries
         GeoPkgMetadataExtension ext = geopkg.getExtension(GeoPkgMetadataExtension.class);
@@ -1105,5 +1099,28 @@ public class GeoPackageTest {
         // clean up
         ext.removeReference(reference);
         assertEquals(0, ext.getReferences(metadata).size());
+    }
+
+    @Test
+    public void testRangeExtension() throws Exception {
+        createBugSites();
+
+        // grab the metadata extension and add a couple of metadata entries
+        GeoPkgSchemaExtension ext = geopkg.getExtension(GeoPkgSchemaExtension.class);
+        String constraintName = "oneToTen";
+        DataColumnConstraint.Range<Double> range =
+                new DataColumnConstraint.Range<>(constraintName, NumberRange.create(1d, 10d));
+        ext.addConstraint(range);
+
+        DataColumnConstraint constraint = ext.getConstraint(constraintName);
+        assertEquals(range, constraint);
+    }
+
+    private void createBugSites() throws Exception {
+        // create a geopackage from a shapefile
+        ShapefileDataStore shp = new ShapefileDataStore(setUpShapefile());
+        FeatureEntry entry = new FeatureEntry();
+        geopkg.add(entry, shp.getFeatureSource(), null);
+        assertTableExists("bugsites");
     }
 }


### PR DESCRIPTION
[![GEOT-6962](https://badgen.net/badge/JIRA/GEOT-6962/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6962) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->