### PR TITLE
[GEOT-7013] Remove deprecated functions from gt-wmts

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
@@ -250,15 +250,6 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
         return type;
     }
 
-    /**
-     * @deprecated headers should be set by a constructor
-     * @return
-     */
-    @Deprecated
-    public Map<String, String> getHeaders() {
-        return headers;
-    }
-
     /** */
     public GeneralEnvelope getEnvelope(Layer layer, CoordinateReferenceSystem crs) {
         Map<String, CRSEnvelope> boundingBoxes = layer.getBoundingBoxes();

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
@@ -25,7 +25,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.http.HTTPResponse;
 import org.geotools.image.io.ImageIOExt;
-import org.geotools.ows.wmts.model.WMTSServiceType;
 import org.geotools.tile.Tile;
 import org.geotools.tile.TileIdentifier;
 import org.geotools.tile.TileService;
@@ -88,12 +87,6 @@ class WMTSTile extends Tile {
                         .getTileWidth());
 
         this.service = (WMTSTileService) service;
-    }
-
-    /** @return the type of WMTS KVP or REST */
-    @Deprecated
-    public WMTSServiceType getType() {
-        return getService().getType();
     }
 
     private WMTSTileService getService() {

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
@@ -67,10 +67,6 @@ public class WMTSTileService extends TileService {
 
     protected static final Logger LOGGER = Logging.getLogger(WMTSTileService.class);
 
-    @Deprecated public static final String DIMENSION_TIME = "time";
-
-    @Deprecated public static final String DIMENSION_ELEVATION = "elevation";
-
     public static final String EXTRA_HEADERS = "HEADERS";
 
     private static final TileFactory tileFactory = new WMTSTileFactory();
@@ -83,19 +79,9 @@ public class WMTSTileService extends TileService {
 
     private final WMTSLayer layer;
 
-    private String layerName;
-
-    private String styleName = ""; // Default style is ""
-
     private ReferencedEnvelope envelope;
 
     private final TileURLBuilder urlBuilder;
-
-    private WMTSServiceType type = WMTSServiceType.REST;
-
-    private String format = "image/png";
-
-    private Map<String, String> dimensions = new HashMap<>();
 
     private Map<String, Object> extrainfo = new HashMap<>();
 
@@ -536,36 +522,6 @@ public class WMTSTileService extends TileService {
         return tileList;
     }
 
-    /** @return the type */
-    @Deprecated
-    public WMTSServiceType getType() {
-        return type;
-    }
-
-    /** @param type the type to set */
-    @Deprecated
-    public void setType(WMTSServiceType type) {
-        this.type = type;
-    }
-
-    /** @return the layerName */
-    @Deprecated
-    public String getLayerName() {
-        return layerName;
-    }
-
-    /** @return the styleName */
-    @Deprecated
-    public String getStyleName() {
-        return styleName;
-    }
-
-    /** @param styleName the styleName to set */
-    @Deprecated
-    public void setStyleName(String styleName) {
-        this.styleName = styleName;
-    }
-
     @Override
     public double[] getScaleList() {
         return scaleList;
@@ -586,35 +542,9 @@ public class WMTSTileService extends TileService {
         return tileFactory;
     }
 
-    /** @return the tileMatrixSetName */
-    @Deprecated
-    public String getTileMatrixSetName() {
-        return tileMatrixSetName;
-    }
-
-    /** @param tileMatrixSetName the tileMatrixSetName to set */
-    @Deprecated
-    public void setTileMatrixSetName(String tileMatrixSetName) {
-        if (tileMatrixSetName == null || tileMatrixSetName.isEmpty()) {
-            throw new IllegalArgumentException("Tile matrix set name cannot be null");
-        }
-
-        this.tileMatrixSetName = tileMatrixSetName;
-    }
-
     public TileMatrixSetLink getMatrixSetLink() {
         return layer.getTileMatrixLinks().get(tileMatrixSetName);
     }
-
-    /** @return the templateURL */
-    @Deprecated
-    public String getTemplateURL() {
-        return getBaseUrl();
-    }
-
-    /** @param templateURL the templateURL to set */
-    @Deprecated
-    public void setTemplateURL(String templateURL) {}
 
     TileURLBuilder getURLBuilder() {
         return urlBuilder;
@@ -643,29 +573,8 @@ public class WMTSTileService extends TileService {
         }
     }
 
-    /** @return */
-    @Deprecated
-    public String getFormat() {
-        return format;
-    }
-
-    /**
-     * @param format the format to set
-     * @deprecated include in templateURL
-     */
-    @Deprecated
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public WMTSZoomLevel getZoomLevel(int zoom) {
         return new WMTSZoomLevel(zoom, this);
-    }
-
-    /** @deprecated Dimensions should be a part of templateUrl */
-    @Deprecated
-    public Map<String, String> getDimensions() {
-        return dimensions;
     }
 
     /**


### PR DESCRIPTION
[![GEOT-7013](https://badgen.net/badge/JIRA/GEOT-7013/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7013) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removing some functions that were deprecated in 26.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).