### PR TITLE
[Backport 25.x] [GEOT-6959] SimpleHttpClient does support proxy (#3606)

### DIFF
--- a/modules/library/http/src/main/java/org/geotools/http/SimpleHttpClient.java
+++ b/modules/library/http/src/main/java/org/geotools/http/SimpleHttpClient.java
@@ -36,7 +36,7 @@ import org.geotools.util.logging.Logging;
  *
  * @author groldan
  */
-public class SimpleHttpClient implements HTTPClient {
+public class SimpleHttpClient implements HTTPClient, HTTPProxy {
 
     private static final Logger LOGGER = Logging.getLogger(SimpleHttpClient.class);
 

--- a/modules/library/http/src/test/java/org/geotools/http/HTTPClientFinderTest.java
+++ b/modules/library/http/src/test/java/org/geotools/http/HTTPClientFinderTest.java
@@ -108,8 +108,7 @@ public class HTTPClientFinderTest {
     }
 
     /**
-     * Test that a HTTPProxy behavior is added when http.proxyhost is set. And that it ends with a
-     * HTTPFactoryException, because SimpleHttpClient doesn't support it. In support of GEOT-6850.
+     * Test that a HTTPProxy behavior is added when http.proxyhost is set. In support of GEOT-6850.
      */
     @Test
     public void createClientWithSystemProxyHost() throws Exception {
@@ -118,10 +117,8 @@ public class HTTPClientFinderTest {
             System.setProperty("http.proxyHost", "http://proxy.dummy/");
         }
         try {
-            HTTPClientFinder.createClient(HTTPProxy.class);
-            Assert.fail("Should throw HTTPFactoryException exception.");
-        } catch (HTTPFactoryException e) {
-            // Check message?
+            HTTPClient client = HTTPClientFinder.createClient(HTTPProxy.class);
+            assertTrue(client instanceof SimpleHttpClient);
         } finally {
             if (nullInitially) {
                 System.clearProperty("http.proxyHost");


### PR DESCRIPTION
[![GEOT-6959](https://badgen.net/badge/JIRA/GEOT-6959/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6959) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* [GEOT-6959] SimpleHttpClient does support proxy

Backport to 25.x

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->