### PR TITLE
avoid masking common.py settings

### DIFF
--- a/docs/developer/conf.py
+++ b/docs/developer/conf.py
@@ -2,15 +2,6 @@ import sys, os
 sys.path.append(os.path.abspath('..'))
 from common import *
 
-# The suffix of source filenames.
-source_suffix = '.rst'
-
-# The encoding of source files.
-#source_encoding = 'utf-8'
-
-# The master toctree document.
-master_doc = 'index'
-
 # Options for HTML output
 # -----------------------
 

--- a/docs/user/conf.py
+++ b/docs/user/conf.py
@@ -2,22 +2,8 @@ import sys, os
 sys.path.append(os.path.abspath('..'))
 from common import *
 
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.extlinks']
-
-extlinks = {
-    'geoserver': ('http://docs.geoserver.org/latest/en/user/%s','')
-}
-
-# The suffix of source filenames.
-source_suffix = '.rst'
 
 # The encoding of source files.
-#source_encoding = 'utf-8'
-
-# The master toctree document.
-master_doc = 'index'
 
 html_title='GeoTools %s User Guide' % release
 


### PR DESCRIPTION
Noticed user guide was masking common external link settings. This is a documentation, non functional change helping sphinx-build environment to be easier to maintain.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->