### PR TITLE
Try to restore build on build server

### DIFF
--- a/modules/plugin/imagepyramid/src/test/java/org/geotools/gce/imagepyramid/AbstractPyramidTest.java
+++ b/modules/plugin/imagepyramid/src/test/java/org/geotools/gce/imagepyramid/AbstractPyramidTest.java
@@ -1,0 +1,61 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagepyramid;
+
+import static org.apache.commons.io.filefilter.FileFilterUtils.and;
+import static org.apache.commons.io.filefilter.FileFilterUtils.nameFileFilter;
+import static org.apache.commons.io.filefilter.FileFilterUtils.notFileFilter;
+import static org.apache.commons.io.filefilter.FileFilterUtils.or;
+import static org.apache.commons.io.filefilter.FileFilterUtils.suffixFileFilter;
+
+import java.io.File;
+import java.io.FileFilter;
+import org.geotools.referencing.CRS;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class AbstractPyramidTest {
+    protected static final Double DELTA = 1E-6;
+
+    @BeforeClass
+    public static void init() {
+        System.setProperty("org.geotools.referencing.forceXY", "true");
+        CRS.reset("all");
+    }
+
+    @AfterClass
+    public static void close() {
+        System.clearProperty("org.geotools.referencing.forceXY");
+        CRS.reset("all");
+    }
+
+    protected void cleanFiles(File mosaicFolder) {
+        FileFilter filter =
+                or(
+                        suffixFileFilter("db"),
+                        suffixFileFilter("sample_image"),
+                        and(
+                                suffixFileFilter(".properties"),
+                                notFileFilter(
+                                        or(
+                                                nameFileFilter("indexer.properties"),
+                                                nameFileFilter("datastore.properties")))));
+        for (File configFile : mosaicFolder.listFiles(filter)) {
+            configFile.delete();
+        }
+    }
+}

--- a/modules/plugin/imagepyramid/src/test/java/org/geotools/gce/imagepyramid/ImageLevelsMapperTest.java
+++ b/modules/plugin/imagepyramid/src/test/java/org/geotools/gce/imagepyramid/ImageLevelsMapperTest.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.gce.imagepyramid;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.color.ColorSpace;
@@ -34,12 +37,8 @@ import org.geotools.coverage.grid.GridEnvelope2D;
 import org.geotools.coverage.grid.GridGeometry2D;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.geometry.GeneralEnvelope;
-import org.geotools.referencing.CRS;
 import org.geotools.test.TestData;
 import org.geotools.util.URLs;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.coverage.grid.GridEnvelope;
 import org.opengis.geometry.MismatchedDimensionException;
@@ -49,21 +48,7 @@ import org.opengis.parameter.ParameterValue;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 
 /** Test the resolutionLevel-to-ImageMosaicReader mapping machinery. */
-public class ImageLevelsMapperTest extends Assert {
-
-    protected static final Double DELTA = 1E-6;
-
-    @BeforeClass
-    public static void init() {
-        System.setProperty("org.geotools.referencing.forceXY", "true");
-        CRS.reset("all");
-    }
-
-    @AfterClass
-    public static void close() {
-        System.clearProperty("org.geotools.referencing.forceXY");
-        CRS.reset("all");
-    }
+public class ImageLevelsMapperTest extends AbstractPyramidTest {
 
     @Test
     public void multicoveragePyramidWithOverviews()
@@ -204,24 +189,5 @@ public class ImageLevelsMapperTest extends Assert {
     private void match(double[] expected, double[] actual) {
         assertEquals(expected[0], actual[0], DELTA);
         assertEquals(expected[1], actual[1], DELTA);
-    }
-
-    protected void cleanFiles(File mosaicFolder) {
-        for (File configFile :
-                mosaicFolder.listFiles(
-                        (FileFilter)
-                                FileFilterUtils.or(
-                                        FileFilterUtils.suffixFileFilter("db"),
-                                        FileFilterUtils.suffixFileFilter("sample_image"),
-                                        FileFilterUtils.and(
-                                                FileFilterUtils.suffixFileFilter(".properties"),
-                                                FileFilterUtils.notFileFilter(
-                                                        FileFilterUtils.or(
-                                                                FileFilterUtils.nameFileFilter(
-                                                                        "indexer.properties"),
-                                                                FileFilterUtils.nameFileFilter(
-                                                                        "datastore.properties"))))))) {
-            configFile.delete();
-        }
     }
 }

--- a/modules/plugin/imagepyramid/src/test/java/org/geotools/gce/imagepyramid/ImagePyramidReaderTest.java
+++ b/modules/plugin/imagepyramid/src/test/java/org/geotools/gce/imagepyramid/ImagePyramidReaderTest.java
@@ -16,6 +16,12 @@
  */
 package org.geotools.gce.imagepyramid;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Rectangle;
@@ -67,7 +73,7 @@ import org.opengis.referencing.NoSuchAuthorityCodeException;
  *     and referenced by URLs
  * @since 2.3
  */
-public class ImagePyramidReaderTest extends ImageLevelsMapperTest {
+public class ImagePyramidReaderTest extends AbstractPyramidTest {
 
     /** File to be used for testing purposes. */
     private static final String TEST_FILE = "pyramid.properties";


### PR DESCRIPTION
The tests in image pyramid are failing on build.geoserver.org. The test that's failing is in a base class, and ends up running multiple times. One of them, it fails. Refactored the code so that it gets run only once instead.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->