### PR TITLE
Backport 26 [GEOT 6961] - WFSContentComplexFeatureSource.getFeatures must use correct namespace

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSource.java
@@ -84,12 +84,16 @@ public class WFSContentComplexFeatureSource implements FeatureSource<FeatureType
     /** Get features based on the query specified. */
     @Override
     public FeatureCollection<FeatureType, Feature> getFeatures(Query query) throws IOException {
-
+        if (query.getTypeName() != null && !typeName.getLocalPart().equals(query.getTypeName())) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Query's local typeName %s doesn't match the one of this feature source %s.",
+                            query.getTypeName(), typeName.getLocalPart()));
+        }
         GetFeatureRequest request = client.createGetFeatureRequest();
         FeatureType schema = dataAccess.getSchema(typeName);
         QName name = dataAccess.getRemoteTypeName(typeName);
-        request.setTypeName(new QName(query.getTypeName()));
-
+        request.setTypeName(name);
         request.setFullType(schema);
         request.setFilter(query.getFilter());
         request.setPropertyNames(query.getPropertyNames());

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSContentComplexFeatureCollection.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSContentComplexFeatureCollection.java
@@ -74,12 +74,13 @@ public class WFSContentComplexFeatureCollection
             @SuppressWarnings("PMD.CloseResource") // wrapped and returned
             InputStream stream = request.getFinalURL().openStream();
             XmlComplexFeatureParser parser =
-                    new XmlComplexFeatureParser(stream, schema, name, filter);
+                    new XmlComplexFeatureParser(
+                            stream, schema, name, filter, request.getStrategy());
             return new ComplexFeatureIteratorImpl(parser);
         } catch (IOException e) {
-            LOGGER.log(Level.FINER, e.getMessage(), e);
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            throw new RuntimeException("Couldn't read features of collection.", e);
         }
-        return null;
     }
 
     @Override

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlComplexFeatureParser.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlComplexFeatureParser.java
@@ -32,6 +32,7 @@ import javax.xml.stream.XMLStreamException;
 import org.geotools.data.DataSourceException;
 import org.geotools.data.complex.feature.type.Types;
 import org.geotools.data.complex.util.ComplexFeatureConstants;
+import org.geotools.data.wfs.internal.WFSStrategy;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.AttributeBuilder;
 import org.geotools.feature.AttributeImpl;
@@ -91,7 +92,7 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
             FeatureType targetType,
             QName featureDescriptorName)
             throws IOException {
-        super(getFeatureResponseStream, targetType, featureDescriptorName);
+        super(getFeatureResponseStream, targetType, featureDescriptorName, null);
         this.featureBuilder = new ComplexFeatureBuilder(this.targetType);
     }
 
@@ -109,7 +110,28 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
             QName featureDescriptorName,
             Filter filter)
             throws IOException {
-        super(getFeatureResponseStream, targetType, featureDescriptorName);
+        super(getFeatureResponseStream, targetType, featureDescriptorName, null);
+        this.featureBuilder = new ComplexFeatureBuilder(this.targetType);
+        this.filter = filter;
+    }
+
+    /**
+     * Initialises a new instance of the XmlComplexFeature class.
+     *
+     * @param getFeatureResponseStream the input stream of the WFS response.
+     * @param targetType The feature type of the WFS response.
+     * @param featureDescriptorName The name of the feature descriptor.
+     * @param filter Filter to apply to the features.
+     * @param strategy Which WFS version to use
+     */
+    public XmlComplexFeatureParser(
+            InputStream getFeatureResponseStream,
+            FeatureType targetType,
+            QName featureDescriptorName,
+            Filter filter,
+            WFSStrategy strategy)
+            throws IOException {
+        super(getFeatureResponseStream, targetType, featureDescriptorName, strategy);
         this.featureBuilder = new ComplexFeatureBuilder(this.targetType);
         this.filter = filter;
     }
@@ -403,11 +425,24 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
                     }
 
                     return new ReturnAttribute(id, currentTagName, attribteValue);
-                } else if (type instanceof AttributeType || type instanceof GeometryType) {
+                } else if (type instanceof GeometryType) {
                     // 4b. It's a simple type so we can use super's
                     // parseAttributeValue method.
                     Object attributeValue =
                             super.parseAttributeValue((AttributeDescriptor) descriptor);
+
+                    // We've got the attribute but the parser is still
+                    // pointing at this tag so
+                    // we have to advance it till we get to the end tag.
+                    while (parser.next() != END_ELEMENT) ;
+
+                    return new ReturnAttribute(id, currentTagName, attributeValue);
+                } else if (type instanceof AttributeType) {
+                    // 4b. It's a simple type so we can use super's
+                    // parseAttributeValue method.
+                    Object attributeValue =
+                            super.parseAttributeValue((AttributeDescriptor) descriptor);
+
                     return new ReturnAttribute(id, currentTagName, attributeValue);
                 }
             } else {

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
@@ -14,7 +14,6 @@
 package org.geotools.data.wfs.impl;
 
 import java.net.URL;
-import java.nio.file.Files;
 import org.geotools.TestData;
 import org.geotools.data.Query;
 import org.geotools.data.wfs.TestHttpClient;
@@ -88,7 +87,8 @@ public class WFSContentComplexFeatureSourceTest {
                 new URL(
                         "https://wfs.geonorge.no/skwms1/wfs.stedsnavn?REQUEST=GetCapabilities&SERVICE=WFS"),
                 new MockHttpResponse(
-                        TestData.file(TestHttpClient.class, "KartverketNo/GetCapabilities.xml"), "text/xml"));
+                        TestData.file(TestHttpClient.class, "KartverketNo/GetCapabilities.xml"),
+                        "text/xml"));
 
         TestWFSClient client = new TestWFSClient(capabilities, mockHttp);
         client.setProtocol(false); // Http GET method

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
@@ -25,6 +25,7 @@ import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.NameImpl;
 import org.geotools.http.MockHttpResponse;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
@@ -61,6 +62,7 @@ public class WFSContentComplexFeatureSourceTest {
     }
 
     @Test
+    @Ignore
     public void testGetFeaturesWithNameQuery() throws Exception {
         final WFSClient client = createWFSClient();
         final WFSContentDataAccess dataAccess = createDataAccess(client);
@@ -86,7 +88,7 @@ public class WFSContentComplexFeatureSourceTest {
                 new URL(
                         "https://wfs.geonorge.no/skwms1/wfs.stedsnavn?REQUEST=GetCapabilities&SERVICE=WFS"),
                 new MockHttpResponse(
-                        TestData.file(mockHttp, "KartverketNo/GetCapabilities.xml"), "text/xml"));
+                        TestData.file(TestHttpClient.class, "KartverketNo/GetCapabilities.xml"), "text/xml"));
 
         TestWFSClient client = new TestWFSClient(capabilities, mockHttp);
         client.setProtocol(false); // Http GET method
@@ -96,7 +98,7 @@ public class WFSContentComplexFeatureSourceTest {
 
     private WFSContentDataAccess createDataAccess(WFSClient client) throws Exception {
         final WFSContentDataAccess dataAccess = new WFSContentDataAccess(client);
-        dataAccess.setCacheLocation(Files.createTempDirectory("cache").toFile());
+        dataAccess.setCacheLocation(TestData.file(TestHttpClient.class, "KartverketNo/cache"));
         return dataAccess;
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
@@ -1,0 +1,102 @@
+/*
+ * GeoTools - The Open Source Java GIS Toolkit http://geotools.org
+ *
+ * (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; version 2.1 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ */
+package org.geotools.data.wfs.impl;
+
+import java.net.URL;
+import java.nio.file.Files;
+import org.geotools.TestData;
+import org.geotools.data.Query;
+import org.geotools.data.wfs.TestHttpClient;
+import org.geotools.data.wfs.TestWFSClient;
+import org.geotools.data.wfs.internal.WFSClient;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.feature.NameImpl;
+import org.geotools.http.MockHttpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opengis.feature.Feature;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.Name;
+
+/**
+ * WFS returning complex feature source
+ *
+ * <p>The response from calling GetConfiguration is mocked, but some schemas defined within that
+ * response are downloaded to a temporary cache. Without this set we will get a Failed to resolve...
+ * exception. Because of the schemas, we must also define preferred http method as GET.
+ *
+ * @author Roar Brænden
+ */
+public class WFSContentComplexFeatureSourceTest {
+
+    private static final String STED = "Sted";
+
+    private static final Name STED_NAME =
+            new NameImpl(
+                    "http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115",
+                    STED);
+
+    @Test
+    public void testGetFeaturesWithoutArgument() throws Exception {
+        final WFSClient client = createWFSClient();
+        final WFSContentDataAccess dataAccess = createDataAccess(client);
+
+        WFSContentComplexFeatureSource featureSource =
+                new WFSContentComplexFeatureSource(STED_NAME, client, dataAccess);
+
+        FeatureCollection<FeatureType, Feature> features = featureSource.getFeatures();
+        Assert.assertNotNull(features);
+    }
+
+    @Test
+    public void testGetFeaturesWithNameQuery() throws Exception {
+        final WFSClient client = createWFSClient();
+        final WFSContentDataAccess dataAccess = createDataAccess(client);
+
+        WFSContentComplexFeatureSource featureSource =
+                new WFSContentComplexFeatureSource(STED_NAME, client, dataAccess);
+
+        Query query = new Query(STED);
+
+        FeatureCollection<FeatureType, Feature> collection = featureSource.getFeatures(query);
+        Assert.assertNotNull(collection);
+
+        try (FeatureIterator<Feature> features = collection.features()) {
+            Assert.assertNotNull(features);
+        }
+    }
+
+    private TestWFSClient createWFSClient() throws Exception {
+        final URL capabilities = new URL("https://wfs.geonorge.no/skwms1/wfs.stedsnavn");
+
+        TestHttpClient mockHttp = new TestHttpClient();
+        mockHttp.expectGet(
+                new URL(
+                        "https://wfs.geonorge.no/skwms1/wfs.stedsnavn?REQUEST=GetCapabilities&SERVICE=WFS"),
+                new MockHttpResponse(
+                        TestData.file(mockHttp, "KartverketNo/GetCapabilities.xml"), "text/xml"));
+
+        TestWFSClient client = new TestWFSClient(capabilities, mockHttp);
+        client.setProtocol(false); // Http GET method
+
+        return client;
+    }
+
+    private WFSContentDataAccess createDataAccess(WFSClient client) throws Exception {
+        final WFSContentDataAccess dataAccess = new WFSContentDataAccess(client);
+        dataAccess.setCacheLocation(Files.createTempDirectory("cache").toFile());
+        return dataAccess;
+    }
+}

--- a/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/cache/no/geonorge/wfs/skwms1/wfs.administrative_enheter.161e2708f54bc4bf058256a8ea569fa6.xsd
+++ b/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/cache/no/geonorge/wfs/skwms1/wfs.administrative_enheter.161e2708f54bc4bf058256a8ea569fa6.xsd
@@ -1,0 +1,14656 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:app="http://skjema.geonorge.no/SOSI/produktspesifikasjon/AdmEnheter/4.1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" elementFormDefault="qualified" targetNamespace="http://skjema.geonorge.no/SOSI/produktspesifikasjon/AdmEnheter/4.1" version="4.1">
+  
+  <annotation>
+    
+    <documentation>spesifikasjon av innholdet i leveransedatasettet administrative enheter</documentation>
+  
+  </annotation>
+  
+  <!--import namespace="http://www.interactive-instruments.de/ShapeChange/AppInfo" schemaLocation="http://shapechange.net/resources/schema/ShapeChangeAppinfo.xsd"/-->
+  
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  
+  <!--XML Schema document created by ShapeChange - http://shapechange.net/-->
+  
+  <element abstract="true" name="AdministrativEnhet" substitutionGroup="app:Supertype_SOSI_Objekt_adm_enheter" type="app:AdministrativEnhetType">
+    
+    <annotation>
+      
+      <documentation>område hvor det utøves offentlig forvaltning på lokalt, regionalt eller nasjonalt nivå</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="AdministrativEnhetType">
+    
+    <complexContent>
+      
+      <extension base="app:Supertype_SOSI_Objekt_adm_enheterType">
+        
+        <sequence>
+          
+          <element name="område" type="gml:SurfacePropertyType">
+            
+            <annotation>
+              
+              <documentation>objektets utstrekning</documentation>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="AdministrativEnhetPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:AdministrativEnhet"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element name="AdministrativEnhetNavn" substitutionGroup="gml:AbstractObject" type="app:AdministrativEnhetNavnType">
+    
+    <annotation>
+      
+      <documentation>offisielt navn på en kommune, et fylke eller en nasjon</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">ADMENHETNAVN</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="AdministrativEnhetNavnType">
+    
+    <sequence>
+      
+      <element name="navn" type="string">
+        
+        <annotation>
+          
+          <documentation>offisielt navn på administrativ enhet</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVN</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="språk" type="app:SpråkkodeType">
+        
+        <annotation>
+          
+          <documentation>angir hvilket språk navnet hører til</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SPRÅK</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element minOccurs="0" name="rekkefølge" type="integer">
+        
+        <annotation>
+          
+          <documentation>angir hvilken plassering man skal bruke for flerspråklige navn på skilt eller kart og lignende der det blir brukt mer enn ett navn
+
+Merknad: Vedtaksorganet fastsetter rekkefølgen av navnene. I forvaltningsområdet for samisk språk skal rekkefølgen være samisk, norsk, kvensk. I sammenhengende tekst skal man bruke det navnet som samsvarer med språket i teksten. Se forskrift om skrivemåten av stadnamn, § 7.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">REKKEFØLGE</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="AdministrativEnhetNavnPropertyType">
+    
+    <sequence>
+      
+      <element ref="app:AdministrativEnhetNavn"/>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <element abstract="true" name="AdministrativGrense" substitutionGroup="app:Supertype_SOSI_Objekt_adm_grenser" type="app:AdministrativGrenseType">
+    
+    <annotation>
+      
+      <documentation>grense for regional eller lokal administrasjon</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="AdministrativGrenseType">
+    
+    <complexContent>
+      
+      <extension base="app:Supertype_SOSI_Objekt_adm_grenserType">
+        
+        <sequence>
+          
+          <element name="grense" type="gml:CurvePropertyType">
+            
+            <annotation>
+              
+              <documentation>forløp som følger overgang mellom ulike fenomener</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="omtvistet" type="boolean">
+            
+            <annotation>
+              
+              <documentation>angir om grensen er omtvistet, eller det er tvil om forløpet</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="nøyaktighetsklasse" type="app:NøyaktighetsklasseKodeType">
+            
+            <annotation>
+              
+              <documentation>klassifikasjon av stedfestingsnøyaktighet på grenser, og er basert på dårligste nøyaktighet til grensepunktene til grensen</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NØYAKTIGHETSKLASSE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element maxOccurs="unbounded" minOccurs="0" name="dokumentasjonsreferanse" type="app:DokumentasjonsreferansePropertyType">
+            
+            <annotation>
+              
+              <documentation>henviser til fastsettings- eller lovinformasjon</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DOKUMENTASJONSREFERANSE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="grensestatus" type="app:GrensestatusType">
+            
+            <annotation>
+              
+              <documentation>juridisk status på grensa</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">GRENSESTATUS</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="fastsettingstype" type="app:FastsettingstypeType">
+            
+            <annotation>
+              
+              <documentation>måte en administrativ grense er fastsatt på</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSTYPE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="følgerTerrengdetalj" type="app:TerrengdetaljKodeType">
+            
+            <annotation>
+              
+              <documentation>opplysning om at grense følger naturlige skillelinjer i terrenget</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FØLGER_TERRENGDET</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="AdministrativGrensePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:AdministrativGrense"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element name="AvtaltAvgrensningslinje" substitutionGroup="app:AvtalteGrenser" type="app:AvtaltAvgrensningslinjeType">
+    
+    <annotation>
+      
+      <documentation>avtalt avgrensningslinje til havs basert på folkerettslig bindende avtaler
+
+Merknad:
+Avtalt avgrensningslinje vil normalt gjelde alle aktuelle former for kyststatsjurisdiksjon. Detaljene vil framgå av den aktuelle avgrensningsavtale.
+
+Merknad 2: 
+Benyttes også som avgrensning av kontinentalsokkel i internasjonalt farvann, der flere stater kan framlegge dokumentasjon om rettigheter til sokkelen, men der statene har kommet til enighet om en avgrensningslinje.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">AVTALTAVGRENSNINGSLINJE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="AvtaltAvgrensningslinjeType">
+    
+    <complexContent>
+      
+      <extension base="app:AvtalteGrenserType">
+        
+        <sequence/>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="AvtaltAvgrensningslinjePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:AvtaltAvgrensningslinje"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element abstract="true" name="AvtalteGrenser" substitutionGroup="app:GrenseMellomNasjoner" type="app:AvtalteGrenserType">
+    
+    <annotation>
+      
+      <documentation>avtale mellom to eller flere stater om en felles grense, enten mellom nasjonene eller som avgrensning av felles område for ressursutnyttelse</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="AvtalteGrenserType">
+    
+    <complexContent>
+      
+      <extension base="app:GrenseMellomNasjonerType">
+        
+        <sequence>
+          
+          <element maxOccurs="unbounded" name="dokumentasjonsreferanse" type="app:DokumentasjonsreferansePropertyType">
+            
+            <annotation>
+              
+              <documentation>henviser til fastsettings- eller lovinformasjon</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DOKUMENTASJONSREFERANSE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="fastsettingstype" type="app:FastsettingstypeType">
+            
+            <annotation>
+              
+              <documentation>måte en grense kan være fastsatt på</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSTYPE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="AvtalteGrenserPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:AvtalteGrenser"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element abstract="true" name="BeregnetGrense" substitutionGroup="app:NorskeGrenser" type="app:BeregnetGrenseType">
+    
+    <annotation>
+      
+      <documentation>grenser som er beregnet utenfor og parallelt med grunnlinjen i en gitt avstand fra denne</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="BeregnetGrenseType">
+    
+    <complexContent>
+      
+      <extension base="app:NorskeGrenserType">
+        
+        <sequence/>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="BeregnetGrensePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:BeregnetGrense"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element name="Dokumentasjonsreferanse" substitutionGroup="gml:AbstractObject" type="app:DokumentasjonsreferanseType">
+    
+    <annotation>
+      
+      <documentation>henviser til fastsettings- eller lovinformasjon</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DOKUMENTASJONSREFERANSE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="DokumentasjonsreferanseType">
+    
+    <sequence>
+      
+      <element name="rettskildeTittel" type="string">
+        
+        <annotation>
+          
+          <documentation>navn på lov, forskrift, vedtak, dom eller traktat</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">RETTSKILDETITTEL</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element minOccurs="0" name="rettskildeId" type="string">
+        
+        <annotation>
+          
+          <documentation>referanse til lov, forskrift, vedtak, dom eller traktat i form av kode som angir type dokument, dato og nummer
+
+For eksempel: LOV-2012-09-07-65</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">RETTSKILDEID</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element minOccurs="0" name="hjemmel" type="string">
+        
+        <annotation>
+          
+          <documentation>lov som rettskilden er begrunnet i</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">HJEMMEL</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element minOccurs="0" name="fastsettingsmyndighet" type="string">
+        
+        <annotation>
+          
+          <documentation>offentlig instans som har fastsatt en grense</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSMYNDIGHET</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="fastsettingsdato" type="date">
+        
+        <annotation>
+          
+          <documentation>dato for når dokumentet ble skrevet, publisert eller revidert</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSDATO</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element minOccurs="0" name="dokumentlink" type="string">
+        
+        <annotation>
+          
+          <documentation>URL til saksdokument</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DOKUMENTLINK</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element minOccurs="0" name="internReferanseKartverket" type="string">
+        
+        <annotation>
+          
+          <documentation>henvisning til saksdokument i Kartverkets eget arkiv
+
+Merknad: Gjelder også link til skannet dokument på intern server.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">INTERNREFERANSEKARTVERKET</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="DokumentasjonsreferansePropertyType">
+    
+    <sequence>
+      
+      <element ref="app:Dokumentasjonsreferanse"/>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <simpleType name="FastsettingstypeType">
+    
+    <annotation>
+      
+      <documentation>liste over ulike måter en administrativ grense kan være fastsatt på 
+
+Merknad: Måten for fastsetting av administrativ grense sier ikke noe om hvor nøyaktig posisjonsbestemmelsen er i forhold til grensemerket eller terrengdetaljer i marka. For grenser kan det derfor framkomme nye og bedre målinger som gir en mer nøyaktig posisjonsbestemmelse.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSTYPE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:FastsettingstypeEnumerationType app:FastsettingstypeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="FastsettingstypeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>liste over ulike måter en administrativ grense kan være fastsatt på 
+
+Merknad: Måten for fastsetting av administrativ grense sier ikke noe om hvor nøyaktig posisjonsbestemmelsen er i forhold til grensemerket eller terrengdetaljer i marka. For grenser kan det derfor framkomme nye og bedre målinger som gir en mer nøyaktig posisjonsbestemmelse.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSTYPE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="Beregnet">
+        
+        <annotation>
+          
+          <documentation>grenseforløpet er kalkulert ut fra gjeldende geodetiske prinsipper for administrative grenser i sjø og innsjø
+
+Merknad: For eksempel midtlinjeprinsippet eller beregning av paralleller.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="BestemteKoordinater">
+        
+        <annotation>
+          
+          <documentation>grensefastsettelsen inneholder liste med koordinater for grenseforløpet 
+
+Merknad: En grense med bestemte koordinater kan ikke få målt bedre posisjon uten at det også gjøres et nytt vedtak, for her er det selve koordinatene som er fastsatt.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Grensebeskrivelse">
+        
+        <annotation>
+          
+          <documentation>grenseforløpet er tekstlig skildret
+
+Merknad: Kan være detaljert beskrevet med stedsnavn og retningsangivelser, eller være en oppramsing av bygder el. som overføres til en annen kommune.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Oppmålt">
+        
+        <annotation>
+          
+          <documentation>grensa er merket og målt i marka, og oppgitt med koordinater
+
+Merknad: Punktet registreres sammen med en posisjonsnøyaktighet, oftest standardavvik (kvalitet).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="FastsettingstypeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Fylke" substitutionGroup="app:AdministrativEnhet" type="app:FylkeType">
+    
+    <annotation>
+      
+      <documentation>County: administrativ inndeling av nasjonen på regionalt nivå
+
+Merknad: Tilsvarer NUTS 3 på internasjonalt statistisk nivå</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="FylkeType">
+    
+    <complexContent>
+      
+      <extension base="app:AdministrativEnhetType">
+        
+        <sequence>
+          
+          <element name="fylkesnummer" type="app:FylkesnummerType">
+            
+            <annotation>
+              
+              <documentation>countyNumber: nummerering av fylket i henhold til Statistisk sentralbyrå sin offisielle liste
+
+Merknad:
+Det presiseres at fylkesnummer alltid skal ha 2 sifre, dvs. eventuelt med ledende null. Fylkesnummer benyttes for kopling mot en rekke andre registre som også benytter 2 sifre.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESNUMMER</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element maxOccurs="unbounded" name="fylkesnavn" type="app:AdministrativEnhetNavnPropertyType">
+            
+            <annotation>
+              
+              <documentation>offisielt navn på fylket</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESNAVN</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="samiskForvaltningsområde" type="boolean">
+            
+            <annotation>
+              
+              <documentation>om fylket er en del av samisk forvaltningsområde
+
+Merknad: Fylket fungerer kun som samisk forvaltningsområde for de kommunene som er innlemmet i samisk forvaltningsområde.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SAMISKFORVALTNINGSOMRÅDE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="FylkePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Fylke"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element name="Fylkesgrense" substitutionGroup="app:AdministrativGrense" type="app:FylkesgrenseType">
+    
+    <annotation>
+      
+      <documentation>CountyBoundary: avgrensning av fylke</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESGRENSE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="FylkesgrenseType">
+    
+    <complexContent>
+      
+      <extension base="app:AdministrativGrenseType">
+        
+        <sequence/>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="FylkesgrensePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Fylkesgrense"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <simpleType name="FylkesnummerType">
+    
+    <annotation>
+      
+      <documentation>CountyNumber: nummerering av fylker i henhold til Statistisk sentralbyrå sin offisielle liste
+
+Merknad:
+Det presiseres at fylkesnummer alltid skal ha 2 sifre, dvs. eventuelt med ledende null. Fylkesnummer benyttes for kopling mot en rekke andre registre som også benytter 2 sifre.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESNUMMER</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:FylkesnummerEnumerationType app:FylkesnummerOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="FylkesnummerEnumerationType">
+    
+    <annotation>
+      
+      <documentation>CountyNumber: nummerering av fylker i henhold til Statistisk sentralbyrå sin offisielle liste
+
+Merknad:
+Det presiseres at fylkesnummer alltid skal ha 2 sifre, dvs. eventuelt med ledende null. Fylkesnummer benyttes for kopling mot en rekke andre registre som også benytter 2 sifre.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESNUMMER</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="01">
+        
+        <annotation>
+          
+          <documentation>Østfold: Østfold (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="30">
+        
+        <annotation>
+          
+          <documentation>Viken</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="30">
+        
+        <annotation>
+          
+          <documentation>Viken</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="02">
+        
+        <annotation>
+          
+          <documentation>Akershus: Akershus (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="03">
+        
+        <annotation>
+          
+          <documentation>Oslo: Oslo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="04">
+        
+        <annotation>
+          
+          <documentation>Hedmark: Hedmark (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="34">
+        
+        <annotation>
+          
+          <documentation>Innlandet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="34">
+        
+        <annotation>
+          
+          <documentation>Innlandet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="05">
+        
+        <annotation>
+          
+          <documentation>Oppland: Oppland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="06">
+        
+        <annotation>
+          
+          <documentation>Buskerud: Buskerud (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="07">
+        
+        <annotation>
+          
+          <documentation>Vestfold: Vestfold (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="38">
+        
+        <annotation>
+          
+          <documentation>Telemark og Vestfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="38">
+        
+        <annotation>
+          
+          <documentation>Telemark og Vestfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="08">
+        
+        <annotation>
+          
+          <documentation>Telemark: Telemark (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="09">
+        
+        <annotation>
+          
+          <documentation>Aust-Agder: Aust-Agder (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="42">
+        
+        <annotation>
+          
+          <documentation>Agder</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="42">
+        
+        <annotation>
+          
+          <documentation>Agder</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="10">
+        
+        <annotation>
+          
+          <documentation>Vest-Agder: Vest-Agder (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="11">
+        
+        <annotation>
+          
+          <documentation>Rogaland: Rogaland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="12">
+        
+        <annotation>
+          
+          <documentation>Hordaland: Hordaland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="46">
+        
+        <annotation>
+          
+          <documentation>Vestland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="46">
+        
+        <annotation>
+          
+          <documentation>Vestland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="13">
+        
+        <annotation>
+          
+          <documentation>Bergen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="14">
+        
+        <annotation>
+          
+          <documentation>Sogn og Fjordane: Sogn og Fjordane (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="15">
+        
+        <annotation>
+          
+          <documentation>Møre og Romsdal: Møre og Romsdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="16">
+        
+        <annotation>
+          
+          <documentation>Sør-Trøndelag: Sør-Trøndelag (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="50">
+        
+        <annotation>
+          
+          <documentation>Trøndelag: Trøndelag</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="17">
+        
+        <annotation>
+          
+          <documentation>Nord-Trøndelag: Nord-Trøndelag (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="18">
+        
+        <annotation>
+          
+          <documentation>Nordland: Nordland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="19">
+        
+        <annotation>
+          
+          <documentation>Troms: Troms - Romsa (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="54">
+        
+        <annotation>
+          
+          <documentation>Troms og Finnmark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="54">
+        
+        <annotation>
+          
+          <documentation>Troms og Finnmark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="20">
+        
+        <annotation>
+          
+          <documentation>Finnmark: Finnmark - Finnmárku (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="21">
+        
+        <annotation>
+          
+          <documentation>Svalbard: Svalbard</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="22">
+        
+        <annotation>
+          
+          <documentation>Jan Mayen: Jan Mayen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="23">
+        
+        <annotation>
+          
+          <documentation>the continental shelf: Kontinentalsokkelen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="FylkesnummerOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element abstract="true" name="GrenseMellomNasjoner" substitutionGroup="app:MaritimeGrenser" type="app:GrenseMellomNasjonerType">
+    
+    <annotation>
+      
+      <documentation>grenser i hav som avgrenser norske områder fra andre lands områder, eller avgrensning av områder hvor flere stater har avtale om felles ressursutnyttelse</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="GrenseMellomNasjonerType">
+    
+    <complexContent>
+      
+      <extension base="app:MaritimeGrenserType">
+        
+        <sequence>
+          
+          <element maxOccurs="unbounded" name="land" type="app:LandkodeType">
+            
+            <annotation>
+              
+              <documentation>angivelse av hvilke land grensa er knyttet til
+
+Merknad: Alfanumerisk kode (ISO 3166-1 alpha-2) for land som definert i ISO 3166</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">LANDKODE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="GrenseMellomNasjonerPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:GrenseMellomNasjoner"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <simpleType name="GrensestatusType">
+    
+    <annotation>
+      
+      <documentation>liste over juridisk status på den administrative grensa</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">GRENSESTATUS</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:GrensestatusEnumerationType app:GrensestatusOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="GrensestatusEnumerationType">
+    
+    <annotation>
+      
+      <documentation>liste over juridisk status på den administrative grensa</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">GRENSESTATUS</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="Traktat">
+        
+        <annotation>
+          
+          <documentation>folkerettslig bindende avtale mellom to eller flere stater</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Lovfestet">
+        
+        <annotation>
+          
+          <documentation>fastsatt med hjemmel i lov</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="KongeligResolusjon">
+        
+        <annotation>
+          
+          <documentation>beslutning fattet av Kongen i statsråd
+
+Merknad: Gjelder også Kronprinsregentens resolusjon og regjeringens resolusjon.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="RettskraftigDom">
+        
+        <annotation>
+          
+          <documentation>grenseforløpet er bestemt av domstol, for eksempel Høyesterett, lagmannsrett, tingrett eller jordskifterett</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Godkjent">
+        
+        <annotation>
+          
+          <documentation>grenseforløpet er vedtatt og godkjent av øverste rette myndighet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Foreslått">
+        
+        <annotation>
+          
+          <documentation>grenseforløp som er i bruk, men som ikke er vedtatt av øverste rette myndighet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Historisk">
+        
+        <annotation>
+          
+          <documentation>grenseforløp som ikke lenger er i bruk til det opprinnelige formålet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="GrensestatusOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Grunnlinje" substitutionGroup="app:NorskeGrenser" type="app:GrunnlinjeType">
+    
+    <annotation>
+      
+      <documentation>Baseline: rette linjer trukket opp mellom punkter på de ytterste nes og skjær som stikker opp av havet ved lavvann (fjære sjø)
+
+Merknad: Med rett linje forstås den korteste linje mellom to punkt på sfæroiden (såkalt geodetisk linje). Grunnlinjepunktene skal være valgt slik at det ikke fins tørt land ved fjære sjø utenfor forbindelseslinjen mellom grunnlinjepunktene.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">GRUNNLINJE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="GrunnlinjeType">
+    
+    <complexContent>
+      
+      <extension base="app:NorskeGrenserType">
+        
+        <sequence>
+          
+          <element name="kommunenummer" type="app:KommunenummerType">
+            
+            <annotation>
+              
+              <documentation>nummerering av kommunen i henhold til Statistisk sentralbyrå sin offisielle liste
+
+Merknad: Det presiseres at kommune alltid skal ha 4 siffer, dvs. eventuelt med ledende null. Kommune benyttes for kopling mot en rekke andre registre som også benytter 4 siffer.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="GrunnlinjePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Grunnlinje"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element name="Identifikasjon" substitutionGroup="gml:AbstractObject" type="app:IdentifikasjonType">
+    
+    <annotation>
+      
+      <documentation>Identification: Unik identifikasjon av et objekt, ivaretatt av den ansvarlige produsent/forvalter, som kan benyttes av eksterne applikasjoner som referanse til objektet. 
+
+NOTE1 Denne eksterne objektidentifikasjonen må ikke forveksles med en tematisk objektidentifikasjon, slik som f.eks bygningsnummer. 
+
+NOTE 2 Denne unike identifikatoren vil ikke endres i løpet av objektets levetid.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">IDENT</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="IdentifikasjonType">
+    
+    <sequence>
+      
+      <element name="lokalId" type="string">
+        
+        <annotation>
+          
+          <documentation>localId: lokal identifikator, tildelt av dataleverendør/dataforvalter. Den lokale identifikatoren er unik innenfor navnerommet, ingen andre objekter har samme identifikator.
+
+NOTE: Det er data leverendørens ansvar å sørge for at denne lokale identifikatoren er unik innenfor navnerommet.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">LOKALID</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="navnerom" type="string">
+        
+        <annotation>
+          
+          <documentation>namespace: navnerom som unikt identifiserer datakilden til objektet, starter med to bokstavs kode jfr ISO 3166. Benytter understreking  ("_") dersom data produsenten ikke er assosiert med bare et land.
+
+NOTE 1 : Verdien for nanverom vil eies av den dataprodusent som har ansvar for de unike identifikatorene og vil registreres i "INSPIRE external  Object Identifier Namespaces Register"
+
+Eksempel: NO for Norge.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVNEROM</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element minOccurs="0" name="versjonId" type="string">
+        
+        <annotation>
+          
+          <documentation>versionId: identifikasjon av en spesiell versjon av et geografisk objekt (instans), maksimum lengde på 25 karakterers. Dersom spesifikasjonen av et geografisk objekt med en identifikasjon inkludererer livsløpssyklusinformasjon, benyttes denne versjonId for å skille mellom ulike versjoner av samme objekt. versjonId er en unik  identifikasjon av versjonen. 
+
+NOTE Maksimum lengde er valgt for å tillate tidsregistrering i henhold til  ISO 8601, slik som  "2007-02-12T12:12:12+05:30" som versjonId.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">VERSJONID</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="IdentifikasjonPropertyType">
+    
+    <sequence>
+      
+      <element ref="app:Identifikasjon"/>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <element name="Kommune" substitutionGroup="app:AdministrativEnhet" type="app:KommuneType">
+    
+    <annotation>
+      
+      <documentation>Municipality: inndeling i administrative og politiske enheter innenfor fylket
+
+Merknad: Tilsvarer NUTS 5 og LAU 2 på internasjonalt statistisk nivå</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="KommuneType">
+    
+    <complexContent>
+      
+      <extension base="app:AdministrativEnhetType">
+        
+        <sequence>
+          
+          <element name="kommunenummer" type="app:KommunenummerType">
+            
+            <annotation>
+              
+              <documentation>municipalityNumber: nummerering av kommunen i henhold til Statistisk sentralbyrå sin offisielle liste
+
+Merknad: Det presiseres at kommune alltid skal ha 4 siffer, dvs. eventuelt med ledende null. Kommune benyttes for kopling mot en rekke andre registre som også benytter 4 siffer.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element maxOccurs="unbounded" name="kommunenavn" type="app:AdministrativEnhetNavnPropertyType">
+            
+            <annotation>
+              
+              <documentation>offisielt navn på kommunen</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENAVN</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="samiskForvaltningsområde" type="boolean">
+            
+            <annotation>
+              
+              <documentation>om kommunen er en del av samisk forvaltningsområde</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SAMISKFORVALTNINGSOMRÅDE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="KommunePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Kommune"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element name="Kommunegrense" substitutionGroup="app:AdministrativGrense" type="app:KommunegrenseType">
+    
+    <annotation>
+      
+      <documentation>MunicipalityBoundary: avgrensing av kommune</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNEGRENSE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="KommunegrenseType">
+    
+    <complexContent>
+      
+      <extension base="app:AdministrativGrenseType">
+        
+        <sequence/>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="KommunegrensePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Kommunegrense"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <simpleType name="KommunenummerType">
+    
+    <annotation>
+      
+      <documentation>nummerering av kommuner i henhold til Statistisk sentralbyrå sin offisielle liste samt et utvalg av utgåtte numre
+
+Merknad: Det presiseres at kommune alltid skal ha 4 sifre, dvs. eventuelt med ledende null. Kommune benyttes for kopling mot en rekke andre registre som også benytter 4 sifre.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:KommunenummerEnumerationType app:KommunenummerOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="KommunenummerEnumerationType">
+    
+    <annotation>
+      
+      <documentation>nummerering av kommuner i henhold til Statistisk sentralbyrå sin offisielle liste samt et utvalg av utgåtte numre
+
+Merknad: Det presiseres at kommune alltid skal ha 4 sifre, dvs. eventuelt med ledende null. Kommune benyttes for kopling mot en rekke andre registre som også benytter 4 sifre.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="0101">
+        
+        <annotation>
+          
+          <documentation>Halden (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3001">
+        
+        <annotation>
+          
+          <documentation>Halden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3001">
+        
+        <annotation>
+          
+          <documentation>Halden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0102">
+        
+        <annotation>
+          
+          <documentation>Sarpsborg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0103">
+        
+        <annotation>
+          
+          <documentation>Fredrikstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0104">
+        
+        <annotation>
+          
+          <documentation>Moss (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3002">
+        
+        <annotation>
+          
+          <documentation>Moss</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3002">
+        
+        <annotation>
+          
+          <documentation>Moss</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0105">
+        
+        <annotation>
+          
+          <documentation>Sarpsborg (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3003">
+        
+        <annotation>
+          
+          <documentation>Sarpsborg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3003">
+        
+        <annotation>
+          
+          <documentation>Sarpsborg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0106">
+        
+        <annotation>
+          
+          <documentation>Fredrikstad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3004">
+        
+        <annotation>
+          
+          <documentation>Fredrikstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3004">
+        
+        <annotation>
+          
+          <documentation>Fredrikstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0111">
+        
+        <annotation>
+          
+          <documentation>Hvaler (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3011">
+        
+        <annotation>
+          
+          <documentation>Hvaler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3011">
+        
+        <annotation>
+          
+          <documentation>Hvaler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0113">
+        
+        <annotation>
+          
+          <documentation>Borge (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0114">
+        
+        <annotation>
+          
+          <documentation>Varteig (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0115">
+        
+        <annotation>
+          
+          <documentation>Skjeberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0118">
+        
+        <annotation>
+          
+          <documentation>Aremark (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3012">
+        
+        <annotation>
+          
+          <documentation>Aremark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3012">
+        
+        <annotation>
+          
+          <documentation>Aremark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0119">
+        
+        <annotation>
+          
+          <documentation>Marker (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3013">
+        
+        <annotation>
+          
+          <documentation>Marker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3013">
+        
+        <annotation>
+          
+          <documentation>Marker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0121">
+        
+        <annotation>
+          
+          <documentation>Rømskog (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3026">
+        
+        <annotation>
+          
+          <documentation>Aurskog-Høland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3026">
+        
+        <annotation>
+          
+          <documentation>Aurskog-Høland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0122">
+        
+        <annotation>
+          
+          <documentation>Trøgstad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3014">
+        
+        <annotation>
+          
+          <documentation>Indre Østfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3014">
+        
+        <annotation>
+          
+          <documentation>Indre Østfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0123">
+        
+        <annotation>
+          
+          <documentation>Spydeberg (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0124">
+        
+        <annotation>
+          
+          <documentation>Askim (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0125">
+        
+        <annotation>
+          
+          <documentation>Eidsberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0127">
+        
+        <annotation>
+          
+          <documentation>Skiptvet (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3015">
+        
+        <annotation>
+          
+          <documentation>Skiptvet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3015">
+        
+        <annotation>
+          
+          <documentation>Skiptvet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0128">
+        
+        <annotation>
+          
+          <documentation>Rakkestad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3016">
+        
+        <annotation>
+          
+          <documentation>Rakkestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3016">
+        
+        <annotation>
+          
+          <documentation>Rakkestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0130">
+        
+        <annotation>
+          
+          <documentation>Tune (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0131">
+        
+        <annotation>
+          
+          <documentation>Rolvsøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0133">
+        
+        <annotation>
+          
+          <documentation>Kråkerøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0134">
+        
+        <annotation>
+          
+          <documentation>Onsøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0135">
+        
+        <annotation>
+          
+          <documentation>Råde (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3017">
+        
+        <annotation>
+          
+          <documentation>Råde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3017">
+        
+        <annotation>
+          
+          <documentation>Råde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0136">
+        
+        <annotation>
+          
+          <documentation>Rygge (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3002">
+        
+        <annotation>
+          
+          <documentation>Moss</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0137">
+        
+        <annotation>
+          
+          <documentation>Våler i Østfold (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3018">
+        
+        <annotation>
+          
+          <documentation>Våler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3018">
+        
+        <annotation>
+          
+          <documentation>Våler i Østfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="0138">
+        
+        <annotation>
+          
+          <documentation>Hobøl (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0211">
+        
+        <annotation>
+          
+          <documentation>Vestby (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3019">
+        
+        <annotation>
+          
+          <documentation>Vestby</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3019">
+        
+        <annotation>
+          
+          <documentation>Vestby</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0213">
+        
+        <annotation>
+          
+          <documentation>Ski (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3020">
+        
+        <annotation>
+          
+          <documentation>Nordre Follo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3020">
+        
+        <annotation>
+          
+          <documentation>Nordre Follo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0214">
+        
+        <annotation>
+          
+          <documentation>Ås (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3021">
+        
+        <annotation>
+          
+          <documentation>Ås</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3021">
+        
+        <annotation>
+          
+          <documentation>Ås</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0215">
+        
+        <annotation>
+          
+          <documentation>Frogn (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3022">
+        
+        <annotation>
+          
+          <documentation>Frogn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3022">
+        
+        <annotation>
+          
+          <documentation>Frogn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0216">
+        
+        <annotation>
+          
+          <documentation>Nesodden (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3023">
+        
+        <annotation>
+          
+          <documentation>Nesodden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3023">
+        
+        <annotation>
+          
+          <documentation>Nesodden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0217">
+        
+        <annotation>
+          
+          <documentation>Oppegård (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0219">
+        
+        <annotation>
+          
+          <documentation>Bærum (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3024">
+        
+        <annotation>
+          
+          <documentation>Bærum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3024">
+        
+        <annotation>
+          
+          <documentation>Bærum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0220">
+        
+        <annotation>
+          
+          <documentation>Asker (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3025">
+        
+        <annotation>
+          
+          <documentation>Asker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3025">
+        
+        <annotation>
+          
+          <documentation>Asker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0221">
+        
+        <annotation>
+          
+          <documentation>Aurskog-Høland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3026">
+        
+        <annotation>
+          
+          <documentation>Aurskog-Høland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0226">
+        
+        <annotation>
+          
+          <documentation>Sørum (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3030">
+        
+        <annotation>
+          
+          <documentation>Lillestrøm</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3030">
+        
+        <annotation>
+          
+          <documentation>Lillestrøm</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0227">
+        
+        <annotation>
+          
+          <documentation>Fet (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0228">
+        
+        <annotation>
+          
+          <documentation>Rælingen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3027">
+        
+        <annotation>
+          
+          <documentation>Rælingen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3027">
+        
+        <annotation>
+          
+          <documentation>Rælingen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0229">
+        
+        <annotation>
+          
+          <documentation>Enebakk (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3028">
+        
+        <annotation>
+          
+          <documentation>Enebakk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3028">
+        
+        <annotation>
+          
+          <documentation>Enebakk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0230">
+        
+        <annotation>
+          
+          <documentation>Lørenskog (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3029">
+        
+        <annotation>
+          
+          <documentation>Lørenskog</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3029">
+        
+        <annotation>
+          
+          <documentation>Lørenskog</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0231">
+        
+        <annotation>
+          
+          <documentation>Skedsmo (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0233">
+        
+        <annotation>
+          
+          <documentation>Nittedal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3031">
+        
+        <annotation>
+          
+          <documentation>Nittedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3031">
+        
+        <annotation>
+          
+          <documentation>Nittedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0234">
+        
+        <annotation>
+          
+          <documentation>Gjerdrum (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3032">
+        
+        <annotation>
+          
+          <documentation>Gjerdrum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3032">
+        
+        <annotation>
+          
+          <documentation>Gjerdrum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0235">
+        
+        <annotation>
+          
+          <documentation>Ullensaker (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3033">
+        
+        <annotation>
+          
+          <documentation>Ullensaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3033">
+        
+        <annotation>
+          
+          <documentation>Ullensaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0236">
+        
+        <annotation>
+          
+          <documentation>Nes i Akershus (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3034">
+        
+        <annotation>
+          
+          <documentation>Nes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3034">
+        
+        <annotation>
+          
+          <documentation>Nes i Akershus</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="0237">
+        
+        <annotation>
+          
+          <documentation>Eidsvoll (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3035">
+        
+        <annotation>
+          
+          <documentation>Eidsvoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3035">
+        
+        <annotation>
+          
+          <documentation>Eidsvoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0238">
+        
+        <annotation>
+          
+          <documentation>Nannestad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3036">
+        
+        <annotation>
+          
+          <documentation>Nannestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3036">
+        
+        <annotation>
+          
+          <documentation>Nannestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0239">
+        
+        <annotation>
+          
+          <documentation>Hurdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3037">
+        
+        <annotation>
+          
+          <documentation>Hurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3037">
+        
+        <annotation>
+          
+          <documentation>Hurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0301">
+        
+        <annotation>
+          
+          <documentation>Oslo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0401">
+        
+        <annotation>
+          
+          <documentation>Hamar (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0402">
+        
+        <annotation>
+          
+          <documentation>Kongsvinger (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3401">
+        
+        <annotation>
+          
+          <documentation>Kongsvinger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3401">
+        
+        <annotation>
+          
+          <documentation>Kongsvinger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0403">
+        
+        <annotation>
+          
+          <documentation>Hamar (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3403">
+        
+        <annotation>
+          
+          <documentation>Hamar</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3403">
+        
+        <annotation>
+          
+          <documentation>Hamar</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0412">
+        
+        <annotation>
+          
+          <documentation>Ringsaker (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3411">
+        
+        <annotation>
+          
+          <documentation>Ringsaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3411">
+        
+        <annotation>
+          
+          <documentation>Ringsaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0414">
+        
+        <annotation>
+          
+          <documentation>Vang (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0415">
+        
+        <annotation>
+          
+          <documentation>Løten (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3412">
+        
+        <annotation>
+          
+          <documentation>Løten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3412">
+        
+        <annotation>
+          
+          <documentation>Løten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0417">
+        
+        <annotation>
+          
+          <documentation>Stange (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3413">
+        
+        <annotation>
+          
+          <documentation>Stange</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3413">
+        
+        <annotation>
+          
+          <documentation>Stange</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0418">
+        
+        <annotation>
+          
+          <documentation>Nord-Odal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3414">
+        
+        <annotation>
+          
+          <documentation>Nord-Odal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3414">
+        
+        <annotation>
+          
+          <documentation>Nord-Odal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0419">
+        
+        <annotation>
+          
+          <documentation>Sør-Odal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3415">
+        
+        <annotation>
+          
+          <documentation>Sør-Odal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3415">
+        
+        <annotation>
+          
+          <documentation>Sør-Odal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0420">
+        
+        <annotation>
+          
+          <documentation>Eidskog (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3416">
+        
+        <annotation>
+          
+          <documentation>Eidskog</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3416">
+        
+        <annotation>
+          
+          <documentation>Eidskog</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0423">
+        
+        <annotation>
+          
+          <documentation>Grue (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3417">
+        
+        <annotation>
+          
+          <documentation>Grue</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3417">
+        
+        <annotation>
+          
+          <documentation>Grue</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0425">
+        
+        <annotation>
+          
+          <documentation>Åsnes (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3418">
+        
+        <annotation>
+          
+          <documentation>Åsnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3418">
+        
+        <annotation>
+          
+          <documentation>Åsnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0426">
+        
+        <annotation>
+          
+          <documentation>Våler i Hedmark (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3419">
+        
+        <annotation>
+          
+          <documentation>Våler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3419">
+        
+        <annotation>
+          
+          <documentation>Våler i Hedmark</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="0427">
+        
+        <annotation>
+          
+          <documentation>Elverum (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3420">
+        
+        <annotation>
+          
+          <documentation>Elverum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3420">
+        
+        <annotation>
+          
+          <documentation>Elverum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0428">
+        
+        <annotation>
+          
+          <documentation>Trysil (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3421">
+        
+        <annotation>
+          
+          <documentation>Trysil</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3421">
+        
+        <annotation>
+          
+          <documentation>Trysil</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0429">
+        
+        <annotation>
+          
+          <documentation>Åmot (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3422">
+        
+        <annotation>
+          
+          <documentation>Åmot</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3422">
+        
+        <annotation>
+          
+          <documentation>Åmot</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0430">
+        
+        <annotation>
+          
+          <documentation>Stor-Elvdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3423">
+        
+        <annotation>
+          
+          <documentation>Stor-Elvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3423">
+        
+        <annotation>
+          
+          <documentation>Stor-Elvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0432">
+        
+        <annotation>
+          
+          <documentation>Rendalen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3424">
+        
+        <annotation>
+          
+          <documentation>Rendalen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3424">
+        
+        <annotation>
+          
+          <documentation>Rendalen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0434">
+        
+        <annotation>
+          
+          <documentation>Engerdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3425">
+        
+        <annotation>
+          
+          <documentation>Engerdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3425">
+        
+        <annotation>
+          
+          <documentation>Engerdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0436">
+        
+        <annotation>
+          
+          <documentation>Tolga (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3426">
+        
+        <annotation>
+          
+          <documentation>Tolga</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3426">
+        
+        <annotation>
+          
+          <documentation>Tolga</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0437">
+        
+        <annotation>
+          
+          <documentation>Tynset (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3427">
+        
+        <annotation>
+          
+          <documentation>Tynset</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3427">
+        
+        <annotation>
+          
+          <documentation>Tynset</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0438">
+        
+        <annotation>
+          
+          <documentation>Alvdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3428">
+        
+        <annotation>
+          
+          <documentation>Alvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3428">
+        
+        <annotation>
+          
+          <documentation>Alvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0439">
+        
+        <annotation>
+          
+          <documentation>Folldal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3429">
+        
+        <annotation>
+          
+          <documentation>Folldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3429">
+        
+        <annotation>
+          
+          <documentation>Folldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0441">
+        
+        <annotation>
+          
+          <documentation>Os i Hedmark (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3430">
+        
+        <annotation>
+          
+          <documentation>Os</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3430">
+        
+        <annotation>
+          
+          <documentation>Os i Hedmark</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="0501">
+        
+        <annotation>
+          
+          <documentation>Lillehammer (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3405">
+        
+        <annotation>
+          
+          <documentation>Lillehammer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3405">
+        
+        <annotation>
+          
+          <documentation>Lillehammer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0502">
+        
+        <annotation>
+          
+          <documentation>Gjøvik (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3407">
+        
+        <annotation>
+          
+          <documentation>Gjøvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3407">
+        
+        <annotation>
+          
+          <documentation>Gjøvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0511">
+        
+        <annotation>
+          
+          <documentation>Dovre (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3431">
+        
+        <annotation>
+          
+          <documentation>Dovre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3431">
+        
+        <annotation>
+          
+          <documentation>Dovre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0512">
+        
+        <annotation>
+          
+          <documentation>Lesja (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3432">
+        
+        <annotation>
+          
+          <documentation>Lesja</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3432">
+        
+        <annotation>
+          
+          <documentation>Lesja</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0513">
+        
+        <annotation>
+          
+          <documentation>Skjåk (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3433">
+        
+        <annotation>
+          
+          <documentation>Skjåk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3433">
+        
+        <annotation>
+          
+          <documentation>Skjåk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0514">
+        
+        <annotation>
+          
+          <documentation>Lom (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3434">
+        
+        <annotation>
+          
+          <documentation>Lom</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3434">
+        
+        <annotation>
+          
+          <documentation>Lom</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0515">
+        
+        <annotation>
+          
+          <documentation>Vågå (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3435">
+        
+        <annotation>
+          
+          <documentation>Vågå</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3435">
+        
+        <annotation>
+          
+          <documentation>Vågå</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0516">
+        
+        <annotation>
+          
+          <documentation>Nord-Fron (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3436">
+        
+        <annotation>
+          
+          <documentation>Nord-Fron</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3436">
+        
+        <annotation>
+          
+          <documentation>Nord-Fron</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0517">
+        
+        <annotation>
+          
+          <documentation>Sel (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3437">
+        
+        <annotation>
+          
+          <documentation>Sel</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3437">
+        
+        <annotation>
+          
+          <documentation>Sel</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0519">
+        
+        <annotation>
+          
+          <documentation>Sør-Fron (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3438">
+        
+        <annotation>
+          
+          <documentation>Sør-Fron</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3438">
+        
+        <annotation>
+          
+          <documentation>Sør-Fron</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0520">
+        
+        <annotation>
+          
+          <documentation>Ringebu (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3439">
+        
+        <annotation>
+          
+          <documentation>Ringebu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3439">
+        
+        <annotation>
+          
+          <documentation>Ringebu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0521">
+        
+        <annotation>
+          
+          <documentation>Øyer (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3440">
+        
+        <annotation>
+          
+          <documentation>Øyer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3440">
+        
+        <annotation>
+          
+          <documentation>Øyer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0522">
+        
+        <annotation>
+          
+          <documentation>Gausdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3441">
+        
+        <annotation>
+          
+          <documentation>Gausdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3441">
+        
+        <annotation>
+          
+          <documentation>Gausdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0528">
+        
+        <annotation>
+          
+          <documentation>Østre Toten (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3442">
+        
+        <annotation>
+          
+          <documentation>Østre Toten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3442">
+        
+        <annotation>
+          
+          <documentation>Østre Toten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0529">
+        
+        <annotation>
+          
+          <documentation>Vestre Toten (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3443">
+        
+        <annotation>
+          
+          <documentation>Vestre Toten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3443">
+        
+        <annotation>
+          
+          <documentation>Vestre Toten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0532">
+        
+        <annotation>
+          
+          <documentation>Jevnaker (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3053">
+        
+        <annotation>
+          
+          <documentation>Jevnaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3053">
+        
+        <annotation>
+          
+          <documentation>Jevnaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0533">
+        
+        <annotation>
+          
+          <documentation>Lunner (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3054">
+        
+        <annotation>
+          
+          <documentation>Lunner</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3054">
+        
+        <annotation>
+          
+          <documentation>Lunner</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0534">
+        
+        <annotation>
+          
+          <documentation>Gran (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3446">
+        
+        <annotation>
+          
+          <documentation>Gran</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3446">
+        
+        <annotation>
+          
+          <documentation>Gran</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0536">
+        
+        <annotation>
+          
+          <documentation>Søndre Land (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3447">
+        
+        <annotation>
+          
+          <documentation>Søndre Land</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3447">
+        
+        <annotation>
+          
+          <documentation>Søndre Land</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0538">
+        
+        <annotation>
+          
+          <documentation>Nordre Land (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3448">
+        
+        <annotation>
+          
+          <documentation>Nordre Land</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3448">
+        
+        <annotation>
+          
+          <documentation>Nordre Land</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0540">
+        
+        <annotation>
+          
+          <documentation>Sør-Aurdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3449">
+        
+        <annotation>
+          
+          <documentation>Sør-Aurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3449">
+        
+        <annotation>
+          
+          <documentation>Sør-Aurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0541">
+        
+        <annotation>
+          
+          <documentation>Etnedal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3450">
+        
+        <annotation>
+          
+          <documentation>Etnedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3450">
+        
+        <annotation>
+          
+          <documentation>Etnedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0542">
+        
+        <annotation>
+          
+          <documentation>Nord-Aurdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3451">
+        
+        <annotation>
+          
+          <documentation>Nord-Aurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3451">
+        
+        <annotation>
+          
+          <documentation>Nord-Aurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0543">
+        
+        <annotation>
+          
+          <documentation>Vestre Slidre (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3452">
+        
+        <annotation>
+          
+          <documentation>Vestre Slidre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3452">
+        
+        <annotation>
+          
+          <documentation>Vestre Slidre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0544">
+        
+        <annotation>
+          
+          <documentation>Øystre Slidre (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3453">
+        
+        <annotation>
+          
+          <documentation>Øystre Slidre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3453">
+        
+        <annotation>
+          
+          <documentation>Øystre Slidre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0545">
+        
+        <annotation>
+          
+          <documentation>Vang (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3454">
+        
+        <annotation>
+          
+          <documentation>Vang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3454">
+        
+        <annotation>
+          
+          <documentation>Vang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0602">
+        
+        <annotation>
+          
+          <documentation>Drammen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3005">
+        
+        <annotation>
+          
+          <documentation>Drammen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3005">
+        
+        <annotation>
+          
+          <documentation>Drammen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0604">
+        
+        <annotation>
+          
+          <documentation>Kongsberg (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3006">
+        
+        <annotation>
+          
+          <documentation>Kongsberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3006">
+        
+        <annotation>
+          
+          <documentation>Kongsberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0605">
+        
+        <annotation>
+          
+          <documentation>Ringerike (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3007">
+        
+        <annotation>
+          
+          <documentation>Ringerike</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3007">
+        
+        <annotation>
+          
+          <documentation>Ringerike</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0612">
+        
+        <annotation>
+          
+          <documentation>Hole (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3038">
+        
+        <annotation>
+          
+          <documentation>Hole</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3038">
+        
+        <annotation>
+          
+          <documentation>Hole</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0615">
+        
+        <annotation>
+          
+          <documentation>Flå (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3039">
+        
+        <annotation>
+          
+          <documentation>Flå</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3039">
+        
+        <annotation>
+          
+          <documentation>Flå</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0616">
+        
+        <annotation>
+          
+          <documentation>Nes i Buskerud (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3040">
+        
+        <annotation>
+          
+          <documentation>Nesbyen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3040">
+        
+        <annotation>
+          
+          <documentation>Nes i Buskerud</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="0617">
+        
+        <annotation>
+          
+          <documentation>Gol (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3041">
+        
+        <annotation>
+          
+          <documentation>Gol</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3041">
+        
+        <annotation>
+          
+          <documentation>Gol</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0618">
+        
+        <annotation>
+          
+          <documentation>Hemsedal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3042">
+        
+        <annotation>
+          
+          <documentation>Hemsedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3042">
+        
+        <annotation>
+          
+          <documentation>Hemsedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0619">
+        
+        <annotation>
+          
+          <documentation>Ål (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3043">
+        
+        <annotation>
+          
+          <documentation>Ål</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3043">
+        
+        <annotation>
+          
+          <documentation>Ål</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0620">
+        
+        <annotation>
+          
+          <documentation>Hol (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3044">
+        
+        <annotation>
+          
+          <documentation>Hol</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3044">
+        
+        <annotation>
+          
+          <documentation>Hol</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0621">
+        
+        <annotation>
+          
+          <documentation>Sigdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3045">
+        
+        <annotation>
+          
+          <documentation>Sigdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3045">
+        
+        <annotation>
+          
+          <documentation>Sigdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0622">
+        
+        <annotation>
+          
+          <documentation>Krødsherad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3046">
+        
+        <annotation>
+          
+          <documentation>Krødsherad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3046">
+        
+        <annotation>
+          
+          <documentation>Krødsherad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0623">
+        
+        <annotation>
+          
+          <documentation>Modum (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3047">
+        
+        <annotation>
+          
+          <documentation>Modum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3047">
+        
+        <annotation>
+          
+          <documentation>Modum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0624">
+        
+        <annotation>
+          
+          <documentation>Øvre Eiker (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3048">
+        
+        <annotation>
+          
+          <documentation>Øvre Eiker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3048">
+        
+        <annotation>
+          
+          <documentation>Øvre Eiker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0625">
+        
+        <annotation>
+          
+          <documentation>Nedre Eiker (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3005">
+        
+        <annotation>
+          
+          <documentation>Drammen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0626">
+        
+        <annotation>
+          
+          <documentation>Lier (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3049">
+        
+        <annotation>
+          
+          <documentation>Lier</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3049">
+        
+        <annotation>
+          
+          <documentation>Lier</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0627">
+        
+        <annotation>
+          
+          <documentation>Røyken (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3025">
+        
+        <annotation>
+          
+          <documentation>Asker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0628">
+        
+        <annotation>
+          
+          <documentation>Hurum (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0631">
+        
+        <annotation>
+          
+          <documentation>Flesberg (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3050">
+        
+        <annotation>
+          
+          <documentation>Flesberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3050">
+        
+        <annotation>
+          
+          <documentation>Flesberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0632">
+        
+        <annotation>
+          
+          <documentation>Rollag (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3051">
+        
+        <annotation>
+          
+          <documentation>Rollag</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3051">
+        
+        <annotation>
+          
+          <documentation>Rollag</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0633">
+        
+        <annotation>
+          
+          <documentation>Nore og Uvdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3052">
+        
+        <annotation>
+          
+          <documentation>Nore og Uvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3052">
+        
+        <annotation>
+          
+          <documentation>Nore og Uvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0701">
+        
+        <annotation>
+          
+          <documentation>Horten (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3801">
+        
+        <annotation>
+          
+          <documentation>Horten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3801">
+        
+        <annotation>
+          
+          <documentation>Horten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0702">
+        
+        <annotation>
+          
+          <documentation>Holmestrand (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0715">
+        
+        <annotation>
+          
+          <documentation>Holmestrand (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3802">
+        
+        <annotation>
+          
+          <documentation>Holmestrand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0703">
+        
+        <annotation>
+          
+          <documentation>Horten (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0704">
+        
+        <annotation>
+          
+          <documentation>Tønsberg (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3803">
+        
+        <annotation>
+          
+          <documentation>Tønsberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3803">
+        
+        <annotation>
+          
+          <documentation>Tønsberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0705">
+        
+        <annotation>
+          
+          <documentation>Tønsberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0706">
+        
+        <annotation>
+          
+          <documentation>Sandefjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0707">
+        
+        <annotation>
+          
+          <documentation>Larvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0708">
+        
+        <annotation>
+          
+          <documentation>Stavern (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0709">
+        
+        <annotation>
+          
+          <documentation>Larvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0712">
+        
+        <annotation>
+          
+          <documentation>Larvik (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3805">
+        
+        <annotation>
+          
+          <documentation>Larvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3805">
+        
+        <annotation>
+          
+          <documentation>Larvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0710">
+        
+        <annotation>
+          
+          <documentation>Sandefjord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3804">
+        
+        <annotation>
+          
+          <documentation>Sandefjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3804">
+        
+        <annotation>
+          
+          <documentation>Sandefjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0711">
+        
+        <annotation>
+          
+          <documentation>Svelvik (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0713">
+        
+        <annotation>
+          
+          <documentation>Sande i Vestfold (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3802">
+        
+        <annotation>
+          
+          <documentation>Holmestrand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0714">
+        
+        <annotation>
+          
+          <documentation>Hof (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0716">
+        
+        <annotation>
+          
+          <documentation>Re (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3803">
+        
+        <annotation>
+          
+          <documentation>Tønsberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0717">
+        
+        <annotation>
+          
+          <documentation>Borre (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0718">
+        
+        <annotation>
+          
+          <documentation>Ramnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0719">
+        
+        <annotation>
+          
+          <documentation>Andebu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0720">
+        
+        <annotation>
+          
+          <documentation>Stokke (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0721">
+        
+        <annotation>
+          
+          <documentation>Sem (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0722">
+        
+        <annotation>
+          
+          <documentation>Nøtterøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0729">
+        
+        <annotation>
+          
+          <documentation>Færder (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3811">
+        
+        <annotation>
+          
+          <documentation>Færder</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3811">
+        
+        <annotation>
+          
+          <documentation>Færder</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0723">
+        
+        <annotation>
+          
+          <documentation>Tjøme (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0725">
+        
+        <annotation>
+          
+          <documentation>Tjølling (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0726">
+        
+        <annotation>
+          
+          <documentation>Brunlanes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0727">
+        
+        <annotation>
+          
+          <documentation>Hedrum (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0728">
+        
+        <annotation>
+          
+          <documentation>Lardal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0805">
+        
+        <annotation>
+          
+          <documentation>Porsgrunn (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3806">
+        
+        <annotation>
+          
+          <documentation>Porsgrunn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3806">
+        
+        <annotation>
+          
+          <documentation>Porsgrunn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0806">
+        
+        <annotation>
+          
+          <documentation>Skien (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3807">
+        
+        <annotation>
+          
+          <documentation>Skien</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3807">
+        
+        <annotation>
+          
+          <documentation>Skien</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0807">
+        
+        <annotation>
+          
+          <documentation>Notodden (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3808">
+        
+        <annotation>
+          
+          <documentation>Notodden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3808">
+        
+        <annotation>
+          
+          <documentation>Notodden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0811">
+        
+        <annotation>
+          
+          <documentation>Siljan (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3812">
+        
+        <annotation>
+          
+          <documentation>Siljan</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3812">
+        
+        <annotation>
+          
+          <documentation>Siljan</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0814">
+        
+        <annotation>
+          
+          <documentation>Bamble (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3813">
+        
+        <annotation>
+          
+          <documentation>Bamble</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3813">
+        
+        <annotation>
+          
+          <documentation>Bamble</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0815">
+        
+        <annotation>
+          
+          <documentation>Kragerø (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3814">
+        
+        <annotation>
+          
+          <documentation>Kragerø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3814">
+        
+        <annotation>
+          
+          <documentation>Kragerø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0817">
+        
+        <annotation>
+          
+          <documentation>Drangedal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3815">
+        
+        <annotation>
+          
+          <documentation>Drangedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3815">
+        
+        <annotation>
+          
+          <documentation>Drangedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0819">
+        
+        <annotation>
+          
+          <documentation>Nome (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3816">
+        
+        <annotation>
+          
+          <documentation>Nome</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3816">
+        
+        <annotation>
+          
+          <documentation>Nome</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0821">
+        
+        <annotation>
+          
+          <documentation>Bø i Telemark (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3817">
+        
+        <annotation>
+          
+          <documentation>Midt-Telemark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3817">
+        
+        <annotation>
+          
+          <documentation>Midt-Telemark</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="0822">
+        
+        <annotation>
+          
+          <documentation>Sauherad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0826">
+        
+        <annotation>
+          
+          <documentation>Tinn (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3818">
+        
+        <annotation>
+          
+          <documentation>Tinn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3818">
+        
+        <annotation>
+          
+          <documentation>Tinn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0827">
+        
+        <annotation>
+          
+          <documentation>Hjartdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3819">
+        
+        <annotation>
+          
+          <documentation>Hjartdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3819">
+        
+        <annotation>
+          
+          <documentation>Hjartdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0828">
+        
+        <annotation>
+          
+          <documentation>Seljord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3820">
+        
+        <annotation>
+          
+          <documentation>Seljord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3820">
+        
+        <annotation>
+          
+          <documentation>Seljord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0829">
+        
+        <annotation>
+          
+          <documentation>Kviteseid (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3821">
+        
+        <annotation>
+          
+          <documentation>Kviteseid</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3821">
+        
+        <annotation>
+          
+          <documentation>Kviteseid</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0830">
+        
+        <annotation>
+          
+          <documentation>Nissedal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3822">
+        
+        <annotation>
+          
+          <documentation>Nissedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3822">
+        
+        <annotation>
+          
+          <documentation>Nissedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0831">
+        
+        <annotation>
+          
+          <documentation>Fyresdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3823">
+        
+        <annotation>
+          
+          <documentation>Fyresdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3823">
+        
+        <annotation>
+          
+          <documentation>Fyresdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0833">
+        
+        <annotation>
+          
+          <documentation>Tokke (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3824">
+        
+        <annotation>
+          
+          <documentation>Tokke</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3824">
+        
+        <annotation>
+          
+          <documentation>Tokke</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0834">
+        
+        <annotation>
+          
+          <documentation>Vinje (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3825">
+        
+        <annotation>
+          
+          <documentation>Vinje</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3825">
+        
+        <annotation>
+          
+          <documentation>Vinje</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0901">
+        
+        <annotation>
+          
+          <documentation>Risør (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4201">
+        
+        <annotation>
+          
+          <documentation>Risør</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4201">
+        
+        <annotation>
+          
+          <documentation>Risør</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0903">
+        
+        <annotation>
+          
+          <documentation>Arendal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0904">
+        
+        <annotation>
+          
+          <documentation>Grimstad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4202">
+        
+        <annotation>
+          
+          <documentation>Grimstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4202">
+        
+        <annotation>
+          
+          <documentation>Grimstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0906">
+        
+        <annotation>
+          
+          <documentation>Arendal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4203">
+        
+        <annotation>
+          
+          <documentation>Arendal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4203">
+        
+        <annotation>
+          
+          <documentation>Arendal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0911">
+        
+        <annotation>
+          
+          <documentation>Gjerstad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4211">
+        
+        <annotation>
+          
+          <documentation>Gjerstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4211">
+        
+        <annotation>
+          
+          <documentation>Gjerstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0912">
+        
+        <annotation>
+          
+          <documentation>Vegårshei (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4212">
+        
+        <annotation>
+          
+          <documentation>Vegårshei</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4212">
+        
+        <annotation>
+          
+          <documentation>Vegårshei</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0914">
+        
+        <annotation>
+          
+          <documentation>Tvedestrand (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4213">
+        
+        <annotation>
+          
+          <documentation>Tvedestrand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4213">
+        
+        <annotation>
+          
+          <documentation>Tvedestrand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0918">
+        
+        <annotation>
+          
+          <documentation>Moland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0919">
+        
+        <annotation>
+          
+          <documentation>Froland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4214">
+        
+        <annotation>
+          
+          <documentation>Froland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4214">
+        
+        <annotation>
+          
+          <documentation>Froland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0920">
+        
+        <annotation>
+          
+          <documentation>Øyestad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0921">
+        
+        <annotation>
+          
+          <documentation>Tromøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0922">
+        
+        <annotation>
+          
+          <documentation>Hisøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0926">
+        
+        <annotation>
+          
+          <documentation>Lillesand (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4215">
+        
+        <annotation>
+          
+          <documentation>Lillesand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4215">
+        
+        <annotation>
+          
+          <documentation>Lillesand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0928">
+        
+        <annotation>
+          
+          <documentation>Birkenes (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4216">
+        
+        <annotation>
+          
+          <documentation>Birkenes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4216">
+        
+        <annotation>
+          
+          <documentation>Birkenes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0929">
+        
+        <annotation>
+          
+          <documentation>Åmli (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4217">
+        
+        <annotation>
+          
+          <documentation>Åmli</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4217">
+        
+        <annotation>
+          
+          <documentation>Åmli</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0935">
+        
+        <annotation>
+          
+          <documentation>Iveland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4218">
+        
+        <annotation>
+          
+          <documentation>Iveland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4218">
+        
+        <annotation>
+          
+          <documentation>Iveland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0937">
+        
+        <annotation>
+          
+          <documentation>Evje og Hornnes (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4219">
+        
+        <annotation>
+          
+          <documentation>Evje og Hornnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4219">
+        
+        <annotation>
+          
+          <documentation>Evje og Hornnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0938">
+        
+        <annotation>
+          
+          <documentation>Bygland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4220">
+        
+        <annotation>
+          
+          <documentation>Bygland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4220">
+        
+        <annotation>
+          
+          <documentation>Bygland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0940">
+        
+        <annotation>
+          
+          <documentation>Valle (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4221">
+        
+        <annotation>
+          
+          <documentation>Valle</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4221">
+        
+        <annotation>
+          
+          <documentation>Valle</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0941">
+        
+        <annotation>
+          
+          <documentation>Bykle (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4222">
+        
+        <annotation>
+          
+          <documentation>Bykle</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4222">
+        
+        <annotation>
+          
+          <documentation>Bykle</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1001">
+        
+        <annotation>
+          
+          <documentation>Kristiansand (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4204">
+        
+        <annotation>
+          
+          <documentation>Kristiansand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4204">
+        
+        <annotation>
+          
+          <documentation>Kristiansand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1002">
+        
+        <annotation>
+          
+          <documentation>Mandal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4205">
+        
+        <annotation>
+          
+          <documentation>Lindesnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4205">
+        
+        <annotation>
+          
+          <documentation>Lindesnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1003">
+        
+        <annotation>
+          
+          <documentation>Farsund (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4206">
+        
+        <annotation>
+          
+          <documentation>Farsund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4206">
+        
+        <annotation>
+          
+          <documentation>Farsund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1004">
+        
+        <annotation>
+          
+          <documentation>Flekkefjord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4207">
+        
+        <annotation>
+          
+          <documentation>Flekkefjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4207">
+        
+        <annotation>
+          
+          <documentation>Flekkefjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1014">
+        
+        <annotation>
+          
+          <documentation>Vennesla (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4223">
+        
+        <annotation>
+          
+          <documentation>Vennesla</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4223">
+        
+        <annotation>
+          
+          <documentation>Vennesla</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1017">
+        
+        <annotation>
+          
+          <documentation>Songdalen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4204">
+        
+        <annotation>
+          
+          <documentation>Kristiansand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1018">
+        
+        <annotation>
+          
+          <documentation>Søgne (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1021">
+        
+        <annotation>
+          
+          <documentation>Marnardal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1026">
+        
+        <annotation>
+          
+          <documentation>Åseral (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4224">
+        
+        <annotation>
+          
+          <documentation>Åseral</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4224">
+        
+        <annotation>
+          
+          <documentation>Åseral</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1027">
+        
+        <annotation>
+          
+          <documentation>Audnedal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4225">
+        
+        <annotation>
+          
+          <documentation>Lyngdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4225">
+        
+        <annotation>
+          
+          <documentation>Lyngdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1029">
+        
+        <annotation>
+          
+          <documentation>Lindesnes (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4205">
+        
+        <annotation>
+          
+          <documentation>Lindesnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1032">
+        
+        <annotation>
+          
+          <documentation>Lyngdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4225">
+        
+        <annotation>
+          
+          <documentation>Lyngdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1034">
+        
+        <annotation>
+          
+          <documentation>Hægebostad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4226">
+        
+        <annotation>
+          
+          <documentation>Hægebostad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4226">
+        
+        <annotation>
+          
+          <documentation>Hægebostad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1037">
+        
+        <annotation>
+          
+          <documentation>Kvinesdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4227">
+        
+        <annotation>
+          
+          <documentation>Kvinesdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4227">
+        
+        <annotation>
+          
+          <documentation>Kvinesdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1046">
+        
+        <annotation>
+          
+          <documentation>Sirdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4228">
+        
+        <annotation>
+          
+          <documentation>Sirdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4228">
+        
+        <annotation>
+          
+          <documentation>Sirdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1101">
+        
+        <annotation>
+          
+          <documentation>Eigersund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1102">
+        
+        <annotation>
+          
+          <documentation>Sandnes (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1108">
+        
+        <annotation>
+          
+          <documentation>Sandnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1108">
+        
+        <annotation>
+          
+          <documentation>Sandnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1103">
+        
+        <annotation>
+          
+          <documentation>Stavanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1106">
+        
+        <annotation>
+          
+          <documentation>Haugesund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1111">
+        
+        <annotation>
+          
+          <documentation>Sokndal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1112">
+        
+        <annotation>
+          
+          <documentation>Lund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1114">
+        
+        <annotation>
+          
+          <documentation>Bjerkreim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1119">
+        
+        <annotation>
+          
+          <documentation>Hå</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1120">
+        
+        <annotation>
+          
+          <documentation>Klepp</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1121">
+        
+        <annotation>
+          
+          <documentation>Time</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1122">
+        
+        <annotation>
+          
+          <documentation>Gjesdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1124">
+        
+        <annotation>
+          
+          <documentation>Sola</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1127">
+        
+        <annotation>
+          
+          <documentation>Randaberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1129">
+        
+        <annotation>
+          
+          <documentation>Forsand (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1108">
+        
+        <annotation>
+          
+          <documentation>Sandnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1130">
+        
+        <annotation>
+          
+          <documentation>Strand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1133">
+        
+        <annotation>
+          
+          <documentation>Hjelmeland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1134">
+        
+        <annotation>
+          
+          <documentation>Suldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1135">
+        
+        <annotation>
+          
+          <documentation>Sauda</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1141">
+        
+        <annotation>
+          
+          <documentation>Finnøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1103">
+        
+        <annotation>
+          
+          <documentation>Stavanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1103">
+        
+        <annotation>
+          
+          <documentation>Stavanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1142">
+        
+        <annotation>
+          
+          <documentation>Rennesøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1144">
+        
+        <annotation>
+          
+          <documentation>Kvitsøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1145">
+        
+        <annotation>
+          
+          <documentation>Bokn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1146">
+        
+        <annotation>
+          
+          <documentation>Tysvær</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1149">
+        
+        <annotation>
+          
+          <documentation>Karmøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1151">
+        
+        <annotation>
+          
+          <documentation>Utsira</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1154">
+        
+        <annotation>
+          
+          <documentation>Vindafjord ((utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1159">
+        
+        <annotation>
+          
+          <documentation>Ølen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1160">
+        
+        <annotation>
+          
+          <documentation>Vindafjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1201">
+        
+        <annotation>
+          
+          <documentation>Bergen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4601">
+        
+        <annotation>
+          
+          <documentation>Bergen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4601">
+        
+        <annotation>
+          
+          <documentation>Bergen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1211">
+        
+        <annotation>
+          
+          <documentation>Etne (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4611">
+        
+        <annotation>
+          
+          <documentation>Etne</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4611">
+        
+        <annotation>
+          
+          <documentation>Etne</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1214">
+        
+        <annotation>
+          
+          <documentation>Ølen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1216">
+        
+        <annotation>
+          
+          <documentation>Sveio (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4612">
+        
+        <annotation>
+          
+          <documentation>Sveio</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4612">
+        
+        <annotation>
+          
+          <documentation>Sveio</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1219">
+        
+        <annotation>
+          
+          <documentation>Bømlo (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4613">
+        
+        <annotation>
+          
+          <documentation>Bømlo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4613">
+        
+        <annotation>
+          
+          <documentation>Bømlo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1221">
+        
+        <annotation>
+          
+          <documentation>Stord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4614">
+        
+        <annotation>
+          
+          <documentation>Stord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4614">
+        
+        <annotation>
+          
+          <documentation>Stord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1222">
+        
+        <annotation>
+          
+          <documentation>Fitjar (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4615">
+        
+        <annotation>
+          
+          <documentation>Fitjar</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4615">
+        
+        <annotation>
+          
+          <documentation>Fitjar</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1223">
+        
+        <annotation>
+          
+          <documentation>Tysnes (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4616">
+        
+        <annotation>
+          
+          <documentation>Tysnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4616">
+        
+        <annotation>
+          
+          <documentation>Tysnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1224">
+        
+        <annotation>
+          
+          <documentation>Kvinnherad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4617">
+        
+        <annotation>
+          
+          <documentation>Kvinnherad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4617">
+        
+        <annotation>
+          
+          <documentation>Kvinnherad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1227">
+        
+        <annotation>
+          
+          <documentation>Jondal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4618">
+        
+        <annotation>
+          
+          <documentation>Ullensvang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4618">
+        
+        <annotation>
+          
+          <documentation>Ullensvang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1228">
+        
+        <annotation>
+          
+          <documentation>Odda (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1231">
+        
+        <annotation>
+          
+          <documentation>Ullensvang (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4618">
+        
+        <annotation>
+          
+          <documentation>Ullensvang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1232">
+        
+        <annotation>
+          
+          <documentation>Eidfjord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4619">
+        
+        <annotation>
+          
+          <documentation>Eidfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4619">
+        
+        <annotation>
+          
+          <documentation>Eidfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1233">
+        
+        <annotation>
+          
+          <documentation>Ulvik (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4620">
+        
+        <annotation>
+          
+          <documentation>Ulvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4620">
+        
+        <annotation>
+          
+          <documentation>Ulvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1234">
+        
+        <annotation>
+          
+          <documentation>Granvin (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4621">
+        
+        <annotation>
+          
+          <documentation>Voss</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4621">
+        
+        <annotation>
+          
+          <documentation>Voss</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1235">
+        
+        <annotation>
+          
+          <documentation>Voss (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4621">
+        
+        <annotation>
+          
+          <documentation>Voss</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1238">
+        
+        <annotation>
+          
+          <documentation>Kvam (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4622">
+        
+        <annotation>
+          
+          <documentation>Kvam</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4622">
+        
+        <annotation>
+          
+          <documentation>Kvam</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1241">
+        
+        <annotation>
+          
+          <documentation>Fusa (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4624">
+        
+        <annotation>
+          
+          <documentation>Bjørnafjorden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4624">
+        
+        <annotation>
+          
+          <documentation>Bjørnafjorden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1242">
+        
+        <annotation>
+          
+          <documentation>Samnanger (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4623">
+        
+        <annotation>
+          
+          <documentation>Samnanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4623">
+        
+        <annotation>
+          
+          <documentation>Samnanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1243">
+        
+        <annotation>
+          
+          <documentation>Os i Hordaland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="1244">
+        
+        <annotation>
+          
+          <documentation>Austevoll (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4625">
+        
+        <annotation>
+          
+          <documentation>Austevoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4625">
+        
+        <annotation>
+          
+          <documentation>Austevoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1245">
+        
+        <annotation>
+          
+          <documentation>Sund (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4626">
+        
+        <annotation>
+          
+          <documentation>Øygarden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4626">
+        
+        <annotation>
+          
+          <documentation>Øygarden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1246">
+        
+        <annotation>
+          
+          <documentation>Fjell (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1247">
+        
+        <annotation>
+          
+          <documentation>Askøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4627">
+        
+        <annotation>
+          
+          <documentation>Askøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4627">
+        
+        <annotation>
+          
+          <documentation>Askøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1251">
+        
+        <annotation>
+          
+          <documentation>Vaksdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4628">
+        
+        <annotation>
+          
+          <documentation>Vaksdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4628">
+        
+        <annotation>
+          
+          <documentation>Vaksdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1252">
+        
+        <annotation>
+          
+          <documentation>Modalen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4629">
+        
+        <annotation>
+          
+          <documentation>Modalen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4629">
+        
+        <annotation>
+          
+          <documentation>Modalen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1253">
+        
+        <annotation>
+          
+          <documentation>Osterøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4630">
+        
+        <annotation>
+          
+          <documentation>Osterøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4630">
+        
+        <annotation>
+          
+          <documentation>Osterøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1256">
+        
+        <annotation>
+          
+          <documentation>Meland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4631">
+        
+        <annotation>
+          
+          <documentation>Alver</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4631">
+        
+        <annotation>
+          
+          <documentation>Alver</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1259">
+        
+        <annotation>
+          
+          <documentation>Øygarden (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4626">
+        
+        <annotation>
+          
+          <documentation>Øygarden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1260">
+        
+        <annotation>
+          
+          <documentation>Radøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1263">
+        
+        <annotation>
+          
+          <documentation>Lindås (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1264">
+        
+        <annotation>
+          
+          <documentation>Austrheim (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4632">
+        
+        <annotation>
+          
+          <documentation>Austrheim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4632">
+        
+        <annotation>
+          
+          <documentation>Austrheim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1265">
+        
+        <annotation>
+          
+          <documentation>Fedje (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4633">
+        
+        <annotation>
+          
+          <documentation>Fedje</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4633">
+        
+        <annotation>
+          
+          <documentation>Fedje</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1266">
+        
+        <annotation>
+          
+          <documentation>Masfjorden (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4634">
+        
+        <annotation>
+          
+          <documentation>Masfjorden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4634">
+        
+        <annotation>
+          
+          <documentation>Masfjorden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1401">
+        
+        <annotation>
+          
+          <documentation>Flora (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4602">
+        
+        <annotation>
+          
+          <documentation>Kinn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4602">
+        
+        <annotation>
+          
+          <documentation>Kinn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1411">
+        
+        <annotation>
+          
+          <documentation>Gulen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4635">
+        
+        <annotation>
+          
+          <documentation>Gulen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4635">
+        
+        <annotation>
+          
+          <documentation>Gulen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1412">
+        
+        <annotation>
+          
+          <documentation>Solund (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4636">
+        
+        <annotation>
+          
+          <documentation>Solund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4636">
+        
+        <annotation>
+          
+          <documentation>Solund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1413">
+        
+        <annotation>
+          
+          <documentation>Hyllestad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4637">
+        
+        <annotation>
+          
+          <documentation>Hyllestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4637">
+        
+        <annotation>
+          
+          <documentation>Hyllestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1416">
+        
+        <annotation>
+          
+          <documentation>Høyanger (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4638">
+        
+        <annotation>
+          
+          <documentation>Høyanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4638">
+        
+        <annotation>
+          
+          <documentation>Høyanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1417">
+        
+        <annotation>
+          
+          <documentation>Vik (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4639">
+        
+        <annotation>
+          
+          <documentation>Vik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4639">
+        
+        <annotation>
+          
+          <documentation>Vik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1418">
+        
+        <annotation>
+          
+          <documentation>Balestrand (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4640">
+        
+        <annotation>
+          
+          <documentation>Sogndal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4640">
+        
+        <annotation>
+          
+          <documentation>Sogndal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1419">
+        
+        <annotation>
+          
+          <documentation>Leikanger (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1420">
+        
+        <annotation>
+          
+          <documentation>Sogndal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4640">
+        
+        <annotation>
+          
+          <documentation>Sogndal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1421">
+        
+        <annotation>
+          
+          <documentation>Aurland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4641">
+        
+        <annotation>
+          
+          <documentation>Aurland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4641">
+        
+        <annotation>
+          
+          <documentation>Aurland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1422">
+        
+        <annotation>
+          
+          <documentation>Lærdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4642">
+        
+        <annotation>
+          
+          <documentation>Lærdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4642">
+        
+        <annotation>
+          
+          <documentation>Lærdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1424">
+        
+        <annotation>
+          
+          <documentation>Årdal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4643">
+        
+        <annotation>
+          
+          <documentation>Årdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4643">
+        
+        <annotation>
+          
+          <documentation>Årdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1426">
+        
+        <annotation>
+          
+          <documentation>Luster (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4644">
+        
+        <annotation>
+          
+          <documentation>Luster</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4644">
+        
+        <annotation>
+          
+          <documentation>Luster</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1428">
+        
+        <annotation>
+          
+          <documentation>Askvoll (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4645">
+        
+        <annotation>
+          
+          <documentation>Askvoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4645">
+        
+        <annotation>
+          
+          <documentation>Askvoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1429">
+        
+        <annotation>
+          
+          <documentation>Fjaler (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4646">
+        
+        <annotation>
+          
+          <documentation>Fjaler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4646">
+        
+        <annotation>
+          
+          <documentation>Fjaler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1430">
+        
+        <annotation>
+          
+          <documentation>Gaular (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4647">
+        
+        <annotation>
+          
+          <documentation>Sunnfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4647">
+        
+        <annotation>
+          
+          <documentation>Sunnfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1431">
+        
+        <annotation>
+          
+          <documentation>Jølster (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1432">
+        
+        <annotation>
+          
+          <documentation>Førde (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1433">
+        
+        <annotation>
+          
+          <documentation>Naustdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1438">
+        
+        <annotation>
+          
+          <documentation>Bremanger (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4648">
+        
+        <annotation>
+          
+          <documentation>Bremanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4648">
+        
+        <annotation>
+          
+          <documentation>Bremanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1439">
+        
+        <annotation>
+          
+          <documentation>Vågsøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1441">
+        
+        <annotation>
+          
+          <documentation>Selje (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4649">
+        
+        <annotation>
+          
+          <documentation>Stad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4649">
+        
+        <annotation>
+          
+          <documentation>Stad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1443">
+        
+        <annotation>
+          
+          <documentation>Eid (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1444">
+        
+        <annotation>
+          
+          <documentation>Hornindal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1577">
+        
+        <annotation>
+          
+          <documentation>Volda</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1577">
+        
+        <annotation>
+          
+          <documentation>Volda</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1445">
+        
+        <annotation>
+          
+          <documentation>Gloppen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4650">
+        
+        <annotation>
+          
+          <documentation>Gloppen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4650">
+        
+        <annotation>
+          
+          <documentation>Gloppen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1449">
+        
+        <annotation>
+          
+          <documentation>Stryn (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4651">
+        
+        <annotation>
+          
+          <documentation>Stryn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4651">
+        
+        <annotation>
+          
+          <documentation>Stryn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1502">
+        
+        <annotation>
+          
+          <documentation>Molde (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1506">
+        
+        <annotation>
+          
+          <documentation>Molde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1506">
+        
+        <annotation>
+          
+          <documentation>Molde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1504">
+        
+        <annotation>
+          
+          <documentation>Ålesund (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1507">
+        
+        <annotation>
+          
+          <documentation>Ålesund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1507">
+        
+        <annotation>
+          
+          <documentation>Ålesund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1505">
+        
+        <annotation>
+          
+          <documentation>Kristiansund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1511">
+        
+        <annotation>
+          
+          <documentation>Vanylven</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1514">
+        
+        <annotation>
+          
+          <documentation>Sande i Møre og Romsdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1515">
+        
+        <annotation>
+          
+          <documentation>Herøy i  Møre og Romsdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1516">
+        
+        <annotation>
+          
+          <documentation>Ulstein</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1517">
+        
+        <annotation>
+          
+          <documentation>Hareid</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1519">
+        
+        <annotation>
+          
+          <documentation>Volda (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1577">
+        
+        <annotation>
+          
+          <documentation>Volda</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1520">
+        
+        <annotation>
+          
+          <documentation>Ørsta</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1523">
+        
+        <annotation>
+          
+          <documentation>Ørskog (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1507">
+        
+        <annotation>
+          
+          <documentation>Ålesund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1524">
+        
+        <annotation>
+          
+          <documentation>Norddal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1578">
+        
+        <annotation>
+          
+          <documentation>Fjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1578">
+        
+        <annotation>
+          
+          <documentation>Fjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1525">
+        
+        <annotation>
+          
+          <documentation>Stranda</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1526">
+        
+        <annotation>
+          
+          <documentation>Stordal (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1528">
+        
+        <annotation>
+          
+          <documentation>Sykkylven</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1529">
+        
+        <annotation>
+          
+          <documentation>Skodje (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1531">
+        
+        <annotation>
+          
+          <documentation>Sula</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1532">
+        
+        <annotation>
+          
+          <documentation>Giske</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1534">
+        
+        <annotation>
+          
+          <documentation>Haram (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1535">
+        
+        <annotation>
+          
+          <documentation>Vestnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1539">
+        
+        <annotation>
+          
+          <documentation>Rauma</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1543">
+        
+        <annotation>
+          
+          <documentation>Nesset (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1506">
+        
+        <annotation>
+          
+          <documentation>Molde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1545">
+        
+        <annotation>
+          
+          <documentation>Midsund (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1546">
+        
+        <annotation>
+          
+          <documentation>Sandøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1547">
+        
+        <annotation>
+          
+          <documentation>Aukra</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1548">
+        
+        <annotation>
+          
+          <documentation>Fræna (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1579">
+        
+        <annotation>
+          
+          <documentation>Hustadvika</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1579">
+        
+        <annotation>
+          
+          <documentation>Hustadvika</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1551">
+        
+        <annotation>
+          
+          <documentation>Eide (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1554">
+        
+        <annotation>
+          
+          <documentation>Averøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1557">
+        
+        <annotation>
+          
+          <documentation>Gjemnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1560">
+        
+        <annotation>
+          
+          <documentation>Tingvoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1563">
+        
+        <annotation>
+          
+          <documentation>Sunndal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1566">
+        
+        <annotation>
+          
+          <documentation>Surnadal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1567">
+        
+        <annotation>
+          
+          <documentation>Rindal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5061">
+        
+        <annotation>
+          
+          <documentation>Rindal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1569">
+        
+        <annotation>
+          
+          <documentation>Aure (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1571">
+        
+        <annotation>
+          
+          <documentation>Halsa (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5055">
+        
+        <annotation>
+          
+          <documentation>Heim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5055">
+        
+        <annotation>
+          
+          <documentation>Heim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1572">
+        
+        <annotation>
+          
+          <documentation>Tustna (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1573">
+        
+        <annotation>
+          
+          <documentation>Smøla</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1576">
+        
+        <annotation>
+          
+          <documentation>Aure</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1601">
+        
+        <annotation>
+          
+          <documentation>Trondheim (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5001">
+        
+        <annotation>
+          
+          <documentation>Trondheim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1612">
+        
+        <annotation>
+          
+          <documentation>Hemne (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5011">
+        
+        <annotation>
+          
+          <documentation>Hemne (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1613">
+        
+        <annotation>
+          
+          <documentation>Snillfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5012">
+        
+        <annotation>
+          
+          <documentation>Snillfjord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5059">
+        
+        <annotation>
+          
+          <documentation>Orkland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5059">
+        
+        <annotation>
+          
+          <documentation>Orkland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1617">
+        
+        <annotation>
+          
+          <documentation>Hitra (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5013">
+        
+        <annotation>
+          
+          <documentation>Hitra (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5056">
+        
+        <annotation>
+          
+          <documentation>Hitra</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5056">
+        
+        <annotation>
+          
+          <documentation>Hitra</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1620">
+        
+        <annotation>
+          
+          <documentation>Frøya (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5014">
+        
+        <annotation>
+          
+          <documentation>Frøya</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1621">
+        
+        <annotation>
+          
+          <documentation>Ørland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5015">
+        
+        <annotation>
+          
+          <documentation>Ørland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5057">
+        
+        <annotation>
+          
+          <documentation>Ørland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5057">
+        
+        <annotation>
+          
+          <documentation>Ørland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1622">
+        
+        <annotation>
+          
+          <documentation>Agdenes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5016">
+        
+        <annotation>
+          
+          <documentation>Agdenes (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1624">
+        
+        <annotation>
+          
+          <documentation>Rissa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5054">
+        
+        <annotation>
+          
+          <documentation>Indre Fosen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1627">
+        
+        <annotation>
+          
+          <documentation>Bjugn (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5017">
+        
+        <annotation>
+          
+          <documentation>Bjugn (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5057">
+        
+        <annotation>
+          
+          <documentation>Ørland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1630">
+        
+        <annotation>
+          
+          <documentation>Åfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5018">
+        
+        <annotation>
+          
+          <documentation>Åfjord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5058">
+        
+        <annotation>
+          
+          <documentation>Åfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5058">
+        
+        <annotation>
+          
+          <documentation>Åfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1632">
+        
+        <annotation>
+          
+          <documentation>Roan (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5019">
+        
+        <annotation>
+          
+          <documentation>Roan (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5058">
+        
+        <annotation>
+          
+          <documentation>Åfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1633">
+        
+        <annotation>
+          
+          <documentation>Osen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5020">
+        
+        <annotation>
+          
+          <documentation>Osen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1634">
+        
+        <annotation>
+          
+          <documentation>Oppdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5021">
+        
+        <annotation>
+          
+          <documentation>Oppdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1635">
+        
+        <annotation>
+          
+          <documentation>Rennebu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5022">
+        
+        <annotation>
+          
+          <documentation>Rennebu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1636">
+        
+        <annotation>
+          
+          <documentation>Meldal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5023">
+        
+        <annotation>
+          
+          <documentation>Meldal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1638">
+        
+        <annotation>
+          
+          <documentation>Orkdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5024">
+        
+        <annotation>
+          
+          <documentation>Orkdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1640">
+        
+        <annotation>
+          
+          <documentation>Røros (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5025">
+        
+        <annotation>
+          
+          <documentation>Røros</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1644">
+        
+        <annotation>
+          
+          <documentation>Holtålen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5026">
+        
+        <annotation>
+          
+          <documentation>Holtålen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1648">
+        
+        <annotation>
+          
+          <documentation>Midtre Gauldal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5027">
+        
+        <annotation>
+          
+          <documentation>Midtre Gauldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1653">
+        
+        <annotation>
+          
+          <documentation>Melhus (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5028">
+        
+        <annotation>
+          
+          <documentation>Melhus</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1657">
+        
+        <annotation>
+          
+          <documentation>Skaun (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5029">
+        
+        <annotation>
+          
+          <documentation>Skaun</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1662">
+        
+        <annotation>
+          
+          <documentation>Klæbu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5030">
+        
+        <annotation>
+          
+          <documentation>Klæbu (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5001">
+        
+        <annotation>
+          
+          <documentation>Trondheim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5001">
+        
+        <annotation>
+          
+          <documentation>Trondheim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1663">
+        
+        <annotation>
+          
+          <documentation>Malvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5031">
+        
+        <annotation>
+          
+          <documentation>Malvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1664">
+        
+        <annotation>
+          
+          <documentation>Selbu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5032">
+        
+        <annotation>
+          
+          <documentation>Selbu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1665">
+        
+        <annotation>
+          
+          <documentation>Tydal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5033">
+        
+        <annotation>
+          
+          <documentation>Tydal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1702">
+        
+        <annotation>
+          
+          <documentation>Steinkjer (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5004">
+        
+        <annotation>
+          
+          <documentation>Steinkjer (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5006">
+        
+        <annotation>
+          
+          <documentation>Steinkjer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5006">
+        
+        <annotation>
+          
+          <documentation>Steinkjer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1703">
+        
+        <annotation>
+          
+          <documentation>Namsos (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5005">
+        
+        <annotation>
+          
+          <documentation>Namsos (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5007">
+        
+        <annotation>
+          
+          <documentation>Namsos</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5007">
+        
+        <annotation>
+          
+          <documentation>Namsos</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1711">
+        
+        <annotation>
+          
+          <documentation>Meråker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5034">
+        
+        <annotation>
+          
+          <documentation>Meråker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1714">
+        
+        <annotation>
+          
+          <documentation>Stjørdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5035">
+        
+        <annotation>
+          
+          <documentation>Stjørdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1717">
+        
+        <annotation>
+          
+          <documentation>Frosta (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5036">
+        
+        <annotation>
+          
+          <documentation>Frosta</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1718">
+        
+        <annotation>
+          
+          <documentation>Leksvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1719">
+        
+        <annotation>
+          
+          <documentation>Levanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5037">
+        
+        <annotation>
+          
+          <documentation>Levanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1721">
+        
+        <annotation>
+          
+          <documentation>Verdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5038">
+        
+        <annotation>
+          
+          <documentation>Verdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1723">
+        
+        <annotation>
+          
+          <documentation>Mosvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1724">
+        
+        <annotation>
+          
+          <documentation>Verran (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5039">
+        
+        <annotation>
+          
+          <documentation>Verran (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5006">
+        
+        <annotation>
+          
+          <documentation>Steinkjer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1725">
+        
+        <annotation>
+          
+          <documentation>Namdalseid (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5040">
+        
+        <annotation>
+          
+          <documentation>Namdalseid (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5007">
+        
+        <annotation>
+          
+          <documentation>Namsos</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1729">
+        
+        <annotation>
+          
+          <documentation>Inderøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1736">
+        
+        <annotation>
+          
+          <documentation>Snåase – Snåsa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5041">
+        
+        <annotation>
+          
+          <documentation>Snåase – Snåsa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1738">
+        
+        <annotation>
+          
+          <documentation>Lierne (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5042">
+        
+        <annotation>
+          
+          <documentation>Lierne</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1739">
+        
+        <annotation>
+          
+          <documentation>Raarvikhe – Røyrvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5043">
+        
+        <annotation>
+          
+          <documentation>Raarvikhe – Røyrvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1740">
+        
+        <annotation>
+          
+          <documentation>Namsskogan (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5044">
+        
+        <annotation>
+          
+          <documentation>Namsskogan</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1742">
+        
+        <annotation>
+          
+          <documentation>Grong (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5045">
+        
+        <annotation>
+          
+          <documentation>Grong</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1743">
+        
+        <annotation>
+          
+          <documentation>Høylandet (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5046">
+        
+        <annotation>
+          
+          <documentation>Høylandet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1744">
+        
+        <annotation>
+          
+          <documentation>Overhalla (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5047">
+        
+        <annotation>
+          
+          <documentation>Overhalla</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1748">
+        
+        <annotation>
+          
+          <documentation>Fosnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5048">
+        
+        <annotation>
+          
+          <documentation>Fosnes (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1749">
+        
+        <annotation>
+          
+          <documentation>Flatanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5049">
+        
+        <annotation>
+          
+          <documentation>Flatanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1750">
+        
+        <annotation>
+          
+          <documentation>Vikna (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5050">
+        
+        <annotation>
+          
+          <documentation>Vikna (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5060">
+        
+        <annotation>
+          
+          <documentation>Nærøysund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5060">
+        
+        <annotation>
+          
+          <documentation>Nærøysund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1751">
+        
+        <annotation>
+          
+          <documentation>Nærøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5051">
+        
+        <annotation>
+          
+          <documentation>Nærøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1755">
+        
+        <annotation>
+          
+          <documentation>Leka (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5052">
+        
+        <annotation>
+          
+          <documentation>Leka</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1756">
+        
+        <annotation>
+          
+          <documentation>Inderøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5053">
+        
+        <annotation>
+          
+          <documentation>Inderøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1804">
+        
+        <annotation>
+          
+          <documentation>Bodø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1805">
+        
+        <annotation>
+          
+          <documentation>Narvik (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1806">
+        
+        <annotation>
+          
+          <documentation>Narvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1806">
+        
+        <annotation>
+          
+          <documentation>Narvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1811">
+        
+        <annotation>
+          
+          <documentation>Bindal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1812">
+        
+        <annotation>
+          
+          <documentation>Sømna</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1813">
+        
+        <annotation>
+          
+          <documentation>Brønnøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1815">
+        
+        <annotation>
+          
+          <documentation>Vega</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1816">
+        
+        <annotation>
+          
+          <documentation>Vevelstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1818">
+        
+        <annotation>
+          
+          <documentation>Herøy i Nordland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1820">
+        
+        <annotation>
+          
+          <documentation>Alstahaug</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1822">
+        
+        <annotation>
+          
+          <documentation>Leirfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1824">
+        
+        <annotation>
+          
+          <documentation>Vefsn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1825">
+        
+        <annotation>
+          
+          <documentation>Grane</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1826">
+        
+        <annotation>
+          
+          <documentation>Hattfjelldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1827">
+        
+        <annotation>
+          
+          <documentation>Dønna</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1828">
+        
+        <annotation>
+          
+          <documentation>Nesna</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1832">
+        
+        <annotation>
+          
+          <documentation>Hemnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1833">
+        
+        <annotation>
+          
+          <documentation>Rana</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1834">
+        
+        <annotation>
+          
+          <documentation>Lurøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1835">
+        
+        <annotation>
+          
+          <documentation>Træna</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1836">
+        
+        <annotation>
+          
+          <documentation>Rødøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1837">
+        
+        <annotation>
+          
+          <documentation>Meløy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1838">
+        
+        <annotation>
+          
+          <documentation>Gildeskål</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1839">
+        
+        <annotation>
+          
+          <documentation>Beiarn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1840">
+        
+        <annotation>
+          
+          <documentation>Saltdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1841">
+        
+        <annotation>
+          
+          <documentation>Fauske - Fuossko</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1842">
+        
+        <annotation>
+          
+          <documentation>Skjerstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1845">
+        
+        <annotation>
+          
+          <documentation>Sørfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1848">
+        
+        <annotation>
+          
+          <documentation>Steigen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1849">
+        
+        <annotation>
+          
+          <documentation>Hamarøy - Hábmer (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1875">
+        
+        <annotation>
+          
+          <documentation>Hamarøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+            
+      <enumeration value="1875">
+        
+        <annotation>
+          
+          <documentation>Hamarøy - Hábmer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+	  
+      <enumeration value="1850">
+        
+        <annotation>
+          
+          <documentation>Divtasvuodna - Tysfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1851">
+        
+        <annotation>
+          
+          <documentation>Lødingen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1852">
+        
+        <annotation>
+          
+          <documentation>Tjeldsund (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5412">
+        
+        <annotation>
+          
+          <documentation>Tjeldsund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5412">
+        
+        <annotation>
+          
+          <documentation>Tjeldsund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1853">
+        
+        <annotation>
+          
+          <documentation>Evenes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1854">
+        
+        <annotation>
+          
+          <documentation>Ballangen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1806">
+        
+        <annotation>
+          
+          <documentation>Narvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1856">
+        
+        <annotation>
+          
+          <documentation>Røst</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1857">
+        
+        <annotation>
+          
+          <documentation>Værøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1859">
+        
+        <annotation>
+          
+          <documentation>Flakstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1860">
+        
+        <annotation>
+          
+          <documentation>Vestvågøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1865">
+        
+        <annotation>
+          
+          <documentation>Vågan</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1866">
+        
+        <annotation>
+          
+          <documentation>Hadsel</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1867">
+        
+        <annotation>
+          
+          <documentation>Bø i Nordland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1868">
+        
+        <annotation>
+          
+          <documentation>Øksnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1870">
+        
+        <annotation>
+          
+          <documentation>Sortland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1871">
+        
+        <annotation>
+          
+          <documentation>Andøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1874">
+        
+        <annotation>
+          
+          <documentation>Moskenes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1901">
+        
+        <annotation>
+          
+          <documentation>Harstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1902">
+        
+        <annotation>
+          
+          <documentation>Tromsø (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5401">
+        
+        <annotation>
+          
+          <documentation>Tromsø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5401">
+        
+        <annotation>
+          
+          <documentation>Tromsø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1903">
+        
+        <annotation>
+          
+          <documentation>Harstad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5402">
+        
+        <annotation>
+          
+          <documentation>Harstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5402">
+        
+        <annotation>
+          
+          <documentation>Harstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1911">
+        
+        <annotation>
+          
+          <documentation>Kvæfjord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5411">
+        
+        <annotation>
+          
+          <documentation>Kvæfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5411">
+        
+        <annotation>
+          
+          <documentation>Kvæfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1913">
+        
+        <annotation>
+          
+          <documentation>Skånland (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5412">
+        
+        <annotation>
+          
+          <documentation>Tjeldsund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1915">
+        
+        <annotation>
+          
+          <documentation>Bjarkøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1917">
+        
+        <annotation>
+          
+          <documentation>Ibestad (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5413">
+        
+        <annotation>
+          
+          <documentation>Ibestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5413">
+        
+        <annotation>
+          
+          <documentation>Ibestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1919">
+        
+        <annotation>
+          
+          <documentation>Gratangen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5414">
+        
+        <annotation>
+          
+          <documentation>Gratangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5414">
+        
+        <annotation>
+          
+          <documentation>Gratangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1920">
+        
+        <annotation>
+          
+          <documentation>Loabák - Lavangen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5415">
+        
+        <annotation>
+          
+          <documentation>Lavangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5415">
+        
+        <annotation>
+          
+          <documentation>Loabák - Lavangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="1922">
+        
+        <annotation>
+          
+          <documentation>Bardu (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5416">
+        
+        <annotation>
+          
+          <documentation>Bardu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5416">
+        
+        <annotation>
+          
+          <documentation>Bardu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1923">
+        
+        <annotation>
+          
+          <documentation>Salangen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5417">
+        
+        <annotation>
+          
+          <documentation>Salangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5417">
+        
+        <annotation>
+          
+          <documentation>Salangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1924">
+        
+        <annotation>
+          
+          <documentation>Målselv (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5418">
+        
+        <annotation>
+          
+          <documentation>Målselv</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5418">
+        
+        <annotation>
+          
+          <documentation>Målselv</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1925">
+        
+        <annotation>
+          
+          <documentation>Sørreisa (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5419">
+        
+        <annotation>
+          
+          <documentation>Sørreisa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5419">
+        
+        <annotation>
+          
+          <documentation>Sørreisa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1926">
+        
+        <annotation>
+          
+          <documentation>Dyrøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5420">
+        
+        <annotation>
+          
+          <documentation>Dyrøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5420">
+        
+        <annotation>
+          
+          <documentation>Dyrøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1927">
+        
+        <annotation>
+          
+          <documentation>Tranøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5421">
+        
+        <annotation>
+          
+          <documentation>Senja</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5421">
+        
+        <annotation>
+          
+          <documentation>Senja</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1928">
+        
+        <annotation>
+          
+          <documentation>Torsken (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1929">
+        
+        <annotation>
+          
+          <documentation>Berg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1931">
+        
+        <annotation>
+          
+          <documentation>Lenvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1933">
+        
+        <annotation>
+          
+          <documentation>Balsfjord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5422">
+        
+        <annotation>
+          
+          <documentation>Balsfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5422">
+        
+        <annotation>
+          
+          <documentation>Balsfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1936">
+        
+        <annotation>
+          
+          <documentation>Karlsøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5423">
+        
+        <annotation>
+          
+          <documentation>Karlsøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5423">
+        
+        <annotation>
+          
+          <documentation>Karlsøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1938">
+        
+        <annotation>
+          
+          <documentation>Lyngen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5424">
+        
+        <annotation>
+          
+          <documentation>Lyngen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5424">
+        
+        <annotation>
+          
+          <documentation>Lyngen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1939">
+        
+        <annotation>
+          
+          <documentation>Storfjord - Omasvuotna - Omasvuono (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5425">
+        
+        <annotation>
+          
+          <documentation>Storfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5425">
+        
+        <annotation>
+          
+          <documentation>Storfjord - Omasvuotna - Omasvuono</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="1940">
+        
+        <annotation>
+          
+          <documentation>Gáivuotna - Kåfjord - Kaivuono (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5426">
+        
+        <annotation>
+          
+          <documentation>Kåfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5426">
+        
+        <annotation>
+          
+          <documentation>Gáivuotna - Kåfjord - Kaivuono</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="1941">
+        
+        <annotation>
+          
+          <documentation>Skjervøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5427">
+        
+        <annotation>
+          
+          <documentation>Skjervøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5427">
+        
+        <annotation>
+          
+          <documentation>Skjervøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1942">
+        
+        <annotation>
+          
+          <documentation>Nordreisa (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5428">
+        
+        <annotation>
+          
+          <documentation>Nordreisa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5428">
+        
+        <annotation>
+          
+          <documentation>Nordreisa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1943">
+        
+        <annotation>
+          
+          <documentation>Kvænangen (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5429">
+        
+        <annotation>
+          
+          <documentation>Kvænangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5429">
+        
+        <annotation>
+          
+          <documentation>Kvænangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2001">
+        
+        <annotation>
+          
+          <documentation>Hammerfest (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2002">
+        
+        <annotation>
+          
+          <documentation>Vardø (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5404">
+        
+        <annotation>
+          
+          <documentation>Vardø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5404">
+        
+        <annotation>
+          
+          <documentation>Vardø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2003">
+        
+        <annotation>
+          
+          <documentation>Vadsø (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5405">
+        
+        <annotation>
+          
+          <documentation>Vadsø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5405">
+        
+        <annotation>
+          
+          <documentation>Vadsø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2004">
+        
+        <annotation>
+          
+          <documentation>Hammerfest (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5406">
+        
+        <annotation>
+          
+          <documentation>Hammerfest</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5406">
+        
+        <annotation>
+          
+          <documentation>Hammerfest</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2011">
+        
+        <annotation>
+          
+          <documentation>Guovdageaidnu - Kautokeino (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5430">
+        
+        <annotation>
+          
+          <documentation>Kautokeino</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5430">
+        
+        <annotation>
+          
+          <documentation>Guovdageaidnu - Kautokeino</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="2012">
+        
+        <annotation>
+          
+          <documentation>Alta (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5403">
+        
+        <annotation>
+          
+          <documentation>Alta</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5403">
+        
+        <annotation>
+          
+          <documentation>Alta</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2014">
+        
+        <annotation>
+          
+          <documentation>Loppa (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5432">
+        
+        <annotation>
+          
+          <documentation>Loppa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5432">
+        
+        <annotation>
+          
+          <documentation>Loppa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2015">
+        
+        <annotation>
+          
+          <documentation>Hasvik (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5433">
+        
+        <annotation>
+          
+          <documentation>Hasvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5433">
+        
+        <annotation>
+          
+          <documentation>Hasvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2016">
+        
+        <annotation>
+          
+          <documentation>Sørøysund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2017">
+        
+        <annotation>
+          
+          <documentation>Kvalsund (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5406">
+        
+        <annotation>
+          
+          <documentation>Hammerfest</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2018">
+        
+        <annotation>
+          
+          <documentation>Måsøy (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5434">
+        
+        <annotation>
+          
+          <documentation>Måsøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5434">
+        
+        <annotation>
+          
+          <documentation>Måsøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2019">
+        
+        <annotation>
+          
+          <documentation>Nordkapp (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5435">
+        
+        <annotation>
+          
+          <documentation>Nordkapp</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5435">
+        
+        <annotation>
+          
+          <documentation>Nordkapp</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2020">
+        
+        <annotation>
+          
+          <documentation>Porsanger - Porsá?gu - Porsanki (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5436">
+        
+        <annotation>
+          
+          <documentation>Porsanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5436">
+        
+        <annotation>
+          
+          <documentation>Porsanger - Porsá?gu - Porsanki</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="2021">
+        
+        <annotation>
+          
+          <documentation>Kárášjohka - Karasjok (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5437">
+        
+        <annotation>
+          
+          <documentation>Karasjok</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5437">
+        
+        <annotation>
+          
+          <documentation>Kárášjohka - Karasjok</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="2022">
+        
+        <annotation>
+          
+          <documentation>Lebesby (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5438">
+        
+        <annotation>
+          
+          <documentation>Lebesby</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5438">
+        
+        <annotation>
+          
+          <documentation>Lebesby</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2023">
+        
+        <annotation>
+          
+          <documentation>Gamvik (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5439">
+        
+        <annotation>
+          
+          <documentation>Gamvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5439">
+        
+        <annotation>
+          
+          <documentation>Gamvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2024">
+        
+        <annotation>
+          
+          <documentation>Berlevåg (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5440">
+        
+        <annotation>
+          
+          <documentation>Berlevåg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5440">
+        
+        <annotation>
+          
+          <documentation>Berlevåg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2025">
+        
+        <annotation>
+          
+          <documentation>Deatnu - Tana (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5441">
+        
+        <annotation>
+          
+          <documentation>Tana</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5441">
+        
+        <annotation>
+          
+          <documentation>Deatnu - Tana</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="2027">
+        
+        <annotation>
+          
+          <documentation>Unjárga - Nesseby (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5442">
+        
+        <annotation>
+          
+          <documentation>Nesseby</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5442">
+        
+        <annotation>
+          
+          <documentation>Unjárga - Nesseby</documentation>
+        
+        </annotation>
+      
+      </enumeration>	  
+      
+      <enumeration value="2028">
+        
+        <annotation>
+          
+          <documentation>Båtsfjord (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5443">
+        
+        <annotation>
+          
+          <documentation>Båtsfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5443">
+        
+        <annotation>
+          
+          <documentation>Båtsfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2030">
+        
+        <annotation>
+          
+          <documentation>Sør-Varanger (utgått) (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5444">
+        
+        <annotation>
+          
+          <documentation>Sør-Varanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5444">
+        
+        <annotation>
+          
+          <documentation>Sør-Varanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2111">
+        
+        <annotation>
+          
+          <documentation>Spitsbergen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2100">
+        
+        <annotation>
+          
+          <documentation>Svalbard</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2121">
+        
+        <annotation>
+          
+          <documentation>Bjørnøya (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2131">
+        
+        <annotation>
+          
+          <documentation>Hopen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2211">
+        
+        <annotation>
+          
+          <documentation>Jan Mayen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2311">
+        
+        <annotation>
+          
+          <documentation>Sokkelen sør for 62 grader Nord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2321">
+        
+        <annotation>
+          
+          <documentation>Sokkelen nord for 62 grader Nord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="KommunenummerOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Kopidata" substitutionGroup="gml:AbstractObject" type="app:KopidataType">
+    
+    <annotation>
+      
+      <documentation>angivelse av at objektet er hentet fra en kopi av originaldata
+
+Merknad: 
+Kan benyttes dersom man gjør et uttak av en database som ikke inneholder originaldataene.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOPIDATA</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="KopidataType">
+    
+    <sequence>
+      
+      <element name="områdeId" type="integer">
+        
+        <annotation>
+          
+          <documentation>identifikasjon av område som dataene dekker
+
+Merknad: Kan angis med kommunenummer eller fylkesnummer. Disse bør spesifiseres nærmere.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OMRÅDEID</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="originalDatavert" type="string">
+        
+        <annotation>
+          
+          <documentation>ansvarlig etat for forvaltning av data</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">ORIGINALDATAVERT</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="kopidato" type="dateTime">
+        
+        <annotation>
+          
+          <documentation>dato når objektet ble kopiert fra originaldatasettet  
+
+Merknad:
+Er en del av egenskapen Kopidata. Brukes i de tilfeller hvor en kopidatabase brukes til distribusjon.
+Å kopiere et datasett til en kopidatabase skal ikke føre til at Oppdateringsdato blir endret.
+Eventuell redigering av data i et kopidatasett medfører ny Oppdateringsdato, Datafangstdato og/eller Verifiseringsdato.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOPIDATO</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="KopidataPropertyType">
+    
+    <sequence>
+      
+      <element ref="app:Kopidata"/>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <simpleType name="LandkodeType">
+    
+    <annotation>
+      
+      <documentation>alfanumerisk kode (ISO 3166-1 alpha-2) for land som definert i ISO 3166 Codes for the representation of names of countries and their subdivisions</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">LANDKODE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:LandkodeEnumerationType app:LandkodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="LandkodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>alfanumerisk kode (ISO 3166-1 alpha-2) for land som definert i ISO 3166 Codes for the representation of names of countries and their subdivisions</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">LANDKODE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="BV"/>
+      
+      <enumeration value="DK"/>
+      
+      <enumeration value="FO"/>
+      
+      <enumeration value="FI"/>
+      
+      <enumeration value="GL"/>
+      
+      <enumeration value="IS"/>
+      
+      <enumeration value="NO"/>
+      
+      <enumeration value="RU"/>
+      
+      <enumeration value="SJ"/>
+      
+      <enumeration value="SE"/>
+      
+      <enumeration value="GB"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="LandkodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="LovVirkeområdeGrense" substitutionGroup="app:Virkeområde" type="app:LovVirkeområdeGrenseType">
+    
+    <annotation>
+      
+      <documentation>avgrensningen av det området som en lov virker innenfor</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">LOVVIRKEOMRÅDEGRENSE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="LovVirkeområdeGrenseType">
+    
+    <complexContent>
+      
+      <extension base="app:VirkeområdeType">
+        
+        <sequence>
+          
+          <element name="grense" type="gml:CurvePropertyType">
+            
+            <annotation>
+              
+              <documentation>forløp som følger overgang mellom ulike fenomener</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="grensestatus" type="app:GrensestatusType">
+            
+            <annotation>
+              
+              <documentation>juridisk status på grensa</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">GRENSESTATUS</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="fastsettingstype" type="app:FastsettingstypeType">
+            
+            <annotation>
+              
+              <documentation>måte en grense er fastsatt på</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSTYPE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="soneNautisk" type="integer">
+            
+            <annotation>
+              
+              <documentation>sonebredde, avstand fra grunnlinjen (i nautiske mil)
+
+Merknad: 1 nautisk mil = 1852 meter</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SONENAUTISK</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="kommunenummer" type="app:KommunenummerType">
+            
+            <annotation>
+              
+              <documentation>nummerering av kommuner i henhold til Statistisk sentralbyrå sin offisielle liste samt et utvalg av utgåtte numre
+
+Merknad: Det presiseres at kommune alltid skal ha 4 sifre, dvs. eventuelt med ledende null. Kommune benyttes for kopling mot en rekke andre registre som også benytter 4 sifre.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="LovVirkeområdeGrensePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:LovVirkeområdeGrense"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element abstract="true" name="MaritimeGrenser" substitutionGroup="app:Supertype_SOSI_Objekt_andre_grenser" type="app:MaritimeGrenserType">
+    
+    <annotation>
+      
+      <documentation>grense i hav som er knyttet til forvaltning og ressursutnyttelse med hjemmel i Havrettskonvensjonen eller som er knyttet til overenskomster med andre stater</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="MaritimeGrenserType">
+    
+    <complexContent>
+      
+      <extension base="app:Supertype_SOSI_Objekt_andre_grenserType">
+        
+        <sequence>
+          
+          <element name="grense" type="gml:CurvePropertyType">
+            
+            <annotation>
+              
+              <documentation>forløp som følger overgang mellom ulike fenomener</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="grensestatus" type="app:GrensestatusType">
+            
+            <annotation>
+              
+              <documentation>juridisk status på grensa</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">GRENSESTATUS</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="MaritimeGrenserPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:MaritimeGrenser"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <simpleType name="MålemetodeType">
+    
+    <annotation>
+      
+      <documentation>MeasuringMethod: metode som ligger til grunn for registrering av posisjon
+
+
+-- Definition - - 
+method on which registration of position is based</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">MÅLEMETODE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:MålemetodeEnumerationType app:MålemetodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="MålemetodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>MeasuringMethod: metode som ligger til grunn for registrering av posisjon
+
+
+-- Definition - - 
+method on which registration of position is based</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">MÅLEMETODE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="10">
+        
+        <annotation>
+          
+          <documentation>Measured in terrain: Målt i terrenget , uspesifisert metode/måleinstrument</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="11">
+        
+        <annotation>
+          
+          <documentation>Total station: Målt i terrenget med totalstasjon</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="12">
+        
+        <annotation>
+          
+          <documentation>Theodolite with electronic rangefinder: Målt i terrenget med teodolitt og elektronisk avstandsmåler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="13">
+        
+        <annotation>
+          
+          <documentation>Theodolite with measuring tape: Målt i terrenget med teodolitt og målebånd</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="14">
+        
+        <annotation>
+          
+          <documentation>Orthogonal method: Målt i terrenget, ortogonalmetoden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="15">
+        
+        <annotation>
+          
+          <documentation>MeasureOut: Point calculated on the basis of other items, such as two distances or distance + direction.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="18">
+        
+        <annotation>
+          
+          <documentation>Taken from plan: Tatt fra plan eller godkjent tiltak</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="19">
+        
+        <annotation>
+          
+          <documentation>Annet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="20">
+        
+        <annotation>
+          
+          <documentation>Stereo instrument: Målt i stereoinstrument, uspesifisert instrument</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="21">
+        
+        <annotation>
+          
+          <documentation>Aerotriangulated: Point calculated by aerotriangulation</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="22">
+        
+        <annotation>
+          
+          <documentation>Analytical plotter: Målt i stereoinstrument, analytisk plotter</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="23">
+        
+        <annotation>
+          
+          <documentation>Autograph - normal registration: Målt i stereoinstrument, autograf, analogt instrument</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="24">
+        
+        <annotation>
+          
+          <documentation>Digital stereo instrument: Målt i stereoinstrument, digitalt instrument</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="30">
+        
+        <annotation>
+          
+          <documentation>Scanned from map: Geometri overført fra kart maskinelt ved hjelp av skanner, uspesifisert kartmedium</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="31">
+        
+        <annotation>
+          
+          <documentation>Scannet from pencilled original: Geometri overført fra kart maskinelt ved hjelp av skanner. Kartmedium er blyantoriginal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="32">
+        
+        <annotation>
+          
+          <documentation>Scanned from ??scribing folio: Geometri overført fra kart maskinelt ved hjelp av skanner. Kartmedium er rissefolie</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="33">
+        
+        <annotation>
+          
+          <documentation>Scanned from transparency folio - good quality: Geometri overført fra kart maskinelt ved hjelp av skanner. Kartmedium er transparent folie av  god kvalitet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="34">
+        
+        <annotation>
+          
+          <documentation>Scanned from transparency folio - inferior quality: Geometri overført fra kart maskinelt ved hjelp av skanner. Kartmedium er transparent folie av mindre god kvalitet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="35">
+        
+        <annotation>
+          
+          <documentation>Scannet from paper / hard copy: Geometri overført fra kart maskinelt ved hjelp av skanner. Kartmedium er papirkopi.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="36">
+        
+        <annotation>
+          
+          <documentation>Airbourne laser scanner: Målt med laserskanner fra fly</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="37">
+        
+        <annotation>
+          
+          <documentation>Målt med laserskanner plassert i kjøretøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="38">
+        
+        <annotation>
+          
+          <documentation>brukes for objekter som er stedfestet med lineær referanse, enten disse leveres med stedfesting kun som lineære referanser, eller med koordinatgeometri avledet fra lineære referanser</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="40">
+        
+        <annotation>
+          
+          <documentation>Digitised on dig.table from orthophoto/aerial photo: Geometri overført fra ortofoto eller flybilde ved hjelp av manuell registrering på et digitaliseringsbord, uspesifisert bildemedium</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="41">
+        
+        <annotation>
+          
+          <documentation>Digitised from orthophoto - film: Geometri overført fra ortofoto ved hjelp av manuell registrering på et digitaliseringsbord. Bildemedium er film</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="42">
+        
+        <annotation>
+          
+          <documentation>Digitised from orthophoto - photocopy: Geometri overført fra ortofoto ved hjelp av manuell registrering på et digitaliseringsbord. Bildemedium er fotokopi</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="43">
+        
+        <annotation>
+          
+          <documentation>Digitised from aerial photo - mono-digitised from film: Geometri overført fra flybilde ved hjelp av manuell registrering på et digitaliseringsbord. Bildemedium er film</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="44">
+        
+        <annotation>
+          
+          <documentation>Digitised from aerial photo - mono-digitised from photocopy: Geometri overført fra flybilde ved hjelp av manuell registrering på et digitaliseringsbord. Bildemedium er fotokopi</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="45">
+        
+        <annotation>
+          
+          <documentation>Digitised from orthophoto: Geometri overført fra ortofoto ved hjelp av manuell registrering på skjerm</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="46">
+        
+        <annotation>
+          
+          <documentation>Digitised on screen from satellite photo: Geometri overført fra satellittbilde ved hjelp av manuell registrering på skjerm</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="47"/>
+      
+      <enumeration value="48"/>
+      
+      <enumeration value="49">
+        
+        <annotation>
+          
+          <documentation>Vektorisering fra laserdata, brukes også der vektoriseringen støttes av ortofoto</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="50">
+        
+        <annotation>
+          
+          <documentation>Digitised on dig.table from line-map: Geometri overført fra kart ved hjelp av manuell registrering på et digitaliseringsbord, medium uspesifisert</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="51">
+        
+        <annotation>
+          
+          <documentation>Digitised on dig.table from pencilled original: Geometri overført fra kart ved hjelp av manuell registrering på et digitaliseringsbord. Kartmedium er blyantoriginal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="52">
+        
+        <annotation>
+          
+          <documentation>Digitised on dig.table from ??scribing folio: Geometri overført fra kart ved hjelp av manuell registrering på et digitaliseringsbord. Kartmedium er rissefolie</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="53">
+        
+        <annotation>
+          
+          <documentation>Digitised on dig.table from transparency film - good quality: Geometri overført fra kart ved hjelp av manuell registrering på et digitaliseringsbord. Kartmedium er transparent folie av god kvalitet, samkopi</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="54">
+        
+        <annotation>
+          
+          <documentation>Digitised on dig.table from transparency film - lower quality: Geometri overført fra kart ved hjelp av manuell registrering på et digitaliseringsbord. Kartmedium er transparent folie av mindre god kvalitet, samkopi</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="55">
+        
+        <annotation>
+          
+          <documentation>Digitised on dig.table from paper copy: Geometri overført fra kart ved hjelp av manuell registrering på et digitaliseringsbord. Kartmedium er papirkopi</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="56">
+        
+        <annotation>
+          
+          <documentation>Digitised on screen from scanned photographic combination: Geometri overført fra kart ved hjelp av manuell registrering på skjerm, medium skannet kart (raster), samkopi</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="60">
+        
+        <annotation>
+          
+          <documentation>Generated data (interpolation): Genererte data, interpolasjonsmetode. Ikke nærmere spesifisert</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="61">
+        
+        <annotation>
+          
+          <documentation>Generated in terrain model: Genererte data, interpolasjonsmetode, fra terrengmodell</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="62">
+        
+        <annotation>
+          
+          <documentation>Weighted mean: Genererte data, interpolasjonsmetode, vektet middel</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="63">
+        
+        <annotation>
+          
+          <documentation>Generated circular geometry: Genererte data: Sirkelgeometri, korridor eller annen geometri generert ut fra f.eks et punkt eller en linje (f.eks midtlinje veg)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="64">
+        
+        <annotation>
+          
+          <documentation>Generalised: Genererte data: Generalisering</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="65">
+        
+        <annotation>
+          
+          <documentation>Generated central point: Genererte data: Sentralpunkt</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="66">
+        
+        <annotation>
+          
+          <documentation>Connection point/edge point: Genererte data: Sammenknytningspunkt (f.eks mellom ulike kartlegginger), randpunkt (f.eks mellom ulike kilder til kart)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="67">
+        
+        <annotation>
+          
+          <documentation>Coordinates retrieved from GAB: Koordinater hentet fra GAB, forløperen til registerdelen av matrikkelen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="68">
+        
+        <annotation>
+          
+          <documentation>Coordinates retrieved from JREG: Koordinater hentet fra JREG, jordregisteret</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="69">
+        
+        <annotation>
+          
+          <documentation>Calculated: Beregnet, uspesifisert hvordan</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="70">
+        
+        <annotation>
+          
+          <documentation>Special methods: Spesielle metoder, uspesifisert</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="71">
+        
+        <annotation>
+          
+          <documentation>Measured with range pole: Spesielle metoder: Målt med stikkstang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="72">
+        
+        <annotation>
+          
+          <documentation>Measured with: Spesielle metoder: Målt med waterstang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="73">
+        
+        <annotation>
+          
+          <documentation>Measured with measuring wheel: Spesielle metoder: Målt med målehjul</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="74">
+        
+        <annotation>
+          
+          <documentation>Measured with rate of climb indicator: Spesielle metoder: Målt med stigningsmåler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="77">
+        
+        <annotation>
+          
+          <documentation>Punkt fastsatt ut fra et grunnlag (kart, bilde), f.eks ved partenes enighet ved en oppmålingsforretning</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="78">
+        
+        <annotation>
+          
+          <documentation>Stipulated by court decision or royal decree: Geometri fastsatt ved dom, lov, traktat eller kongelig resolusjon</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="79">
+        
+        <annotation>
+          
+          <documentation>????: Annet (spesifiseres i filhode)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="80">
+        
+        <annotation>
+          
+          <documentation>Free-hand drawing: Digitalisert ut fra frihåndstegning.  Frihåndstegning er basert på svært grovt grunnlag eller ikke noe grunnlag</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="81">
+        
+        <annotation>
+          
+          <documentation>Digitised from sketching on map: Digitalisert fra krokering på kart, dvs grovt skissert på kart</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="82">
+        
+        <annotation>
+          
+          <documentation>Directly input on screen: Digitalisert ut fra frihåndstegning (direkte på skjerm). Frihåndstegning er basert på svært grovt grunnlag eller ikke noe grunnlag</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="90">
+        
+        <annotation>
+          
+          <documentation>Inertial ??positioning/localization: Treghetsstedfesting</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="91">
+        
+        <annotation>
+          
+          <documentation>GPS code measurement, relatively measurements: Innmålt med satellittbaserte systemer for navigasjon og posisjonering med global dekning (f.eks GPS, GLONASS, GALILEO): Kodemåling, relative målinger.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="92">
+        
+        <annotation>
+          
+          <documentation>GPS code measurement, individual measurements: Innmålt med satellittbaserte systemer for navigasjon og posisjonering med global dekning (f.eks GPS, GLONASS, GALILEO): Kodemåling, enkle målinger.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="93">
+        
+        <annotation>
+          
+          <documentation>GPS phase measurement, static measurement: Innmålt med satellittbaserte systemer for navigasjon og posisjonering med global dekning (f.eks GPS, GLONASS, GALILEO): Fasemåling statisk måling.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="94">
+        
+        <annotation>
+          
+          <documentation>GPS phase measurement, other methods: Innmålt med satellittbaserte systemer for navigasjon og posisjonering med global dekning (f.eks GPS, GLONASS, GALILEO): Fasemåling andre metoder.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="95">
+        
+        <annotation>
+          
+          <documentation>Combination of GPS/Inertia: Kombinasjon av GPS/Treghet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="96">
+        
+        <annotation>
+          
+          <documentation>GPS phase measurement RTK: Innmålt med satellittbaserte systemer for navigasjon og posisjonering med global dekning (f.eks GPS, GLONASS, GALILEO).: Fasemåling RTK (realtids kinematisk måling)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="97">
+        
+        <annotation>
+          
+          <documentation>GPS phase measurement, float solution: Innmålt med satellittbaserte systemer for navigasjon og posisjonering med global dekning (f.eks GPS, GLONASS, GALILEO). Fasemåling float-løsning</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="99">
+        
+        <annotation>
+          
+          <documentation>Unknown measurement method: Målemetode er ukjent</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="MålemetodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Nasjon" substitutionGroup="app:AdministrativEnhet" type="app:NasjonType">
+    
+    <annotation>
+      
+      <documentation>Nation: selvstendig stat hvor landområdene, sammen med eventuelle havområder for kyststater, utgjør statens suverenitetsområde
+
+Merknad 1: Også kalt territorialområde
+
+Merknad 2: Tilsvarer NUTS 1 på internasjonalt statistisk nivå</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NASJON</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="NasjonType">
+    
+    <complexContent>
+      
+      <extension base="app:AdministrativEnhetType">
+        
+        <sequence>
+          
+          <element maxOccurs="unbounded" name="nasjonnavn" type="app:AdministrativEnhetNavnPropertyType">
+            
+            <annotation>
+              
+              <documentation>offisielt navn på nasjonen</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NASJONNAVN</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="NasjonPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Nasjon"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element abstract="true" name="NorskeGrenser" substitutionGroup="app:MaritimeGrenser" type="app:NorskeGrenserType">
+    
+    <annotation>
+      
+      <documentation>grense i hav som eksisterer for å avgrense norske områder</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="NorskeGrenserType">
+    
+    <complexContent>
+      
+      <extension base="app:MaritimeGrenserType">
+        
+        <sequence>
+          
+          <element maxOccurs="unbounded" name="dokumentasjonsreferanse" type="app:DokumentasjonsreferansePropertyType">
+            
+            <annotation>
+              
+              <documentation>henviser til fastsettings- eller lovinformasjon</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DOKUMENTASJONSREFERANSE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="land" type="app:LandkodeType">
+            
+            <annotation>
+              
+              <documentation>angivelse av hvilket land grensa er knyttet til
+
+Merknad: Alfanumerisk kode (ISO 3166-1 alpha-2) for land som definert i ISO 3166</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">LANDKODE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="fastsettingstype" type="app:FastsettingstypeType">
+            
+            <annotation>
+              
+              <documentation>måte en grense kan være fastsatt på</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSTYPE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="NorskeGrenserPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:NorskeGrenser"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <simpleType name="NøyaktighetsklasseKodeType">
+    
+    <annotation>
+      
+      <documentation>Klassifikasjon av stedfestingsnøyaktighet på teiggrensepunkt er basert på kodet nøyaktighet på teiggrensepunktene.
+
+Klassifikasjon av stedfestingsnøyaktighet på grenser er basert på dårligste nøyaktighet til grensepunktene til grensen.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NØYAKTIGHETSKLASSE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:NøyaktighetsklasseKodeEnumerationType app:NøyaktighetsklasseKodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="NøyaktighetsklasseKodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Klassifikasjon av stedfestingsnøyaktighet på teiggrensepunkt er basert på kodet nøyaktighet på teiggrensepunktene.
+
+Klassifikasjon av stedfestingsnøyaktighet på grenser er basert på dårligste nøyaktighet til grensepunktene til grensen.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NØYAKTIGHETSKLASSE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="NøyaktigeMålinger">
+        
+        <annotation>
+          
+          <documentation>Nøyaktige målinger
+
+Utvalg: S&lt;= 10 cm. S er (antatt) standardavvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="MiddelsNøyaktigeOgTransformerteMålinger">
+        
+        <annotation>
+          
+          <documentation>Middels nøyaktige målinger og gamle nøyaktige målinger som er transformerte
+
+Utvalg: S&gt;10 og S&lt;=30 cm. S er (antatt) standardavvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="MindreNøyaktigeMålingerOgGrenserFraTK">
+        
+        <annotation>
+          
+          <documentation>Mindre nøyaktige målinger og grenser hentet fra tekniske kart
+
+Utvalg: S&gt;30 og S&lt;200 cm. S er (antatt) standardavvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="MindreNøyaktigeGrenserOgGrenserFraØK">
+        
+        <annotation>
+          
+          <documentation>Mindre nøyaktige grenser og grenser hentet fra kartserien Økonomisk kartverk (M: 5000)
+
+Utvalg: S&gt;=200 og S&lt;500 cm. S er (antatt) standardavvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="LiteNøyaktigeGrenserOgGrenserFraN50">
+        
+        <annotation>
+          
+          <documentation>Lite nøyaktige grenser og grenser hentet fra kartserien Norge 1:50 000
+
+Utvalg: S&gt;= 500 cm og målemetode er ikke lik 80, 81 eller 82 (skisserte data). S er (antatt) standardavvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="SkisserteGrenser">
+        
+        <annotation>
+          
+          <documentation>Skisserte data.
+
+Utvalg: S>=500  og Målemetode =80, 81 eller 82 (skisserte data). S er (antatt) standardavvik.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="IngenNøyaktighet">
+        
+        <annotation>
+          
+          <documentation>Data uten nøyaktighet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NøyaktighetsklasseKodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Posisjonskvalitet" substitutionGroup="gml:AbstractObject" type="app:PosisjonskvalitetType">
+    
+    <annotation>
+      
+      <documentation>beskrivelse av kvaliteten på stedfestingen</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KVALITET</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="PosisjonskvalitetType">
+    
+    <sequence>
+      
+      <element name="målemetode" type="app:MålemetodeType">
+        
+        <annotation>
+          
+          <documentation>metode for måling i grunnriss (x,y), og høyde (z) når metoden er den samme som ved måling i grunnriss</documentation>
+        
+        </annotation>
+      
+      </element>
+      
+      <element minOccurs="0" name="nøyaktighet" type="integer">
+        
+        <annotation>
+          
+          <documentation>punktstandardavviket i grunnriss for punkter samt tverravvik for linjer
+
+Merknad:
+Oppgitt i cm</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NØYAKTIGHET</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="PosisjonskvalitetPropertyType">
+    
+    <sequence>
+      
+      <element ref="app:Posisjonskvalitet"/>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <element name="Riksgrense" substitutionGroup="app:Supertype_SOSI_Objekt_andre_grenser" type="app:RiksgrenseType">
+    
+    <annotation>
+      
+      <documentation>avgrensningen av nasjonen Norge på land mot andre nasjoner</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">RIKSGRENSE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="RiksgrenseType">
+    
+    <complexContent>
+      
+      <extension base="app:Supertype_SOSI_Objekt_andre_grenserType">
+        
+        <sequence>
+          
+          <element name="grense" type="gml:CurvePropertyType">
+            
+            <annotation>
+              
+              <documentation>forløp som følger overgang mellom ulike fenomener</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="grensestatus" type="app:GrensestatusType">
+            
+            <annotation>
+              
+              <documentation>juridisk status på grensa</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">GRENSESTATUS</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="fastsettingstype" type="app:FastsettingstypeType">
+            
+            <annotation>
+              
+              <documentation>måte en grense er fastsatt på</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FASTSETTINGSTYPE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="RiksgrensePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Riksgrense"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <simpleType name="SpråkkodeType">
+    
+    <annotation>
+      
+      <documentation>ISO 639 del 3 språkkodetabell
+
+Merknad: ufullstendig kodeliste pga. importfeil
+
+language code tables of ISO 639 part 3
+
+ISO 639-3 is a code that aims to define three-letter identifiers for all known human languages. At the core of ISO 639-3 are the individual languages already accounted for in ISO 639-2.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SPRÅK</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:SpråkkodeEnumerationType app:SpråkkodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="SpråkkodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>ISO 639 del 3 språkkodetabell
+
+Merknad: ufullstendig kodeliste pga. importfeil
+
+language code tables of ISO 639 part 3
+
+ISO 639-3 is a code that aims to define three-letter identifiers for all known human languages. At the core of ISO 639-3 are the individual languages already accounted for in ISO 639-2.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SPRÅK</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="eng">
+        
+        <annotation>
+          
+          <documentation>English</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fkv">
+        
+        <annotation>
+          
+          <documentation>Kven Finnish</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="smj">
+        
+        <annotation>
+          
+          <documentation>Lule Sami</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sme">
+        
+        <annotation>
+          
+          <documentation>Northern Sami</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nor">
+        
+        <annotation>
+          
+          <documentation>Norwegian</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sma">
+        
+        <annotation>
+          
+          <documentation>Southern Sami</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="SpråkkodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element abstract="true" name="Supertype_SOSI_Objekt_adm_enheter" substitutionGroup="gml:AbstractFeature" type="app:Supertype_SOSI_Objekt_adm_enheterType">
+    
+    <annotation>
+      
+      <documentation>abstrakt objekt som bærer en rekke egenskaper som er fagområde-uavhengige og kan benyttes for alle objekttyper
+
+Merknad:
+Spesielt i produktspesifikasjonsarbeid vil en velge egenskaper og av grensningslinjer fra denne klassen.</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="Supertype_SOSI_Objekt_adm_enheterType">
+    
+    <complexContent>
+      
+      <extension base="gml:AbstractFeatureType">
+        
+        <sequence>
+          
+          <element name="identifikasjon" type="app:IdentifikasjonPropertyType">
+            
+            <annotation>
+              
+              <documentation>unik identifikasjon av et objekt</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">IDENT</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="datafangstdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato når objektet siste gang ble registrert/observert/målt i terrenget
+
+Merknad: I mange tilfeller er denne forskjellig fra Oppdateringsdato, da registrerte endringer kan bufres i en kortere eller lengre periode før disse legges inn i databasen.
+Ved førstegangsregistrering settes Datafangstdato lik førsteDatafangstdato.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DATAFANGSTDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="oppdateringsdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato for siste endring på objektetdataene 
+
+Merknad: 
+Oppdateringsdato kan være forskjellig fra Datafangsdato ved at data som er registrert kan bufres en kortere eller lengre periode før disse legges inn i datasystemet (databasen).
+
+-Definition-
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OPPDATERINGSDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="datauttaksdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato for uttak fra en database
+
+Merknad:
+Skiller seg fra Kopidato ved at en ikke skiller på om det er uttak fra en originaldatabase eller en kopidatabase.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DATAUTTAKSDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="opphav" type="string">
+            
+            <annotation>
+              
+              <documentation>referanse til opphavsmaterialet, kildematerialet, organisasjons/publiseringskilde
+
+Merknad: 
+Kan også beskrive navn på person og årsak til oppdatering</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OPPHAV</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="Supertype_SOSI_Objekt_adm_enheterPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Supertype_SOSI_Objekt_adm_enheter"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element abstract="true" name="Supertype_SOSI_Objekt_adm_grenser" substitutionGroup="gml:AbstractFeature" type="app:Supertype_SOSI_Objekt_adm_grenserType">
+    
+    <annotation>
+      
+      <documentation>abstrakt objekt som bærer en rekke egenskaper som er fagområde-uavhengige og kan benyttes for alle objekttyper
+
+Merknad:
+Spesielt i produktspesifikasjonsarbeid vil en velge egenskaper og av grensningslinjer fra denne klassen.</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="Supertype_SOSI_Objekt_adm_grenserType">
+    
+    <complexContent>
+      
+      <extension base="gml:AbstractFeatureType">
+        
+        <sequence>
+          
+          <element name="identifikasjon" type="app:IdentifikasjonPropertyType">
+            
+            <annotation>
+              
+              <documentation>unik identifikasjon av et objekt</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">IDENT</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="datafangstdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato når objektet siste gang ble registrert/observert/målt i terrenget
+
+Merknad: I mange tilfeller er denne forskjellig fra Oppdateringsdato, da registrerte endringer kan bufres i en kortere eller lengre periode før disse legges inn i databasen.
+Ved førstegangsregistrering settes Datafangstdato lik førsteDatafangstdato.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DATAFANGSTDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="oppdateringsdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato for siste endring på objektetdataene 
+
+Merknad: 
+Oppdateringsdato kan være forskjellig fra Datafangsdato ved at data som er registrert kan bufres en kortere eller lengre periode før disse legges inn i datasystemet (databasen).
+
+-Definition-
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OPPDATERINGSDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="datauttaksdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato for uttak fra en database
+
+Merknad:
+Skiller seg fra Kopidato ved at en ikke skiller på om det er uttak fra en originaldatabase eller en kopidatabase.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DATAUTTAKSDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="kvalitet" type="app:PosisjonskvalitetPropertyType">
+            
+            <annotation>
+              
+              <documentation>beskrivelse av kvaliteten på stedfestingen</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KVALITET</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="opphav" type="string">
+            
+            <annotation>
+              
+              <documentation>referanse til opphavsmaterialet, kildematerialet, organisasjons/publiseringskilde
+
+Merknad: 
+Kan også beskrive navn på person og årsak til oppdatering</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OPPHAV</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="kopidata" type="app:KopidataPropertyType">
+            
+            <annotation>
+              
+              <documentation>angivelse av at objektet er hentet fra et kopidatasett og ikke fra originaldatasettet
+
+Merknad: Inneholder informasjon om når kopidatasettet ble kopiert fra originaldatasettet og hvem som er originaldataansvarlig</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOPIDATA</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="Supertype_SOSI_Objekt_adm_grenserPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Supertype_SOSI_Objekt_adm_grenser"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element abstract="true" name="Supertype_SOSI_Objekt_andre_grenser" substitutionGroup="gml:AbstractFeature" type="app:Supertype_SOSI_Objekt_andre_grenserType">
+    
+    <annotation>
+      
+      <documentation>abstrakt objekt som bærer en rekke egenskaper som er fagområde-uavhengige og kan benyttes for alle objekttyper
+
+Merknad:
+Spesielt i produktspesifikasjonsarbeid vil en velge egenskaper og av grensningslinjer fra denne klassen.</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="Supertype_SOSI_Objekt_andre_grenserType">
+    
+    <complexContent>
+      
+      <extension base="gml:AbstractFeatureType">
+        
+        <sequence>
+          
+          <element name="identifikasjon" type="app:IdentifikasjonPropertyType">
+            
+            <annotation>
+              
+              <documentation>unik identifikasjon av et objekt</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">IDENT</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="datafangstdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato når objektet siste gang ble registrert/observert/målt i terrenget
+
+Merknad: I mange tilfeller er denne forskjellig fra Oppdateringsdato, da registrerte endringer kan bufres i en kortere eller lengre periode før disse legges inn i databasen.
+Ved førstegangsregistrering settes Datafangstdato lik førsteDatafangstdato.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DATAFANGSTDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="oppdateringsdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato for siste endring på objektetdataene 
+
+Merknad: 
+Oppdateringsdato kan være forskjellig fra Datafangsdato ved at data som er registrert kan bufres en kortere eller lengre periode før disse legges inn i datasystemet (databasen).
+
+-Definition-
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OPPDATERINGSDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="datauttaksdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato for uttak fra en database
+
+Merknad:
+Skiller seg fra Kopidato ved at en ikke skiller på om det er uttak fra en originaldatabase eller en kopidatabase.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DATAUTTAKSDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="kvalitet" type="app:PosisjonskvalitetPropertyType">
+            
+            <annotation>
+              
+              <documentation>beskrivelse av kvaliteten på stedfestingen
+
+Merknad: Denne er identisk med ..KVALITET i tidligere versjoner av SOSI.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KVALITET</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="opphav" type="string">
+            
+            <annotation>
+              
+              <documentation>referanse til opphavsmaterialet, kildematerialet, organisasjons/publiseringskilde
+
+Merknad: 
+Kan også beskrive navn på person og årsak til oppdatering</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OPPHAV</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="kopidata" type="app:KopidataPropertyType">
+            
+            <annotation>
+              
+              <documentation>angivelse av at objektet er hentet fra et kopidatasett og ikke fra originaldatasettet
+
+Merknad: Inneholder informasjon om når kopidatasettet ble kopiert fra originaldatasettet og hvem som er originaldataansvarlig</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOPIDATA</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element maxOccurs="unbounded" minOccurs="0" name="informasjon" type="string">
+            
+            <annotation>
+              
+              <documentation>generell opplysning
+
+Merknad:
+mulighet til å legge inn utfyllende informasjon om objektet</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">INFORMASJON</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="gyldigFra" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>validFrom: Tidspunktet når objektet oppstod i den virkelige verden
+
+-Definition-
+The time when the phenomenon started to exist in the real world.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">GYLDIGFRA</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="Supertype_SOSI_Objekt_andre_grenserPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Supertype_SOSI_Objekt_andre_grenser"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <simpleType name="TerrengdetaljKodeType">
+    
+    <annotation>
+      
+      <documentation>Kodeliste over hvilke terrengdetaljer en teiggrense kan følge.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FØLGER_TERRENGDET</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:TerrengdetaljKodeEnumerationType app:TerrengdetaljKodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="TerrengdetaljKodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Kodeliste over hvilke terrengdetaljer en teiggrense kan følge.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FØLGER_TERRENGDET</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="ANN">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger annen terrengdetalj.
+Merknad:
+Spesifiser eventuelt hva grensen følger under "informasjon" (kommunal tilleggsdel i matrikkelen)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="AGJ">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger annet gjerde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="BYG">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger fasadelivet på bygning</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="BYA">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger kant av bygningsmessig anlegg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="EBD">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger djupålen i elv eller bekk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="EBK">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger kanten av elv eller bekk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="EBM">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger midtlinjen av elv eller bekk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="GGM">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger generalisert geometrisk midtlinje (innsjø, fjord)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="HKO">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger havkontur.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ITD">
+        
+        <annotation>
+          
+          <documentation>Teiggrensen følger ingen terrengdetalj. (En "ikke-verdi")</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="IKA">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger innsjøkant.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="LBR">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger lavbrekk (motsatt av vannskille).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="SGJ">
+        
+        <annotation>
+          
+          <documentation>Grenselinje følger steingjerde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="SKJ">
+        
+        <annotation>
+          
+          <documentation>Grenselinjen følger sti eller kjerreveg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="VSK">
+        
+        <annotation>
+          
+          <documentation>Grenselinjen følger vannskillet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="VKA">
+        
+        <annotation>
+          
+          <documentation>Grenselinjen følger vegkant.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="VMI">
+        
+        <annotation>
+          
+          <documentation>Grenselinjen følger midten av veg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="TerrengdetaljKodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Territorialgrense" substitutionGroup="app:BeregnetGrense" type="app:TerritorialgrenseType">
+    
+    <annotation>
+      
+      <documentation>TerritorialBoundary: avgrensning i havet av statens suverenitetsområde, beregnet 12 nm (22 224 m) utenfor og parallelt med grunnlinjen</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">TERRITORIALGRENSE</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="TerritorialgrenseType">
+    
+    <complexContent>
+      
+      <extension base="app:BeregnetGrenseType">
+        
+        <sequence/>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="TerritorialgrensePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Territorialgrense"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element abstract="true" name="Virkeområde" substitutionGroup="app:Supertype_SOSI_Objekt_andre_grenser" type="app:VirkeområdeType">
+    
+    <annotation>
+      
+      <documentation>sone for eller avgrensning av et område hvor det er spesiell administrasjon, regulering eller restiksjon</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="VirkeområdeType">
+    
+    <complexContent>
+      
+      <extension base="app:Supertype_SOSI_Objekt_andre_grenserType">
+        
+        <sequence>
+          
+          <element maxOccurs="unbounded" name="dokumentasjonsreferanse" type="app:DokumentasjonsreferansePropertyType">
+            
+            <annotation>
+              
+              <documentation>henviser til fastsettings- eller lovinformasjon</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DOKUMENTASJONSREFERANSE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="VirkeområdePropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Virkeområde"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+
+</schema>

--- a/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/cache/no/geonorge/wfs/skwms1/wfs.stedsnavn.196d7b04d92a7fbfdcfd8bb26d9b2969.xsd
+++ b/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/cache/no/geonorge/wfs/skwms1/wfs.stedsnavn.196d7b04d92a7fbfdcfd8bb26d9b2969.xsd
@@ -1,0 +1,13848 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:app="http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" elementFormDefault="qualified" targetNamespace="http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115" version="20181115">
+  
+  <annotation>
+    
+    <documentation>spesifikasjonen omfatter de vanlig brukte stedsnavn som inngår i Sentralt stedsnavnregister - SSR2</documentation>
+  
+  </annotation>
+  
+  <import namespace="http://www.interactive-instruments.de/ShapeChange/AppInfo" schemaLocation="http://shapechange.net/resources/schema/ShapeChangeAppinfo.xsd"/>
+  
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  
+  <!--XML Schema document created by ShapeChange - http://shapechange.net/-->
+  
+  <element abstract="true" name="Fellesegenskaper" substitutionGroup="gml:AbstractFeature" type="app:FellesegenskaperType">
+    
+    <annotation>
+      
+      <documentation>abstrakt objekttype som bærer sentrale egenskaper som er anbefalt for bruk i produktspesifikasjoner.
+
+Merknad: Disse egenskapene skal derfor ikke modelleres inn i fagområdemodeller.</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType abstract="true" name="FellesegenskaperType">
+    
+    <complexContent>
+      
+      <extension base="gml:AbstractFeatureType">
+        
+        <sequence>
+          
+          <element name="identifikasjon" type="app:IdentifikasjonPropertyType">
+            
+            <annotation>
+              
+              <documentation>unik identifikasjon av et objekt</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">IDENT</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="oppdateringsdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato for siste endring på objektetdataene 
+
+Merknad: 
+Oppdateringsdato kan være forskjellig fra Datafangsdato ved at data som er registrert kan bufres en kortere eller lengre periode før disse legges inn i datasystemet (databasen).</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OPPDATERINGSDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="datauttaksdato" type="dateTime">
+            
+            <annotation>
+              
+              <documentation>dato for uttak fra en database
+
+Merknad:
+Skiller seg fra Kopidato ved at en ikke skiller på om det er uttak fra en originaldatabase eller en kopidatabase.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">DATAUTTAKSDATO</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="FellesegenskaperPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Fellesegenskaper"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <simpleType name="FylkesnummerType">
+    
+    <annotation>
+      
+      <documentation>nummerering av fylker i henhold til Statistisk sentralbyrå sin offisielle liste
+
+Merknad:
+Det presiseres at fylkesnummer alltid skal ha 2 sifre, dvs. eventuelt med ledende null. Fylkesnummer benyttes for kopling mot en rekke andre registre som også benytter 2 sifre.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESNR</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:FylkesnummerEnumerationType app:FylkesnummerOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="FylkesnummerEnumerationType">
+    
+    <annotation>
+      
+      <documentation>nummerering av fylker i henhold til Statistisk sentralbyrå sin offisielle liste
+
+Merknad:
+Det presiseres at fylkesnummer alltid skal ha 2 sifre, dvs. eventuelt med ledende null. Fylkesnummer benyttes for kopling mot en rekke andre registre som også benytter 2 sifre.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESNR</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="01">
+        
+        <annotation>
+          
+          <documentation>Østfold (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="30">
+        
+        <annotation>
+          
+          <documentation>Viken</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="02">
+        
+        <annotation>
+          
+          <documentation>Akershus (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="03">
+        
+        <annotation>
+          
+          <documentation>Oslo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="04">
+        
+        <annotation>
+          
+          <documentation>Hedmark (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="34">
+        
+        <annotation>
+          
+          <documentation>Innlandet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="05">
+        
+        <annotation>
+          
+          <documentation>Oppland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="06">
+        
+        <annotation>
+          
+          <documentation>Buskerud (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="07">
+        
+        <annotation>
+          
+          <documentation>Vestfold (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="38">
+        
+        <annotation>
+          
+          <documentation>Telemark og Vestfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="08">
+        
+        <annotation>
+          
+          <documentation>Telemark (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="09">
+        
+        <annotation>
+          
+          <documentation>Aust-Agder (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="42">
+        
+        <annotation>
+          
+          <documentation>Agder</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="10">
+        
+        <annotation>
+          
+          <documentation>Vest-Agder (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="11">
+        
+        <annotation>
+          
+          <documentation>Rogaland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="12">
+        
+        <annotation>
+          
+          <documentation>Hordaland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="46">
+        
+        <annotation>
+          
+          <documentation>Vestland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="13">
+        
+        <annotation>
+          
+          <documentation>Bergen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="14">
+        
+        <annotation>
+          
+          <documentation>Sogn og Fjordane (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="15">
+        
+        <annotation>
+          
+          <documentation>Møre og Romsdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="16">
+        
+        <annotation>
+          
+          <documentation>Sør-Trøndelag (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="17">
+        
+        <annotation>
+          
+          <documentation>Nord-Trøndelag (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="18">
+        
+        <annotation>
+          
+          <documentation>Nordland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="19">
+        
+        <annotation>
+          
+          <documentation>Troms - Romsa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="54">
+        
+        <annotation>
+          
+          <documentation>Troms og Finnmark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="20">
+        
+        <annotation>
+          
+          <documentation>Finnmark - Finnmárku (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="21">
+        
+        <annotation>
+          
+          <documentation>Svalbard</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="22">
+        
+        <annotation>
+          
+          <documentation>Jan Mayen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="23">
+        
+        <annotation>
+          
+          <documentation>Kontinentalsokkelen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="50">
+        
+        <annotation>
+          
+          <documentation>Trøndelag</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="FylkesnummerOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Identifikasjon" substitutionGroup="gml:AbstractObject" type="app:IdentifikasjonType">
+    
+    <annotation>
+      
+      <documentation>Identification: Unik identifikasjon av et objekt i et datasett, forvaltet av den ansvarlige produsent/forvalter, og kan benyttes av eksterne applikasjoner som stabil referanse til objektet. 
+
+Merknad 1: Denne objektidentifikasjonen må ikke forveksles med en tematisk objektidentifikasjon, slik som f.eks bygningsnummer. 
+
+Merknad 2: Denne unike identifikatoren vil ikke endres i løpet av objektets levetid, og ikke gjenbrukes i andre objekt.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">IDENT</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="IdentifikasjonType">
+    
+    <sequence>
+      
+      <element name="lokalId" type="string">
+        
+        <annotation>
+          
+          <documentation>localId: lokal identifikator av et objekt
+
+Merknad: Det er dataleverendørens ansvar å sørge for at den lokale identifikatoren er unik innenfor navnerommet.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">LOKALID</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="navnerom" type="string">
+        
+        <annotation>
+          
+          <documentation>namespace: navnerom som unikt identifiserer datakilden til et objekt, anbefales å være en http-URI
+
+Eksempel: http://data.geonorge.no/SentraltStedsnavnsregister/1.0
+
+Merknad : Verdien for nanverom vil eies av den dataprodusent som har ansvar for de unike identifikatorene og må være registrert i data.geonorge.no eller data.norge.no</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVNEROM</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="versjonId" type="string">
+        
+        <annotation>
+          
+          <documentation>versionId: identifikasjon av en spesiell versjon av et geografisk objekt (instans)</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">VERSJONID</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="IdentifikasjonPropertyType">
+    
+    <sequence>
+      
+      <element ref="app:Identifikasjon"/>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <element name="Kommune" substitutionGroup="gml:AbstractObject" type="app:KommuneType">
+    
+    <annotation>
+      
+      <documentation>Selvstendig objekt som kan pekes til fra flere steder, og skal vise kommunen(e) det registrerte stedet er i. Denne skal ikke brukes for navnetypen "Kommune".</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="KommuneType">
+    
+    <sequence>
+      
+      <element name="kommunenummer" type="app:KommunenummerType">
+        
+        <annotation>
+          
+          <documentation>Kommunenummer er nummer for å identifisere kommunerer og er et firesifret nummer (eks.: 0101) som er unikt for hver kommune i Norge</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="kommunenavn" type="string">
+        
+        <annotation>
+          
+          <documentation>Navnet på kommunen, navnet vises på flere språk dersom kommunen er flerspråklig.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENAVN</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="fylkesnummer" type="app:FylkesnummerType">
+        
+        <annotation>
+          
+          <documentation>Fylkesnummer er definerte identifikasjonskoder for norske fylker og to territorier (Svalbard og Jan Mayen)</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESNR</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="fylkesnavn" type="string">
+        
+        <annotation>
+          
+          <documentation>Navnet på fylket, navnet vises på flere språk med riktig rekkefølge på spårkene dersom fylket er flerspråklig.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">FYLKESNAVN</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="KommunePropertyType">
+    
+    <sequence>
+      
+      <element ref="app:Kommune"/>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <simpleType name="KommunenummerType">
+    
+    <annotation>
+      
+      <documentation>nummerering av kommuner i henhold til Statistisk sentralbyrå sin offisielle liste samt et utvalg av utgåtte numre
+
+Merknad: Det presiseres at kommune alltid skal ha 4 sifre, dvs. eventuelt med ledende null. Kommune benyttes for kopling mot en rekke andre registre som også benytter 4 sifre.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <union memberTypes="app:KommunenummerEnumerationType app:KommunenummerOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="KommunenummerEnumerationType">
+    
+    <annotation>
+      
+      <documentation>nummerering av kommuner i henhold til Statistisk sentralbyrå sin offisielle liste samt et utvalg av utgåtte numre
+
+Merknad: Det presiseres at kommune alltid skal ha 4 sifre, dvs. eventuelt med ledende null. Kommune benyttes for kopling mot en rekke andre registre som også benytter 4 sifre.</documentation>
+      
+      <appinfo>
+        
+        <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNENUMMER</taggedValue>
+      
+      </appinfo>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="0101">
+        
+        <annotation>
+          
+          <documentation>Halden (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3001">
+        
+        <annotation>
+          
+          <documentation>Halden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0102">
+        
+        <annotation>
+          
+          <documentation>Sarpsborg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0103">
+        
+        <annotation>
+          
+          <documentation>Fredrikstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0104">
+        
+        <annotation>
+          
+          <documentation>Moss (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3002">
+        
+        <annotation>
+          
+          <documentation>Moss</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0105">
+        
+        <annotation>
+          
+          <documentation>Sarpsborg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3003">
+        
+        <annotation>
+          
+          <documentation>Sarpsborg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0106">
+        
+        <annotation>
+          
+          <documentation>Fredrikstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3004">
+        
+        <annotation>
+          
+          <documentation>Fredrikstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0111">
+        
+        <annotation>
+          
+          <documentation>Hvaler (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3011">
+        
+        <annotation>
+          
+          <documentation>Hvaler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0113">
+        
+        <annotation>
+          
+          <documentation>Borge (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0114">
+        
+        <annotation>
+          
+          <documentation>Varteig (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0115">
+        
+        <annotation>
+          
+          <documentation>Skjeberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0118">
+        
+        <annotation>
+          
+          <documentation>Aremark (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3012">
+        
+        <annotation>
+          
+          <documentation>Aremark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0119">
+        
+        <annotation>
+          
+          <documentation>Marker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3013">
+        
+        <annotation>
+          
+          <documentation>Marker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0121">
+        
+        <annotation>
+          
+          <documentation>Rømskog (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3026">
+        
+        <annotation>
+          
+          <documentation>Aurskog-Høland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0122">
+        
+        <annotation>
+          
+          <documentation>Trøgstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3014">
+        
+        <annotation>
+          
+          <documentation>Indre Østfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0123">
+        
+        <annotation>
+          
+          <documentation>Spydeberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0124">
+        
+        <annotation>
+          
+          <documentation>Askim (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0125">
+        
+        <annotation>
+          
+          <documentation>Eidsberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0127">
+        
+        <annotation>
+          
+          <documentation>Skiptvet (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3015">
+        
+        <annotation>
+          
+          <documentation>Skiptvet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0128">
+        
+        <annotation>
+          
+          <documentation>Rakkestad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3016">
+        
+        <annotation>
+          
+          <documentation>Rakkestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0130">
+        
+        <annotation>
+          
+          <documentation>Tune (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0131">
+        
+        <annotation>
+          
+          <documentation>Rolvsøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0133">
+        
+        <annotation>
+          
+          <documentation>Kråkerøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0134">
+        
+        <annotation>
+          
+          <documentation>Onsøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0135">
+        
+        <annotation>
+          
+          <documentation>Råde (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3017">
+        
+        <annotation>
+          
+          <documentation>Råde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0136">
+        
+        <annotation>
+          
+          <documentation>Rygge (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0137">
+        
+        <annotation>
+          
+          <documentation>Våler i Østfold (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3018">
+        
+        <annotation>
+          
+          <documentation>Våler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0138">
+        
+        <annotation>
+          
+          <documentation>Hobøl (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0211">
+        
+        <annotation>
+          
+          <documentation>Vestby (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3019">
+        
+        <annotation>
+          
+          <documentation>Vestby</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0213">
+        
+        <annotation>
+          
+          <documentation>Ski (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3020">
+        
+        <annotation>
+          
+          <documentation>Nordre Follo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0214">
+        
+        <annotation>
+          
+          <documentation>Ås (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3021">
+        
+        <annotation>
+          
+          <documentation>Ås</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0215">
+        
+        <annotation>
+          
+          <documentation>Frogn (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3022">
+        
+        <annotation>
+          
+          <documentation>Frogn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0216">
+        
+        <annotation>
+          
+          <documentation>Nesodden (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3023">
+        
+        <annotation>
+          
+          <documentation>Nesodden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0217">
+        
+        <annotation>
+          
+          <documentation>Oppegård (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0219">
+        
+        <annotation>
+          
+          <documentation>Bærum (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3024">
+        
+        <annotation>
+          
+          <documentation>Bærum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0220">
+        
+        <annotation>
+          
+          <documentation>Asker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3025">
+        
+        <annotation>
+          
+          <documentation>Asker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0221">
+        
+        <annotation>
+          
+          <documentation>Aurskog-Høland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0226">
+        
+        <annotation>
+          
+          <documentation>Sørum (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3030">
+        
+        <annotation>
+          
+          <documentation>Lillestrøm</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0227">
+        
+        <annotation>
+          
+          <documentation>Fet (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0228">
+        
+        <annotation>
+          
+          <documentation>Rælingen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3027">
+        
+        <annotation>
+          
+          <documentation>Rælingen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0229">
+        
+        <annotation>
+          
+          <documentation>Enebakk (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3028">
+        
+        <annotation>
+          
+          <documentation>Enebakk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0230">
+        
+        <annotation>
+          
+          <documentation>Lørenskog (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3029">
+        
+        <annotation>
+          
+          <documentation>Lørenskog</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0231">
+        
+        <annotation>
+          
+          <documentation>Skedsmo (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0233">
+        
+        <annotation>
+          
+          <documentation>Nittedal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3031">
+        
+        <annotation>
+          
+          <documentation>Nittedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0234">
+        
+        <annotation>
+          
+          <documentation>Gjerdrum (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3032">
+        
+        <annotation>
+          
+          <documentation>Gjerdrum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0235">
+        
+        <annotation>
+          
+          <documentation>Ullensaker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3033">
+        
+        <annotation>
+          
+          <documentation>Ullensaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0236">
+        
+        <annotation>
+          
+          <documentation>Nes i Akershus (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3034">
+        
+        <annotation>
+          
+          <documentation>Nes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0237">
+        
+        <annotation>
+          
+          <documentation>Eidsvoll (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3035">
+        
+        <annotation>
+          
+          <documentation>Eidsvoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0238">
+        
+        <annotation>
+          
+          <documentation>Nannestad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3036">
+        
+        <annotation>
+          
+          <documentation>Nannestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0239">
+        
+        <annotation>
+          
+          <documentation>Hurdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3037">
+        
+        <annotation>
+          
+          <documentation>Hurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0301">
+        
+        <annotation>
+          
+          <documentation>Oslo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0401">
+        
+        <annotation>
+          
+          <documentation>Hamar (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0402">
+        
+        <annotation>
+          
+          <documentation>Kongsvinger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3401">
+        
+        <annotation>
+          
+          <documentation>Kongsvinger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0403">
+        
+        <annotation>
+          
+          <documentation>Hamar (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3403">
+        
+        <annotation>
+          
+          <documentation>Hamar</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0412">
+        
+        <annotation>
+          
+          <documentation>Ringsaker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3411">
+        
+        <annotation>
+          
+          <documentation>Ringsaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0414">
+        
+        <annotation>
+          
+          <documentation>Vang (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0415">
+        
+        <annotation>
+          
+          <documentation>Løten (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3412">
+        
+        <annotation>
+          
+          <documentation>Løten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0417">
+        
+        <annotation>
+          
+          <documentation>Stange (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3413">
+        
+        <annotation>
+          
+          <documentation>Stange</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0418">
+        
+        <annotation>
+          
+          <documentation>Nord-Odal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3414">
+        
+        <annotation>
+          
+          <documentation>Nord-Odal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0419">
+        
+        <annotation>
+          
+          <documentation>Sør-Odal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3415">
+        
+        <annotation>
+          
+          <documentation>Sør-Odal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0420">
+        
+        <annotation>
+          
+          <documentation>Eidskog (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3416">
+        
+        <annotation>
+          
+          <documentation>Eidskog</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0423">
+        
+        <annotation>
+          
+          <documentation>Grue (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3417">
+        
+        <annotation>
+          
+          <documentation>Grue</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0425">
+        
+        <annotation>
+          
+          <documentation>Åsnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3418">
+        
+        <annotation>
+          
+          <documentation>Åsnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0426">
+        
+        <annotation>
+          
+          <documentation>Våler i Hedmark (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3419">
+        
+        <annotation>
+          
+          <documentation>Våler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0427">
+        
+        <annotation>
+          
+          <documentation>Elverum (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3420">
+        
+        <annotation>
+          
+          <documentation>Elverum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0428">
+        
+        <annotation>
+          
+          <documentation>Trysil (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3421">
+        
+        <annotation>
+          
+          <documentation>Trysil</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0429">
+        
+        <annotation>
+          
+          <documentation>Åmot (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3422">
+        
+        <annotation>
+          
+          <documentation>Åmot</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0430">
+        
+        <annotation>
+          
+          <documentation>Stor-Elvdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3423">
+        
+        <annotation>
+          
+          <documentation>Stor-Elvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0432">
+        
+        <annotation>
+          
+          <documentation>Rendalen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3424">
+        
+        <annotation>
+          
+          <documentation>Rendalen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0434">
+        
+        <annotation>
+          
+          <documentation>Engerdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3425">
+        
+        <annotation>
+          
+          <documentation>Engerdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0436">
+        
+        <annotation>
+          
+          <documentation>Tolga (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3426">
+        
+        <annotation>
+          
+          <documentation>Tolga</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0437">
+        
+        <annotation>
+          
+          <documentation>Tynset (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3427">
+        
+        <annotation>
+          
+          <documentation>Tynset</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0438">
+        
+        <annotation>
+          
+          <documentation>Alvdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3428">
+        
+        <annotation>
+          
+          <documentation>Alvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0439">
+        
+        <annotation>
+          
+          <documentation>Folldal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3429">
+        
+        <annotation>
+          
+          <documentation>Folldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0441">
+        
+        <annotation>
+          
+          <documentation>Os i Hedmark (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3430">
+        
+        <annotation>
+          
+          <documentation>Os</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0501">
+        
+        <annotation>
+          
+          <documentation>Lillehammer (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3405">
+        
+        <annotation>
+          
+          <documentation>Lillehammer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0502">
+        
+        <annotation>
+          
+          <documentation>Gjøvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3407">
+        
+        <annotation>
+          
+          <documentation>Gjøvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0511">
+        
+        <annotation>
+          
+          <documentation>Dovre (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3431">
+        
+        <annotation>
+          
+          <documentation>Dovre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0512">
+        
+        <annotation>
+          
+          <documentation>Lesja (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3432">
+        
+        <annotation>
+          
+          <documentation>Lesja</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0513">
+        
+        <annotation>
+          
+          <documentation>Skjåk (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3433">
+        
+        <annotation>
+          
+          <documentation>Skjåk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0514">
+        
+        <annotation>
+          
+          <documentation>Lom (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3434">
+        
+        <annotation>
+          
+          <documentation>Lom</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0515">
+        
+        <annotation>
+          
+          <documentation>Vågå (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3435">
+        
+        <annotation>
+          
+          <documentation>Vågå</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0516">
+        
+        <annotation>
+          
+          <documentation>Nord-Fron (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3436">
+        
+        <annotation>
+          
+          <documentation>Nord-Fron</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0517">
+        
+        <annotation>
+          
+          <documentation>Sel (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3437">
+        
+        <annotation>
+          
+          <documentation>Sel</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0519">
+        
+        <annotation>
+          
+          <documentation>Sør-Fron (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3438">
+        
+        <annotation>
+          
+          <documentation>Sør-Fron</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0520">
+        
+        <annotation>
+          
+          <documentation>Ringebu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3439">
+        
+        <annotation>
+          
+          <documentation>Ringebu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0521">
+        
+        <annotation>
+          
+          <documentation>Øyer (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3440">
+        
+        <annotation>
+          
+          <documentation>Øyer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0522">
+        
+        <annotation>
+          
+          <documentation>Gausdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3441">
+        
+        <annotation>
+          
+          <documentation>Gausdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0528">
+        
+        <annotation>
+          
+          <documentation>Østre Toten (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3442">
+        
+        <annotation>
+          
+          <documentation>Østre Toten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0529">
+        
+        <annotation>
+          
+          <documentation>Vestre Toten (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3443">
+        
+        <annotation>
+          
+          <documentation>Vestre Toten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0532">
+        
+        <annotation>
+          
+          <documentation>Jevnaker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3053">
+        
+        <annotation>
+          
+          <documentation>Jevnaker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0533">
+        
+        <annotation>
+          
+          <documentation>Lunner (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3054">
+        
+        <annotation>
+          
+          <documentation>Lunner</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0534">
+        
+        <annotation>
+          
+          <documentation>Gran (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3446">
+        
+        <annotation>
+          
+          <documentation>Gran</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0536">
+        
+        <annotation>
+          
+          <documentation>Søndre Land (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3447">
+        
+        <annotation>
+          
+          <documentation>Søndre Land</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0538">
+        
+        <annotation>
+          
+          <documentation>Nordre Land (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3448">
+        
+        <annotation>
+          
+          <documentation>Nordre Land</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0540">
+        
+        <annotation>
+          
+          <documentation>Sør-Aurdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3449">
+        
+        <annotation>
+          
+          <documentation>Sør-Aurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0541">
+        
+        <annotation>
+          
+          <documentation>Etnedal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3450">
+        
+        <annotation>
+          
+          <documentation>Etnedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0542">
+        
+        <annotation>
+          
+          <documentation>Nord-Aurdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3451">
+        
+        <annotation>
+          
+          <documentation>Nord-Aurdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0543">
+        
+        <annotation>
+          
+          <documentation>Vestre Slidre (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3452">
+        
+        <annotation>
+          
+          <documentation>Vestre Slidre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0544">
+        
+        <annotation>
+          
+          <documentation>Øystre Slidre (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3453">
+        
+        <annotation>
+          
+          <documentation>Øystre Slidre</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0545">
+        
+        <annotation>
+          
+          <documentation>Vang (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3454">
+        
+        <annotation>
+          
+          <documentation>Vang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0602">
+        
+        <annotation>
+          
+          <documentation>Drammen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3005">
+        
+        <annotation>
+          
+          <documentation>Drammen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0604">
+        
+        <annotation>
+          
+          <documentation>Kongsberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3006">
+        
+        <annotation>
+          
+          <documentation>Kongsberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0605">
+        
+        <annotation>
+          
+          <documentation>Ringerike (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3007">
+        
+        <annotation>
+          
+          <documentation>Ringerike</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0612">
+        
+        <annotation>
+          
+          <documentation>Hole (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3038">
+        
+        <annotation>
+          
+          <documentation>Hole</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0615">
+        
+        <annotation>
+          
+          <documentation>Flå (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3039">
+        
+        <annotation>
+          
+          <documentation>Flå</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0616">
+        
+        <annotation>
+          
+          <documentation>Nes i Buskerud (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3040">
+        
+        <annotation>
+          
+          <documentation>Nes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0617">
+        
+        <annotation>
+          
+          <documentation>Gol (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3041">
+        
+        <annotation>
+          
+          <documentation>Gol</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0618">
+        
+        <annotation>
+          
+          <documentation>Hemsedal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3042">
+        
+        <annotation>
+          
+          <documentation>Hemsedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0619">
+        
+        <annotation>
+          
+          <documentation>Ål (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3043">
+        
+        <annotation>
+          
+          <documentation>Ål</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0620">
+        
+        <annotation>
+          
+          <documentation>Hol (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3044">
+        
+        <annotation>
+          
+          <documentation>Hol</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0621">
+        
+        <annotation>
+          
+          <documentation>Sigdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3045">
+        
+        <annotation>
+          
+          <documentation>Sigdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0622">
+        
+        <annotation>
+          
+          <documentation>Krødsherad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3046">
+        
+        <annotation>
+          
+          <documentation>Krødsherad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0623">
+        
+        <annotation>
+          
+          <documentation>Modum (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3047">
+        
+        <annotation>
+          
+          <documentation>Modum</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0624">
+        
+        <annotation>
+          
+          <documentation>Øvre Eiker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3048">
+        
+        <annotation>
+          
+          <documentation>Øvre Eiker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0625">
+        
+        <annotation>
+          
+          <documentation>Nedre Eiker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0626">
+        
+        <annotation>
+          
+          <documentation>Lier (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3049">
+        
+        <annotation>
+          
+          <documentation>Lier</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0627">
+        
+        <annotation>
+          
+          <documentation>Røyken (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0628">
+        
+        <annotation>
+          
+          <documentation>Hurum (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0631">
+        
+        <annotation>
+          
+          <documentation>Flesberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3050">
+        
+        <annotation>
+          
+          <documentation>Flesberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0632">
+        
+        <annotation>
+          
+          <documentation>Rollag (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3051">
+        
+        <annotation>
+          
+          <documentation>Rollag</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0633">
+        
+        <annotation>
+          
+          <documentation>Nore og Uvdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3052">
+        
+        <annotation>
+          
+          <documentation>Nore og Uvdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0701">
+        
+        <annotation>
+          
+          <documentation>Horten (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3801">
+        
+        <annotation>
+          
+          <documentation>Horten</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0702">
+        
+        <annotation>
+          
+          <documentation>Holmestrand (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0703">
+        
+        <annotation>
+          
+          <documentation>Horten (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0704">
+        
+        <annotation>
+          
+          <documentation>Tønsberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3803">
+        
+        <annotation>
+          
+          <documentation>Tønsberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0705">
+        
+        <annotation>
+          
+          <documentation>Tønsberg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0706">
+        
+        <annotation>
+          
+          <documentation>Sandefjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0707">
+        
+        <annotation>
+          
+          <documentation>Larvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0708">
+        
+        <annotation>
+          
+          <documentation>Stavern (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0709">
+        
+        <annotation>
+          
+          <documentation>Larvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0710">
+        
+        <annotation>
+          
+          <documentation>Sandefjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3804">
+        
+        <annotation>
+          
+          <documentation>Sandefjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0711">
+        
+        <annotation>
+          
+          <documentation>Svelvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0713">
+        
+        <annotation>
+          
+          <documentation>Sande i Vestfold (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3802">
+        
+        <annotation>
+          
+          <documentation>Holmestrand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0714">
+        
+        <annotation>
+          
+          <documentation>Hof (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0716">
+        
+        <annotation>
+          
+          <documentation>Re (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0717">
+        
+        <annotation>
+          
+          <documentation>Borre (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0718">
+        
+        <annotation>
+          
+          <documentation>Ramnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0719">
+        
+        <annotation>
+          
+          <documentation>Andebu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0720">
+        
+        <annotation>
+          
+          <documentation>Stokke (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0721">
+        
+        <annotation>
+          
+          <documentation>Sem (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0722">
+        
+        <annotation>
+          
+          <documentation>Nøtterøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0723">
+        
+        <annotation>
+          
+          <documentation>Tjøme (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0725">
+        
+        <annotation>
+          
+          <documentation>Tjølling (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0726">
+        
+        <annotation>
+          
+          <documentation>Brunlanes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0727">
+        
+        <annotation>
+          
+          <documentation>Hedrum (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0728">
+        
+        <annotation>
+          
+          <documentation>Lardal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0805">
+        
+        <annotation>
+          
+          <documentation>Porsgrunn (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3806">
+        
+        <annotation>
+          
+          <documentation>Porsgrunn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0806">
+        
+        <annotation>
+          
+          <documentation>Skien (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3807">
+        
+        <annotation>
+          
+          <documentation>Skien</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0807">
+        
+        <annotation>
+          
+          <documentation>Notodden (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3808">
+        
+        <annotation>
+          
+          <documentation>Notodden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0811">
+        
+        <annotation>
+          
+          <documentation>Siljan (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3812">
+        
+        <annotation>
+          
+          <documentation>Siljan</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0814">
+        
+        <annotation>
+          
+          <documentation>Bamble (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3813">
+        
+        <annotation>
+          
+          <documentation>Bamble</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0815">
+        
+        <annotation>
+          
+          <documentation>Kragerø (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3814">
+        
+        <annotation>
+          
+          <documentation>Kragerø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0817">
+        
+        <annotation>
+          
+          <documentation>Drangedal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3815">
+        
+        <annotation>
+          
+          <documentation>Drangedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0819">
+        
+        <annotation>
+          
+          <documentation>Nome (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3816">
+        
+        <annotation>
+          
+          <documentation>Nome</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0821">
+        
+        <annotation>
+          
+          <documentation>Bø i Telemark (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3817">
+        
+        <annotation>
+          
+          <documentation>Midt-Telemark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0822">
+        
+        <annotation>
+          
+          <documentation>Sauherad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0826">
+        
+        <annotation>
+          
+          <documentation>Tinn (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3818">
+        
+        <annotation>
+          
+          <documentation>Tinn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0827">
+        
+        <annotation>
+          
+          <documentation>Hjartdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3819">
+        
+        <annotation>
+          
+          <documentation>Hjartdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0828">
+        
+        <annotation>
+          
+          <documentation>Seljord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3820">
+        
+        <annotation>
+          
+          <documentation>Seljord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0829">
+        
+        <annotation>
+          
+          <documentation>Kviteseid (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3821">
+        
+        <annotation>
+          
+          <documentation>Kviteseid</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0830">
+        
+        <annotation>
+          
+          <documentation>Nissedal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3822">
+        
+        <annotation>
+          
+          <documentation>Nissedal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0831">
+        
+        <annotation>
+          
+          <documentation>Fyresdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3823">
+        
+        <annotation>
+          
+          <documentation>Fyresdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0833">
+        
+        <annotation>
+          
+          <documentation>Tokke (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3824">
+        
+        <annotation>
+          
+          <documentation>Tokke</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0834">
+        
+        <annotation>
+          
+          <documentation>Vinje (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3825">
+        
+        <annotation>
+          
+          <documentation>Vinje</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0901">
+        
+        <annotation>
+          
+          <documentation>Risør (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4201">
+        
+        <annotation>
+          
+          <documentation>Risør</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0903">
+        
+        <annotation>
+          
+          <documentation>Arendal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0904">
+        
+        <annotation>
+          
+          <documentation>Grimstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4202">
+        
+        <annotation>
+          
+          <documentation>Grimstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0906">
+        
+        <annotation>
+          
+          <documentation>Arendal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4203">
+        
+        <annotation>
+          
+          <documentation>Arendal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0911">
+        
+        <annotation>
+          
+          <documentation>Gjerstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4211">
+        
+        <annotation>
+          
+          <documentation>Gjerstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0912">
+        
+        <annotation>
+          
+          <documentation>Vegårshei (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4212">
+        
+        <annotation>
+          
+          <documentation>Vegårshei</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0914">
+        
+        <annotation>
+          
+          <documentation>Tvedestrand (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4213">
+        
+        <annotation>
+          
+          <documentation>Tvedestrand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0918">
+        
+        <annotation>
+          
+          <documentation>Moland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0919">
+        
+        <annotation>
+          
+          <documentation>Froland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4214">
+        
+        <annotation>
+          
+          <documentation>Froland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0920">
+        
+        <annotation>
+          
+          <documentation>Øyestad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0921">
+        
+        <annotation>
+          
+          <documentation>Tromøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0922">
+        
+        <annotation>
+          
+          <documentation>Hisøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0926">
+        
+        <annotation>
+          
+          <documentation>Lillesand (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4215">
+        
+        <annotation>
+          
+          <documentation>Lillesand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0928">
+        
+        <annotation>
+          
+          <documentation>Birkenes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4216">
+        
+        <annotation>
+          
+          <documentation>Birkenes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0929">
+        
+        <annotation>
+          
+          <documentation>Åmli (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4217">
+        
+        <annotation>
+          
+          <documentation>Åmli</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0935">
+        
+        <annotation>
+          
+          <documentation>Iveland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4218">
+        
+        <annotation>
+          
+          <documentation>Iveland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0937">
+        
+        <annotation>
+          
+          <documentation>Evje og Hornnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4219">
+        
+        <annotation>
+          
+          <documentation>Evje og Hornnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0938">
+        
+        <annotation>
+          
+          <documentation>Bygland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4220">
+        
+        <annotation>
+          
+          <documentation>Bygland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0940">
+        
+        <annotation>
+          
+          <documentation>Valle (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4221">
+        
+        <annotation>
+          
+          <documentation>Valle</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0941">
+        
+        <annotation>
+          
+          <documentation>Bykle (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4222">
+        
+        <annotation>
+          
+          <documentation>Bykle</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1001">
+        
+        <annotation>
+          
+          <documentation>Kristiansand (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4204">
+        
+        <annotation>
+          
+          <documentation>Kristiansand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1002">
+        
+        <annotation>
+          
+          <documentation>Mandal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4205">
+        
+        <annotation>
+          
+          <documentation>Lindesnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1003">
+        
+        <annotation>
+          
+          <documentation>Farsund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4206">
+        
+        <annotation>
+          
+          <documentation>Farsund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1004">
+        
+        <annotation>
+          
+          <documentation>Flekkefjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4207">
+        
+        <annotation>
+          
+          <documentation>Flekkefjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1014">
+        
+        <annotation>
+          
+          <documentation>Vennesla (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4223">
+        
+        <annotation>
+          
+          <documentation>Vennesla</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1017">
+        
+        <annotation>
+          
+          <documentation>Songdalen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1018">
+        
+        <annotation>
+          
+          <documentation>Søgne (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1021">
+        
+        <annotation>
+          
+          <documentation>Marnardal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1026">
+        
+        <annotation>
+          
+          <documentation>Åseral (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4224">
+        
+        <annotation>
+          
+          <documentation>Åseral</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1027">
+        
+        <annotation>
+          
+          <documentation>Audnedal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4225">
+        
+        <annotation>
+          
+          <documentation>Lyngdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1029">
+        
+        <annotation>
+          
+          <documentation>Lindesnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1032">
+        
+        <annotation>
+          
+          <documentation>Lyngdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1034">
+        
+        <annotation>
+          
+          <documentation>Hægebostad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4226">
+        
+        <annotation>
+          
+          <documentation>Hægebostad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1037">
+        
+        <annotation>
+          
+          <documentation>Kvinesdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4227">
+        
+        <annotation>
+          
+          <documentation>Kvinesdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1046">
+        
+        <annotation>
+          
+          <documentation>Sirdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4228">
+        
+        <annotation>
+          
+          <documentation>Sirdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1101">
+        
+        <annotation>
+          
+          <documentation>Eigersund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1102">
+        
+        <annotation>
+          
+          <documentation>Sandnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1108">
+        
+        <annotation>
+          
+          <documentation>Sandnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1103">
+        
+        <annotation>
+          
+          <documentation>Stavanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1106">
+        
+        <annotation>
+          
+          <documentation>Haugesund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1111">
+        
+        <annotation>
+          
+          <documentation>Sokndal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1112">
+        
+        <annotation>
+          
+          <documentation>Lund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1114">
+        
+        <annotation>
+          
+          <documentation>Bjerkreim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1119">
+        
+        <annotation>
+          
+          <documentation>Hå</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1120">
+        
+        <annotation>
+          
+          <documentation>Klepp</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1121">
+        
+        <annotation>
+          
+          <documentation>Time</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1122">
+        
+        <annotation>
+          
+          <documentation>Gjesdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1124">
+        
+        <annotation>
+          
+          <documentation>Sola</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1127">
+        
+        <annotation>
+          
+          <documentation>Randaberg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1129">
+        
+        <annotation>
+          
+          <documentation>Forsand (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1130">
+        
+        <annotation>
+          
+          <documentation>Strand</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1133">
+        
+        <annotation>
+          
+          <documentation>Hjelmeland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1134">
+        
+        <annotation>
+          
+          <documentation>Suldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1135">
+        
+        <annotation>
+          
+          <documentation>Sauda</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1141">
+        
+        <annotation>
+          
+          <documentation>Finnøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1103">
+        
+        <annotation>
+          
+          <documentation>Stavanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1142">
+        
+        <annotation>
+          
+          <documentation>Rennesøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1144">
+        
+        <annotation>
+          
+          <documentation>Kvitsøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1145">
+        
+        <annotation>
+          
+          <documentation>Bokn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1146">
+        
+        <annotation>
+          
+          <documentation>Tysvær</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1149">
+        
+        <annotation>
+          
+          <documentation>Karmøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1151">
+        
+        <annotation>
+          
+          <documentation>Utsira</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1154">
+        
+        <annotation>
+          
+          <documentation>Vindafjord ((utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1159">
+        
+        <annotation>
+          
+          <documentation>Ølen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1160">
+        
+        <annotation>
+          
+          <documentation>Vindafjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1201">
+        
+        <annotation>
+          
+          <documentation>Bergen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4601">
+        
+        <annotation>
+          
+          <documentation>Bergen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1211">
+        
+        <annotation>
+          
+          <documentation>Etne (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4611">
+        
+        <annotation>
+          
+          <documentation>Etne</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1214">
+        
+        <annotation>
+          
+          <documentation>Ølen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1216">
+        
+        <annotation>
+          
+          <documentation>Sveio (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4612">
+        
+        <annotation>
+          
+          <documentation>Sveio</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1219">
+        
+        <annotation>
+          
+          <documentation>Bømlo (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4613">
+        
+        <annotation>
+          
+          <documentation>Bømlo</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1221">
+        
+        <annotation>
+          
+          <documentation>Stord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4614">
+        
+        <annotation>
+          
+          <documentation>Stord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1222">
+        
+        <annotation>
+          
+          <documentation>Fitjar (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4615">
+        
+        <annotation>
+          
+          <documentation>Fitjar</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1223">
+        
+        <annotation>
+          
+          <documentation>Tysnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4616">
+        
+        <annotation>
+          
+          <documentation>Tysnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1224">
+        
+        <annotation>
+          
+          <documentation>Kvinnherad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4617">
+        
+        <annotation>
+          
+          <documentation>Kvinnherad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1227">
+        
+        <annotation>
+          
+          <documentation>Jondal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4618">
+        
+        <annotation>
+          
+          <documentation>Ullensvang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1228">
+        
+        <annotation>
+          
+          <documentation>Odda (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1231">
+        
+        <annotation>
+          
+          <documentation>Ullensvang (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1232">
+        
+        <annotation>
+          
+          <documentation>Eidfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4619">
+        
+        <annotation>
+          
+          <documentation>Eidfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1233">
+        
+        <annotation>
+          
+          <documentation>Ulvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4620">
+        
+        <annotation>
+          
+          <documentation>Ulvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1234">
+        
+        <annotation>
+          
+          <documentation>Granvin (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4621">
+        
+        <annotation>
+          
+          <documentation>Voss</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1235">
+        
+        <annotation>
+          
+          <documentation>Voss (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1238">
+        
+        <annotation>
+          
+          <documentation>Kvam (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4622">
+        
+        <annotation>
+          
+          <documentation>Kvam</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1241">
+        
+        <annotation>
+          
+          <documentation>Fusa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4624">
+        
+        <annotation>
+          
+          <documentation>Bjørnafjorden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1242">
+        
+        <annotation>
+          
+          <documentation>Samnanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4623">
+        
+        <annotation>
+          
+          <documentation>Samnanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1243">
+        
+        <annotation>
+          
+          <documentation>Os i Hordaland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1244">
+        
+        <annotation>
+          
+          <documentation>Austevoll (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4625">
+        
+        <annotation>
+          
+          <documentation>Austevoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1245">
+        
+        <annotation>
+          
+          <documentation>Sund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4626">
+        
+        <annotation>
+          
+          <documentation>Øygarden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1246">
+        
+        <annotation>
+          
+          <documentation>Fjell (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1247">
+        
+        <annotation>
+          
+          <documentation>Askøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4627">
+        
+        <annotation>
+          
+          <documentation>Askøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1251">
+        
+        <annotation>
+          
+          <documentation>Vaksdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4628">
+        
+        <annotation>
+          
+          <documentation>Vaksdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1252">
+        
+        <annotation>
+          
+          <documentation>Modalen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4629">
+        
+        <annotation>
+          
+          <documentation>Modalen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1253">
+        
+        <annotation>
+          
+          <documentation>Osterøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4630">
+        
+        <annotation>
+          
+          <documentation>Osterøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1256">
+        
+        <annotation>
+          
+          <documentation>Meland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4631">
+        
+        <annotation>
+          
+          <documentation>Alver</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1259">
+        
+        <annotation>
+          
+          <documentation>Øygarden (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1260">
+        
+        <annotation>
+          
+          <documentation>Radøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1263">
+        
+        <annotation>
+          
+          <documentation>Lindås (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1264">
+        
+        <annotation>
+          
+          <documentation>Austrheim (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4632">
+        
+        <annotation>
+          
+          <documentation>Austrheim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1265">
+        
+        <annotation>
+          
+          <documentation>Fedje (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4633">
+        
+        <annotation>
+          
+          <documentation>Fedje</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1266">
+        
+        <annotation>
+          
+          <documentation>Masfjorden (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4634">
+        
+        <annotation>
+          
+          <documentation>Masfjorden</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1401">
+        
+        <annotation>
+          
+          <documentation>Flora (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4602">
+        
+        <annotation>
+          
+          <documentation>Kinn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1411">
+        
+        <annotation>
+          
+          <documentation>Gulen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4635">
+        
+        <annotation>
+          
+          <documentation>Gulen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1412">
+        
+        <annotation>
+          
+          <documentation>Solund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4636">
+        
+        <annotation>
+          
+          <documentation>Solund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1413">
+        
+        <annotation>
+          
+          <documentation>Hyllestad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4637">
+        
+        <annotation>
+          
+          <documentation>Hyllestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1416">
+        
+        <annotation>
+          
+          <documentation>Høyanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4638">
+        
+        <annotation>
+          
+          <documentation>Høyanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1417">
+        
+        <annotation>
+          
+          <documentation>Vik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4639">
+        
+        <annotation>
+          
+          <documentation>Vik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1418">
+        
+        <annotation>
+          
+          <documentation>Balestrand (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4640">
+        
+        <annotation>
+          
+          <documentation>Sogndal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1419">
+        
+        <annotation>
+          
+          <documentation>Leikanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1420">
+        
+        <annotation>
+          
+          <documentation>Sogndal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1421">
+        
+        <annotation>
+          
+          <documentation>Aurland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4641">
+        
+        <annotation>
+          
+          <documentation>Aurland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1422">
+        
+        <annotation>
+          
+          <documentation>Lærdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4642">
+        
+        <annotation>
+          
+          <documentation>Lærdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1424">
+        
+        <annotation>
+          
+          <documentation>Årdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4643">
+        
+        <annotation>
+          
+          <documentation>Årdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1426">
+        
+        <annotation>
+          
+          <documentation>Luster (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4644">
+        
+        <annotation>
+          
+          <documentation>Luster</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1428">
+        
+        <annotation>
+          
+          <documentation>Askvoll (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4645">
+        
+        <annotation>
+          
+          <documentation>Askvoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1429">
+        
+        <annotation>
+          
+          <documentation>Fjaler (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4646">
+        
+        <annotation>
+          
+          <documentation>Fjaler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1430">
+        
+        <annotation>
+          
+          <documentation>Gaular (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4647">
+        
+        <annotation>
+          
+          <documentation>Sunnfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1431">
+        
+        <annotation>
+          
+          <documentation>Jølster (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1432">
+        
+        <annotation>
+          
+          <documentation>Førde (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1433">
+        
+        <annotation>
+          
+          <documentation>Naustdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1438">
+        
+        <annotation>
+          
+          <documentation>Bremanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4648">
+        
+        <annotation>
+          
+          <documentation>Bremanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1439">
+        
+        <annotation>
+          
+          <documentation>Vågsøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1441">
+        
+        <annotation>
+          
+          <documentation>Selje (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4649">
+        
+        <annotation>
+          
+          <documentation>Stad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1443">
+        
+        <annotation>
+          
+          <documentation>Eid (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1444">
+        
+        <annotation>
+          
+          <documentation>Hornindal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1577">
+        
+        <annotation>
+          
+          <documentation>Volda</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1445">
+        
+        <annotation>
+          
+          <documentation>Gloppen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4650">
+        
+        <annotation>
+          
+          <documentation>Gloppen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1449">
+        
+        <annotation>
+          
+          <documentation>Stryn (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="4651">
+        
+        <annotation>
+          
+          <documentation>Stryn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1502">
+        
+        <annotation>
+          
+          <documentation>Molde (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1506">
+        
+        <annotation>
+          
+          <documentation>Molde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1504">
+        
+        <annotation>
+          
+          <documentation>Ålesund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1507">
+        
+        <annotation>
+          
+          <documentation>Ålesund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1505">
+        
+        <annotation>
+          
+          <documentation>Kristiansund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1511">
+        
+        <annotation>
+          
+          <documentation>Vanylven</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1514">
+        
+        <annotation>
+          
+          <documentation>Sande i Møre og Romsdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1515">
+        
+        <annotation>
+          
+          <documentation>Herøy i Møre og Romsdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1516">
+        
+        <annotation>
+          
+          <documentation>Ulstein</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1517">
+        
+        <annotation>
+          
+          <documentation>Hareid</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1519">
+        
+        <annotation>
+          
+          <documentation>Volda (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1520">
+        
+        <annotation>
+          
+          <documentation>Ørsta</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1523">
+        
+        <annotation>
+          
+          <documentation>Ørskog (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1524">
+        
+        <annotation>
+          
+          <documentation>Norddal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1578">
+        
+        <annotation>
+          
+          <documentation>Fjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1525">
+        
+        <annotation>
+          
+          <documentation>Stranda</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1526">
+        
+        <annotation>
+          
+          <documentation>Stordal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1528">
+        
+        <annotation>
+          
+          <documentation>Sykkylven</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1529">
+        
+        <annotation>
+          
+          <documentation>Skodje (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1531">
+        
+        <annotation>
+          
+          <documentation>Sula</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1532">
+        
+        <annotation>
+          
+          <documentation>Giske</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1534">
+        
+        <annotation>
+          
+          <documentation>Haram (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1535">
+        
+        <annotation>
+          
+          <documentation>Vestnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1539">
+        
+        <annotation>
+          
+          <documentation>Rauma</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1543">
+        
+        <annotation>
+          
+          <documentation>Nesset (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1545">
+        
+        <annotation>
+          
+          <documentation>Midsund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1546">
+        
+        <annotation>
+          
+          <documentation>Sandøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1547">
+        
+        <annotation>
+          
+          <documentation>Aukra</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1548">
+        
+        <annotation>
+          
+          <documentation>Fræna (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1579">
+        
+        <annotation>
+          
+          <documentation>Hustadvika</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1551">
+        
+        <annotation>
+          
+          <documentation>Eide (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1554">
+        
+        <annotation>
+          
+          <documentation>Averøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1557">
+        
+        <annotation>
+          
+          <documentation>Gjemnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1560">
+        
+        <annotation>
+          
+          <documentation>Tingvoll</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1563">
+        
+        <annotation>
+          
+          <documentation>Sunndal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1566">
+        
+        <annotation>
+          
+          <documentation>Surnadal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1567">
+        
+        <annotation>
+          
+          <documentation>Rindal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5061">
+        
+        <annotation>
+          
+          <documentation>Rindal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1569">
+        
+        <annotation>
+          
+          <documentation>Aure (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1571">
+        
+        <annotation>
+          
+          <documentation>Halsa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5055">
+        
+        <annotation>
+          
+          <documentation>Heim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1572">
+        
+        <annotation>
+          
+          <documentation>Tustna (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1573">
+        
+        <annotation>
+          
+          <documentation>Smøla</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1576">
+        
+        <annotation>
+          
+          <documentation>Aure</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1601">
+        
+        <annotation>
+          
+          <documentation>Trondheim (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1612">
+        
+        <annotation>
+          
+          <documentation>Hemne (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1613">
+        
+        <annotation>
+          
+          <documentation>Snillfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1617">
+        
+        <annotation>
+          
+          <documentation>Hitra (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1620">
+        
+        <annotation>
+          
+          <documentation>Frøya (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1621">
+        
+        <annotation>
+          
+          <documentation>Ørland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1622">
+        
+        <annotation>
+          
+          <documentation>Agdenes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1624">
+        
+        <annotation>
+          
+          <documentation>Rissa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1627">
+        
+        <annotation>
+          
+          <documentation>Bjugn (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1630">
+        
+        <annotation>
+          
+          <documentation>Åfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1632">
+        
+        <annotation>
+          
+          <documentation>Roan (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1633">
+        
+        <annotation>
+          
+          <documentation>Osen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1634">
+        
+        <annotation>
+          
+          <documentation>Oppdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1635">
+        
+        <annotation>
+          
+          <documentation>Rennebu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1636">
+        
+        <annotation>
+          
+          <documentation>Meldal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1638">
+        
+        <annotation>
+          
+          <documentation>Orkdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1640">
+        
+        <annotation>
+          
+          <documentation>Røros (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1644">
+        
+        <annotation>
+          
+          <documentation>Holtålen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1648">
+        
+        <annotation>
+          
+          <documentation>Midtre Gauldal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1653">
+        
+        <annotation>
+          
+          <documentation>Melhus (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1657">
+        
+        <annotation>
+          
+          <documentation>Skaun (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1662">
+        
+        <annotation>
+          
+          <documentation>Klæbu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1663">
+        
+        <annotation>
+          
+          <documentation>Malvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1664">
+        
+        <annotation>
+          
+          <documentation>Selbu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1665">
+        
+        <annotation>
+          
+          <documentation>Tydal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1702">
+        
+        <annotation>
+          
+          <documentation>Steinkjer (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1703">
+        
+        <annotation>
+          
+          <documentation>Namsos (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1711">
+        
+        <annotation>
+          
+          <documentation>Meråker (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1714">
+        
+        <annotation>
+          
+          <documentation>Stjørdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1717">
+        
+        <annotation>
+          
+          <documentation>Frosta (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1718">
+        
+        <annotation>
+          
+          <documentation>Leksvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1719">
+        
+        <annotation>
+          
+          <documentation>Levanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1721">
+        
+        <annotation>
+          
+          <documentation>Verdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1723">
+        
+        <annotation>
+          
+          <documentation>Mosvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1724">
+        
+        <annotation>
+          
+          <documentation>Verran (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1725">
+        
+        <annotation>
+          
+          <documentation>Namdalseid (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1729">
+        
+        <annotation>
+          
+          <documentation>Inderøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1736">
+        
+        <annotation>
+          
+          <documentation>Snåase – Snåsa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1738">
+        
+        <annotation>
+          
+          <documentation>Lierne (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1739">
+        
+        <annotation>
+          
+          <documentation>Raarvihke – Røyrvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1740">
+        
+        <annotation>
+          
+          <documentation>Namsskogan (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1742">
+        
+        <annotation>
+          
+          <documentation>Grong (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1743">
+        
+        <annotation>
+          
+          <documentation>Høylandet (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1744">
+        
+        <annotation>
+          
+          <documentation>Overhalla (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1748">
+        
+        <annotation>
+          
+          <documentation>Fosnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1749">
+        
+        <annotation>
+          
+          <documentation>Flatanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1750">
+        
+        <annotation>
+          
+          <documentation>Vikna (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1751">
+        
+        <annotation>
+          
+          <documentation>Nærøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1755">
+        
+        <annotation>
+          
+          <documentation>Leka (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1756">
+        
+        <annotation>
+          
+          <documentation>Inderøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1804">
+        
+        <annotation>
+          
+          <documentation>Bodø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1805">
+        
+        <annotation>
+          
+          <documentation>Narvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1806">
+        
+        <annotation>
+          
+          <documentation>Narvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1811">
+        
+        <annotation>
+          
+          <documentation>Bindal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1812">
+        
+        <annotation>
+          
+          <documentation>Sømna</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1813">
+        
+        <annotation>
+          
+          <documentation>Brønnøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1815">
+        
+        <annotation>
+          
+          <documentation>Vega</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1816">
+        
+        <annotation>
+          
+          <documentation>Vevelstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1818">
+        
+        <annotation>
+          
+          <documentation>Herøy i Nordland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1820">
+        
+        <annotation>
+          
+          <documentation>Alstahaug</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1822">
+        
+        <annotation>
+          
+          <documentation>Leirfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1824">
+        
+        <annotation>
+          
+          <documentation>Vefsn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1825">
+        
+        <annotation>
+          
+          <documentation>Grane</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1826">
+        
+        <annotation>
+          
+          <documentation>Hattfjelldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1827">
+        
+        <annotation>
+          
+          <documentation>Dønna</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1828">
+        
+        <annotation>
+          
+          <documentation>Nesna</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1832">
+        
+        <annotation>
+          
+          <documentation>Hemnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1833">
+        
+        <annotation>
+          
+          <documentation>Rana</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1834">
+        
+        <annotation>
+          
+          <documentation>Lurøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1835">
+        
+        <annotation>
+          
+          <documentation>Træna</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1836">
+        
+        <annotation>
+          
+          <documentation>Rødøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1837">
+        
+        <annotation>
+          
+          <documentation>Meløy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1838">
+        
+        <annotation>
+          
+          <documentation>Gildeskål</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1839">
+        
+        <annotation>
+          
+          <documentation>Beiarn</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1840">
+        
+        <annotation>
+          
+          <documentation>Saltdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1841">
+        
+        <annotation>
+          
+          <documentation>Fauske – Fuossko</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1842">
+        
+        <annotation>
+          
+          <documentation>Skjerstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1845">
+        
+        <annotation>
+          
+          <documentation>Sørfold</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1848">
+        
+        <annotation>
+          
+          <documentation>Steigen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1849">
+        
+        <annotation>
+          
+          <documentation>Hamarøy – Hábmer (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1875">
+        
+        <annotation>
+          
+          <documentation>Hamarøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1850">
+        
+        <annotation>
+          
+          <documentation>Divtasvuodna – Tysfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1851">
+        
+        <annotation>
+          
+          <documentation>Lødingen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1852">
+        
+        <annotation>
+          
+          <documentation>Tjeldsund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5412">
+        
+        <annotation>
+          
+          <documentation>Tjeldsund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1853">
+        
+        <annotation>
+          
+          <documentation>Evenes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1854">
+        
+        <annotation>
+          
+          <documentation>Ballangen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1856">
+        
+        <annotation>
+          
+          <documentation>Røst</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1857">
+        
+        <annotation>
+          
+          <documentation>Værøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1859">
+        
+        <annotation>
+          
+          <documentation>Flakstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1860">
+        
+        <annotation>
+          
+          <documentation>Vestvågøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1865">
+        
+        <annotation>
+          
+          <documentation>Vågan</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1866">
+        
+        <annotation>
+          
+          <documentation>Hadsel</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1867">
+        
+        <annotation>
+          
+          <documentation>Bø i Nordland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1868">
+        
+        <annotation>
+          
+          <documentation>Øksnes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1870">
+        
+        <annotation>
+          
+          <documentation>Sortland – Suortá</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1871">
+        
+        <annotation>
+          
+          <documentation>Andøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1874">
+        
+        <annotation>
+          
+          <documentation>Moskenes</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1901">
+        
+        <annotation>
+          
+          <documentation>Harstad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1902">
+        
+        <annotation>
+          
+          <documentation>Tromsø (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5401">
+        
+        <annotation>
+          
+          <documentation>Tromsø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1903">
+        
+        <annotation>
+          
+          <documentation>Harstad – Hárstták (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5402">
+        
+        <annotation>
+          
+          <documentation>Harstad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1911">
+        
+        <annotation>
+          
+          <documentation>Kvæfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5411">
+        
+        <annotation>
+          
+          <documentation>Kvæfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1913">
+        
+        <annotation>
+          
+          <documentation>Skånland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1915">
+        
+        <annotation>
+          
+          <documentation>Bjarkøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1917">
+        
+        <annotation>
+          
+          <documentation>Ibestad (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5413">
+        
+        <annotation>
+          
+          <documentation>Ibestad</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1919">
+        
+        <annotation>
+          
+          <documentation>Gratangen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5414">
+        
+        <annotation>
+          
+          <documentation>Gratangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1920">
+        
+        <annotation>
+          
+          <documentation>Loabák – Lavangen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5415">
+        
+        <annotation>
+          
+          <documentation>Lavangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1922">
+        
+        <annotation>
+          
+          <documentation>Bardu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5416">
+        
+        <annotation>
+          
+          <documentation>Bardu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1923">
+        
+        <annotation>
+          
+          <documentation>Salangen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5417">
+        
+        <annotation>
+          
+          <documentation>Salangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1924">
+        
+        <annotation>
+          
+          <documentation>Målselv (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5418">
+        
+        <annotation>
+          
+          <documentation>Målselv</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1925">
+        
+        <annotation>
+          
+          <documentation>Sørreisa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5419">
+        
+        <annotation>
+          
+          <documentation>Sørreisa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1926">
+        
+        <annotation>
+          
+          <documentation>Dyrøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5420">
+        
+        <annotation>
+          
+          <documentation>Dyrøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1927">
+        
+        <annotation>
+          
+          <documentation>Tranøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5421">
+        
+        <annotation>
+          
+          <documentation>Senja</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1928">
+        
+        <annotation>
+          
+          <documentation>Torsken (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1929">
+        
+        <annotation>
+          
+          <documentation>Berg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1931">
+        
+        <annotation>
+          
+          <documentation>Lenvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1933">
+        
+        <annotation>
+          
+          <documentation>Balsfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5422">
+        
+        <annotation>
+          
+          <documentation>Balsfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1936">
+        
+        <annotation>
+          
+          <documentation>Karlsøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5423">
+        
+        <annotation>
+          
+          <documentation>Karlsøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1938">
+        
+        <annotation>
+          
+          <documentation>Lyngen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5424">
+        
+        <annotation>
+          
+          <documentation>Lyngen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1939">
+        
+        <annotation>
+          
+          <documentation>Storfjord – Omasvuotna – Omasvuono (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5425">
+        
+        <annotation>
+          
+          <documentation>Storfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1940">
+        
+        <annotation>
+          
+          <documentation>Gáivuotna – Kåfjord – Kaivuono (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5426">
+        
+        <annotation>
+          
+          <documentation>Kåfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1941">
+        
+        <annotation>
+          
+          <documentation>Skjervøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5427">
+        
+        <annotation>
+          
+          <documentation>Skjervøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1942">
+        
+        <annotation>
+          
+          <documentation>Nordreisa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5428">
+        
+        <annotation>
+          
+          <documentation>Nordreisa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="1943">
+        
+        <annotation>
+          
+          <documentation>Kvænangen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5429">
+        
+        <annotation>
+          
+          <documentation>Kvænangen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2001">
+        
+        <annotation>
+          
+          <documentation>Hammerfest (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2002">
+        
+        <annotation>
+          
+          <documentation>Vardø (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5404">
+        
+        <annotation>
+          
+          <documentation>Vardø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2003">
+        
+        <annotation>
+          
+          <documentation>Vadsø (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5405">
+        
+        <annotation>
+          
+          <documentation>Vadsø</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2004">
+        
+        <annotation>
+          
+          <documentation>Hammerfest (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5406">
+        
+        <annotation>
+          
+          <documentation>Hammerfest</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2011">
+        
+        <annotation>
+          
+          <documentation>Guovdageaidnu – Kautokeino (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5430">
+        
+        <annotation>
+          
+          <documentation>Kautokeino</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2012">
+        
+        <annotation>
+          
+          <documentation>Alta (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5403">
+        
+        <annotation>
+          
+          <documentation>Alta</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2014">
+        
+        <annotation>
+          
+          <documentation>Loppa (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5432">
+        
+        <annotation>
+          
+          <documentation>Loppa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2015">
+        
+        <annotation>
+          
+          <documentation>Hasvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5433">
+        
+        <annotation>
+          
+          <documentation>Hasvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2016">
+        
+        <annotation>
+          
+          <documentation>Sørøysund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2017">
+        
+        <annotation>
+          
+          <documentation>Kvalsund (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2018">
+        
+        <annotation>
+          
+          <documentation>Måsøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5434">
+        
+        <annotation>
+          
+          <documentation>Måsøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2019">
+        
+        <annotation>
+          
+          <documentation>Nordkapp (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5435">
+        
+        <annotation>
+          
+          <documentation>Nordkapp</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2020">
+        
+        <annotation>
+          
+          <documentation>Porsanger – Porsá?gu – Porsanki (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5436">
+        
+        <annotation>
+          
+          <documentation>Porsanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2021">
+        
+        <annotation>
+          
+          <documentation>Kárášjohka – Karasjok (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5437">
+        
+        <annotation>
+          
+          <documentation>Karasjok</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2022">
+        
+        <annotation>
+          
+          <documentation>Lebesby (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5438">
+        
+        <annotation>
+          
+          <documentation>Lebesby</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2023">
+        
+        <annotation>
+          
+          <documentation>Gamvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5439">
+        
+        <annotation>
+          
+          <documentation>Gamvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2024">
+        
+        <annotation>
+          
+          <documentation>Berlevåg (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5440">
+        
+        <annotation>
+          
+          <documentation>Berlevåg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2025">
+        
+        <annotation>
+          
+          <documentation>Deatnu – Tana (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5441">
+        
+        <annotation>
+          
+          <documentation>Tana</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2027">
+        
+        <annotation>
+          
+          <documentation>Unjárga – Nesseby (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5442">
+        
+        <annotation>
+          
+          <documentation>Nesseby</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2028">
+        
+        <annotation>
+          
+          <documentation>Båtsfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5443">
+        
+        <annotation>
+          
+          <documentation>Båtsfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2030">
+        
+        <annotation>
+          
+          <documentation>Sør-Varanger (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5444">
+        
+        <annotation>
+          
+          <documentation>Sør-Varanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2111">
+        
+        <annotation>
+          
+          <documentation>Spitsbergen (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2100">
+        
+        <annotation>
+          
+          <documentation>Svalbard</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2121">
+        
+        <annotation>
+          
+          <documentation>Bjørnøya (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2131">
+        
+        <annotation>
+          
+          <documentation>Hopen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2211">
+        
+        <annotation>
+          
+          <documentation>Jan Mayen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2311">
+        
+        <annotation>
+          
+          <documentation>Sokkelen sør for 62 grader Nord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="2321">
+        
+        <annotation>
+          
+          <documentation>Sokkelen nord for 62 grader Nord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5001">
+        
+        <annotation>
+          
+          <documentation>Trondheim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5004">
+        
+        <annotation>
+          
+          <documentation>Steinkjer (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5006">
+        
+        <annotation>
+          
+          <documentation>Steinkjer</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5005">
+        
+        <annotation>
+          
+          <documentation>Namsos (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5007">
+        
+        <annotation>
+          
+          <documentation>Namsos</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5011">
+        
+        <annotation>
+          
+          <documentation>Hemne (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5012">
+        
+        <annotation>
+          
+          <documentation>Snillfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5059">
+        
+        <annotation>
+          
+          <documentation>Orkland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5013">
+        
+        <annotation>
+          
+          <documentation>Hitra (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5056">
+        
+        <annotation>
+          
+          <documentation>Hitra</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5014">
+        
+        <annotation>
+          
+          <documentation>Frøya</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5015">
+        
+        <annotation>
+          
+          <documentation>Ørland (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5057">
+        
+        <annotation>
+          
+          <documentation>Ørland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5016">
+        
+        <annotation>
+          
+          <documentation>Agdenes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5017">
+        
+        <annotation>
+          
+          <documentation>Bjugn (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5018">
+        
+        <annotation>
+          
+          <documentation>Åfjord (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5058">
+        
+        <annotation>
+          
+          <documentation>Åfjord</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5019">
+        
+        <annotation>
+          
+          <documentation>Roan (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5020">
+        
+        <annotation>
+          
+          <documentation>Osen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5021">
+        
+        <annotation>
+          
+          <documentation>Oppdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5022">
+        
+        <annotation>
+          
+          <documentation>Rennebu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5023">
+        
+        <annotation>
+          
+          <documentation>Meldal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5024">
+        
+        <annotation>
+          
+          <documentation>Orkdal (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5025">
+        
+        <annotation>
+          
+          <documentation>Røros</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5026">
+        
+        <annotation>
+          
+          <documentation>Holtålen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5027">
+        
+        <annotation>
+          
+          <documentation>Midtre Gauldal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5028">
+        
+        <annotation>
+          
+          <documentation>Melhus</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5029">
+        
+        <annotation>
+          
+          <documentation>Skaun</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5030">
+        
+        <annotation>
+          
+          <documentation>Klæbu (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5001">
+        
+        <annotation>
+          
+          <documentation>Trondheim</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5031">
+        
+        <annotation>
+          
+          <documentation>Malvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5032">
+        
+        <annotation>
+          
+          <documentation>Selbu</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5033">
+        
+        <annotation>
+          
+          <documentation>Tydal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5034">
+        
+        <annotation>
+          
+          <documentation>Meråker</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5035">
+        
+        <annotation>
+          
+          <documentation>Stjørdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5036">
+        
+        <annotation>
+          
+          <documentation>Frosta</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5037">
+        
+        <annotation>
+          
+          <documentation>Levanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5038">
+        
+        <annotation>
+          
+          <documentation>Verdal</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5039">
+        
+        <annotation>
+          
+          <documentation>Verran (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5040">
+        
+        <annotation>
+          
+          <documentation>Namdalseid (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5041">
+        
+        <annotation>
+          
+          <documentation>Snåase – Snåsa</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5042">
+        
+        <annotation>
+          
+          <documentation>Lierne</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5043">
+        
+        <annotation>
+          
+          <documentation>Raarvihke – Røyrvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5044">
+        
+        <annotation>
+          
+          <documentation>Namsskogan</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5045">
+        
+        <annotation>
+          
+          <documentation>Grong</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5046">
+        
+        <annotation>
+          
+          <documentation>Høylandet</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5047">
+        
+        <annotation>
+          
+          <documentation>Overhalla</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5048">
+        
+        <annotation>
+          
+          <documentation>Frosnes (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5049">
+        
+        <annotation>
+          
+          <documentation>Flatanger</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5050">
+        
+        <annotation>
+          
+          <documentation>Vikna (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5060">
+        
+        <annotation>
+          
+          <documentation>Nærøysund</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5051">
+        
+        <annotation>
+          
+          <documentation>Nærøy (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5052">
+        
+        <annotation>
+          
+          <documentation>Leka</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5053">
+        
+        <annotation>
+          
+          <documentation>Inderøy</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="5054">
+        
+        <annotation>
+          
+          <documentation>Indre Fosen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0712">
+        
+        <annotation>
+          
+          <documentation>Larvik (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3805">
+        
+        <annotation>
+          
+          <documentation>Larvik</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0715">
+        
+        <annotation>
+          
+          <documentation>Holmestrand (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="0729">
+        
+        <annotation>
+          
+          <documentation>Færder (utgått)</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="3811">
+        
+        <annotation>
+          
+          <documentation>Færder</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="KommunenummerOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="LandKodeType">
+    
+    <annotation>
+      
+      <documentation>Landkoder, subsett av&lt;b> ISO 3166-1 alpha-2&lt;/b> som kun inneholder de landkodene som vi har bruk for for å konvertere SSR til SSR 2.0. Etter produksjonsetting utvides kodelista ved behov.
+
+Merk: XZ - "Internasjonalt farvann" og ZZ "Uspesifisert" er brukerdefinerte koder (tillatt etter ISO-beskrivelsen). Det vil si at koden ikke har noen bestemt betydning i ISO-kodelista, og vår kodeliste må være tilgjengelig for at eksterne parter kan tolke vår bruk av kodeverdiene.</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:LandKodeEnumerationType app:LandKodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="LandKodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Landkoder, subsett av&lt;b> ISO 3166-1 alpha-2&lt;/b> som kun inneholder de landkodene som vi har bruk for for å konvertere SSR til SSR 2.0. Etter produksjonsetting utvides kodelista ved behov.
+
+Merk: XZ - "Internasjonalt farvann" og ZZ "Uspesifisert" er brukerdefinerte koder (tillatt etter ISO-beskrivelsen). Det vil si at koden ikke har noen bestemt betydning i ISO-kodelista, og vår kodeliste må være tilgjengelig for at eksterne parter kan tolke vår bruk av kodeverdiene.</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="Norge">
+        
+        <annotation>
+          
+          <documentation>Norge</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Danmark">
+        
+        <annotation>
+          
+          <documentation>Danmark</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Sverige">
+        
+        <annotation>
+          
+          <documentation>Sverige</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Finland">
+        
+        <annotation>
+          
+          <documentation>Finland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Island">
+        
+        <annotation>
+          
+          <documentation>Island</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Grønland">
+        
+        <annotation>
+          
+          <documentation>Grønland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Russland">
+        
+        <annotation>
+          
+          <documentation>Russland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Storbritannia">
+        
+        <annotation>
+          
+          <documentation>Storbritannia</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Tyskland">
+        
+        <annotation>
+          
+          <documentation>Tyskland</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Svalbard_og_Jan_Mayen">
+        
+        <annotation>
+          
+          <documentation>Svalbard og Jan Mayen</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="Færøyene">
+        
+        <annotation>
+          
+          <documentation>Færøyene</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="internasjonaltFarvann">
+        
+        <annotation>
+          
+          <documentation>Brukerdefinert</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="uspesifisert">
+        
+        <annotation>
+          
+          <documentation>Brukerdefinert</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="LandKodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjektgruppeType">
+    
+    <annotation>
+      
+      <documentation>Gruppeinndelingen av navneobjekttypene</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:NavneobjektgruppeEnumerationType app:NavneobjektgruppeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjektgruppeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Gruppeinndelingen av navneobjekttypene</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="terrengområder">
+        
+        <annotation>
+          
+          <documentation>Terrengområder: Samlegruppe for objekttyper som beskriver terrengoverflate over større områder.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="høyder">
+        
+        <annotation>
+          
+          <documentation>Høyder: Samlegruppe for objekttyper som er høyere enn andre objektyper i samme område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="senkninger">
+        
+        <annotation>
+          
+          <documentation>Senkninger: Samlegruppe for objekttyper som er senket ned i forhold til andre objekttyper i samme område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="flater">
+        
+        <annotation>
+          
+          <documentation>Flater: Samlegruppe for objekttyper som flate terrengområder.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skråninger">
+        
+        <annotation>
+          
+          <documentation>Skråninger: Samlegruppe for objekttyper som beskriver hellende terreng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="terrengdetaljer">
+        
+        <annotation>
+          
+          <documentation>Terrengdetaljer: Samlegruppe for objekttyper som beskriver spesielle terrengdetaljer.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bartFjell">
+        
+        <annotation>
+          
+          <documentation>Bart fjell: Samlegruppe for objekttyper som beskriver overflater av bart fjell.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="løsmasseavsetninger">
+        
+        <annotation>
+          
+          <documentation>Løsmasseavsetninger: Samlegruppe for objekttyper som beskriver avsetting av løse masser.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vegetasjon">
+        
+        <annotation>
+          
+          <documentation>Vegetasjon: Samlegruppe for objekttyper som beskriver vegetasjonen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="våtmark">
+        
+        <annotation>
+          
+          <documentation>Våtmark: Samlegruppe for objekttyper som beskriver våt/fuktig mark.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="dyrkamark">
+        
+        <annotation>
+          
+          <documentation>Dyrkamark: Samlegruppe for objekttyper som beskriver ulike typer dyrket mark.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="isOgPermafrost">
+        
+        <annotation>
+          
+          <documentation>Is og permafrost: Samlegruppe for objekttyper som er fryst.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="uttakOgDeponi">
+        
+        <annotation>
+          
+          <documentation>Uttak og deponi: Samlegruppe for objekttyper av menneskeskapte uttak eller fyllinger.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stilleståendeVann">
+        
+        <annotation>
+          
+          <documentation>Stillestående vann: Samlegruppe for objekttyper av ferskvann som ser ut til å stå stille.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ferskvannskontur">
+        
+        <annotation>
+          
+          <documentation>Ferskvannskontur: Samlegruppe for objekttyper som beskriver omrisset av objekter med ferskvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grunnerIFerskvann">
+        
+        <annotation>
+          
+          <documentation>Grunner i ferskvann: Samlegruppe for objekttyper under vannflaten som stikker høyere opp enn resten av området, men ikke vesentlig over vannflaten.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="rennendeVann">
+        
+        <annotation>
+          
+          <documentation>Rennende vann: Samlegruppe for objekttyper som beskriver rennenede ferskvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="detaljerIFerskvann">
+        
+        <annotation>
+          
+          <documentation>Detaljer i ferskvann: Samlegruppe for objekttyper som beskriver detaljer i ferskvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="farvann">
+        
+        <annotation>
+          
+          <documentation>Farvann: Samlegruppe for objekttyper som beskriver større områder av sjø.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kystkontur">
+        
+        <annotation>
+          
+          <documentation>Kystkontur: Samlegruppe for objekttyper som beskriver grensa mellom sjø og tørt land.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grunnerISjø">
+        
+        <annotation>
+          
+          <documentation>Grunner i sjø: Samlegruppe for objekttyper under havflaten som stikker høyere opp enn resten av området, men ikke vesentlig over vannflaten.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sjøbunn">
+        
+        <annotation>
+          
+          <documentation>Sjøbunn: Samlegruppe for objekttyper som beskriver sjøbunnen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="detaljISjø">
+        
+        <annotation>
+          
+          <documentation>Detalj i sjø: Samlegruppe for objekttyper som beskriver detaljer i sjøen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bebyggelsesområder">
+        
+        <annotation>
+          
+          <documentation>Bebyggelsesområder: Samlegruppe for objekttyper som beskriver områder med flere bygninger samlet innenfor et begrenset område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="gardsbebyggelse">
+        
+        <annotation>
+          
+          <documentation>Gardsbebyggelse: Samlegruppe for objekttyper som beskriver områder med samling av bebyggelse som hovedsakelig er knyttet til landbruk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bolighus">
+        
+        <annotation>
+          
+          <documentation>Bolighus: Samlegruppe for objekttyper som beskriver enkeltbygninger til boligformål som er bebodd midlertidig eller permanent.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="næring">
+        
+        <annotation>
+          
+          <documentation>Næring: Samlegruppe for objekttyper som beskriver enkeltbygninger til næringsformål.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="institusjoner">
+        
+        <annotation>
+          
+          <documentation>Institusjoner: Samlegruppe for objekttyper som beskriver enkeltbygninger eller mindre samlinger av bygninger av institusjonell karakter.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fritidsanlegg">
+        
+        <annotation>
+          
+          <documentation>Fritidsanlegg: Samlegruppe for objekttyper som beskriver bygningsmessige og naturlige anlegg for rekreasjon og fritidsaktiviteter.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="veg">
+        
+        <annotation>
+          
+          <documentation>Veg: Samlegruppe for objekttyper som beskriver objekter som brukes til ferdsel, både motorisert og til fots.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bane">
+        
+        <annotation>
+          
+          <documentation>Bane: Samlegruppe for objekttyper som beskriver funksjoner knyttet til skinnegående kjøretøy.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="luftfart">
+        
+        <annotation>
+          
+          <documentation>Luftfart: Samlegruppe for objekttyper som beskriver anlegg hvor luftfartøy lander og tar av.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sjøfart">
+        
+        <annotation>
+          
+          <documentation>Sjøfart: Samlegruppe for objekttyper som beskriver anlegg som har tilknytning til sjøfart.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="navigasjon">
+        
+        <annotation>
+          
+          <documentation>Navigasjon: Samlegruppe for objekttyper som beskriver navigasjonshjelpemidler for skipsfart.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="samferdselsanlegg">
+        
+        <annotation>
+          
+          <documentation>Samferdselsanlegg: Samlegruppe for objekttyper som beskriver anlegg som brukes i forbindelse med transport, både for kjøretøy og til fots.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="energi">
+        
+        <annotation>
+          
+          <documentation>Energi: Samlegruppe for objekttyper som beskriver anlegg for energi produksjon og transport.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kommunikasjon">
+        
+        <annotation>
+          
+          <documentation>Kommunikasjon: Samlegruppe for objekttyper som beskriver anlegg for radiokommunikasjon.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="administrativeIndelinger">
+        
+        <annotation>
+          
+          <documentation>Administrative indelinger: Samlegruppe for objekttyper som beskriver alle typer administrative inndelinger.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="verne-OgBruksområder">
+        
+        <annotation>
+          
+          <documentation>Verne- og bruksområder: Samlegruppe for objekttyper som regulerer vern og bruksrettigheter.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kulturminner">
+        
+        <annotation>
+          
+          <documentation>Kulturminner: Samlegruppe for objekttyper som er vernet som kulturminner.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kulturinstitusjoner">
+        
+        <annotation>
+          
+          <documentation>Kulturinstitusjoner: Samlegruppe for objekttyper som beskriver institusjoner for kulturell aktivitet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjektgruppeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjekthovedgruppeType">
+    
+    <annotation>
+      
+      <documentation>Hovedgruppeinndelingen av navneobjekttyper.</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:NavneobjekthovedgruppeEnumerationType app:NavneobjekthovedgruppeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjekthovedgruppeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Hovedgruppeinndelingen av navneobjekttyper.</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="terreng">
+        
+        <annotation>
+          
+          <documentation>Terreng: Alle  grupper som beskriver terrengformasjoner.
+Tilsvarer Inspire temaet "landform".</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="markslag">
+        
+        <annotation>
+          
+          <documentation>Markslag: Alle grupper som er relevante under hovedgruppe Markslag. Tilsvarer Inspire temaet "landcover".</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ferskvann">
+        
+        <annotation>
+          
+          <documentation>Ferskvann: Alle grupper som er relevante under hovedgruppe Ferskvann. Under Inspire temaet "hydrography" som vi har delt i to.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sjø">
+        
+        <annotation>
+          
+          <documentation>Sjø: Alle grupper som er relevante under hovedgruppe Sjø. Under Inspire temaet "hydrography" som vi har delt i to.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bebyggelse">
+        
+        <annotation>
+          
+          <documentation>Bebyggelse: Alle grupper som er relevante under hovedgruppe bebyggelse. Tilsvarer Inspire temaet "building" og "populatedPlace".</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="infrastruktur">
+        
+        <annotation>
+          
+          <documentation>Infrastruktur: Alle grupper som er relevante under hovedgruppe infrastruktur. Tilsvarer Inspire temaet "transportNetwork".</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="offentligAdministrasjon">
+        
+        <annotation>
+          
+          <documentation>Offentlig administrasjon: Alle grupper som er relevante under hovedgruppe offentlig administrasjon. Tilsvarer Inspire temaet "administrativUnit".</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kultur">
+        
+        <annotation>
+          
+          <documentation>Kultur: Alle grupper som er relevante under hovedgruppe Kultur.
+Tilsvarer Inspire temaet "protctedSite".</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjekthovedgruppeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjekttypeType">
+    
+    <annotation>
+      
+      <documentation>Navneobjekttypene som stedsnavn er delt inn i.</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:NavneobjekttypeEnumerationType app:NavneobjekttypeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjekttypeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Navneobjekttypene som stedsnavn er delt inn i.</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="eiendomsteig">
+        
+        <annotation>
+          
+          <documentation>eiendomsteig</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="våtmarksområde">
+        
+        <annotation>
+          
+          <documentation>våtmarksområde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="busstasjon">
+        
+        <annotation>
+          
+          <documentation>busstasjon</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vannstandsmåler">
+        
+        <annotation>
+          
+          <documentation>vannstandsmåler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="friluftsområde">
+        
+        <annotation>
+          
+          <documentation>friluftsområde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sjømerkeMedIndirekteBelysning">
+        
+        <annotation>
+          
+          <documentation>sjømerkeMedIndirekteBelysning</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="reinbeitedistrikt">
+        
+        <annotation>
+          
+          <documentation>reinbeitedistrikt</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="boinstitusjon">
+        
+        <annotation>
+          
+          <documentation>boinstitusjon</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="egg">
+        
+        <annotation>
+          
+          <documentation>egg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellvegg">
+        
+        <annotation>
+          
+          <documentation>fjellvegg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="delAvVann">
+        
+        <annotation>
+          
+          <documentation>delAvVann</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="jernbanebru">
+        
+        <annotation>
+          
+          <documentation>jernbanebru</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="jernbanetunnel">
+        
+        <annotation>
+          
+          <documentation>jernbanetunnel</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="helikopterlandingsplass">
+        
+        <annotation>
+          
+          <documentation>helikopterlandingsplass</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kulturMessehall">
+        
+        <annotation>
+          
+          <documentation>kulturMessehall</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="overbygg">
+        
+        <annotation>
+          
+          <documentation>overbygg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="mindreBrukonstruksjon">
+        
+        <annotation>
+          
+          <documentation>mindreBrukonstruksjon</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stølsSetereiendom">
+        
+        <annotation>
+          
+          <documentation>stølsSetereiendom</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tuft">
+        
+        <annotation>
+          
+          <documentation>tuft</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vannverk">
+        
+        <annotation>
+          
+          <documentation>vannverk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="hammar">
+        
+        <annotation>
+          
+          <documentation>hammar</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellovergang">
+        
+        <annotation>
+          
+          <documentation>fjellovergang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sva">
+        
+        <annotation>
+          
+          <documentation>sva</documentation>
+        
+        </annotation>
+      
+      </enumeration>	
+      
+      <enumeration value="administrativBydel">
+        
+        <annotation>
+          
+          <documentation>Administrativ bydel: Offisielt navn på bydelsforvaltningen i et angitt område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="adressenavn">
+        
+        <annotation>
+          
+          <documentation>Adressenavn: Offisielt adressenavn, veg-/gatenavn eller områdenavn, jf. § 2 bokstav e i matrikkelforskriften.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="adressetilleggsnavn">
+        
+        <annotation>
+          
+          <documentation>Adressetilleggsnavn: Et stedsnavn som er en del av den offisielle (veg-)adressen, jf. § 54 i matrikkelforskriften; vanligvis bruksnavn eller sjeldnere bygnings-/institusjonsnavn.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="allmenning">
+        
+        <annotation>
+          
+          <documentation>Allmenning: Område hvor rettighetene er regulert og fordelt på flere.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="alpinanlegg">
+        
+        <annotation>
+          
+          <documentation>Alpinanlegg: Anlegg for slalåm, utfor, snøbrett osv.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ankringsplass">
+        
+        <annotation>
+          
+          <documentation>Ankringsplass: Opplagsplass for store fartøy.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="annenAdministrativInndeling">
+        
+        <annotation>
+          
+          <documentation>Annen administrativ inndeling: Andre administrative inndelinger som ikke tilhører øvrige navneobjekttyper.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="annenBygningForReligionsutøvelse">
+        
+        <annotation>
+          
+          <documentation>Annen bygning for religionsutøvelse: Synagoge, moské, frikirke, menighetshus, kloster, gravkapell, bårehus, krematorium.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="annenIndustri-OgLagerbygning">
+        
+        <annotation>
+          
+          <documentation>Annen industri- og lagerbygning: Mindre industri- og produksjonsbedrift eller lager.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="annenKulturdetalj">
+        
+        <annotation>
+          
+          <documentation>Annen kulturdetalj: Alle andre typer kulturdetaljer, f.eks. lekeplass, utkikkstårn, fiskeplass, og lignende.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="annenTerrengdetalj">
+        
+        <annotation>
+          
+          <documentation>Annen terrengdetalj: Små detaljer som ikke dekkes av andre navneobjekttyper innenfor kategorien.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="annenVanndetalj">
+        
+        <annotation>
+          
+          <documentation>Annen vanndetalj: Andre navngitte forhold i ferskvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="badeplass">
+        
+        <annotation>
+          
+          <documentation>Badeplass: Offentlig eller privat badeplass.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bakke">
+        
+        <annotation>
+          
+          <documentation>Bakke: Terrengskråning, særlig om siden av en ås eller haug.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bakkeVeg">
+        
+        <annotation>
+          
+          <documentation>Bakke (Veg): Allment kjent bakke på alle typer veger og gater.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bakkeISjø">
+        
+        <annotation>
+          
+          <documentation>Bakke i sjø: Skrånende sjøbunn.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bakketoppISjø">
+        
+        <annotation>
+          
+          <documentation>Bakketopp i sjø: Undersjøisk knaus, kolle eller haug.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="banestrekning">
+        
+        <annotation>
+          
+          <documentation>Banestrekning: Jernbanestrekning, tunnelbane eller trikkelinje/-strekning.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="banke">
+        
+        <annotation>
+          
+          <documentation>Banke: Flatt, større undervannsområde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bankeISjø">
+        
+        <annotation>
+          
+          <documentation>Banke i sjø: Større grunt område i sjøen med dypere vann omkring; fiskegrunn.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="barnehage">
+        
+        <annotation>
+          
+          <documentation>Barnehage: Offentlig og privat barnehage.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bassengISjø">
+        
+        <annotation>
+          
+          <documentation>Basseng i sjø: Vid, undersjøisk dal.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bekk">
+        
+        <annotation>
+          
+          <documentation>Bekk: Rennende vann i naturlig vannvei, vanligvis smalere enn 3 meter.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="berg">
+        
+        <annotation>
+          
+          <documentation>Berg: Markert eller avrunda høyde med stein, steinmasse (med eller uten vegetasjon).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bergverk">
+        
+        <annotation>
+          
+          <documentation>Bergverk: Gruve, skjerp og mineraluttak i dagen eller under jorda.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="boligblokk">
+        
+        <annotation>
+          
+          <documentation>Boligblokk: Stort (bolig)hus av mur, betong med over fire boliger som har felles trapp(er) eller heis(er).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="boligfelt">
+        
+        <annotation>
+          
+          <documentation>Boligfelt: Regulert boligområde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bomstasjon">
+        
+        <annotation>
+          
+          <documentation>Bomstasjon: Større bomanlegg på offentlig veg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="borettslag">
+        
+        <annotation>
+          
+          <documentation>Borettslag: Bofellesskap i blokk eller flerbebyggelse.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="botn">
+        
+        <annotation>
+          
+          <documentation>Botn: Innerste del av en dal; rundaktig, bratt dal eller uthulning i fjellet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bru">
+        
+        <annotation>
+          
+          <documentation>Bru: Både på veg og jernbane.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bruk">
+        
+        <annotation>
+          
+          <documentation>Bruk: Navn på (landbruks)eiendom med ett eller flere bruksnummer under ett gardsnummer, jf. lov om stadnamn §§ 2 og 8.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="brygge">
+        
+        <annotation>
+          
+          <documentation>Brygge: Mindre, fastbygd bryggeanlegg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="busstopp">
+        
+        <annotation>
+          
+          <documentation>Busstopp: Stoppested for rutegående vegtrafikk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="by">
+        
+        <annotation>
+          
+          <documentation>By: Tettbygd sted som er større og (til dels) innehar viktigere funksjoner enn andre tettbygde steder / tettsteder.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bydel">
+        
+        <annotation>
+          
+          <documentation>Bydel: Kulturmessig del av by.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="bygdelagBygd">
+        
+        <annotation>
+          
+          <documentation>Bygdelag (bygd): Stort, uregulert gards- og boligområde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="byggForJordbrukFiskeOgFangst">
+        
+        <annotation>
+          
+          <documentation>Bygg for jordbruk, fiske og fangst: Til primærnæring, f.eks. naust, uthus, sommerfjøs eller gamme.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="båe">
+        
+        <annotation>
+          
+          <documentation>Båe: Fjell eller stein under vannflaten.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="båeISjø">
+        
+        <annotation>
+          
+          <documentation>Båe i sjø: Spiss grunne; blindskjær som sjøen bryter over.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="båke">
+        
+        <annotation>
+          
+          <documentation>Båke: Fast sjømerke. Sprinkelverk bygget i tre eller metall.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="campingplass">
+        
+        <annotation>
+          
+          <documentation>Campingplass: Alle typer, med/uten campinghytter, campingvogner og telt.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="dal">
+        
+        <annotation>
+          
+          <documentation>Dal: Mellomstor eller liten dal.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="dalføre">
+        
+        <annotation>
+          
+          <documentation>Dalføre: Stor dal med sidedaler.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="dam">
+        
+        <annotation>
+          
+          <documentation>Dam: Vann bak oppbygd hindring, oftest i en elv, for å få jevn vannføring til fløting, til kraftverk eller for å hindre skadeflom.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="delAvInnsjø">
+        
+        <annotation>
+          
+          <documentation>Del av innsjø: Mindre del av innsjø.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="eggISjø">
+        
+        <annotation>
+          
+          <documentation>Egg i sjø: Undersjøisk kant mot havdyp.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="eid">
+        
+        <annotation>
+          
+          <documentation>Eid: Lavt eller smalt parti mellom to vannkanter (elv eller vann).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="eidISjø">
+        
+        <annotation>
+          
+          <documentation>Eid i sjø: Landstripe med sjø på begge sider som binder sammen to landområder.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="eiendom">
+        
+        <annotation>
+          
+          <documentation>Eiendom: Navn på eiendom som ikke er bruksnavn, ev. felles stedsnavn for flere eiendommer.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="elv">
+        
+        <annotation>
+          
+          <documentation>Elv: Rennende vann i naturlig vannvei, vanligvis bredere enn 3 meter.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="elvemel">
+        
+        <annotation>
+          
+          <documentation>Elvemel: Bratt sand-/grusskråning langs elv eller vann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="elvesving">
+        
+        <annotation>
+          
+          <documentation>Elvesving: Naturlig sving i elv eller bekk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="eneboligMindreBoligbygg">
+        
+        <annotation>
+          
+          <documentation>Enebolig/mindre boligbygg: Navn på mindre eiendom for fast bosetting. Hovedsakelig eiendom hvor eier kan bestemme skrivemåten (jf. § 8 i lov om stadnamn og § 54 i matrikkelforskriften). Kan også omfatte eget navn på bygg, eller våningshus/gardsbruk som ikke er gitt eget matrikkelnummer.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="eng">
+        
+        <annotation>
+          
+          <documentation>Eng: Kultivert slåtte-/gressmark.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fabrikk">
+        
+        <annotation>
+          
+          <documentation>Fabrikk: Større industrivirksomhet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="farledSkipslei">
+        
+        <annotation>
+          
+          <documentation>Farled/skipslei: Allment kjent seglingslei/farvannsområde med dybdeforhold passende for skip av en viss størrelse.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fengsel">
+        
+        <annotation>
+          
+          <documentation>Fengsel: Bygning der arresterte eller dømte personer soner straff.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ferjekai">
+        
+        <annotation>
+          
+          <documentation>Ferjekai: Ferjekai i fast regulert ferjesamband.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ferjestrekning">
+        
+        <annotation>
+          
+          <documentation>Ferjestrekning: Ferjesamband som inngår i områdets samferdselsnett.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fiskeplassISjø">
+        
+        <annotation>
+          
+          <documentation>Fiskeplass i sjø: Navngitt fiskested; fiskemed.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjell">
+        
+        <annotation>
+          
+          <documentation>Fjell: Høyereliggende område (over tregrensa) med stein og sva og lite vegetasjon som reiser seg over landskapet omkring (med høye berg og nuter).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellIDagen">
+        
+        <annotation>
+          
+          <documentation>Fjell i dagen: Lite/ingen vegetasjon; sva, svaberg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellheis">
+        
+        <annotation>
+          
+          <documentation>Fjellheis: Gondolbane og trallebane for frakt av folk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellkant">
+        
+        <annotation>
+          
+          <documentation>Fjellkant: Aksel, skulder, nese og bryn.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellkjedeISjø">
+        
+        <annotation>
+          
+          <documentation>Fjellkjede i sjø: Lengre, sammenhengende undersjøisk fjellformasjon.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellområde">
+        
+        <annotation>
+          
+          <documentation>Fjellområde: Større område med fjell og fjellandskap.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellside">
+        
+        <annotation>
+          
+          <documentation>Fjellside: Åpent, skrånende terreng i fjellet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjelltoppISjø">
+        
+        <annotation>
+          
+          <documentation>Fjelltopp i sjø: Undersjøisk fjelltopp.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjord">
+        
+        <annotation>
+          
+          <documentation>Fjord: Arm av havet inn i fastlandet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjordmunning">
+        
+        <annotation>
+          
+          <documentation>Fjordmunning: Område ytterst i en fjord.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="flyplass">
+        
+        <annotation>
+          
+          <documentation>Flyplass: Offentlig godkjent, avgrenset område med start- og landingsplass for fly.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fløtningsanlegg">
+        
+        <annotation>
+          
+          <documentation>Fløtningsanlegg: Kunstig fløtningsanlegg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fonn">
+        
+        <annotation>
+          
+          <documentation>Fonn: Liten snø- eller isflate som vanligvis ikke smelter om sommeren.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fornøyelsespark">
+        
+        <annotation>
+          
+          <documentation>Fornøyelsespark: Store, regulerte anlegg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="forretningsbygg">
+        
+        <annotation>
+          
+          <documentation>Forretningsbygg: Bygning for kontor-, salg- og servicevirksomhet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="forsamlingshusKulturhus">
+        
+        <annotation>
+          
+          <documentation>Forsamlingshus/kulturhus: Teater, kino, samfunnshus, grendehus o.l.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="forskningsstasjon">
+        
+        <annotation>
+          
+          <documentation>Forskningsstasjon: Bemannet forskningsstasjon eller meteorologisk stasjon med bygningsmasse.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="foss">
+        
+        <annotation>
+          
+          <documentation>Foss: Vann i tilnærmet fritt fall.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fritidsbolig">
+        
+        <annotation>
+          
+          <documentation>Fritidsbolig: Eget navn på hytter og hus som ikke er ment for fast bosetting.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fylke">
+        
+        <annotation>
+          
+          <documentation>Fylke: Offisielt navn.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fyllplass">
+        
+        <annotation>
+          
+          <documentation>Fyllplass: Plass for deponering av masse som stein, jord og søppel.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fyrlykt">
+        
+        <annotation>
+          
+          <documentation>Fyrlykt: Linse og lyskilde anbrakt i hus eller liknende. Ikke flytende.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fyrstasjon">
+        
+        <annotation>
+          
+          <documentation>Fyrstasjon: Automatisk og ubemannet. Et fast anlegg hvor linse og lyskilde er anbrakt i hus, tårn eller spesielt bygg. Ikke flytende.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="gammelBosettingsplass">
+        
+        <annotation>
+          
+          <documentation>Gammel bosettingsplass: Nedlagt bruk, seter, boplass hvor bygningen(e) er borte eller bare tuftene er tilbake.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="garasjeHangarbygg">
+        
+        <annotation>
+          
+          <documentation>Garasje/hangarbygg: Trikkestall, bussgarasje, flyhangar eller lokomotivstall.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="gard">
+        
+        <annotation>
+          
+          <documentation>Gard: Felles navn for et helt gardsnummer (jf. § 8 i lov om stadnamn).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="gass-OljefeltISjø">
+        
+        <annotation>
+          
+          <documentation>Gass-/oljefelt i sjø: Navngitt gass- eller oljefelt i havet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="geologiskStruktur">
+        
+        <annotation>
+          
+          <documentation>Geologisk struktur: Navngitt struktur/formasjon i berggrunnen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="gjerde">
+        
+        <annotation>
+          
+          <documentation>Gjerde: Oppsatt stengsel, vern, skille mellom jordstykker, eiendommer eller beiteområder.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="gravplass">
+        
+        <annotation>
+          
+          <documentation>Gravplass: Alle typer gravlunder, gravplasser.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grend">
+        
+        <annotation>
+          
+          <documentation>Grend: Mindre uregulert gards-, seter- og boligområde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grensemerke">
+        
+        <annotation>
+          
+          <documentation>Grensemerke: Offisielt grensemerke: Varde, tre, stein, bolt, kors o.l.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grind">
+        
+        <annotation>
+          
+          <documentation>Grind: Port i gjerde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grotte">
+        
+        <annotation>
+          
+          <documentation>Grotte: Naturlig fjellgrotte.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grunne">
+        
+        <annotation>
+          
+          <documentation>Grunne: Lite område under vann som hever seg fra området rundt.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grunneISjø">
+        
+        <annotation>
+          
+          <documentation>Grunne i sjø: Markant forhøyning av havbunnen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grunnkrets">
+        
+        <annotation>
+          
+          <documentation>Grunnkrets: Offisielt navn på grunnkrets.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="gruppeAvTjern">
+        
+        <annotation>
+          
+          <documentation>Gruppe av tjern: To eller flere små tjern.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="gruppeAvVann">
+        
+        <annotation>
+          
+          <documentation>Gruppe av vann: To eller flere vann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grustakSteinbrudd">
+        
+        <annotation>
+          
+          <documentation>Grustak/steinbrudd: Uttaksplass/-område for sand, grus, pukk, skifer eller stein.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grøft">
+        
+        <annotation>
+          
+          <documentation>Grøft: Rennende vann i oppgravd vannvei, f.eks. dreneringsgrøft i myr.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="halvøy">
+        
+        <annotation>
+          
+          <documentation>Halvøy: Større nes i ferskvann med smalt eid mot fastland.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="halvøyISjø">
+        
+        <annotation>
+          
+          <documentation>Halvøy i sjø: Større nes med smalt eid mot fastland.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="haug">
+        
+        <annotation>
+          
+          <documentation>Haug: Liten, markant forhøynet terrengform.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="havdyp">
+        
+        <annotation>
+          
+          <documentation>Havdyp: Stort, dypt område i havet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="havn">
+        
+        <annotation>
+          
+          <documentation>Havn: Sted der fartøy laster, losser eller søker ly for vær og sjø.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="havnehage">
+        
+        <annotation>
+          
+          <documentation>Havnehage: Inngjerdet beitemark.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="havområde">
+        
+        <annotation>
+          
+          <documentation>Havområde: Del av et hav.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="havstrøm">
+        
+        <annotation>
+          
+          <documentation>Havstrøm: Kontinuerlig bevegelse av vann (i havet) på grunn av klimatiske forhold eller tidevann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="hei">
+        
+        <annotation>
+          
+          <documentation>Hei: Berglendt, høyere beliggende område med beitemark.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="heller">
+        
+        <annotation>
+          
+          <documentation>Heller: Utoverhengende bergvegg eller berghule.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="helseinstitusjon">
+        
+        <annotation>
+          
+          <documentation>Helseinstitusjon: Aldershjem, rekreasjonshjem og lignende.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="historiskBosetting">
+        
+        <annotation>
+          
+          <documentation>Historisk bosetting: Ubebodd eller forlatt bosetting med bestående bygningsmasse eller ruiner.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="holdeplass">
+        
+        <annotation>
+          
+          <documentation>Holdeplass: Ubetjent stoppested for jernbane, tunnelbane og/eller trikk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="holme">
+        
+        <annotation>
+          
+          <documentation>Holme: Liten øy i ferskvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="holmeISjø">
+        
+        <annotation>
+          
+          <documentation>Holme i sjø: Liten øy.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="holmegruppeISjø">
+        
+        <annotation>
+          
+          <documentation>Holmegruppe i sjø: To eller flere små øyer.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="hotell">
+        
+        <annotation>
+          
+          <documentation>Hotell: Større, offentlig godkjent overnattingssted.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="hylle">
+        
+        <annotation>
+          
+          <documentation>Hylle: Flatt, tilnærmet vannrett område i fjellside.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="hylleISjø">
+        
+        <annotation>
+          
+          <documentation>Hylle i sjø: Undersjøisk benk; klippeavsats, kant, fremspring, avsats.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="hyttefelt">
+        
+        <annotation>
+          
+          <documentation>Hyttefelt: Offentlig eller privat hyttefelt. Regulert område med høy utnyttelsesgrad.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="høl">
+        
+        <annotation>
+          
+          <documentation>Høl: Dyp elvebunn under foss eller etter et stryk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="høyde">
+        
+        <annotation>
+          
+          <documentation>Høyde: Høyereliggende terrengform, mindre omfattende enn ås og større enn haug.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="idrettsanlegg">
+        
+        <annotation>
+          
+          <documentation>Idrettsanlegg: Alle typer utendørsanlegg for idrett.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="idrettshall">
+        
+        <annotation>
+          
+          <documentation>Idrettshall: Alle typer innendørsanlegg, f.eks. ishall, svømmehall, idrettshall og ridehall.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="industriområde">
+        
+        <annotation>
+          
+          <documentation>Industriområde: Større, sammenhengende område til industri- og næringsformål.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="innsjø">
+        
+        <annotation>
+          
+          <documentation>Innsjø: Stort vann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="isbre">
+        
+        <annotation>
+          
+          <documentation>Isbre: Større sammenhengende snø- eller isområde som ikke smelter i løpet av sommeren.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="iskuppel">
+        
+        <annotation>
+          
+          <documentation>Iskuppel: Konveks ismasse av en viss tykkelse i større bre eller innlandsis.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="jernstang">
+        
+        <annotation>
+          
+          <documentation>Jernstang: Fast sjømerke av typen jernstang eller jernsøyle.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="jorde">
+        
+        <annotation>
+          
+          <documentation>Jorde: Kultivert dyrkningsmark.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="juv">
+        
+        <annotation>
+          
+          <documentation>Juv: Kløftlignende dal eller canyon.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kabel">
+        
+        <annotation>
+          
+          <documentation>Kabel: Alle typer kabler i sjø eller i ferskvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kai">
+        
+        <annotation>
+          
+          <documentation>Kai: Større, fastbygd bryggeanlegg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kanal">
+        
+        <annotation>
+          
+          <documentation>Kanal: Kunstig eller naturlig vannvei eller gjennomseiling.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kilde">
+        
+        <annotation>
+          
+          <documentation>Kilde: Oppkomme, olle, kildeutspring, osv.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kirke">
+        
+        <annotation>
+          
+          <documentation>Kirke: Kirke, kapell, arbeidskirke o.l.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="klakkISjø">
+        
+        <annotation>
+          
+          <documentation>Klakk i sjø: Fjellknatt på sjøbunnen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="klopp">
+        
+        <annotation>
+          
+          <documentation>Klopp: Liten gangbru av stokker og/eller stein over bekker og elver, i myr eller i fjæra.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kommune">
+        
+        <annotation>
+          
+          <documentation>Kommune: Offisielt navn.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kontinentalsokkel">
+        
+        <annotation>
+          
+          <documentation>Kontinentalsokkel: Område med grunt hav rundt kontinentene. Ofte brukt om et lands økonomiske interessesone til sjøs.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="korallrev">
+        
+        <annotation>
+          
+          <documentation>Korallrev: Rev som er dannet av koraller.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kraftgateRørgate">
+        
+        <annotation>
+          
+          <documentation>Kraftgate (rørgate): Store tilførselsrør for kraftanlegg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kraftledning">
+        
+        <annotation>
+          
+          <documentation>Kraftledning: Stor strømoverføringsledning.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kraftstasjon">
+        
+        <annotation>
+          
+          <documentation>Kraftstasjon: Alle typer / alle størrelser til energiproduksjon (f.eks. el. og varme).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="krater">
+        
+        <annotation>
+          
+          <documentation>Krater: Skål- eller traktformet senkning i jordoverflaten forårsaket av vulkansk aktivitet eller av meteorittnedslag.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="landingsplass">
+        
+        <annotation>
+          
+          <documentation>Landingsplass: Landingsplass for helikopter og/eller privatfly.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="landskapsområde">
+        
+        <annotation>
+          
+          <documentation>Landskapsområde: Område der drag i landskapet, naturforhold, arealbruk og bosetting er samlende og skiller seg fra tilgrensende områder.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="lanterne">
+        
+        <annotation>
+          
+          <documentation>Lanterne: En innretning hvor linsen med eller uten beskyttelsesglass utgjør en del av den bærende del av konstruksjonen. Ikke flytende.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="li">
+        
+        <annotation>
+          
+          <documentation>Li: Skrånende terreng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="lon">
+        
+        <annotation>
+          
+          <documentation>Lon: Utbuktning i elv eller bekk der vannet renner stille.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="lysbøye">
+        
+        <annotation>
+          
+          <documentation>Lysbøye: Flytende innretning for farvannsmerking med en lanterne som lyskilde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="matrikkeladressenavn">
+        
+        <annotation>
+          
+          <documentation>Matrikkeladressenavn: Et stedsnavn som inngår i den offiselle adressen ved matrikkeladresser, jf. § 55 tredje ledd i matrikkelforskriften.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="melkeplass">
+        
+        <annotation>
+          
+          <documentation>Melkeplass: Seterplass uten hus (ev. med enkelt skur) brukt til melking av husdyr.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="militærtByggAnlegg">
+        
+        <annotation>
+          
+          <documentation>Militært bygg/anlegg: Militærleir.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="mo">
+        
+        <annotation>
+          
+          <documentation>Mo: Større, flatt landområde (ofte skogkledd).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="molo">
+        
+        <annotation>
+          
+          <documentation>Molo: Fast byggverk, utstikkende voll i sjøen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="moreneryggISjø">
+        
+        <annotation>
+          
+          <documentation>Morenerygg i sjø: Marin israndavsetning.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="museumGalleriBibliotek">
+        
+        <annotation>
+          
+          <documentation>Museum/galleri/bibliotek: Alle typer museum, galleri og bibliotek.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="myr">
+        
+        <annotation>
+          
+          <documentation>Myr: Alle typer fra åpen gressmyr til våt moldjord dekket med kjerr.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nasjon">
+        
+        <annotation>
+          
+          <documentation>Nasjon: Offisielt navn på selvstendig stat eller land.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="navnegard">
+        
+        <annotation>
+          
+          <documentation>Navnegard: Opprinnelig navn fra før garden ble oppdelt i gards- og bruksenheter. Navnegardens utbredelse kan omfatte flere enn ett gardsnummer.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nes">
+        
+        <annotation>
+          
+          <documentation>Nes: Landområde stikkende ut i ferskvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nesISjø">
+        
+        <annotation>
+          
+          <documentation>Nes i sjø: Landområde stikkende ut i sjø.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nesVedElver">
+        
+        <annotation>
+          
+          <documentation>Nes ved elver: Landet mellom to møtende elver.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="offersted">
+        
+        <annotation>
+          
+          <documentation>Offersted: Alle typer offersted.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="oljeinstallasjon">
+        
+        <annotation>
+          
+          <documentation>Oljeinstallasjon: Stasjonær olje- og gassinstallasjon (fast eller flytende).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="oppdrettsanlegg">
+        
+        <annotation>
+          
+          <documentation>Oppdrettsanlegg: Anlegg for foring og stell av husdyr til de kan settes i produksjon eller slaktes; oppforing av fisk (og andre sjødyr) i fangenskap.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="os">
+        
+        <annotation>
+          
+          <documentation>Os: Innløp eller utløp av elv eller bekk i innsjø/vann/tjern eller sjø (saltvann).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="overett">
+        
+        <annotation>
+          
+          <documentation>Overett: To sjømerker, med eller uten lys, som, når de peiles på linje, viser kurs for gjennomseiling.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="park">
+        
+        <annotation>
+          
+          <documentation>Park: Kultivert grøntområde i by/tettsted.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="parkeringsplass">
+        
+        <annotation>
+          
+          <documentation>Parkeringsplass: Tomt (eller bygning) for parkering av biler.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="pensjonat">
+        
+        <annotation>
+          
+          <documentation>Pensjonat: Mindre, offentlig godkjent overnattingssted.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="platåISjø">
+        
+        <annotation>
+          
+          <documentation>Platå i sjø: Stor, flat forhøyning som skiller seg fra havbunnen omkring.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="poststed">
+        
+        <annotation>
+          
+          <documentation>Poststed: Offisielt poststed/postnummerområde.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="pytt">
+        
+        <annotation>
+          
+          <documentation>Pytt: Lite vannhull (mindre enn tjern).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="rasISjø">
+        
+        <annotation>
+          
+          <documentation>Ras i sjø: Undersjøisk rasområde med stein, jord, sand eller leire.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="rasteplass">
+        
+        <annotation>
+          
+          <documentation>Rasteplass: Rasteplass definert og lagt til rette av Statens vegvesen eller annen offentlig myndighet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="renneKløftISjø">
+        
+        <annotation>
+          
+          <documentation>Renne/Kløft i sjø: Undersjøisk dal, kanal, senkning, ravine, fure, spor, rille o.l.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="revISjø">
+        
+        <annotation>
+          
+          <documentation>Rev i sjø: Grunne, banke av stein/fjell (som strekker seg ut fra en kyst).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="rygg">
+        
+        <annotation>
+          
+          <documentation>Rygg: Langstrakt terrengform.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ryggISjø">
+        
+        <annotation>
+          
+          <documentation>Rygg i sjø: Undersjøisk ås, åskam eller fjellrygg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="rørledning">
+        
+        <annotation>
+          
+          <documentation>Rørledning: Alle typer rørledninger: Olje, gass, vann o.l.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="rådhus">
+        
+        <annotation>
+          
+          <documentation>Rådhus: Administrasjonssenteret i den administrative enheten, f.eks. stat, fylke, kommune.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sadelISjø">
+        
+        <annotation>
+          
+          <documentation>Sadel i sjø: Undersjøisk skar mellom to høyere topper/rygger.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sand">
+        
+        <annotation>
+          
+          <documentation>Sand: Finkornede avsetninger (sand og/eller grus).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="senkning">
+        
+        <annotation>
+          
+          <documentation>Senkning: Flat forsenkning, dalsenkning.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="serveringssted">
+        
+        <annotation>
+          
+          <documentation>Serveringssted: Serveringssted uten overnatting.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="seterStøl">
+        
+        <annotation>
+          
+          <documentation>Seter/støl: Enklere landbruksbebyggelse med hus. Kan ha periodisk fast bosetting, vanligvis sommerstid.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="setervoll">
+        
+        <annotation>
+          
+          <documentation>Setervoll: Ryddet, gressbevokst område på seter uten hus.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="severdighet">
+        
+        <annotation>
+          
+          <documentation>Severdighet: Minnesmerke, arkeologiske funn o.l.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sjødetalj">
+        
+        <annotation>
+          
+          <documentation>Sjødetalj: Detalj som ikke dekkes av andre sjø-navneobjekttyper.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sjøvarde">
+        
+        <annotation>
+          
+          <documentation>Sjømerke: Varde av stein eller betong primært for navigering til sjøs.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sjøstykke">
+        
+        <annotation>
+          
+          <documentation>Sjøstykke: Stykke av sjøen utanfor land, vanligvis innaskjærs eller i kystnære farvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skar">
+        
+        <annotation>
+          
+          <documentation>Skar: Markant senkning i fjell eller berg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skiheis">
+        
+        <annotation>
+          
+          <documentation>Skiheis: Skitrekk og stolheis i skianlegg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skjær">
+        
+        <annotation>
+          
+          <documentation>Skjær: Fjell eller stein i vannflaten.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skjærISjø">
+        
+        <annotation>
+          
+          <documentation>Skjær i sjø: Bergrunn nær eller rett over vannflaten.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skog">
+        
+        <annotation>
+          
+          <documentation>Skog: Alle typer fra stor barskog til og med vierkratt i Finnmark.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skogholt">
+        
+        <annotation>
+          
+          <documentation>Skogholt: Mindre samling av trær.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skogområde">
+        
+        <annotation>
+          
+          <documentation>Skogområde: Større område med skog og mark.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skole">
+        
+        <annotation>
+          
+          <documentation>Skole: Offentlig og privat skole.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skolekrets">
+        
+        <annotation>
+          
+          <documentation>Skolekrets: Skolekrets definert av kommunen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skredområde">
+        
+        <annotation>
+          
+          <documentation>Skredområde: Område der det går eller har gått skred.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skytebane">
+        
+        <annotation>
+          
+          <documentation>Skytebane: Bane for øvelse el. konkurranse i skyting.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skytefelt">
+        
+        <annotation>
+          
+          <documentation>Skytefelt: Militært sprengingsfelt, bombe- og skytefelt, både på land og sjø.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="slette">
+        
+        <annotation>
+          
+          <documentation>Slette: Åpent, flatt område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sluse">
+        
+        <annotation>
+          
+          <documentation>Sluse: Kunstig løfteanretning for båter i vassdrag.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="småbåthavn">
+        
+        <annotation>
+          
+          <documentation>Småbåthavn: Regulert havneanlegg for småbåter.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sokkelISjø">
+        
+        <annotation>
+          
+          <documentation>Sokkel i sjø: Undersjøisk fjellfot.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sokn">
+        
+        <annotation>
+          
+          <documentation>Sokn: Kirkesokn i Den norske kirke.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="soneinndelingTilHavs">
+        
+        <annotation>
+          
+          <documentation>Soneinndeling til havs: Fiskerisone, havrettssone og lignende.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stake">
+        
+        <annotation>
+          
+          <documentation>Stake: Flytende sjømerke. Ofte kalt bøyestake, stakebøye, kubbestake.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stasjon">
+        
+        <annotation>
+          
+          <documentation>Stasjon: Stoppested for jernbane, tunnelbane og/eller trikk. Som regel betjent.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="statistiskTettsted">
+        
+        <annotation>
+          
+          <documentation>Statistisk tettsted: Tettsted etter Statistisk sentralbyrås klassifisering som brukes for å lage statistikk over befolkning og tettsteder.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stein">
+        
+        <annotation>
+          
+          <documentation>Stein: Frittliggende steinblokk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sti">
+        
+        <annotation>
+          
+          <documentation>Sti: Stistrekning, råk, slepe (gammel drifteveg), reindriftsveg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="strand">
+        
+        <annotation>
+          
+          <documentation>Strand: Sand-, grus- eller steindekket område i vannkanten ved elv eller vann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="strandISjø">
+        
+        <annotation>
+          
+          <documentation>Strand i sjø: Sand-, grus- eller steindekket område i sjøkanten.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stryk">
+        
+        <annotation>
+          
+          <documentation>Stryk: Del av elv, bekk der vannet går i stryk (og skiller seg tydelig fra resten av elva/bekken).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stup">
+        
+        <annotation>
+          
+          <documentation>Stup: Loddrett, svært bratt berg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stø">
+        
+        <annotation>
+          
+          <documentation>Stø: Båtplass i vannkanten uten naust.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sund">
+        
+        <annotation>
+          
+          <documentation>Sund: Innsnevret område i vann eller vassdrag.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sundISjø">
+        
+        <annotation>
+          
+          <documentation>Sund i sjø: Innsnevret område mellom øyer eller fastland.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sykehus">
+        
+        <annotation>
+          
+          <documentation>Sykehus: Offentlig og privat sykehus.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="søkk">
+        
+        <annotation>
+          
+          <documentation>Søkk: Mindre markant, begrenset fordypning.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="søkkISjø">
+        
+        <annotation>
+          
+          <documentation>Søkk i sjø: Stor eller liten grop på sjøbunnen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="taubane">
+        
+        <annotation>
+          
+          <documentation>Taubane: Heis til frakt av gods/høy, ikke persontrafikk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tettbebyggelse">
+        
+        <annotation>
+          
+          <documentation>Tettbebyggelse: Bebygd område uten sentrumskarakter.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tettsted">
+        
+        <annotation>
+          
+          <documentation>Tettsted: Mindre, bymessig bebygd område med sentrumskarakter.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tettsteddel">
+        
+        <annotation>
+          
+          <documentation>Tettsteddel: Kulturmessig del av tettsted.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tjern">
+        
+        <annotation>
+          
+          <documentation>Tjern: Lite vann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="topp">
+        
+        <annotation>
+          
+          <documentation>Topp: Tind, markant topp på fjell, berg, ås osv.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="torg">
+        
+        <annotation>
+          
+          <documentation>Torg: Stor, åpen plass i en by.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="torvtak">
+        
+        <annotation>
+          
+          <documentation>Torvtak: Sted for uttak av myrtorv, brenntorv eller veksttorv.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="traktorveg">
+        
+        <annotation>
+          
+          <documentation>Traktorveg: Driftsveg anlagt for traktorbruk. Ikke fremkommelig med vanlig personbil.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tunnel">
+        
+        <annotation>
+          
+          <documentation>Tunnel: Vanlig tunnel, rasoverbygg eller undergang. Både på veg og jernbane.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="turisthytte">
+        
+        <annotation>
+          
+          <documentation>Turisthytte: Overnattingssted utenfor tettbygd område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tV-Radio-EllerMobiltelefontårn">
+        
+        <annotation>
+          
+          <documentation>TV-/radio- eller mobiltelefontårn: Alle typer bakkebasert telekommunikasjon.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tømmervelte">
+        
+        <annotation>
+          
+          <documentation>Tømmervelte: Midlertidig lagringsplass for tømmer.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="undersjøiskVegg">
+        
+        <annotation>
+          
+          <documentation>Undersjøisk vegg: Fjellside i havet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="universitetHøgskole">
+        
+        <annotation>
+          
+          <documentation>Universitet/høgskole: Offentlig og privat høgskole og universitet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ur">
+        
+        <annotation>
+          
+          <documentation>Ur: Steinområde, steinrøys.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="utmark">
+        
+        <annotation>
+          
+          <documentation>Utmark: Beitemark i skog og mark vekk fra garden (og innmarka).</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="utsiktspunkt">
+        
+        <annotation>
+          
+          <documentation>Utsiktspunkt: Både fra tårn og på bakken.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="utstikker">
+        
+        <annotation>
+          
+          <documentation>Utstikker: Flytende bryggeanlegg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vad">
+        
+        <annotation>
+          
+          <documentation>Vad: Vadested, vanligvis der en stistrekning krysser elv, bekk eller vann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vaktstasjonBeredsskapsbygning">
+        
+        <annotation>
+          
+          <documentation>Vaktstasjon/beredsskapsbygning: Bygning for politi/brann/los/toll/ambulanse/fly- og skipsovervåkning.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="valgkrets">
+        
+        <annotation>
+          
+          <documentation>Valgkrets: Valgkrets definert av kommunen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vann">
+        
+        <annotation>
+          
+          <documentation>Vann: Middels stort vann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="varde">
+        
+        <annotation>
+          
+          <documentation>Varde: (Som oftest) oppstablet stein som skal markere sti, grensemerke, trigonometrisk punkt o.l.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vegbom">
+        
+        <annotation>
+          
+          <documentation>Vegbom: Mindre bomanlegg på privat veg.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vegkryss">
+        
+        <annotation>
+          
+          <documentation>Vegkryss: Allment kjent vegkryss i alle typer veger og gater.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vegstrekning">
+        
+        <annotation>
+          
+          <documentation>Vegstrekning: Navn på vegstrekning som ikke nødvendigvis har et formelt vedtak, og ikke er det samme som adressenavnet. Det kan være f.eks. fjelloverganger, turistrekninger og ringveger rundt en by.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vegsving">
+        
+        <annotation>
+          
+          <documentation>Vegsving: Allment kjent sving på alle typer veger og gater.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="verneområde">
+        
+        <annotation>
+          
+          <documentation>Verneområde: Et område med spesiell natur- og/eller kulturverdi som er formelt vedtatt vernet etter offentlig regelverk. Alle typer, både på sjø og land.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vidde">
+        
+        <annotation>
+          
+          <documentation>Vidde: Høyereliggende (fjell)område med lite høydevariasjoner innenfor området, som regel over tregrensa.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vik">
+        
+        <annotation>
+          
+          <documentation>Vik: Kil eller bukt i vann eller vassdrag.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vikISjø">
+        
+        <annotation>
+          
+          <documentation>Vik i sjø: Kil, bukt.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vulkanISjø">
+        
+        <annotation>
+          
+          <documentation>Vulkan i sjø: Vulkan eller slamvulkan på havbunnen.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vågISjø">
+        
+        <annotation>
+          
+          <documentation>Våg i sjø: Fjordarm, større vik.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="øy">
+        
+        <annotation>
+          
+          <documentation>Øy: Tørt landområde i ferskvann atskilt fra fastlandet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="øyISjø">
+        
+        <annotation>
+          
+          <documentation>Øy i sjø: Tørt landområde atskilt fra fastlandet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="øygruppe">
+        
+        <annotation>
+          
+          <documentation>Øygruppe: To eller flere øyer i ferskvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="øygruppeISjø">
+        
+        <annotation>
+          
+          <documentation>Øygruppe i sjø: To eller flere øyer.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="øyr">
+        
+        <annotation>
+          
+          <documentation>Øyr: Sand-/grusområde i elvemunning, elvedelta både mot innsjø/vann og saltvann.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ås">
+        
+        <annotation>
+          
+          <documentation>Ås: Langstrakt høydedrag.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+	        
+      <enumeration value="eiendomsteig">
+        
+        <annotation>
+          
+          <documentation>eiendomsteig</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="våtmarksområde">
+        
+        <annotation>
+          
+          <documentation>våtmarksområde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="busstasjon">
+        
+        <annotation>
+          
+          <documentation>busstasjon</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vannstandsmåler">
+        
+        <annotation>
+          
+          <documentation>vannstandsmåler</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="friluftsområde">
+        
+        <annotation>
+          
+          <documentation>friluftsområde</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sjømerkeMedIndirekteBelysning">
+        
+        <annotation>
+          
+          <documentation>sjømerkeMedIndirekteBelysning</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="reinbeitedistrikt">
+        
+        <annotation>
+          
+          <documentation>reinbeitedistrikt</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="boinstitusjon">
+        
+        <annotation>
+          
+          <documentation>boinstitusjon</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="egg">
+        
+        <annotation>
+          
+          <documentation>egg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellvegg">
+        
+        <annotation>
+          
+          <documentation>fjellvegg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="delAvVann">
+        
+        <annotation>
+          
+          <documentation>delAvVann</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="jernbanebru">
+        
+        <annotation>
+          
+          <documentation>jernbanebru</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="jernbanetunnel">
+        
+        <annotation>
+          
+          <documentation>jernbanetunnel</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="helikopterlandingsplass">
+        
+        <annotation>
+          
+          <documentation>helikopterlandingsplass</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kulturMessehall">
+        
+        <annotation>
+          
+          <documentation>kulturMessehall</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="overbygg">
+        
+        <annotation>
+          
+          <documentation>overbygg</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="mindreBrukonstruksjon">
+        
+        <annotation>
+          
+          <documentation>mindreBrukonstruksjon</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="stølsSetereiendom">
+        
+        <annotation>
+          
+          <documentation>stølsSetereiendom</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tuft">
+        
+        <annotation>
+          
+          <documentation>tuft</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vannverk">
+        
+        <annotation>
+          
+          <documentation>vannverk</documentation>
+        
+        </annotation>
+      
+      </enumeration>      
+      <enumeration value="hammar">
+        
+        <annotation>
+          
+          <documentation>hammar</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fjellovergang">
+        
+        <annotation>
+          
+          <documentation>fjellovergang</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sva">
+        
+        <annotation>
+          
+          <documentation>sva</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavneobjekttypeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavnesakstatusKodeType">
+    
+    <annotation>
+      
+      <documentation>Saksgang/statuser finnes i modellen "Diagrammer" i Perforce (stedsnavnDok/trunk/diagrammer)</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:NavnesakstatusKodeEnumerationType app:NavnesakstatusKodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="NavnesakstatusKodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Saksgang/statuser finnes i modellen "Diagrammer" i Perforce (stedsnavnDok/trunk/diagrammer)</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="forenkletVedtak">
+        
+        <annotation>
+          
+          <documentation>Skrivemåten av stedsnavnet er vedtatt fordi den har vedtak eller er godkjent i en annen funksjon.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="iverksattVedtak">
+        
+        <annotation>
+          
+          <documentation>Skrivemåten av stedsnavnet er bestemt ved vedtak.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="klagenemda">
+        
+        <annotation>
+          
+          <documentation>Hvis vedtaksmyndigheten står ved sitt valg av skrivemåte i klagesaken blir saken sendt videre til klagenemnda. De kan (men trenger ikke) innhente høringsuttalelser fra Språkrådet, Sametinget og departement.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="klageIverksattVedtakIkkeTrukketTilbake">
+        
+        <annotation>
+          
+          <documentation>Det er kommet inn klage på vedtak for stedsnavnet, der vedtaket er iverksatt. Det er ikke fremsatt ønske om at vedtaket trekkes tilbake i klageperioden, eller slikt ønske er ikke tatt til følge av vedtaksmyndigheten.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="klageVedtakTrukketTilbake">
+        
+        <annotation>
+          
+          <documentation>Det er kommet inn klage på vedtak for stedsnavnet, der vedtaket er iverksatt. Det er fremsatt ønske om at vedtaket trekkes tilbake i klageperioden, og ønsket er tatt til følge av vedtaksmyndigheten.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skalIkkeBehandlesEtterLoven">
+        
+        <annotation>
+          
+          <documentation>Registrering av stedsnavn som ikke skal behandles etter lov om stadnamn, der det altså ikke kan reises navnesak og følgelig navnesakstatus ikke er relevant.
+
+Stedsnavnets skrivemåter registreres med status Privat eller Internasjonal.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="navnBestemtAvNavnemyndighet">
+        
+        <annotation>
+          
+          <documentation>Registrering av stedsnavn som er bestemt av navnemyndighet, f.eks. kommunen ved behandling etter matrikkelloven. Ikke alle navnetyper kan behandles på denne måten, det mest aktuelle er adressenavn.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="navnesakReist">
+        
+        <annotation>
+          
+          <documentation>Det er reist navnesak for stedsnavnet etter lov om stadnamn, herunder navnesak reist på bakgrunn av klage på normering av stedsnavn etter samlevedtak.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="samlevedtak">
+        
+        <annotation>
+          
+          <documentation>Stedsnavnet har blitt normert i et samlevedtak, jf. forskrift om skrivemåten av stadnamn § 8, femte ledd.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="samlevedtakTrukketTilbake">
+        
+        <annotation>
+          
+          <documentation>Samlevedtak kreves trukket tilbake i forbindelse med at navnesak reises for stedsnavnet på bakgrunn av klage på normering av stedsnavn etter samlevedtak.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="ubehandlet">
+        
+        <annotation>
+          
+          <documentation>Stedsnavn som det ikke har vært gjennom noen form for saksgang.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vedtakIverksettingUtsatt">
+        
+        <annotation>
+          
+          <documentation>Det er gjort vedtak for stedsnavnet etter lov om stadnamn, men iverksetting av vedtaket er utsatt til klagefristen er ute, jf. forskrift om skrivemåten av stadnamn § 12.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavnesakstatusKodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavnestatuskodeType">
+    
+    <annotation>
+      
+      <documentation>Kodene angir et hierarki stedsnavna i mellom, som sier noe om hvilket som blir brukt mest, like mye eller ikke er i bruk lengre.</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:NavnestatuskodeEnumerationType app:NavnestatuskodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="NavnestatuskodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Kodene angir et hierarki stedsnavna i mellom, som sier noe om hvilket som blir brukt mest, like mye eller ikke er i bruk lengre.</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="hovednavn">
+        
+        <annotation>
+          
+          <documentation>Verdien betyr at stedsnavnet er i større bruk enn andre navn for samme sted innenfor en språkform.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sidenavn">
+        
+        <annotation>
+          
+          <documentation>Brukes der det ikke kan fastslås at ett av to eller flere forskjellige navn har større bruksverdi enn andre.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="undernavn">
+        
+        <annotation>
+          
+          <documentation>Brukes der ett av to forskjellige navn har mindre bruksverdi enn det andre stedsnavnet, som vurderes som hovednavnet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="historisk">
+        
+        <annotation>
+          
+          <documentation>Brukes der stedsnavnet ikke er i bruk lenger og dermed ikke er aktuell å vurdere i en navnesak.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="feilført">
+        
+        <annotation>
+          
+          <documentation>Brukes der stedsnavnet har vært registrert på feil sted.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="NavnestatuskodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Skrivemåte" substitutionGroup="gml:AbstractObject" type="app:SkrivemåteType">
+    
+    <annotation>
+      
+      <documentation>Her registreres en skrivemåte av stedsnavnet med opplysninger om status (godkjent/avslått/samlevedtak), anbefaling til offentlig bruk, løse tillegg, osv...</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="SkrivemåteType">
+    
+    <sequence>
+      
+      <element name="komplettskrivemåte" type="string">
+        
+        <annotation>
+          
+          <documentation>langform av alle skrivemåter avledet fra vanligste kasus for variasjonstillegg, kjernenavn og funksjonstillegg og med korrekt innbyrdes rekkefølge beskrevet i egenskapen rekkefølge.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMPLETTSKRIVEMÅTE</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="skrivemåtestatus" type="app:SkrivemåtestatusKodeType">
+        
+        <annotation>
+          
+          <documentation>henter gjeldende status (godkjent, vedtak, privat osv.) og prioritering for skrivemåten fra datatypen.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SKRIVEMÅTESTATUS</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="statusdato" type="date">
+        
+        <annotation>
+          
+          <documentation>hentes fra "fraDato" på Skrivemåtestatushistorikk. En gyldighetsdato som forteller når en status startet, f.eks. datoen for et vedtak.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">STATUSDATO</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="skrivemåtenummer" type="integer">
+        
+        <annotation>
+          
+          <documentation>stedsnummer, stedsnavnsnummer og skrivemåtenummer skal sammen utgjøre en såkalt tematisk id som brukes av registerførere som opplslagsnummer. Identifikatoren ligner litt på Gnr/Bnr/Fnr.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SKRIVEMÅTENUMMER</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="SkrivemåtePropertyType">
+    
+    <sequence>
+      
+      <element ref="app:Skrivemåte"/>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <simpleType name="SkrivemåtestatusKodeType">
+    
+    <annotation>
+      
+      <documentation>skrivemåtestatus</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:SkrivemåtestatusKodeEnumerationType app:SkrivemåtestatusKodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="SkrivemåtestatusKodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>skrivemåtestatus</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="godkjent">
+        
+        <annotation>
+          
+          <documentation>Dokumentert skrivemåte fra før 01.07.1991 fra offentlig utgitte kart eller dokument (matrikkel, offentlig brevveksling osv.). 
+
+Gjelder også ved forenklet saksgang når primærfunksjonen er godkjent.
+
+Stedsnavnet kan brukes i offentlig sammenheng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="historisk">
+        
+        <annotation>
+          
+          <documentation>Historisk skrivemåte som ikke lenger er aktuell.
+
+Stedsnavnet skal ikke brukes i offentlig sammenheng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="internasjonal">
+        
+        <annotation>
+          
+          <documentation>Brukes i områder utenfor der lov om stadnamn gjelder, og språk/språkform kan være så ymse.
+
+Stedsnavnet kan brukes i offentlig sammenheng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="privat">
+        
+        <annotation>
+          
+          <documentation>Navn på private objekter som hoteller, hytter, bedrifter. Utenfor
+&lt;i>lov om stadnamn&lt;/i>, eier av lokaliteten er ikke offentlig organ etter lovens §1 tredje ledd.
+
+Stedsnavnet kan brukes i offentlig sammenheng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vedtatt">
+        
+        <annotation>
+          
+          <documentation>Skrivemåte som er vedtatt etter Lov om stadnamn.
+
+Gjelder også ved forenklet saksgang når primærfunksjonen er vedtatt.
+
+Stedsnavnet skal alltid brukes i offentlig sammenheng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="vedtattNavneledd">
+        
+        <annotation>
+          
+          <documentation>Godkjent skrivemåte med navneledd (ikke hele navnet) som er vedtatt gjennom samlevedtak.
+
+Ved etterregistrering av godkjent skrivemåte der det finnes samlevedtak, skal skrivemåten ha statusen Godkjent og deretter VedtattNavneledd dersom skrivemåten er i tråd med samlevedtaket.
+
+Stedsnavnet kan brukes i offentlig sammenheng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="uvurdert">
+        
+        <annotation>
+          
+          <documentation>Alle skrivemåter som ikke har vært til behandling som navnesak etter lov om stadnamn, og som heller ikke kan defineres som godkjente.
+
+Stedsnavnet skal ikke brukes i offentlig sammenheng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="foreslått">
+        
+        <annotation>
+          
+          <documentation>Skrivemåte som er til behandling i navnesak etter lov om stadnamn, og som ikke kan defineres som godkjent.
+
+Skal ikke brukes i offentlig sammenheng.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="SkrivemåtestatusKodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="Sortering1KodeType">
+    
+    <annotation>
+      
+      <documentation>Kode for sortering av viktighet av stedsnavn, brukes til å vurdere om stedsnavnet skal vises i ulike målestokker og ved konflikt under visning. Alle store bokstaver fra og med A til og med N, A er minst viktig og N er viktigst. N er navn på land store hav osv, mens A er på terrengdetaljer.</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:Sortering1KodeEnumerationType app:Sortering1KodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="Sortering1KodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Kode for sortering av viktighet av stedsnavn, brukes til å vurdere om stedsnavnet skal vises i ulike målestokker og ved konflikt under visning. Alle store bokstaver fra og med A til og med N, A er minst viktig og N er viktigst. N er navn på land store hav osv, mens A er på terrengdetaljer.</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="viktighetA">
+        
+        <annotation>
+          
+          <documentation>Minst viktige objekt tegnes til slutt vanligvis i små målestokker.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetB">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn A</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetC">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn A og B</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetD">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn C men mindre viktig enn E</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetE">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn D men mindre viktig enn F</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetF">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn E men mindre viktig enn G</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetG">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn F men mindre viktig enn H</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetH">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn G men mindre viktig enn I</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetI">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn H men mindre viktig enn J</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetJ">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn I men mindre viktig enn K</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetK">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn J men mindre viktig enn L</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetL">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn K men mindre viktig enn M</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetM">
+        
+        <annotation>
+          
+          <documentation>Viktigere enn L men mindre viktig enn N</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="viktighetN">
+        
+        <annotation>
+          
+          <documentation>Høyest prioritet, de viktigste navnene, tegnes vanligvis fra små målestokker.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="Sortering1KodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="SpråkKodeType">
+    
+    <annotation>
+      
+      <documentation>Subsett av ISO 639-3 som inneholder trebokstavs-koder de språkene som trengs for å konvertere innholdet fra SSR. Kodelisten kan utvides ved behov etter produksjonssetting.</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:SpråkKodeEnumerationType app:SpråkKodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="SpråkKodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Subsett av ISO 639-3 som inneholder trebokstavs-koder de språkene som trengs for å konvertere innholdet fra SSR. Kodelisten kan utvides ved behov etter produksjonssetting.</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="dansk">
+        
+        <annotation>
+          
+          <documentation>Dansk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="tysk">
+        
+        <annotation>
+          
+          <documentation>Tysk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="engelsk">
+        
+        <annotation>
+          
+          <documentation>Engelsk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="færøysk">
+        
+        <annotation>
+          
+          <documentation>Færøysk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="finsk">
+        
+        <annotation>
+          
+          <documentation>Finsk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kvensk">
+        
+        <annotation>
+          
+          <documentation>Kvensk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="fransk">
+        
+        <annotation>
+          
+          <documentation>Fransk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="irsk">
+        
+        <annotation>
+          
+          <documentation>Irsk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="islandsk">
+        
+        <annotation>
+          
+          <documentation>Islandsk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="grønlandsk">
+        
+        <annotation>
+          
+          <documentation>Grønlandsk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="lulesamisk">
+        
+        <annotation>
+          
+          <documentation>Lulesamisk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nederlandsk">
+        
+        <annotation>
+          
+          <documentation>Nederlandsk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nordsamisk">
+        
+        <annotation>
+          
+          <documentation>Nordsamisk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk">
+        
+        <annotation>
+          
+          <documentation>Norsk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="russisk">
+        
+        <annotation>
+          
+          <documentation>Russisk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="svensk">
+        
+        <annotation>
+          
+          <documentation>Svensk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sørsamisk">
+        
+        <annotation>
+          
+          <documentation>Sørsamisk</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skoltesamisk"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="SpråkKodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="SpråkprioriteringKodeType">
+    
+    <annotation>
+      
+      <documentation>Kodeliste som angir visningsrekkefølgen til stedsnavn på forskjellig språk. 
+
+&lt;b>Det er de første fem verdiene i kodene (de norske språkene) som varierer mellom kodene&lt;/b>, ellers er det lik (alfabetisk i forhold til ISO-kodeverdien) rekkefølge på språkene som ikke er aktuelle for behandling etter lov om stadnamn.</documentation>
+    
+    </annotation>
+    
+    <union memberTypes="app:SpråkprioriteringKodeEnumerationType app:SpråkprioriteringKodeOtherType"/>
+  
+  </simpleType>
+  
+  <simpleType name="SpråkprioriteringKodeEnumerationType">
+    
+    <annotation>
+      
+      <documentation>Kodeliste som angir visningsrekkefølgen til stedsnavn på forskjellig språk. 
+
+&lt;b>Det er de første fem verdiene i kodene (de norske språkene) som varierer mellom kodene&lt;/b>, ellers er det lik (alfabetisk i forhold til ISO-kodeverdien) rekkefølge på språkene som ikke er aktuelle for behandling etter lov om stadnamn.</documentation>
+    
+    </annotation>
+    
+    <restriction base="string">
+      
+      <enumeration value="lulesamisk-nordsamisk-skoltesamisk-sørsamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, lulesamisk område der nordsamisk kan forekomme.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="lulesamisk-sørsamisk-nordsamisk-skoltesamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, lulesamisk område der sørsamisk kan forekomme.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nordsamisk-skoltesamisk-lulesamisk-sørsamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, nordsamisk område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-lulesamisk-nordsamisk-skoltesamisk-sørsamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltingsområde, lulesamisk område der nordsamisk kan forekomme sammen med lulesamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-lulesamisk-sørsamisk-nordsamisk-skoltesamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltingsområde, lulesamisk område der sørdsamisk kan forekomme sammen med lulesamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-nordsamisk-skoltesamisk-lulesamisk-sørsamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltingsområde, nordsamisk område der lulesamisk kan forekomme sammen med nordsamisk.
+
+Denne brukes også for steder utenfor fastlandet.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-sørsamisk-lulesamisk-nordsamisk-skoltesamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltingsområde, sørsamisk område der lulesamisk kan forekomme sammen med sørsamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sørsamisk-lulesamisk-nordsamisk-skoltesamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, sørdsamisk område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kvensk-nordsamisk-skoltesamisk-lulesamisk-sørsamisk-norsk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, dersom kvensk skal prioriteres over nordsamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kvensk-norsk-nordsamisk-skoltesamisk-lulesamisk-sørsamisk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltningsområde dersom kvensk skal prioriteres over norsk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-skoltesamisk-nordsamisk-lulesamisk-sørsamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltningsområde dersom skoltesamisk skal prioriteres over norsk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="skoltesamisk-nordsamisk-lulesamisk-sørsamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i skoltesamisk forvaltningsområde dersom skoltesamisk skal prioriteres over nordsamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kvensk-skoltesamisk-nordsamisk-lulesamisk-sørsamisk-norsk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde dersom kvensk skal prioriteres over skoltesamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kvensk-norsk-skoltesamisk-nordsamisk-lulesamisk-sørsamisk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltningsområde dersom kvensk skal prioriteres over norsk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-nordsamisk-lulesamisk-sørsamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltingsområde, nordsamisk område der lulesamisk kan forekomme sammen med nordsamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-lulesamisk-nordsamisk-sørsamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltingsområde, lulesamisk område der nordsamisk kan forekomme sammen med lulesamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-lulesamisk-sørsamisk-nordsamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltingsområde, lulesamisk område der sørdsamisk kan forekomme sammen med lulesamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="norsk-sørsamisk-lulesamisk-nordsamisk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltingsområde, sørsamisk område der lulesamisk kan forekomme sammen med sørsamisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="nordsamisk-lulesamisk-sørsamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, nordsamisk område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="lulesamisk-nordsamisk-sørsamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, lulesamisk område der nordsamisk kan forekomme.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="lulesamisk-sørsamisk-nordsamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, lulesamisk område der sørsamisk kan forekomme.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="sørsamisk-lulesamisk-nordsamisk-norsk-kvensk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, sørdsamisk område.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kvensk-nordsamisk-lulesamisk-sørsamisk-norsk">
+        
+        <annotation>
+          
+          <documentation>Brukes i samisk forvaltningsområde, dersom kvensk skal prioriteres over samisk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+      
+      <enumeration value="kvensk-norsk-nordsamisk-lulesamisk-sørsamisk">
+        
+        <annotation>
+          
+          <documentation>Brukes i norsk forvaltningsområde dersom kvensk skal prioriteres over norsk.</documentation>
+        
+        </annotation>
+      
+      </enumeration>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <simpleType name="SpråkprioriteringKodeOtherType">
+    
+    <restriction base="string">
+      
+      <pattern value="other: \w{2,}"/>
+    
+    </restriction>
+  
+  </simpleType>
+  
+  <element name="Sted" substitutionGroup="app:Fellesegenskaper" type="app:StedType">
+    
+    <annotation>
+      
+      <documentation>Sted inneholder all egenskapene som er felles for de ulike stedsnavnene (og deres skrivemåter) for en lokalitet, uavhengig av språk.
+
+Med felles egenskaper menes posisjon, presentasjonsinformasjon, land, kommune, matrikkelnummer, navnetype, osv.</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="StedType">
+    
+    <complexContent>
+      
+      <extension base="app:FellesegenskaperType">
+        
+        <sequence>
+          
+          <element minOccurs="0" name="område" type="gml:SurfacePropertyType">
+            
+            <annotation>
+              
+              <documentation>extent: area over which an object extends</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="posisjon" type="gml:PointPropertyType">
+            
+            <annotation>
+              
+              <documentation>centerline: location where the object exists</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="senterlinje" type="gml:CurvePropertyType">
+            
+            <annotation>
+              
+              <documentation>centerline: cource follwed by the central part of the object</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="multipunkt" type="gml:MultiPointPropertyType">
+            
+            <annotation>
+              
+              <documentation>geometritype som benyttes for å representere flere objekter hvor egenskapene med unntak av geometrien er like</documentation>
+            
+            </annotation>
+          
+          </element>
+          
+          <element maxOccurs="unbounded" name="stedsnavn" type="app:StedsnavnPropertyType">
+            
+            <annotation>
+              
+              <documentation>navn på stedet/området/objektet.  Her angir registerføreren hvilket språk (og eventuelt opphavsspråket), alfabetkode (styres av systemet), navnestatus, vedtaksmyndighet, primærfunksjon, osv.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">STEDSNAVN</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="land" type="app:LandKodeType">
+            
+            <annotation>
+              
+              <documentation>Hvilke land steder ligger i.
+
+Tobokstavers kodeliste, subsett av ISO 3166-1 alpha-2.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">LAND</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="navneobjekthovedgruppe" type="app:NavneobjekthovedgruppeType">
+            
+            <annotation>
+              
+              <documentation>Hovedgruppene følger i hovedsak Inspire "NamedPlaceTypeValue", men populatedPlace og building er samlet under bebyggelse og hydrography er delt mellom sjø og ferskvann.</documentation>
+              
+              <appinfo>
+                
+                <defaultCodeSpace xmlns="http://www.opengis.net/gml/3.2">http://skjema.geonorge.no/SOSI/produktspesifikasjon/Stedsnavn/5.0/Navneobjekthovedgruppe</defaultCodeSpace>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVNEOBJEKTHOVEDGRUPPE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="navneobjektgruppe" type="app:NavneobjektgruppeType">
+            
+            <annotation>
+              
+              <documentation>Inndeling i kategorier under hver hovedgruppe.</documentation>
+              
+              <appinfo>
+                
+                <defaultCodeSpace xmlns="http://www.opengis.net/gml/3.2">http://skjema.geonorge.no/SOSI/produktspesifikasjon/Stedsnavn/5.0/Navneobjektgruppe</defaultCodeSpace>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVNEOBJEKTGRUPPE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="navneobjekttype" type="app:NavneobjekttypeType">
+            
+            <annotation>
+              
+              <documentation>Stedets navneobjekttype er en underinndeling av navneobjektgruppene som igjen er inndeling av navneobjekthovedgruppene.</documentation>
+              
+              <appinfo>
+                
+                <defaultCodeSpace xmlns="http://www.opengis.net/gml/3.2">http://skjema.geonorge.no/SOSI/produktspesifikasjon/Stedsnavn/5.0/Navneobjekttype</defaultCodeSpace>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVNEOBJEKTTYPE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="sortering" type="app:Sortering1KodeType">
+            
+            <annotation>
+              
+              <documentation>Sorteringsegenskapene skal benyttes til å angi stedets viktighet i forskjellige målestokker (i forhold til andre stedsnavn).</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SORTERING</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element minOccurs="0" name="språkprioritering" type="app:SpråkprioriteringKodeType">
+            
+            <annotation>
+              
+              <documentation>Angir rekkefølgen av navn på forskjellige språk som skal vises på skilt og kart, jf. forskriften § 7 annet ledd.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SPRÅKPRIORITERING</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element name="stedsnummer" type="integer">
+            
+            <annotation>
+              
+              <documentation>Stedsnummer, stedsnavnsnummer og skrivemåtenummer skal sammen utgjøre en såkalt tematisk id som brukes av registerførere som opplslagsnummer. Identifikatoren ligner litt på Gnr/Bnr/Fnr. 
+
+&lt;b>Stedsnummeret&lt;/b> er et løpende nummer systemet gir stedet som en identifikator. Stedsnummeret er unikt og kan ikke brukes om igjen.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">STEDSNUMMER</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+          
+          <element maxOccurs="unbounded" minOccurs="0" name="kommune" type="app:KommunePropertyType">
+            
+            <annotation>
+              
+              <documentation>Stedets kommunetilknytning avhenger av stedets geografiske beligenhet og viser hvlke kommuner stedet ligger i.</documentation>
+              
+              <appinfo>
+                
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">KOMMUNE</taggedValue>
+              
+              </appinfo>
+            
+            </annotation>
+          
+          </element>
+        
+        </sequence>
+      
+      </extension>
+    
+    </complexContent>
+  
+  </complexType>
+  
+  <complexType name="StedPropertyType">
+    
+    <sequence minOccurs="0">
+      
+      <element ref="app:Sted"/>
+    
+    </sequence>
+    
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  
+  </complexType>
+  
+  <element name="Stedsnavn" substitutionGroup="gml:AbstractObject" type="app:StedsnavnType">
+    
+    <annotation>
+      
+      <documentation>Navn på stedet/området/objektet.
+
+Her angir registerføreren hvilket språk (og eventuelt opphavsspråket), alfabetkode (styres av systemet), navnestatus, vedtaksmyndighet, primærfunksjon, osv...</documentation>
+    
+    </annotation>
+  
+  </element>
+  
+  <complexType name="StedsnavnType">
+    
+    <sequence>
+      
+      <element name="offentligBruk" type="boolean">
+        
+        <annotation>
+          
+          <documentation>om stedsnavnet har skrivemåtestatuser som gjør at det kan godkjennes for offentlig bruk.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">OFFENTLIGBRUK</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="navnesakstatus" type="app:NavnesakstatusKodeType">
+        
+        <annotation>
+          
+          <documentation>nåværende saksbehandlingsstatus for stedsnavnet og de tilhørende skrivemåtene.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVNESAKSTATUS</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="navnestatus" type="app:NavnestatuskodeType">
+        
+        <annotation>
+          
+          <documentation>Nåværende navnestatus (Hovednavn, sidenavn, undernavn, feilført eller historisk).</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVNESTATUS</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="navnesaksstatusdato" type="dateTime">
+        
+        <annotation>
+          
+          <documentation>Hentes fra fraDato på Skrivemåtestatushistorikk. En gyldighetsdato som forteller når en status startet, f.eks. datoen for et vedtak.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">NAVNESAKSSTATUSDATO</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="språk" type="app:SpråkKodeType">
+        
+        <annotation>
+          
+          <documentation>Angir hvilket språk stedsnavnet hører til, norsk, kvensk, nordsamisk, lulesamisk, sørsamisk osv.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SPRÅK</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element name="stedsnavnnummer" type="integer">
+        
+        <annotation>
+          
+          <documentation>Stedsnummer, stedsnavnsnummer og skrivemåtenummer skal sammen utgjøre en såkalt tematisk id som brukes av registerførere som opplslagsnummer. identifikatoren ligner litt på Gnr/Bnr/Fnr. 
+
+&lt;b>Stedsnavnsnummer&lt;/b> er et løpende nummer (starter på 1) systemet gir stedsnavnet som en identifikator. stedsnavnsnummeret er kun unikt under ett stedsnummer og kan ikke brukes om igjen for dette stedet.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">STEDSNAVNNUMMER</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element maxOccurs="unbounded" name="skrivemåte" type="app:SkrivemåtePropertyType">
+        
+        <annotation>
+          
+          <documentation>den skrivemåten av stedsnavnet som har en status som gjør at den anbefales til offentlig bruk.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">SKRIVEMÅTE</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+      
+      <element maxOccurs="unbounded" minOccurs="0" name="annenSkrivemåte" type="app:SkrivemåtePropertyType">
+        
+        <annotation>
+          
+          <documentation>de andre skrivemåtene av stedsnavnet som ikke er anbefalt for offentlig bruk.</documentation>
+          
+          <appinfo>
+            
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="SOSI_navn">ANNENSKRIVEMÅTE</taggedValue>
+          
+          </appinfo>
+        
+        </annotation>
+      
+      </element>
+    
+    </sequence>
+  
+  </complexType>
+  
+  <complexType name="StedsnavnPropertyType">
+    
+    <sequence>
+      
+      <element ref="app:Stedsnavn"/>
+    
+    </sequence>
+  
+  </complexType>
+
+</schema>


### PR DESCRIPTION
This is a back port of some earlier work on WFS Complex features. It is this PR that caused the resent troubles with server errors causing trouble in the build.

I've also included the commits that solved those troubles.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->