### PR TITLE
Double check links on website and index page

### DIFF
--- a/docs/build.xml
+++ b/docs/build.xml
@@ -42,10 +42,10 @@
 	</target>
 
 	<target name="index" depends="init">
-		<antcall target="sphinx-ignore-warnings">
+		<antcall target="sphinx">
 			<param name="id" value="index"/>
 			<param name="build" value="html"/>
-		</antcall>	
+		</antcall>
 	</target>
 
 	<target name="user" depends="init">

--- a/docs/common.py
+++ b/docs/common.py
@@ -28,10 +28,11 @@ extensions = ['sphinx.ext.todo','sphinx.ext.extlinks']
 
 extlinks = { 
     'wiki': ('https://github.com/geotools/geotools/wiki/%s',''),
-    'website': ('http://geotools.org/%s',''),
-    'geoserver': ('http://docs.geoserver.org/latest/en/user/%s',''),
-    'developer': ('http://docs.geotools.org/latest/developer/%s',''),
-    'user': ('http://docs.geotools.org/latest/userguide/%s',''),
+    'website': ('https://geotools.org/%s',''),
+    'geoserver': ('https://docs.geoserver.org/latest/en/user/%s',''),
+    'developer': ('https://docs.geotools.org/latest/developer/%s',''),
+    'user': ('https://docs.geotools.org/latest/userguide/%s',''),
+    'api': ('https://docs.geotools.org/latest/javadocs',''),
     'geot': ('https://osgeo-org.atlassian.net/browse/GEOT-%s','GEOT-')
 }
 

--- a/docs/index/index.rst
+++ b/docs/index/index.rst
@@ -3,48 +3,53 @@ GeoTools Documentation
 
 Quickstart to get up and running with GeoTools in minutes:
 
-* `Eclipse Quickstart <http://docs.geotools.org/latest/userguide/tutorial/quickstart/eclipse.html>`_ ( `stable <http://docs.geotools.org/stable/tutorials/quickstart/eclipse.html>`_ )
-* `NetBeans Quickstart <http://docs.geotools.org/latest/userguide/tutorial/quickstart/netbeans.html>`_ ( `stable <http://docs.geotools.org/stable/tutorials/quickstart/netbeans.html>`_ )
-* `Maven command line Quickstart <http://docs.geotools.org/latest/userguide/tutorial/quickstart/maven.html>`_ 
+* :user:`Eclipse Quickstart <tutorial/quickstart/eclipse.html>`
+  ( `stable <https://docs.geotools.org/stable/userguide/tutorial/quickstart/eclipse.html>`__
+  | `maintenance <https://docs.geotools.org/maintenance/userguide/tutorial/quickstart/eclipse.html>`__ )
+* :user:`NetBeans Quickstart <tutorial/quickstart/netbeans.html>`
+  ( `stable <https://docs.geotools.org/stable/userguide/tutorial/quickstart/netbeans.html>`__
+  | `maintenance <https://docs.geotools.org/maintenance/userguide/tutorial/quickstart/netbeans.html>`__ )
+* :user:`Maven command line Quickstart <tutorial/quickstart/maven.html>`
+  ( `stable <https://docs.geotools.org/stable/userguide/tutorial/quickstart/maven.html>`__
+  | `maintenance <https://docs.geotools.org/maintenance/userguide/tutorial/quickstart/maven.html>`__ )
 
 GeoTools API
 ------------
 
-GeoTools javadocs are `available online <http://docs.geotools.org/latest/javadocs/>`_ ( `stable <http://docs.geotools.org/stable/javadocs/>`_ )
-or `download <http://sourceforge.net/projects/geotools/files/>`_ them as a zip file.
+GeoTools javadocs are :api:`available online <>` ( `stable <https://docs.geotools.org/stable/javadocs/>`__ ) zip file `download <http://sourceforge.net/projects/geotools/files/>`_ download.
 
 User Guide
 ----------
 
-The GeoTools user guide is available online:
+The GeoTools User Guide is available online:
 
-`User Guide <http://docs.geotools.org/latest/userguide/>`_ ( `stable <http://docs.geotools.org/stable/userguide/>`_ | `maintenance <http://docs.geotools.org/maintenance/userguide/>`_ )
+:user:`User Guide <>` ( `stable <https://docs.geotools.org/stable/userguide/>`__ | `maintenance <https://docs.geotools.org/maintenance/userguide/>`__ )
     Tutorials, module reference and examples illustrating the uses of GeoTools. Updated with
     build instructions and advanced tutorials and integration instructions.
     
-    The user guide is available for `download <http://sourceforge.net/projects/geotools/files/>`_
+    The user guide is available for `download <http://sourceforge.net/projects/geotools/files/>`__
     as a zip file.
        
-`Tutorials <http://docs.geotools.org/latest/userguide/tutorial/>`_ ( `stable <http://docs.geotools.org/stable/userguide/tutorial/>`_ | `maintenance <http://docs.geotools.org/maintenance/userguide/tutorial/>`_ )
+:user:`Tutorials <tutorial/>` ( `stable <https://docs.geotools.org/stable/userguide/tutorial/>`__ | `maintenance <https://docs.geotools.org/maintenance/userguide/tutorial/>`__ )
     Step by step tutorials introducing both GeoTools and geospatial concepts for Java developers.
 
-`FAQ <http://docs.geotools.org/latest/userguide/faq.html>`_ ( `stable <http://docs.geotools.org/stable/userguide/faq.html>`_ | `maintenance <http://docs.geotools.org/maintenance/userguide/faq.html>`_ )
+:user:`FAQ <faq.html>` ( `stable <https://docs.geotools.org/stable/userguide/faq.html>`__ | `maintenance <https://docs.geotools.org/maintenance/userguide/faq.html>`__ )
     Convey wisdom gleaned from the GeoTools user list.
 
 Developing GeoTools
 -------------------
 
-See the `Get Involved <http://geotools.org/getinvolved.html>`_ page for the `Developer's Guide <http://docs.geotools.org/latest/developer/index.html>`_ ,
+See the :website:`Get Involved <getinvolved.html>` page for the :developer:`Developer's Guide <>`,
 issue tracker and information on joining the GeoTools community.
 
-**For the impatient**, please read at least the `contributor guidelines <http://docs.geotools.org/latest/developer/roles/contributor.html>`_ before start working
-on your code contributions to the project.
+**For the impatient**, please read at least the :developer:`contributor guidelines <roles/contributor.html>` before starting work
+on code contributions to the project.
 
 Welcome Developers
 ------------------
 
 We would like to welcome developers from the following GeoTools powered projects.
 
-`Geomajas <http://docs.geotools.org/latest/userguide/welcome/geomajas.html>`_
-`GeoServer <http://docs.geotools.org/latest/userguide/welcome/geoserver.html>`_ 
-`uDig <http://docs.geotools.org/latest/userguide/welcome/udig.html>`_ 
+:user:`Geomajas <welcome/geomajas.html>`
+:user:`GeoServer <welcome/geoserver.html>`
+:user:`uDig <welcome/udig.html>`

--- a/docs/index/index.rst
+++ b/docs/index/index.rst
@@ -16,7 +16,7 @@ Quickstart to get up and running with GeoTools in minutes:
 GeoTools API
 ------------
 
-GeoTools javadocs are :api:`available online <>` ( `stable <https://docs.geotools.org/stable/javadocs/>`__ ) zip file `download <http://sourceforge.net/projects/geotools/files/>`_ download.
+GeoTools javadocs are :api:`available online <>` ( `stable <https://docs.geotools.org/stable/javadocs/>`__ ) zip file `download <https://sourceforge.net/projects/geotools/files/>`_ download.
 
 User Guide
 ----------
@@ -27,7 +27,7 @@ The GeoTools User Guide is available online:
     Tutorials, module reference and examples illustrating the uses of GeoTools. Updated with
     build instructions and advanced tutorials and integration instructions.
     
-    The user guide is available for `download <http://sourceforge.net/projects/geotools/files/>`__
+    The user guide is available for `download <https://sourceforge.net/projects/geotools/files/>`__
     as a zip file.
        
 :user:`Tutorials <tutorial/>` ( `stable <https://docs.geotools.org/stable/userguide/tutorial/>`__ | `maintenance <https://docs.geotools.org/maintenance/userguide/tutorial/>`__ )

--- a/docs/web/about.rst
+++ b/docs/web/about.rst
@@ -8,36 +8,34 @@ compliant methods for the manipulation of geospatial data, for example to
 implement Geographic Information Systems (GIS). The GeoTools library implements
 Open Geospatial Consortium (OGC) specifications as they are developed.
 
-For an overview of the capabilities of GeoTools please check the User Guide 
-`feature list <http://docs.geotools.org/latest/userguide/geotools.html>`_.
+For an overview of the capabilities of GeoTools please check the User Guide :user:`feature list <geotools.html>`.
 
-Current `version <http://docs.geotools.org/latest/developer/conventions/version.html>`_ information:
+Current :developer:`version <conventions/version.html>` information:
 
-* `13.x <http://sourceforge.net/projects/geotools/files/GeoTools%2013%20Releases/>`_: Development
-* `12.x <http://sourceforge.net/projects/geotools/files/GeoTools%2012%20Releases/>`_: Stable
-* `11.x <http://sourceforge.net/projects/geotools/files/GeoTools%2011%20Releases/>`_: Maintenance
+* `27.x <http://sourceforge.net/projects/geotools/files/GeoTools%2027%20Releases/>`__: Development
+* `26.x <http://sourceforge.net/projects/geotools/files/GeoTools%2026%20Releases/>`__: Stable
+* `25.x <http://sourceforge.net/projects/geotools/files/GeoTools%2025%20Releases/>`__: Maintenance
 
-GeoTools is used by a `number of projects <https://github.com/geotools/geotools/wiki/screenshots>`_
+GeoTools is used by a `number of projects <https://github.com/geotools/geotools/wiki/screenshots>`__
 including Web Feature Servers, Web Map Servers, and desktop applications.
 
 Open Source
 -----------
 
-GeoTools is proud to be one of the original founding projects for the 
-`Open Source Geospatial Foundation <http://osgeo.org>`_. The foundation holds
+GeoTools is proud to be one of the original founding projects of the 
+`Open Source Geospatial Foundation <https://osgeo.org>`__. The foundation holds
 the copyright on the library and is a wonderful source of assistance and
 community spirit for our project. The GeoTools library is made available under
-the `LGPL <http://www.gnu.org/licenses/lgpl-2.1.html>`_ license. The source code
+the `LGPL <https://www.gnu.org/licenses/lgpl-2.1.html>`_ license. The source code
 is freely available in a public 
 `GIT repository <https://github.com/geotools/geotools>`_.
 
 Open Development
 ----------------
 
-If your organization is making use of GeoTools we invite you to help set the
-release schedule. Please contact us on the 
-`developers mailing list <http://sourceforge.net/mail/?group_id=4091>`_.
+If your organization is making use of GeoTools we invite you to participate directly. Sign up to the 
+`developers mailing list <http://sourceforge.net/mail/?group_id=4091>`_ for details on our online meetings.
 
-GeoTools follows an open development process. Our policies and procedures are
+GeoTools follows an open development process. Project policies and procedures are
 documented in the Developers Guide. Both our change proposals and 
 `issue tracker <https://osgeo-org.atlassian.net/projects/GEOT>`_ are open.

--- a/docs/web/getinvolved.rst
+++ b/docs/web/getinvolved.rst
@@ -27,7 +27,7 @@ Participation
 
 * Bug Tracker
   
-  GeoTools uses an `JIRA <https://osgeo-org.atlassian.net/projects/GEOT>`_ issue tracker to manage
+  GeoTools uses a `JIRA <https://osgeo-org.atlassian.net/projects/GEOT>`_ issue tracker to manage
   bugs, issues, and new features. If you have found a bug, or if there is a feature that you would
   like to see implemented in GeoTools, please report it in JIRA.
 

--- a/docs/web/getinvolved.rst
+++ b/docs/web/getinvolved.rst
@@ -10,34 +10,34 @@ Participation
 
 * Mailing Lists:
   
-  The  `users list <https://lists.sourceforge.net/lists/listinfo/geotools-gt2-users>`_
+  The  `users list <https://lists.sourceforge.net/lists/listinfo/geotools-gt2-users>`__
   is the place to go when you have questions about using GeoTools. Have a look at our
-  `user list posting guide <http://docs.geotools.org/latest/userguide/welcome/userlistguide.html>`_
+  :user:`user list posting guide <welcome/userlistguide.html>`
   and join in the discussion.
 
-  The `developer list <https://lists.sourceforge.net/lists/listinfo/geotools-devel>`_
-  is meant for discussions that pertaining to the actual
+  The `developer list <https://lists.sourceforge.net/lists/listinfo/geotools-devel>`__
+  is restricted to discussions that pertaining to the actual
   development of the GeoTools library. If you have a patch you would like to 
   contribute, or an issue with a plug-in you are working on, discuss it on this 
   list. This is list is also open to anyone who would like to take part in the
-  more day to day development discussion.
+  day to day development activities.
 
-  The `administration list <https://lists.sourceforge.net/lists/listinfo/geotools-administration>`_
+  The `administration list <https://lists.sourceforge.net/lists/listinfo/geotools-administration>`__
   is for the care and feeding of the GeoTools project.
 
 * Bug Tracker
   
-  GeoTools uses an issue tracker known as `JIRA <https://osgeo-org.atlassian.net/projects/GEOT>`_ to manage
+  GeoTools uses an `JIRA <https://osgeo-org.atlassian.net/projects/GEOT>`_ issue tracker to manage
   bugs, issues, and new features. If you have found a bug, or if there is a feature that you would
   like to see implemented in GeoTools, please report it in JIRA.
 
 Development
 -----------
 
-* The `developers guide <http://docs.geotools.org/latest/developer/>`_ records the
+* The :developer:`developers guide <>` records the
   policies, procedures and build environment for the GeoTools project. If you have
   questions about how the project operates this is the right place.
 
-* The developers guide outlines ways to `contribute <http://docs.geotools.org/latest/developer/procedures/contribute.html>`_ to GeoTools using patches, pull requests and starting your own module.
+* The GeoTools Developer Guide outlines ways to :developer:`contribute <procedures/contribute.html>` to the library with documentation, pull requests and starting your own community module.
 
-  If you are already experienced with GitHub please check our `pull request <http://docs.geotools.org/latest/developer/procedures/pull_requests.html>`_ page before you start.
+  If you are already experienced with GitHub please check our :developer:`pull request <procedures/pull_requests.html>` page before you start.


### PR DESCRIPTION
Signed-off-by: Jody Garnett <jody.garnett@gmail.com>

Fix some build warnings and double check index and website page links; some minor updates (such as no longer mentioning "patches" as a contribution method).  I did update the about page to list upcoming latest / stable / maintenance branches. Ideally I would like to pull this from the environment somehow.

This is a non functional documentation change so no test case has been provided.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).