### PR TITLE
[Backport 25.x]Updating to imageio-ext 1.3.10 for ZSTD decompression support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
     <test.forkMode>once</test.forkMode>
     <test.args></test.args>
     <src.output>${basedir}/target</src.output>
-    <imageio.ext.version>1.3.9</imageio.ext.version>
+    <imageio.ext.version>1.3.10</imageio.ext.version>
     <jts.version>1.18.1</jts.version>
     <jaiext.version>1.1.20</jaiext.version>
     <netcdf.version>4.6.15</netcdf.version>


### PR DESCRIPTION
[backport to 25.x]Updating to imageio-ext 1.3.10 for ZSTD support