### PR TITLE
[GEOT-7022]: Referencing factories deadlock prevention

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/ThreadedEpsgFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/ThreadedEpsgFactory.java
@@ -366,7 +366,11 @@ public class ThreadedEpsgFactory extends DeferredAuthorityFactory
      *     code.
      */
     private AbstractAuthorityFactory createBackingStore0() throws FactoryException, SQLException {
-        assert Thread.holdsLock(this);
+        /*
+         * We are locking on ReferencingFactoryFinder to avoid deadlocks.
+         * @see DeferredAuthorityFactory#getBackingStore()
+         */
+        assert Thread.holdsLock(ReferencingFactoryFinder.class);
         final Hints sourceHints = new Hints(hints);
         sourceHints.putAll(factories.getImplementationHints());
         if (datasource != null) {

--- a/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffCRSFactoryDeadlockTest.java
+++ b/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffCRSFactoryDeadlockTest.java
@@ -1,0 +1,109 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ */
+package org.geotools.gce.geotiff;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.measure.Unit;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.factory.AllAuthoritiesFactory;
+import org.geotools.util.factory.Hints;
+import org.junit.Test;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CRSAuthorityFactory;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+public class GeoTiffCRSFactoryDeadlockTest {
+
+    @Test
+    public void testDeadlockOnCRSFactories() throws ExecutionException, InterruptedException {
+        boolean potentialDeadlock = false;
+        final long timeout = 10;
+        final int size = 30;
+
+        final boolean[] exceptionOccurred = {false};
+        ExecutorService executorService = Executors.newFixedThreadPool(8);
+
+        List<Future> futures = new ArrayList<>(size);
+
+        for (int i = 0; i < size; i += 3) {
+            futures.add(getUnit(executorService, exceptionOccurred));
+            futures.add(getCRS(executorService, exceptionOccurred));
+            futures.add(getAuthorityFactory(executorService));
+        }
+
+        try {
+            for (Future future : futures) {
+                future.get(timeout, TimeUnit.SECONDS);
+            }
+            executorService.shutdown();
+            executorService.awaitTermination(timeout, TimeUnit.SECONDS);
+        } catch (InterruptedException | TimeoutException e) {
+            // Timeout occurred while waiting for execution termination.
+            potentialDeadlock = true;
+        }
+        assertFalse("FactoryException occurred", exceptionOccurred[0]);
+        assertFalse("The execution didn't finished yet: potential Deadlock", potentialDeadlock);
+    }
+
+    Future getAuthorityFactory(ExecutorService executorService) {
+        return executorService.submit(
+                () -> {
+                    CRSAuthorityFactory factory = CRS.getAuthorityFactory(true);
+                    assertNotNull(factory);
+                });
+    }
+
+    Future getUnit(ExecutorService executorService, final boolean[] exceptionOccurred) {
+        return executorService.submit(
+                () -> {
+                    Hints hints = new Hints();
+                    hints.add(new Hints(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true));
+                    AllAuthoritiesFactory factory = new AllAuthoritiesFactory(hints);
+                    Unit<?> unit = null;
+                    try {
+                        unit = factory.createUnit("EPSG:9102");
+                    } catch (FactoryException e) {
+                        exceptionOccurred[0] = true;
+                    }
+                    assertNotNull(unit);
+                });
+    }
+
+    Future getCRS(ExecutorService executorService, final boolean[] exceptionOccurred) {
+        return executorService.submit(
+                () -> {
+                    CoordinateReferenceSystem crs = null;
+                    try {
+                        crs = CRS.decode("EPSG:4326", true);
+                    } catch (FactoryException e) {
+                        exceptionOccurred[0] = true;
+                    }
+                    assertNotNull(crs);
+                });
+    }
+}


### PR DESCRIPTION
[![GEOT-7022](https://badgen.net/badge/JIRA/GEOT-7022/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7022) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->