### PR TITLE
[docs] fix version token substitution in upgrade doc

### DIFF
--- a/docs/user/welcome/upgrade.rst
+++ b/docs/user/welcome/upgrade.rst
@@ -5,13 +5,14 @@ With a library as old as GeoTools you will occasionally run into a project from 
 needs to be upgraded. This page collects the upgrade notes for each release change; highlighting any
 fundamental changes with code examples showing how to upgrade your code.
 
-But first to upgrade - change your dependency geotools.version to |release| (or an appropriate stable version):
+The first step to upgrade: change the ``geotools.version`` of your dependencies in your ``pom.xml`` to |release| (or an appropriate stable version):
 
-.. code-block:: xml
+.. use a parsed-literal here instead of a code-block because substitution of the RELEASE token does not work in a code-block
+.. parsed-literal::
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <geotools.version>|release|</geotools.version>
+        <geotools.version>\ |release|\ </geotools.version>
     </properties>
     ....
     <dependencies>
@@ -27,6 +28,7 @@ But first to upgrade - change your dependency geotools.version to |release| (or 
         </dependency>
         ....
     </dependencies>
+
 
 GeoTools 26.x
 -------------


### PR DESCRIPTION
use a `parsed-literal` instead of a `code-block` because substitution of the `|release|` token does not work in a `code-block` and use a whitespace escape to make the substitution work.

Before:
![before](https://user-images.githubusercontent.com/1165786/133751364-5cc4848d-0f39-4f4d-86d1-bd82e0b4143a.png)

After:
![after](https://user-images.githubusercontent.com/1165786/133751393-261768fb-d96e-4c56-a185-8b812a89243d.png)

unfortunately this looses the XML formatting, but it seems it is impossible to have both a formatted code block _and_ substitution (within that block).
see eg. https://stackoverflow.com/questions/8821511/substitutions-inside-sphinx-code-blocks-arent-replaced or https://stackoverflow.com/questions/27392934/sphinx-variable-substitution-in-code-blocks

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->