### PR TITLE
[GEOT-7009] New hint to stop GeoTiffReader from looking into overviews

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/MaskOverviewProvider.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/MaskOverviewProvider.java
@@ -131,6 +131,15 @@ public class MaskOverviewProvider {
         this(layout, inputUrl, spiHelper, DEFAULT_SKIP_EXTERNAL_FILES_LOOKUP);
     }
 
+    public MaskOverviewProvider(DatasetLayout dtLayout, File inputFile, boolean skipOverviews)
+            throws IOException {
+        this(
+                dtLayout,
+                URLs.fileToUrl(inputFile),
+                new SpiHelper(URLs.fileToUrl(inputFile), null),
+                skipOverviews);
+    }
+
     public MaskOverviewProvider(
             DatasetLayout layout, URL inputFile, SpiHelper spiHelper, boolean skipExternalLookup)
             throws IOException {

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
@@ -806,6 +806,13 @@ public class Hints extends RenderingHints {
     public static final Key GRANULE_REMOVAL_POLICY =
             new Key("org.geotools.coverage.grid.io.GranuleRemovalPolicy");
 
+    /**
+     * Indicates whether to skip external overview files when loading a Coverage (on by default in
+     * most raster readers). The lookup can be costly if the files are on a remote server or network
+     * disk.
+     */
+    public static final Key SKIP_EXTERNAL_OVERVIEWS = new Hints.Key(Boolean.class);
+
     ////////////////////////////////////////////////////////////////////////
     ////////                                                        ////////
     ////////                      Data stores                       ////////

--- a/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffReader.java
+++ b/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffReader.java
@@ -381,6 +381,17 @@ public class GeoTiffReader extends AbstractGridCoverage2DReader implements GridC
             //
             dtLayout = TiffDatasetLayoutImpl.parseLayout(reader.getStreamMetadata());
 
+            // allows to skip the .ovr files lookup
+            boolean skipOverviews =
+                    (Boolean)
+                            hints.getOrDefault(
+                                    Hints.SKIP_EXTERNAL_OVERVIEWS,
+                                    ImageIOUtilities.isSkipExternalFilesLookup());
+            if (skipOverviews) {
+                LOGGER.log(Level.FINE, "Skipping GeoTiff overview sidecar files for {0}", source);
+                ((TiffDatasetLayoutImpl) dtLayout).setNumExternalOverviews(0);
+            }
+
             // Creating a new OverviewsProvider instance
             File inputFile = null;
             if (source instanceof File) {
@@ -389,13 +400,12 @@ public class GeoTiffReader extends AbstractGridCoverage2DReader implements GridC
                 inputFile = URLs.urlToFile((URL) source);
             }
             if (inputFile != null) {
-                maskOvrProvider = new MaskOverviewProvider(dtLayout, inputFile);
+                maskOvrProvider = new MaskOverviewProvider(dtLayout, inputFile, skipOverviews);
                 hasMaskOvrProvider = true;
             } else if (dtLayout != null && dtLayout.getExternalMasks() != null) {
                 String path = dtLayout.getExternalMasks().getAbsolutePath();
-                maskOvrProvider =
-                        new MaskOverviewProvider(
-                                dtLayout, new File(path.substring(0, path.length() - 4)));
+                File file = new File(path.substring(0, path.length() - 4));
+                maskOvrProvider = new MaskOverviewProvider(dtLayout, file, skipOverviews);
                 hasMaskOvrProvider = true;
             } else if (source instanceof CogSourceSPIProvider) {
                 CogSourceSPIProvider cogSourceProvider = (CogSourceSPIProvider) source;
@@ -403,7 +413,8 @@ public class GeoTiffReader extends AbstractGridCoverage2DReader implements GridC
                         new MaskOverviewProvider(
                                 null,
                                 cogSourceProvider.getSourceUrl(),
-                                new MaskOverviewProvider.SpiHelper(cogSourceProvider));
+                                new MaskOverviewProvider.SpiHelper(cogSourceProvider),
+                                skipOverviews);
                 hasMaskOvrProvider = true;
             }
 
@@ -1100,5 +1111,11 @@ public class GeoTiffReader extends AbstractGridCoverage2DReader implements GridC
                     layout.getExternalMasks());
         }
         return Collections.singletonList(new FileGroup(file, files, null));
+    }
+
+    /** Returns the {@link MaskOverviewProvider} used by this reader. For testing purposes. */
+    public MaskOverviewProvider getMaskOverviewProvider() {
+        // the object is read only once initialized, not dangerous
+        return maskOvrProvider;
     }
 }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/CogGranuleAccessProvider.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/CogGranuleAccessProvider.java
@@ -89,6 +89,9 @@ public class CogGranuleAccessProvider extends DefaultGranuleAccessProvider
             format = DEFAULT_COG_FORMAT;
         }
         hints.put(GranuleAccessProvider.SUGGESTED_FORMAT, format);
+        if (bean.isSkipExternalOverviews()) {
+            hints.put(Hints.SKIP_EXTERNAL_OVERVIEWS, true);
+        }
 
         hints.add(EXCLUDE_MOSAIC);
         return hints;

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/DefaultGranuleAccessProvider.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/DefaultGranuleAccessProvider.java
@@ -65,8 +65,8 @@ class DefaultGranuleAccessProvider implements GranuleAccessProvider, GranuleDesc
             if (hints.containsKey(SUGGESTED_STREAM_SPI)) {
                 this.imageInputStreamSpi = (ImageInputStreamSpi) hints.get(SUGGESTED_STREAM_SPI);
             }
-            if (hints.containsKey(SKIP_EXTERNAL_OVERVIEWS)) {
-                this.skipExternalOverviews = (Boolean) hints.get(SKIP_EXTERNAL_OVERVIEWS);
+            if (hints.containsKey(Hints.SKIP_EXTERNAL_OVERVIEWS)) {
+                this.skipExternalOverviews = (Boolean) hints.get(Hints.SKIP_EXTERNAL_OVERVIEWS);
             }
         }
     }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleAccessProvider.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleAccessProvider.java
@@ -41,16 +41,13 @@ import org.geotools.util.factory.Hints;
  */
 public interface GranuleAccessProvider {
 
-    public static final Hints.Key SUGGESTED_READER_SPI = new Hints.Key(ImageReaderSpi.class);
+    Hints.Key SUGGESTED_READER_SPI = new Hints.Key(ImageReaderSpi.class);
 
-    public static final Hints.Key SUGGESTED_STREAM_SPI = new Hints.Key(ImageInputStreamSpi.class);
+    Hints.Key SUGGESTED_STREAM_SPI = new Hints.Key(ImageInputStreamSpi.class);
 
-    public static final Hints.Key SUGGESTED_FORMAT = new Hints.Key(AbstractGridFormat.class);
+    Hints.Key SUGGESTED_FORMAT = new Hints.Key(AbstractGridFormat.class);
 
-    public static final Hints.Key SKIP_EXTERNAL_OVERVIEWS = new Hints.Key(Boolean.class);
-
-    public static final Hints.Key GRANULE_ACCESS_PROVIDER =
-            new Hints.Key(GranuleAccessProvider.class);
+    Hints.Key GRANULE_ACCESS_PROVIDER = new Hints.Key(GranuleAccessProvider.class);
 
     /** Input to be set before invoking any method of the provider */
     void setGranuleInput(Object input) throws IOException;

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
@@ -555,8 +555,7 @@ public class GranuleDescriptor {
             suggestedObjectHints.put(GranuleAccessProvider.SUGGESTED_STREAM_SPI, suggestedIsSPI);
         }
         if (skipExternalOverviews) {
-            suggestedObjectHints.put(
-                    GranuleAccessProvider.SKIP_EXTERNAL_OVERVIEWS, skipExternalOverviews);
+            suggestedObjectHints.put(Hints.SKIP_EXTERNAL_OVERVIEWS, skipExternalOverviews);
         }
         // When looking for formats which may parse this file, make sure to exclude the
         // ImageMosaicFormat as return

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicReader.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicReader.java
@@ -450,6 +450,8 @@ public class ImageMosaicReader extends AbstractGridCoverage2DReader
         Hints catalogHints = getHints();
         if (bean != null && bean.getUrlSourceSPIProvider() != null) {
             catalogHints = new Hints(catalogHints);
+            if (bean.isSkipExternalOverviews())
+                catalogHints.put(Hints.SKIP_EXTERNAL_OVERVIEWS, true);
             CogGranuleAccessProvider provider = new CogGranuleAccessProvider(bean);
             catalogHints.put(GranuleAccessProvider.GRANULE_ACCESS_PROVIDER, provider);
         }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/AbstractGTDataStoreGranuleCatalog.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/catalog/AbstractGTDataStoreGranuleCatalog.java
@@ -48,7 +48,6 @@ import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.visitor.FeatureCalc;
-import org.geotools.gce.imagemosaic.GranuleAccessProvider;
 import org.geotools.gce.imagemosaic.GranuleDescriptor;
 import org.geotools.gce.imagemosaic.ImageMosaicReader;
 import org.geotools.gce.imagemosaic.PathType;
@@ -154,7 +153,7 @@ abstract class AbstractGTDataStoreGranuleCatalog extends GranuleCatalog {
                 // depending on the code path, the value may come as a string (initialize from
                 // datastore) or boolean (index and create a shapefile)
                 this.hints.put(
-                        GranuleAccessProvider.SKIP_EXTERNAL_OVERVIEWS,
+                        Hints.SKIP_EXTERNAL_OVERVIEWS,
                         Converters.convert(
                                 params.get(Utils.Prop.SKIP_EXTERNAL_OVERVIEWS), Boolean.class));
             }

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicCogOnlineTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicCogOnlineTest.java
@@ -51,6 +51,7 @@ import org.geotools.data.Query;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.gce.geotiff.GeoTiffReader;
 import org.geotools.gce.imagemosaic.Utils.Prop;
 import org.geotools.gce.imagemosaic.catalog.GranuleCatalog;
 import org.geotools.gce.imagemosaic.properties.FSDateExtractorSPI;
@@ -494,8 +495,13 @@ public class ImageMosaicCogOnlineTest {
             RasterManager manager = reader.rasterManagers.get(name);
             manager.granuleCatalog.getGranuleDescriptors(
                     new Query(name),
-                    (granule, feature) ->
-                            assertTrue(granule.getMaskOverviewProvider().isSkipExternalLookup()));
+                    (granule, feature) -> {
+                        assertTrue(granule.getMaskOverviewProvider().isSkipExternalLookup());
+                        assertTrue(
+                                ((GeoTiffReader) granule.getReader())
+                                        .getMaskOverviewProvider()
+                                        .isSkipExternalLookup());
+                    });
         } finally {
             if (reader != null) reader.dispose();
         }


### PR DESCRIPTION
[![GEOT-7009](https://badgen.net/badge/JIRA/GEOT-7009/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7009) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

More overview lookups removal, when not desirable.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->