### PR TITLE
[GEOT-6944] Deadlock at org.geotools.xsd.XSD.getSchema

### DIFF
--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/SchemasDeadLockTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/SchemasDeadLockTest.java
@@ -1,0 +1,80 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.wfs.v1_1;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.eclipse.xsd.XSDSchema;
+import org.geotools.filter.v1_1.OGC;
+import org.geotools.gml3.GML;
+import org.geotools.xsd.XSD;
+import org.geotools.xsd.ows.OWS;
+import org.junit.Test;
+
+/**
+ * Tests showing deadlock in loading XSD schemas. Done here because it needs a number of
+ * inter-dependent XSD objects in order to manifest. This 4 are enough to make it happen most of the
+ * time on a Ryzen 1700x (8 phsycal cores, the loads actually run in parallel)
+ */
+public class SchemasDeadLockTest {
+    protected static Logger LOGGER =
+            org.geotools.util.logging.Logging.getLogger(SchemasDeadLockTest.class);
+
+    @Test
+    public void testParse() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(4);
+
+        // latch used to make the 4 threads all actually parse in parallel
+        CountDownLatch threadCreationLatch = new CountDownLatch(1);
+
+        // 4 inter-dependent schemas (WFS -> OGC -> GML and WFS -> OWS)
+        executorService.submit(new XSDSchemaFetcher(threadCreationLatch, GML.getInstance()));
+        executorService.submit(new XSDSchemaFetcher(threadCreationLatch, OGC.getInstance()));
+        executorService.submit(new XSDSchemaFetcher(threadCreationLatch, WFS.getInstance()));
+        executorService.submit(new XSDSchemaFetcher(threadCreationLatch, OWS.getInstance()));
+
+        // releasing the schema building for good
+        threadCreationLatch.countDown();
+        executorService.shutdown();
+        assertTrue(
+                "Waited too long for termination, deadlock likely",
+                executorService.awaitTermination(20, TimeUnit.SECONDS));
+    }
+
+    public class XSDSchemaFetcher implements Callable<XSDSchema> {
+
+        private XSD xsd;
+        private CountDownLatch threadCreationLatch;
+
+        XSDSchemaFetcher(CountDownLatch threadCreationLatch, XSD xsd) {
+            this.threadCreationLatch = threadCreationLatch;
+            this.xsd = xsd;
+        }
+
+        @Override
+        public XSDSchema call() throws Exception {
+            threadCreationLatch.await();
+            return xsd.getSchema();
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-6944](https://badgen.net/badge/JIRA/GEOT-6944/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6944) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Supercedes https://github.com/geotools/geotools/pull/3583

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->