### PR TITLE
[GEOT-6960] Amend condition in which force decimals will be applied

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/gml/producer/CoordinateFormatter.java
+++ b/modules/library/xml/src/main/java/org/geotools/gml/producer/CoordinateFormatter.java
@@ -124,9 +124,9 @@ public final class CoordinateFormatter {
         //  e.g. if we want 8 decimals: 3.123456786 * 10E8 = 312345678.6
         double scaled = x * scale;
         // add 0.5 to round the decimal part, e.g 312345678.6 + 0.5 = 312345679.1
-        scaled += 0.5;
+        scaled += Math.signum(x) * 0.5;
         // take only the decimal part, e.g.  312345679
-        scaled = Math.floor(scaled);
+        scaled = Math.signum(x) < 0 ? Math.ceil(scaled) : Math.floor(scaled);
         // remove the scale factor, the number will now have the desired number of decimals
         return scaled / scale;
     }

--- a/modules/library/xml/src/test/java/org/geotools/gml/producer/CoordinateFormatterTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/gml/producer/CoordinateFormatterTest.java
@@ -52,6 +52,15 @@ public class CoordinateFormatterTest {
         formatter.setMaximumFractionDigits(3);
         formatter.setPadWithZeros(true);
         Assert.assertEquals("0.000", formatter.format(0.00001));
+
+        formatter.setPadWithZeros(false);
+        formatter.setForcedDecimal(true);
+        Assert.assertEquals("-0.001", formatter.format(-0.000623D));
+        Assert.assertEquals("0.001", formatter.format(0.000623D));
+        // it is expected that this path returns different results
+        formatter.setForcedDecimal(false);
+        Assert.assertEquals("-6.23E-4", formatter.format(-0.000623D));
+        Assert.assertEquals("6.23E-4", formatter.format(0.000623D));
     }
 
     @Test
@@ -73,6 +82,23 @@ public class CoordinateFormatterTest {
         formatter.setForcedDecimal(true);
         Assert.assertEquals("2139681400.12346", formatter.format(2139681400.123456));
         Assert.assertEquals("-2139681400.12346", formatter.format(-2139681400.123456));
+    }
+
+    @Test
+    public void testTruncate() {
+        CoordinateFormatter formatter = new CoordinateFormatter(1);
+        // Assert.assertEquals(expected,actual,delta)
+        Assert.assertEquals(0D, formatter.truncate(0D), 0D);
+        Assert.assertEquals(0D, formatter.truncate(-0D), 0D);
+        Assert.assertEquals(0.1D, formatter.truncate(0.123D), 0D);
+        Assert.assertEquals(-0.1D, formatter.truncate(-0.123D), 0D);
+        Assert.assertEquals(0.6D, formatter.truncate(0.647D), 0D);
+        Assert.assertEquals(-0.6D, formatter.truncate(-0.647D), 0D);
+        // despite the name "truncate", it rounds up above 0, down below 0
+        Assert.assertEquals(0.7D, formatter.truncate(0.657D), 0D);
+        Assert.assertEquals(-0.7D, formatter.truncate(-0.657D), 0D);
+        Assert.assertEquals(1.0D, formatter.truncate(0.999D), 0D);
+        Assert.assertEquals(-1.0D, formatter.truncate(-0.999D), 0D);
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-6960](https://badgen.net/badge/JIRA/GEOT-6960/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6960) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I submitted a patch earlier, which was [deficient](https://github.com/geotools/geotools/pull/3607#discussion_r692428442), I believe, because it always rounded towards positive infinity.  This version rounds down below 0, and up above 0.  I added a unit test to demonstrate the updated behaviour of the truncate(double x) method.

cc @jodygarnett 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).