### PR TITLE
Include commons-io and other required dependences in binary release bundle

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -81,6 +81,7 @@
       <include name="docs/common.py"/>
       <include name="docs/**/pom3.xml"/>
       <include name="docs/**/pom3.xml"/>
+      <include name="release/README.md"/>
       <replacefilter token="${version}" value="${release}"/>
     </replace>
   </target>

--- a/release/README.md
+++ b/release/README.md
@@ -9,14 +9,14 @@ mvn assembly:single
 To list the bin release:
 
 ```
-unzip -t release/target/gt-release-26-SNAPSHOT-bin.zip 
+unzip -t target/geotools-27-SNAPSHOT-bin.zip
 ```
 
 To test the bin release:
 
 ```
-unzip release/target/gt-release-26-SNAPSHOT-bin.zip
-java -cp "gt-release-26-SNAPSHOT/lib/*" org.geotools.util.factory.GeoTools
+unzip target/geotools-27-SNAPSHOT-bin.zip
+java -cp "geotools-27-SNAPSHOT/lib/*" org.geotools.util.factory.GeoTools
 ```
 
 For more information see [Controlling the Contents of an Assembly](https://books.sonatype.com/mvnref-book/reference/assemblies-sect-controlling-contents.html)
@@ -27,8 +27,8 @@ The binary assembly is defined using dependencySets.
 
 To add a geotools module update:
 
-* pom.xml to list the dependency
-* src/assembly/binaryDistDependency.xml to include the dependency
+* `pom.xml` to list the dependency
+* `src/assembly/binaryDistDependency.xml` to include the dependency
 
 The filters to include/exclude jars are strictly enforced:
 

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -26,10 +26,17 @@
 
   <dependencies>
     <!-- docs dependency only used to schedule release after docs module order        -->
+    <!-- uses exclusions to avoid contributing additional dependencies to release     -->
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>docs</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- please keep the list of dependencies alphabetical so it is easier to maintain -->


### PR DESCRIPTION
jars incuded explicitly as a transitive dependency from gt-docs were incorrectly being excluded from binary downoad

No documentation changes are required.

Signed-off-by: Jody Garnett <jody.garnett@gmail.com>

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->