### PR TITLE
[GEOT-6998] MinVisitor and MaxVisitor avoid NullPointerException

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/MaxVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/MaxVisitor.java
@@ -36,7 +36,6 @@ import org.opengis.filter.expression.Expression;
 public class MaxVisitor implements FeatureCalc, FeatureAttributeVisitor {
     private Expression expr;
     Comparable maxvalue;
-    Comparable curvalue;
     boolean visited = false;
     int countNull = 0;
     int countNaN = 0;
@@ -85,7 +84,7 @@ public class MaxVisitor implements FeatureCalc, FeatureAttributeVisitor {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("rawtypes")
     public void visit(org.opengis.feature.Feature feature) {
         Object attribValue = expr.evaluate(feature);
 
@@ -102,14 +101,22 @@ public class MaxVisitor implements FeatureCalc, FeatureAttributeVisitor {
             }
         }
 
-        curvalue = (Comparable) attribValue;
+        Comparable curvalue = (Comparable) attribValue;
 
-        if ((!visited) || (curvalue.compareTo(maxvalue) > 0)) {
+        if (!visited || compare(curvalue)) {
             maxvalue = curvalue;
             visited = true;
         }
 
         // throw new IllegalStateException("Expression is not comparable!");
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private boolean compare(Comparable curvalue) {
+        if (maxvalue == null) {
+            throw new IllegalStateException("maxvalue shouldn't be null when visited = true");
+        }
+        return curvalue.compareTo(maxvalue) > 0;
     }
 
     /**
@@ -138,7 +145,7 @@ public class MaxVisitor implements FeatureCalc, FeatureAttributeVisitor {
     public void reset() {
         /** Reset the count and current maximum */
         this.visited = false;
-        this.maxvalue = Integer.valueOf(Integer.MIN_VALUE);
+        this.maxvalue = null;
         this.countNaN = 0;
         this.countNull = 0;
     }

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/MinVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/MinVisitor.java
@@ -122,7 +122,7 @@ public class MinVisitor implements FeatureCalc, FeatureAttributeVisitor {
     public void reset() {
         /** Reset the count and current minimum */
         this.visited = false;
-        this.minvalue = Integer.valueOf(0);
+        this.minvalue = null;
     }
 
     @Override

--- a/modules/library/main/src/main/java/org/geotools/feature/visitor/MinVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/visitor/MinVisitor.java
@@ -36,7 +36,6 @@ import org.opengis.filter.expression.Expression;
 public class MinVisitor implements FeatureCalc, FeatureAttributeVisitor {
     private Expression expr;
     Comparable minvalue;
-    Comparable curvalue;
     boolean visited = false;
 
     public MinVisitor(String attributeTypeName) {
@@ -83,7 +82,7 @@ public class MinVisitor implements FeatureCalc, FeatureAttributeVisitor {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("rawtypes")
     public void visit(org.opengis.feature.Feature feature) {
         Object attribValue = expr.evaluate(feature);
 
@@ -91,11 +90,19 @@ public class MinVisitor implements FeatureCalc, FeatureAttributeVisitor {
             return; // attribute is null, therefore skip
         }
 
-        curvalue = (Comparable) attribValue;
-        if ((!visited) || (curvalue.compareTo(minvalue) < 0)) {
+        Comparable curvalue = (Comparable) attribValue;
+        if (!visited || compare(curvalue)) {
             minvalue = curvalue;
             visited = true;
         }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private boolean compare(Comparable curvalue) {
+        if (minvalue == null) {
+            throw new IllegalStateException("minvalue shouldn't be null when visiting = true.");
+        }
+        return curvalue.compareTo(minvalue) < 0;
     }
 
     /**

--- a/modules/library/main/src/test/java/org/geotools/feature/visitor/MaxVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/visitor/MaxVisitorTest.java
@@ -1,0 +1,65 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.feature.visitor;
+
+import org.geotools.data.memory.MemoryFeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+/**
+ * Testing MaxVisitor
+ *
+ * @author Roar Brænden
+ */
+public class MaxVisitorTest {
+
+    private static SimpleFeatureType SCHEMA;
+
+    static {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("Test");
+        builder.add("AInteger", Integer.class);
+        SCHEMA = builder.buildFeatureType();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void visitedFlagSetWithoutValue() throws Exception {
+
+        final MemoryFeatureCollection collection = new MemoryFeatureCollection(SCHEMA);
+        collection.add(SimpleFeatureBuilder.build(SCHEMA, new Object[] {1}, "1"));
+
+        final MaxVisitor falseVisitor = new PreVisitedMaxVisitor("AInteger");
+        try {
+            collection.accepts(falseVisitor, null);
+        } catch (Exception e) {
+            while (e.getCause() != null) {
+                e = (Exception) e.getCause();
+            }
+            throw e;
+        }
+    }
+
+    /** A MaxVisitor that set's visitied without maxvalue being set. */
+    private class PreVisitedMaxVisitor extends MaxVisitor {
+        PreVisitedMaxVisitor(String attribute) {
+            super(attribute);
+            this.visited = true;
+        }
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/feature/visitor/MaxVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/visitor/MaxVisitorTest.java
@@ -19,6 +19,7 @@ package org.geotools.feature.visitor;
 import org.geotools.data.memory.MemoryFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.Assert;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeatureType;
 
@@ -35,6 +36,7 @@ public class MaxVisitorTest {
         SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
         builder.setName("Test");
         builder.add("AInteger", Integer.class);
+        builder.add("ALong", Long.class);
         SCHEMA = builder.buildFeatureType();
     }
 
@@ -42,7 +44,7 @@ public class MaxVisitorTest {
     public void visitedFlagSetWithoutValue() throws Exception {
 
         final MemoryFeatureCollection collection = new MemoryFeatureCollection(SCHEMA);
-        collection.add(SimpleFeatureBuilder.build(SCHEMA, new Object[] {1}, "1"));
+        collection.add(SimpleFeatureBuilder.build(SCHEMA, new Object[] {1, 0}, "1"));
 
         final MaxVisitor falseVisitor = new PreVisitedMaxVisitor("AInteger");
         try {
@@ -53,6 +55,22 @@ public class MaxVisitorTest {
             }
             throw e;
         }
+    }
+
+    /** Check's that maxValue is set to null, and not a presumably low number. */
+    @Test
+    public void resetCallWillNullify() throws Exception {
+        final MemoryFeatureCollection collection = new MemoryFeatureCollection(SCHEMA);
+        collection.add(
+                SimpleFeatureBuilder.build(SCHEMA, new Object[] {0, Integer.MIN_VALUE - 1}, "1"));
+
+        final MaxVisitor visitor = new MaxVisitor("ALong");
+        collection.accepts(visitor, null);
+
+        visitor.reset();
+
+        collection.accepts(visitor, null);
+        Assert.assertEquals(Long.valueOf(Integer.MIN_VALUE - 1), (Long) visitor.getMax());
     }
 
     /** A MaxVisitor that set's visitied without maxvalue being set. */

--- a/modules/library/main/src/test/java/org/geotools/feature/visitor/MinVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/visitor/MinVisitorTest.java
@@ -1,0 +1,65 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.feature.visitor;
+
+import org.geotools.data.memory.MemoryFeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+/**
+ * Testing MinVisitor
+ *
+ * @author Roar Brænden
+ */
+public class MinVisitorTest {
+
+    private static SimpleFeatureType SCHEMA;
+
+    static {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("Test");
+        builder.add("AInteger", Integer.class);
+        SCHEMA = builder.buildFeatureType();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void visitedFlagSetWithoutValue() throws Exception {
+
+        final MemoryFeatureCollection collection = new MemoryFeatureCollection(SCHEMA);
+        collection.add(SimpleFeatureBuilder.build(SCHEMA, new Object[] {1}, "1"));
+
+        final MinVisitor falseVisitor = new PreVisitedMinVisitor("AInteger");
+        try {
+            collection.accepts(falseVisitor, null);
+        } catch (Exception e) {
+            while (e.getCause() != null) {
+                e = (Exception) e.getCause();
+            }
+            throw e;
+        }
+    }
+
+    /** A MinVisitor that set's visitied without minvalue being set. */
+    private class PreVisitedMinVisitor extends MinVisitor {
+        PreVisitedMinVisitor(String attribute) {
+            super(attribute);
+            this.visited = true;
+        }
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/feature/visitor/MinVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/visitor/MinVisitorTest.java
@@ -19,6 +19,7 @@ package org.geotools.feature.visitor;
 import org.geotools.data.memory.MemoryFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.Assert;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeatureType;
 
@@ -55,7 +56,22 @@ public class MinVisitorTest {
         }
     }
 
-    /** A MinVisitor that set's visitied without minvalue being set. */
+    /** Checks that reset causes minvalue to be set to null, and not the integer 0. */
+    @Test
+    public void resetCallWillNullify() throws Exception {
+        final MemoryFeatureCollection collection = new MemoryFeatureCollection(SCHEMA);
+        collection.add(SimpleFeatureBuilder.build(SCHEMA, new Object[] {1}, "1"));
+
+        final MinVisitor visitor = new MinVisitor("AInteger");
+        collection.accepts(visitor, null);
+
+        visitor.reset();
+
+        collection.accepts(visitor, null);
+        Assert.assertEquals(Integer.valueOf(1), (Integer) visitor.getMin());
+    }
+
+    /** A MinVisitor that set's visited without minvalue being set. */
     private class PreVisitedMinVisitor extends MinVisitor {
         PreVisitedMinVisitor(String attribute) {
             super(attribute);


### PR DESCRIPTION
[![GEOT-6998](https://badgen.net/badge/JIRA/GEOT-6998/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6998) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

An IllegalStateException is thrown instead of NullPointerException. Somewhat unclear how the null came into the variable in the first place. Maybe this will clear things up.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->