### PR TITLE
[GEOT-7001] XmlComplexFeatureParser gives wrong name for ComplexAttribute

### DIFF
--- a/docs/src/main/java/org/geotools/wfs/ReadWFSKommuner.java
+++ b/docs/src/main/java/org/geotools/wfs/ReadWFSKommuner.java
@@ -1,0 +1,149 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ */
+
+package org.geotools.wfs;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.HashMap;
+import org.geotools.data.FeatureSource;
+import org.geotools.data.wfs.WFSDataStoreFactory;
+import org.geotools.data.wfs.impl.WFSContentDataAccess;
+import org.geotools.data.wfs.impl.WFSDataAccessFactory;
+import org.geotools.feature.FeatureIterator;
+import org.opengis.feature.ComplexAttribute;
+import org.opengis.feature.Feature;
+import org.opengis.feature.Property;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.Name;
+
+/**
+ * Read the contents of a WFS with complex structure.
+ *
+ * @author Roar Brænden
+ */
+public class ReadWFSKommuner {
+
+    /*
+    	 *   Content of a single feature with only one AdministrativEnhetNavn
+    	 *
+    <wfs:member>
+        <app:Kommune xmlns:app="http://skjema.geonorge.no/SOSI/produktspesifikasjon/AdmEnheter/4.1" gml:id="kommune_view.357">
+          <app:identifikasjon>
+            <app:Identifikasjon>
+              <app:lokalId>173103</app:lokalId>
+              <app:navnerom>https://data.geonorge.no/sosi/administrativeenheter/fylker_kommuner</app:navnerom>
+              <app:versjonId>4.1</app:versjonId>
+            </app:Identifikasjon>
+          </app:identifikasjon>
+          <app:oppdateringsdato>2020-02-07T00:00:00</app:oppdateringsdato>
+          <app:datauttaksdato>2021-01-04T10:07:10</app:datauttaksdato>
+          <app:område>
+            <!--Inlined geometry 'kommune_view.357_APP_OMRÅDE'-->
+            <gml:Polygon gml:id="kommune_view.357_APP_OMRÅDE" srsName="urn:ogc:def:crs:EPSG::4258">
+              <gml:exterior>
+                <gml:LinearRing>
+                  <gml:posList>58.426581 6.605405 58.420867 6.599559 .......
+                </gml:LinearRing>
+              </gml:exterior>
+            </gml:Polygon>
+          </app:område>
+          <app:kommunenummer>4207</app:kommunenummer>
+          <app:kommunenavn>
+            <app:AdministrativEnhetNavn>
+              <app:navn>Flekkefjord</app:navn>
+              <app:språk>nor</app:språk>
+            </app:AdministrativEnhetNavn>
+          </app:kommunenavn>
+          <app:samiskForvaltningsområde>false</app:samiskForvaltningsområde>
+        </app:Kommune>
+      </wfs:member>
+    	 *
+    	 */
+
+    private static final String SCHEMA_CACHE = "../../schemas";
+
+    private static final String CAPABILITIES_URL =
+            "https://wfs.geonorge.no/skwms1/wfs.administrative_enheter?&service=WFS&acceptversions=2.0.0&request=GetCapabilities";
+
+    /** Calls the WFS server and prints out the content. */
+    public void read() throws IOException {
+
+        final HashMap<String, Serializable> params = new HashMap<String, Serializable>();
+        params.put(WFSDataStoreFactory.URL.key, new URL(CAPABILITIES_URL));
+        params.put(WFSDataStoreFactory.TIMEOUT.key, 60000); // 60 seconds
+        params.put(WFSDataStoreFactory.BUFFER_SIZE.key, 100);
+        params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE); // Prefer GET to support Schema
+        params.put("WFSDataStoreFactory:SCHEMA_CACHE_LOCATION", SCHEMA_CACHE);
+
+        WFSContentDataAccess complexDataAccess =
+                (WFSContentDataAccess) new WFSDataAccessFactory().createDataStore(params);
+        Name featureName = null;
+        for (Name name : complexDataAccess.getNames()) {
+            if ("Kommune".equals(name.getLocalPart())) {
+                featureName = name;
+                break;
+            }
+        }
+        if (featureName == null) {
+            throw new RuntimeException("WFS didn't return a Kommune feature.");
+        }
+
+        FeatureSource<FeatureType, Feature> kommuneSource =
+                complexDataAccess.getFeatureSource(featureName);
+
+        try (FeatureIterator<Feature> features = kommuneSource.getFeatures().features()) {
+
+            while (features.hasNext()) {
+                Feature nextFeature = features.next();
+                String kommunenr = (String) nextFeature.getProperty("kommunenummer").getValue();
+                String kommunenavn = "Uten norsk navn";
+                ComplexAttribute kommunenavnAttribute =
+                        (ComplexAttribute) nextFeature.getProperty("kommunenavn");
+                for (Property administrativEnhetNavn : kommunenavnAttribute.getProperties()) {
+                    ComplexAttribute innerElement = innerComplex(administrativEnhetNavn);
+                    if ("nor".equals(innerElement.getProperty("språk").getValue())) {
+                        kommunenavn = (String) innerElement.getProperty("navn").getValue();
+                        break;
+                    }
+                }
+
+                System.out.printf("%s : %s\n-------------\n", kommunenr, kommunenavn);
+                for (Property prop : nextFeature.getProperties()) {
+                    System.out.println(prop.toString());
+                }
+                System.out.println("-------------");
+            }
+        }
+    }
+
+    private static ComplexAttribute innerComplex(Property complex) {
+        return (ComplexAttribute) ((ComplexAttribute) complex).getProperties().iterator().next();
+    }
+
+    /** Call read */
+    public static void main(String[] args) {
+        try {
+            new ReadWFSKommuner().read();
+        } catch (Exception e) {
+            System.out.println("ReadWFSKommuner ended with an exception: " + e.getMessage());
+            e.printStackTrace(System.out);
+        }
+    }
+}

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlComplexFeatureParser.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlComplexFeatureParser.java
@@ -199,16 +199,16 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
     }
 
     /**
-     * Given a href and an expected type, return either the actual manifestation of that href's
-     * target or a placeholder object. The real instance will be returned if it's already been
-     * parsed, otherwise the placeholder will be returned. The placeholder will automatically be
-     * replaced upon calling RegisterGmlTarget(...) once the actual object is parsed.
+     * Given a href and an expected descriptor, return either the actual manifestation of that
+     * href's target or a placeholder object. The real instance will be returned if it's already
+     * been parsed, otherwise the placeholder will be returned. The placeholder will automatically
+     * be replaced upon calling RegisterGmlTarget(...) once the actual object is parsed.
      *
      * @param href The href that you wish to resolve.
-     * @param expectedType The attribute type that you expect the href to point to.
+     * @param expectedDescriptor The attribute descriptor that you expect the href to point to.
      * @return An attribute of the type specified, either the actual attribute or a placeholder.
      */
-    private Attribute resolveHref(String href, AttributeType expectedType) {
+    private Attribute resolveHref(String href, AttributeDescriptor expectedDescriptor) {
         // See what kind of href it is:
         if (href.startsWith("#")) {
             String hrefId = href.substring(1);
@@ -221,7 +221,8 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
             } else {
                 // If not, then we create a placeholderComplexAttribute instead:
                 Attribute placeholderComplexAttribute =
-                        new AttributeImpl(Collections.<Property>emptyList(), expectedType, null);
+                        new AttributeImpl(
+                                Collections.<Property>emptyList(), expectedDescriptor, null);
 
                 // I must maintain a reference back to this object so that I can
                 // change it once its target is found:
@@ -239,7 +240,7 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
             // need be.
             // This is temporary code to get things to work:
             Attribute placeholderComplexAttribute =
-                    new AttributeImpl(Collections.<Property>emptyList(), expectedType, null);
+                    new AttributeImpl(Collections.<Property>emptyList(), expectedDescriptor, null);
 
             return placeholderComplexAttribute;
         }
@@ -304,7 +305,7 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
                 // 4. Parse the tag's contents based on whether it's a:
                 if (href != null) {
                     // Resolve the href:
-                    Attribute hrefAttribute = resolveHref(href, (AttributeType) type);
+                    Attribute hrefAttribute = resolveHref(href, (AttributeDescriptor) descriptor);
 
                     // We've got the attribute but the parser is still
                     // pointing at this tag so
@@ -327,7 +328,7 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
                     // attribute.
                     AttributeBuilder attributeBuilder =
                             new AttributeBuilder(new LenientFeatureFactoryImpl());
-                    attributeBuilder.setType((AttributeType) type);
+                    attributeBuilder.setDescriptor((AttributeDescriptor) descriptor);
 
                     if (type.getBinding() == Collection.class && Types.isSimpleContentType(type)) {
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/XmlComplexFeatureParserTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/XmlComplexFeatureParserTest.java
@@ -102,7 +102,7 @@ public class XmlComplexFeatureParserTest {
 
         // Assert
         Assert.assertEquals(
-                "FeatureImpl:MineType<MineType id=er.mine.S0000001>=[ComplexAttributeImpl:MineNamePropertyType=[ComplexAttributeImpl:MineName<MineNameType id=MINENAMETYPE_TYPE_1>=[ComplexAttributeImpl:MineNameType=[AttributeImpl:isPreferred<boolean id=isPreferred_1>=true, AttributeImpl:mineName<string id=mineName_1>=Pieces of Eight - Admiral Hill]]], ComplexAttributeImpl:MineNamePropertyType=[ComplexAttributeImpl:MineName<MineNameType id=MINENAMETYPE_TYPE_2>=[ComplexAttributeImpl:MineNameType=[AttributeImpl:isPreferred<boolean id=isPreferred_2>=false, AttributeImpl:mineName<string id=mineName_2>=Admiral Hill S - W Shear (WAMIN)]]]]",
+                "FeatureImpl:MineType<MineType id=er.mine.S0000001>=[ComplexAttributeImpl:mineName<MineNamePropertyType>=[ComplexAttributeImpl:MineName<MineNameType id=MINENAMETYPE_TYPE_1>=[ComplexAttributeImpl:MineName<MineNameType>=[AttributeImpl:isPreferred<boolean id=isPreferred_1>=true, AttributeImpl:mineName<string id=mineName_1>=Pieces of Eight - Admiral Hill]]], ComplexAttributeImpl:mineName<MineNamePropertyType>=[ComplexAttributeImpl:MineName<MineNameType id=MINENAMETYPE_TYPE_2>=[ComplexAttributeImpl:MineName<MineNameType>=[AttributeImpl:isPreferred<boolean id=isPreferred_2>=false, AttributeImpl:mineName<string id=mineName_2>=Admiral Hill S - W Shear (WAMIN)]]]]",
                 feature.toString());
     }
 
@@ -121,7 +121,7 @@ public class XmlComplexFeatureParserTest {
 
         // Assert
         Assert.assertEquals(
-                "FeatureImpl:MineType<MineType id=er.mine.S0000005>=[ComplexAttributeImpl:MineNamePropertyType=[ComplexAttributeImpl:MineName<MineNameType>=[ComplexAttributeImpl:MineNameType=[AttributeImpl:isPreferred<boolean>=true, AttributeImpl:mineName<string>=Aspacia]]]]",
+                "FeatureImpl:MineType<MineType id=er.mine.S0000005>=[ComplexAttributeImpl:mineName<MineNamePropertyType>=[ComplexAttributeImpl:MineName<MineNameType>=[ComplexAttributeImpl:MineName<MineNameType>=[AttributeImpl:isPreferred<boolean>=true, AttributeImpl:mineName<string>=Aspacia]]]]",
                 feature.toString());
     }
 
@@ -132,7 +132,7 @@ public class XmlComplexFeatureParserTest {
 
         // Act
         Feature feature = mineParser.parse();
-        Object[] properties = feature.getProperties("MineNamePropertyType").toArray();
+        Object[] properties = feature.getProperties("mineName").toArray();
 
         // Assert
         Assert.assertSame(properties[0], properties[1]);
@@ -145,7 +145,7 @@ public class XmlComplexFeatureParserTest {
 
         // Act
         Feature feature = mineParser.parse();
-        Object[] properties = feature.getProperties("MineNamePropertyType").toArray();
+        Object[] properties = feature.getProperties("mineName").toArray();
 
         // Assert
         Assert.assertEquals(properties[0], properties[1]);
@@ -158,7 +158,7 @@ public class XmlComplexFeatureParserTest {
 
         // Act
         Feature feature = mineParser.parse();
-        Object[] properties = feature.getProperties("MineNamePropertyType").toArray();
+        Object[] properties = feature.getProperties("mineName").toArray();
 
         // Assert
         Assert.assertEquals(properties[0], properties[1]);
@@ -188,8 +188,8 @@ public class XmlComplexFeatureParserTest {
                 getParser("wfs_response_xlink_target_in_another_feature_below.xml");
 
         // Act
-        Property mineNamePropertyType1 = mineParser.parse().getProperty("MineNamePropertyType");
-        Property mineNamePropertyType2 = mineParser.parse().getProperty("MineNamePropertyType");
+        Property mineNamePropertyType1 = mineParser.parse().getProperty("mineName");
+        Property mineNamePropertyType2 = mineParser.parse().getProperty("mineName");
 
         // Assert
         Assert.assertEquals(mineNamePropertyType1, mineNamePropertyType2);
@@ -233,10 +233,10 @@ public class XmlComplexFeatureParserTest {
                 "AttributeImpl:name<CodeType>=[AttributeImpl:simpleContent<string>=rd001]",
                 names[1].toString());
         Assert.assertEquals(
-                "ComplexAttributeImpl:BoreholeCollarPropertyType=[FeatureImpl:BoreholeCollar<BoreholeCollarType id=gsml.borehole.collar.rd001>=[FeatureImpl:BoreholeCollarType<BoreholeCollarType id=gsml.borehole.collar.rd001>=[ComplexAttributeImpl:elevation<DirectPositionType>=[AttributeImpl:simpleContent<doubleList>=0.0]]]]",
-                feature.getProperty("BoreholeCollarPropertyType").toString());
+                "ComplexAttributeImpl:collarLocation<BoreholeCollarPropertyType>=[FeatureImpl:BoreholeCollar<BoreholeCollarType id=gsml.borehole.collar.rd001>=[FeatureImpl:BoreholeCollar<BoreholeCollarType id=gsml.borehole.collar.rd001>=[ComplexAttributeImpl:elevation<DirectPositionType>=[AttributeImpl:simpleContent<doubleList>=0.0]]]]",
+                feature.getProperty("collarLocation").toString());
         Assert.assertEquals(
-                "ComplexAttributeImpl:BoreholeDetailsPropertyType=[ComplexAttributeImpl:BoreholeDetails<BoreholeDetailsType>=[ComplexAttributeImpl:BoreholeDetailsType=[ComplexAttributeImpl:driller<ReferenceType>=[], AttributeImpl:drillingMethod<BoreholeDrillingMethodCodeType>=Diamond, AttributeImpl:startPoint<BoreholeStartPointCodeType>=natural ground surface, AttributeImpl:inclinationType<BoreholeInclinationCodeType>=vertical, ComplexAttributeImpl:coredInterval<BoundingShapeType>=[ComplexAttributeImpl:BoundingShapeType=[ComplexAttributeImpl:Envelope<EnvelopeType>=[ComplexAttributeImpl:EnvelopeType=[ComplexAttributeImpl:lowerCorner<DirectPositionType>=[AttributeImpl:simpleContent<doubleList>=0.0], ComplexAttributeImpl:upperCorner<DirectPositionType>=[AttributeImpl:simpleContent<doubleList>=324.6]]]]], ComplexAttributeImpl:coreCustodian<ReferenceType>=[]]]]",
-                feature.getProperty("BoreholeDetailsPropertyType").toString());
+                "ComplexAttributeImpl:indexData<BoreholeDetailsPropertyType>=[ComplexAttributeImpl:BoreholeDetails<BoreholeDetailsType>=[ComplexAttributeImpl:BoreholeDetails<BoreholeDetailsType>=[ComplexAttributeImpl:driller<ReferenceType>=[], AttributeImpl:drillingMethod<BoreholeDrillingMethodCodeType>=Diamond, AttributeImpl:startPoint<BoreholeStartPointCodeType>=natural ground surface, AttributeImpl:inclinationType<BoreholeInclinationCodeType>=vertical, ComplexAttributeImpl:coredInterval<BoundingShapeType>=[ComplexAttributeImpl:coredInterval<BoundingShapeType>=[ComplexAttributeImpl:Envelope<EnvelopeType>=[ComplexAttributeImpl:Envelope<EnvelopeType>=[ComplexAttributeImpl:lowerCorner<DirectPositionType>=[AttributeImpl:simpleContent<doubleList>=0.0], ComplexAttributeImpl:upperCorner<DirectPositionType>=[AttributeImpl:simpleContent<doubleList>=324.6]]]]], ComplexAttributeImpl:coreCustodian<ReferenceType>=[]]]]",
+                feature.getProperty("indexData").toString());
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/KartverketStedsnavnDataStoreOnlineTest.java
@@ -18,20 +18,34 @@ package org.geotools.data.wfs.online;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import javax.xml.namespace.QName;
+import org.geotools.data.FeatureSource;
 import org.geotools.data.wfs.WFSDataStoreFactory;
+import org.geotools.data.wfs.WFSTestData;
 import org.geotools.data.wfs.WFSTestData.TestDataType;
+import org.geotools.data.wfs.impl.WFSContentDataAccess;
+import org.geotools.data.wfs.impl.WFSDataAccessFactory;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.test.TestData;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.locationtech.jts.geom.Polygon;
+import org.opengis.feature.Feature;
+import org.opengis.feature.Property;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.Name;
+import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.filter.Filter;
 import org.opengis.filter.Id;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -42,13 +56,15 @@ public class KartverketStedsnavnDataStoreOnlineTest extends AbstractWfsDataStore
     static final String SERVER_URL =
             "https://wfs.geonorge.no/skwms1/wfs.stedsnavn?request=GetCapabilities&service=WFS";
 
+    static final String NAME = "Sted";
+
     static final TestDataType KARTVERKET_STEDSNAVN =
             new TestDataType(
                     "KartverketNo",
                     new QName(
                             "http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115",
                             "sted"),
-                    "app_Sted",
+                    "app_" + NAME,
                     "urn:ogc:def:crs:EPSG::4258");
 
     static final String defaultGeometryName = "område";
@@ -97,6 +113,52 @@ public class KartverketStedsnavnDataStoreOnlineTest extends AbstractWfsDataStore
         Assert.assertEquals(geometryType, geometryDescriptor.getType().getBinding());
         CoordinateReferenceSystem crs = geometryDescriptor.getCoordinateReferenceSystem();
         Assert.assertNotNull(crs);
+    }
+
+    /**
+     * Check that the returned feature doesn't have other property names than those specified when
+     * calling getSchema()
+     */
+    @Test
+    public void testComplexSchemaMatches() throws Exception {
+        if (Boolean.FALSE.equals(serviceAvailable)) {
+            return;
+        }
+
+        Map<String, Serializable> params = new HashMap<>();
+        params.put(WFSDataStoreFactory.URL.key, new URL(SERVER_URL));
+        params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE); // Prefer GET to support Schema
+        params.put(
+                "WFSDataStoreFactory:SCHEMA_CACHE_LOCATION",
+                TestData.file(WFSTestData.class, "KartverketNo")
+                        .getAbsolutePath()); // Must be specified when Schema is http
+
+        WFSDataAccessFactory dataStoreFactory = new WFSDataAccessFactory();
+        WFSContentDataAccess dataAccess =
+                (WFSContentDataAccess) dataStoreFactory.createDataStore(params);
+        Name featureName = null;
+        for (Name nextName : dataAccess.getNames()) {
+            if (NAME.equals(nextName.getLocalPart())) {
+                featureName = nextName;
+                break;
+            }
+        }
+        Assert.assertNotNull(String.format("We should find %s here.", NAME), featureName);
+
+        FeatureSource<FeatureType, Feature> source = dataAccess.getFeatureSource(featureName);
+        HashSet<String> properties = new HashSet<>();
+        for (PropertyDescriptor desc : source.getSchema().getDescriptors()) {
+            properties.add(desc.getName().getLocalPart());
+        }
+
+        try (FeatureIterator<Feature> iterator = source.getFeatures().features()) {
+            Feature feature = iterator.next();
+            for (Property prop : feature.getProperties()) {
+                final String name = prop.getName().getLocalPart();
+                Assert.assertTrue(
+                        "Schema doesn't contain property: " + name, properties.contains(name));
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
[![GEOT-7001](https://badgen.net/badge/JIRA/GEOT-7001/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7001) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When accessing a WFS with a complex structure a single feature shouldn't have properties with names other than those reported by a call to getSchema().

That is the basic of my added test in KartverketStedsnavnDataStoreOnlineTest.

Unfortunately a lot of tests were based on the wrong assumption about how to name complex attributes.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->