### PR TITLE
[GEOT-7024] Extend GeoPackage process XSD definition to support arbitrary request parameters for tile layers

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/GeoPackageProcessRequest.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/GeoPackageProcessRequest.java
@@ -221,6 +221,27 @@ public class GeoPackageProcessRequest {
         }
     }
 
+    public static class Parameter {
+        String name;
+        String value;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
     public static class TilesLayer extends Layer {
 
         public static class TilesCoverage {
@@ -290,6 +311,7 @@ public class GeoPackageProcessRequest {
         protected String gridSetName = null;
         protected List<TileMatrix> grids = null;
         protected TilesCoverage coverage = null;
+        protected List<Parameter> parameters;
 
         @Override
         public LayerType getType() {
@@ -374,6 +396,14 @@ public class GeoPackageProcessRequest {
 
         public void setLayers(List<QName> layers) {
             this.layers = layers;
+        }
+
+        public List<Parameter> getParameters() {
+            return parameters;
+        }
+
+        public void setParameters(List<Parameter> parameters) {
+            this.parameters = parameters;
         }
     }
 

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/xml/GPKG.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/xml/GPKG.java
@@ -90,6 +90,9 @@ public final class GPKG extends XSD {
 
     public static final QName overview = new QName("http://www.opengis.net/gpkg", "overview");
 
+    public static final QName parametertype =
+            new QName("http://www.opengis.net/gpkg", "parametertype");
+
     /* Attributes */
 
 }

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/xml/GPKGConfiguration.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/xml/GPKGConfiguration.java
@@ -59,5 +59,6 @@ public class GPKGConfiguration extends Configuration {
                 GPKG.gridsettype_grids, Gridsettype_gridsBinding.class);
         container.registerComponentImplementation(GPKG.bboxtype, BboxtypeBinding.class);
         container.registerComponentImplementation(GPKG.overview, OverviewBinding.class);
+        container.registerComponentImplementation(GPKG.parametertype, ParameterBinding.class);
     }
 }

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/xml/Geopkgtype_tilesBinding.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/xml/Geopkgtype_tilesBinding.java
@@ -21,11 +21,13 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
 import org.geotools.geopkg.TileMatrix;
 import org.geotools.geopkg.wps.GeoPackageProcessRequest;
 import org.geotools.geopkg.wps.GeoPackageProcessRequest.Layer;
+import org.geotools.geopkg.wps.GeoPackageProcessRequest.Parameter;
 import org.geotools.xs.bindings.XSQNameBinding;
 import org.geotools.xsd.ElementInstance;
 import org.geotools.xsd.Node;
@@ -115,6 +117,17 @@ public class Geopkgtype_tilesBinding extends LayertypeBinding {
             List<TileMatrix> list = (List<TileMatrix>) gridSet;
             layer.setGrids(list);
         }
+
+        Object parameters = node.getChildValue("parameters");
+        if (parameters instanceof Parameter) {
+            layer.setParameters(Arrays.asList((Parameter) parameters));
+        } else if (parameters instanceof Map) {
+            @SuppressWarnings("unchecked")
+            List<Parameter> parametersList =
+                    (List<Parameter>) ((Map<?, ?>) parameters).get("parameters");
+            layer.setParameters(parametersList);
+        }
+
         return layer;
     }
 }

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/xml/ParameterBinding.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/wps/xml/ParameterBinding.java
@@ -1,0 +1,47 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2020, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.geopkg.wps.xml;
+
+import javax.xml.namespace.QName;
+import org.geotools.geopkg.wps.GeoPackageProcessRequest;
+import org.geotools.xsd.AbstractComplexBinding;
+import org.geotools.xsd.ElementInstance;
+import org.geotools.xsd.Node;
+
+public class ParameterBinding extends AbstractComplexBinding {
+
+    private static final String NAME = "name";
+
+    @Override
+    public QName getTarget() {
+        return GPKG.parametertype;
+    }
+
+    @Override
+    public Class getType() {
+        return GeoPackageProcessRequest.Parameter.class;
+    }
+
+    @Override
+    public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
+        GeoPackageProcessRequest.Parameter parameter = new GeoPackageProcessRequest.Parameter();
+        parameter.setName((String) node.getAttributeValue(NAME));
+        parameter.setValue(node.getComponent().getText());
+
+        return parameter;
+    }
+}

--- a/modules/plugin/geopkg/src/main/resources/org/geotools/geopkg/wps/xml/gpkg.xsd
+++ b/modules/plugin/geopkg/src/main/resources/org/geotools/geopkg/wps/xml/gpkg.xsd
@@ -87,6 +87,22 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="parametertype">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="name" type="xs:string"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:element name="parameter" type="gpkg:parametertype"/>
+
+  <xs:complexType name="parameterstype">
+    <xs:sequence>
+      <xs:element ref="gpkg:parameter" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:complexType name="geopkgtype">
     <xs:sequence>
       <xs:element name="features" minOccurs="0" maxOccurs="unbounded">
@@ -123,6 +139,7 @@
                 <xs:element name="transparent" type="xs:boolean" minOccurs="0" />
                 <xs:element name="coverage" type="gpkg:coveragetype" minOccurs="0" />
                 <xs:element name="gridset" type="gpkg:gridsettype" minOccurs="0"  />
+                <xs:element name="parameters" type="gpkg:parameterstype" minOccurs="0"  />
               </xs:sequence>
             </xs:extension>
           </xs:complexContent>

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/wps/xml/ParameterBindingTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/wps/xml/ParameterBindingTest.java
@@ -1,0 +1,49 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.geopkg.wps.xml;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.geopkg.wps.GeoPackageProcessRequest;
+import org.geotools.xsd.Binding;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+public class ParameterBindingTest extends GPKGTestSupport {
+    @Test
+    public void testType() {
+        assertEquals(
+                GeoPackageProcessRequest.Parameter.class, binding(GPKG.parametertype).getType());
+    }
+
+    @Test
+    public void testExecutionMode() {
+        assertEquals(Binding.OVERRIDE, binding(GPKG.parametertype).getExecutionMode());
+    }
+
+    @Test
+    public void testParse() throws Exception {
+        buildDocument(
+                "<param name=\"env\" xmlns=\"http://www.opengis.net/gpkg\">date:2010-10-01</param>");
+        Object result = parse(GPKG.parametertype);
+        assertThat(result, CoreMatchers.instanceOf(GeoPackageProcessRequest.Parameter.class));
+        GeoPackageProcessRequest.Parameter parameter = (GeoPackageProcessRequest.Parameter) result;
+        assertEquals("env", parameter.getName());
+        assertEquals("date:2010-10-01", parameter.getValue());
+    }
+}


### PR DESCRIPTION
[![GEOT-7024](https://badgen.net/badge/JIRA/GEOT-7024/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7024) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->