### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1595,6 +1595,7 @@
           <compilerArgs>
             <arg>-Xlint:${lint}</arg>
           </compilerArgs>
+            	<useIncrementalCompilation>true</useIncrementalCompilation>
         </configuration>
       </plugin>
 
@@ -2307,6 +2308,7 @@
                   <version>${errorProne.version}</version>
                 </path>
               </annotationProcessorPaths>
+            	<useIncrementalCompilation>true</useIncrementalCompilation>
             </configuration>
           </plugin>
         </plugins>
@@ -2346,6 +2348,7 @@
                   <version>${errorProne.version}</version>
                 </path>
               </annotationProcessorPaths>
+            	<useIncrementalCompilation>true</useIncrementalCompilation>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Maven can recompile only the classes that were affected by a change. This feature is the default. We can activate it by setting `<useIncrementalCompilation>true</useIncrementalCompilation>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.