### PR TITLE
Change ant target to release for build_release.sh use (previously rename)

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -3,6 +3,21 @@
   xmlns:if="ant:if" xmlns:unless="ant:unless">
   <description>
     Perform common search an replace tasks to support the release process.
+    
+    Information on the current build environment:
+       ant info
+    
+    Update code references during release:
+       ant release -Drelease='27.0'
+       
+    Update main to a new snapshot version:
+       ant latest -Drelease='28-SNAPSHOT
+       
+    Change branch from latest to stable:
+       ant stable
+       
+    Change branch from stable to maintenance:
+       ant maintenance
   </description>
   
   <macrodef name="pom-version">
@@ -46,18 +61,45 @@
       </loadfile>
     </sequential>
   </macrodef>
+
+  <macrodef name="sphinx-property">
+    <attribute name="property"/>
+    <attribute name="definition"/>
+    <attribute name="conf.file" default="../docs/common.py"/>
+    <sequential>
+      <loadfile
+        encoding="UTF-8"
+        property="@{property}"
+        srcFile="@{conf.file}" >
+        <filterchain>
+          <tokenfilter>
+            <containsregex pattern="@{definition} = '(\S*)'" replace="\1" />
+          </tokenfilter>
+          <striplinebreaks/>
+        </filterchain>
+      </loadfile>
+    </sequential>
+  </macrodef>
   
   <!-- extract build environment details -->
   <tstamp/>
   <pom-version property="version"/>
   <property name="date" value="${TODAY}"/>
   <pom-property property="series"/>
+  <!-- master_doc = 'index' -->
+  <sphinx-property property="sphinx.release" definition="release"/>
   
   <!-- review enviornment -->
   <target name="info" description="Review details of build environment.">
+     <echo>pom.xml:</echo>
      <echo>version: '${version}'</echo>
-     <echo>date: '${date}'</echo>
      <echo>series: '${series}' (used for url references)</echo>
+     <echo/>
+     <echo>sphinx-build:</echo>
+     <echo>release: '${sphinx.release}' (used as default when building docs)</echo>
+     <echo/>
+     <echo>environment:</echo>
+     <echo>date: '${date}'</echo>
      
      <echo if:set="release">release: '${release}'</echo>
      <echo unless:set="release"/>
@@ -71,6 +113,9 @@
   <!-- update environment -->
   <target name="latest"
           description="Update version when changing main to latest (requires `release` parameter for new version).">
+    <description>
+    </description>
+    <fail unless:set="release">Property 'release' required to update pom.xml</fail>
     <replace dir="..">
       <include name="**/pom.xml"/>
       <include name="**/GeoTools.java"/>
@@ -131,18 +176,23 @@
   
   <!-- update release version -->
   <target name="release"
-          description="Release updating ${release} references in code and readme for release (requires `release` and `series` parameters).">
+          description="Release updating ${release} references in code and readme for release (requires `release` parameter).">
+    <antcall target="update"/>
+    <replace file="../release/src/markdown/README.md">
+      <replacefilter token="@RELEASE@" value="${release}"/>
+      <replacefilter token="@DATE@" value="${date}"/>
+      <replacefilter token="@LINK@" value="${series}"/>
+    </replace>
+  </target>
+
+  <target name="update"
+          description="Update version references in code and documentation (requires `release` parameter)">
     <fail unless:set="release">Property 'release' required to update pom.xml</fail>
     <replace dir="..">
       <include name="**/pom.xml"/>
       <include name="**/GeoTools.java"/>
       <include name="**/common.py"/>
       <replacefilter token="${version}" value="${release}"/>
-    </replace>
-    <replace file="../release/src/markdown/README.md">
-      <replacefilter token="@RELEASE@" value="${release}"/>
-      <replacefilter token="@DATE@" value="${date}"/>
-      <replacefilter token="@LINK@" value="${series}"/>
     </replace>
   </target>
 

--- a/build/build.xml
+++ b/build/build.xml
@@ -11,7 +11,7 @@
        ant release -Drelease='27.0'
        
     Update main to a new snapshot version:
-       ant latest -Drelease='28-SNAPSHOT
+       ant latest -Drelease='28-SNAPSHOT'
        
     Change branch from latest to stable:
        ant stable

--- a/build/release/build_release.sh
+++ b/build/release/build_release.sh
@@ -135,7 +135,7 @@ git checkout -b rel_$tag $rev
 
 # update versions
 pushd build > /dev/null
-ant -f rename.xml -Drelease=$tag -Dseries=$series
+ant -f build.xml release -Drelease=$tag -Dseries=$series
 popd > /dev/null
 
 # build the release

--- a/docs/developer/procedures/release.rst
+++ b/docs/developer/procedures/release.rst
@@ -128,21 +128,21 @@ When creating the first release candidate of a series, there are some extra step
   
   For the new `stable` branch::
   
-    git checkout 26.x
+    git checkout 27.x
     git pull
-    ant -f build/build.xml latest
+    ant -f build/build.xml stable
     git add .
-    git commit -m "Change 26.x to stable branch"
-    git push geotools 26.x
+    git commit -m "Change 27.x to stable branch"
+    git push geotools 27.x
 
   For the new `maintenance` branch::
   
-    git checkout 25.x
+    git checkout 26.x
     git pull
     ant -f build/build.xml maintenance
     git add .
-    git commit -m "Change 25.x to stable branch"
-    git push geotools 25.x
+    git commit -m "Change 26.x to stable branch"
+    git push geotools 26.x
   
   This change will update the `pom.xml` series used to determine where documentation from the branch is published.
 


### PR DESCRIPTION
This change must be backported (as it contains modification to build_release.sh script).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->