### PR TITLE
Updating nested license on GeometrySmoother to BSD-3-Clause

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometrySmoother.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometrySmoother.java
@@ -26,18 +26,26 @@
  *
  * This file is part of jai-tools.
  *
- * jai-tools is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ *  Redistribution and use in source and binary forms, with or without modification,
+ *  are permitted provided that the following conditions are met:
  *
- * jai-tools is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ *  - Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with jai-tools.  If not, see <http://www.gnu.org/licenses/>.
+ *  - Redistributions in binary form must reproduce the above copyright notice, this
+ *    list of conditions and the following disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.geotools.geometry.jts;
 


### PR DESCRIPTION
[![BSD-3](https://badgen.net/badge/JIRA/BSD-3/0052CC)](https://osgeo-org.atlassian.net/browse/BSD-3) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The GeometrySmoother.java file is derived from LGPL-3.0, which brings LGPL-3.0 into the otherwise LGPL-2.1 licensed geotools. Reviewing the history, I've identified that the code is available under BSD-3-Clause as well. This is a PR to suggest adjust the licensing of the file.

For my review, I have analyzed the 1.1.0, 1.1.1, and 1.2.0 releases made available at https://github.com/mbedward/jaitools (migrated from google code). 

The code GeometrySmoother is based on was introduced in 1.1.0 of jai-tools. It was released under LGPL-3.0. None of the four files referenced changed in 1.1.1. In 1.2.0 the files were relicensed to BSD-3-Clause. Ignoring license header changes and Java package name changes, this is the diff between the two:

```
PolygonSmoother.java
149a157
>         final int LAST = N - 1;
153c161
<         List<Coordinate> smoothCoords = new ArrayList<Coordinate>();
---
>         List<Coordinate> smoothCoords = CollectionFactory.list();
161a170,175
> 
>                 // if this was the last vertex we also need to add
>                 // the closing vertex
>                 if (i == LAST) {
>                     smoothCoords.add(new Coordinate(coords[0]));
>                 }
170c184
<                 int copyN = i < N - 1 ? segment.length - 1 : segment.length;
---
>                 int copyN = i == LAST ? segment.length : segment.length - 1;
AbstractSmoother.java
43c50
<     protected SmootherControl DEFAULT_CONTROL = new SmootherControl() {
---
>     public static final SmootherControl DEFAULT_CONTROL = new SmootherControl() {
```

Where '>' indicates changes added in 1.2.0, and '<' the code removed that was there in 1.1.1. For the analysis, my concern is on whether any expressive code was removed. The removed code equals a 'new ArrayList<Coordinate>', 'protected' statement and tweaked case-switch statement - none of this strikes me as being expressive code that copyright extends to. To my read, the version used to form GeometrySmoother is copyright equivalent to a version of the files from 1.2.0, if you remove a few new lines from 1.2.0. Therefore I believe you can relicense this.

Apologies if this offends anyone. My intent is to remove any LGPL-2.1/LGPL-3.0 compatibility concerns.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->