### PR TITLE
[GEOT-7028] - GetTile request's in WMTS represents one single tile, not a set

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSHelper.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSHelper.java
@@ -33,12 +33,16 @@ public class WMTSHelper {
     public static String replaceToken(String baseUrl, String dimName, String dimValue) {
         String token = "{" + dimName.toLowerCase() + "}";
         int index = baseUrl.toLowerCase().indexOf(token);
-        if (index != -1) {
-            return baseUrl.substring(0, index)
-                    + (dimValue == null ? "" : dimValue)
-                    + baseUrl.substring(index + dimName.length() + 2);
-        } else {
-            return baseUrl;
+        try {
+            if (index != -1) {
+                return baseUrl.substring(0, index)
+                        + (dimValue == null ? "" : URLEncoder.encode(dimValue, "UTF-8"))
+                        + baseUrl.substring(index + dimName.length() + 2);
+            } else {
+                return baseUrl;
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Doesn't support UTF-8", e);
         }
     }
 

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
@@ -97,16 +97,6 @@ public class WMTSSpecification extends Specification {
         return new GetMultiTileRequest(server, props, caps, client);
     }
 
-    /** Create either a GetKVPTileRequest or GetRestTileRequest */
-    GetSingleTileRequest createGetTileRequest(URL url, WMTSServiceType type, HTTPClient client) {
-        Properties props = new Properties();
-        props.put("type", type.name());
-
-        return (type == WMTSServiceType.KVP
-                ? new GetKVPTileRequest(url, props, client)
-                : new GetRestTileRequest(url, props, client));
-    }
-
     /** @deprecated Avoid usage of this - change to GetMultiTileRequest */
     @Deprecated
     public static class GetTileRequest extends GetMultiTileRequest {
@@ -278,6 +268,7 @@ public class WMTSSpecification extends Specification {
 
         GetKVPTileRequest(URL onlineResource, Properties properties, HTTPClient client) {
             super(onlineResource, properties, client);
+            properties.setProperty("type", "KVP");
         }
 
         @Override

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
@@ -17,6 +17,7 @@
 package org.geotools.ows.wmts;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,6 +47,15 @@ import org.geotools.util.logging.Logging;
  *
  * <p>Used to create GetCapabilities and GetTile requests.
  *
+ * <p>GetTile request are separated into three different objects:
+ *
+ * <ul>
+ *   <li>GetMultiTileRequest - Used to get a set of tiles within an extent
+ *   <li>GetKVPTileRequest - Used to get a tile request with query string parameteres
+ *   <li>GetRestTileRequest - Used to get a tile request with url based on resourceurl in
+ *       capabilities
+ * </ul>
+ *
  * @author ian
  * @author Emanuele Tajariol (etj at geo-solutions dot it)
  */
@@ -67,31 +77,71 @@ public class WMTSSpecification extends Specification {
         return new GetCapsRequest(server);
     }
 
+    /** @deprecated Use createGetMultiTileRequest */
+    @Deprecated
     public GetTileRequest createGetTileRequest(
             URL server, Properties props, WMTSCapabilities caps) {
         return this.createGetTileRequest(server, props, caps, HTTPClientFinder.createClient());
     }
 
+    /** @deprecated Use createGetMultiTileRequest */
+    @Deprecated
     public GetTileRequest createGetTileRequest(
             URL server, Properties props, WMTSCapabilities caps, HTTPClient client) {
         return new GetTileRequest(server, props, caps, client);
     }
 
-    public static class GetTileRequest extends AbstractGetTileRequest {
+    /** Create a GetMultiTileRequest */
+    GetMultiTileRequest createGetMultiTileRequest(
+            URL server, Properties props, WMTSCapabilities caps, HTTPClient client) {
+        return new GetMultiTileRequest(server, props, caps, client);
+    }
 
-        private static Logger LOGGER = Logging.getLogger(GetTileRequest.class);
+    /** Create either a GetKVPTileRequest or GetRestTileRequest */
+    GetSingleTileRequest createGetTileRequest(URL url, WMTSServiceType type, HTTPClient client) {
+        Properties props = new Properties();
+        props.put("type", type.name());
+
+        return (type == WMTSServiceType.KVP
+                ? new GetKVPTileRequest(url, props, client)
+                : new GetRestTileRequest(url, props, client));
+    }
+
+    /** @deprecated Avoid usage of this - change to GetMultiTileRequest */
+    @Deprecated
+    public static class GetTileRequest extends GetMultiTileRequest {
+
+        public GetTileRequest(
+                URL onlineResource,
+                Properties properties,
+                WMTSCapabilities capabilities,
+                HTTPClient client) {
+            super(onlineResource, properties, capabilities, client);
+        }
+
+        /** Returns a GetTileResponse which in most cases represents an Image. */
+        @Override
+        public Response createResponse(HTTPResponse response) throws ServiceException, IOException {
+            return new GetTileResponse(response, getType());
+        }
+    }
+
+    /** GetMultiTileRequest - used for getting a Set of tiles */
+    public static class GetMultiTileRequest extends AbstractGetTileRequest {
+
+        private static Logger LOGGER = Logging.getLogger(GetMultiTileRequest.class);
 
         public static final String DIMENSION_TIME = "time";
 
         public static final String DIMENSION_ELEVATION = "elevation";
 
         /** */
-        public GetTileRequest(
+        public GetMultiTileRequest(
                 URL onlineResource, Properties properties, WMTSCapabilities capabilities) {
             this(onlineResource, properties, capabilities, HTTPClientFinder.createClient());
         }
 
-        public GetTileRequest(
+        public GetMultiTileRequest(
                 URL onlineResource,
                 Properties properties,
                 WMTSCapabilities capabilities,
@@ -108,12 +158,6 @@ public class WMTSSpecification extends Specification {
                 this.type = capabilities.getType();
             }
             this.capabilities = capabilities;
-        }
-
-        /** Returns a GetTileResponse which in most cases represents an Image. */
-        @Override
-        public Response createResponse(HTTPResponse response) throws ServiceException, IOException {
-            return new GetTileResponse(response, getType());
         }
 
         @Override
@@ -207,6 +251,113 @@ public class WMTSSpecification extends Specification {
             params.put("TileRow", "{TileRow}");
 
             return params;
+        }
+    }
+
+    /** Represents a GetTile request for a single tile. */
+    abstract static class GetSingleTileRequest extends AbstractGetTileRequest {
+
+        GetSingleTileRequest(URL onlineResource, Properties properties, HTTPClient client) {
+            super(onlineResource, properties, client);
+        }
+
+        @Override
+        protected void initVersion() {
+            setProperty(VERSION, WMTS_VERSION);
+        }
+
+        @Override
+        protected String createTemplateUrl(String tileMatrixSetName) {
+            throw new UnsupportedOperationException(
+                    "Single tile request's shouldn't use a template url.");
+        }
+    }
+
+    /** GetTile request base on query string parameters */
+    public static class GetKVPTileRequest extends GetSingleTileRequest {
+
+        GetKVPTileRequest(URL onlineResource, Properties properties, HTTPClient client) {
+            super(onlineResource, properties, client);
+        }
+
+        @Override
+        public URL getFinalURL() {
+            if (this.layer == null
+                    || this.styleName == null
+                    || this.getFormat() == null
+                    || this.getTileMatrixSet() == null
+                    || this.getTileMatrix() == null
+                    || this.getTileCol() == null
+                    || this.getTileRow() == null) {
+                throw new IllegalStateException(
+                        "Missing some properties for a proper GetTile-request.");
+            }
+
+            this.setProperty("layer", this.layer.getName());
+            this.setProperty("style", this.styleName);
+            this.setProperty("format", this.getFormat());
+            this.setProperty("tilematrixset", this.getTileMatrixSet());
+            this.setProperty("TileMatrix", this.getTileMatrix());
+            this.setProperty("TileCol", this.getTileCol().toString());
+            this.setProperty("TileRow", this.getTileRow().toString());
+
+            return super.getFinalURL();
+        }
+
+        /** Creating a GetTileResponse */
+        @Override
+        public GetTileResponse createResponse(HTTPResponse httpResponse)
+                throws ServiceException, IOException {
+            return new GetTileResponse(httpResponse, WMTSServiceType.KVP);
+        }
+    }
+
+    /** GetTile request based on a resourceUrl specified in Capabilities */
+    public static class GetRestTileRequest extends GetSingleTileRequest {
+
+        GetRestTileRequest(URL onlineResource, Properties properties, HTTPClient client) {
+            super(onlineResource, properties, client);
+        }
+
+        /*
+         * Uses the resourceurl specified in capabilites to create a url for one single tile
+         */
+        @Override
+        public URL getFinalURL() {
+            if (this.layer == null
+                    || this.styleName == null
+                    || this.getFormat() == null
+                    || this.getTileMatrixSet() == null
+                    || this.getTileMatrix() == null
+                    || this.getTileCol() == null
+                    || this.getTileRow() == null) {
+                throw new IllegalStateException(
+                        "Missing some properties for a proper GetTile-request.");
+            }
+            String baseUrl = onlineResource.toExternalForm();
+
+            String layerString = WMTSHelper.usePercentEncodingForSpace(layer.getName());
+            String styleString = WMTSHelper.usePercentEncodingForSpace(styleName);
+
+            baseUrl = WMTSHelper.replaceToken(baseUrl, "layer", layerString);
+            baseUrl = WMTSHelper.replaceToken(baseUrl, "style", styleString);
+            baseUrl = WMTSHelper.replaceToken(baseUrl, "tilematrixset", this.getTileMatrixSet());
+            baseUrl = WMTSHelper.replaceToken(baseUrl, "tilematrix", this.getTileMatrix());
+            baseUrl = WMTSHelper.replaceToken(baseUrl, "tilerow", this.getTileRow().toString());
+            baseUrl = WMTSHelper.replaceToken(baseUrl, "tilecol", this.getTileCol().toString());
+
+            try {
+                return new URL(baseUrl);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException("Error creating URL for GetTile request", e);
+            }
+        }
+
+        /** Creating a GetTileResponse */
+        @Override
+        public GetTileResponse createResponse(HTTPResponse httpResponse)
+                throws ServiceException, IOException {
+            return new GetTileResponse(httpResponse, WMTSServiceType.REST);
         }
     }
 

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
@@ -110,6 +110,7 @@ public class WMTSSpecification extends Specification {
             this.capabilities = capabilities;
         }
 
+        /** Returns a GetTileResponse which in most cases represents an Image. */
         @Override
         public Response createResponse(HTTPResponse response) throws ServiceException, IOException {
             return new GetTileResponse(response, getType());

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
@@ -205,7 +205,7 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
         return (GetTileResponse) internalIssueRequest(tileRequest);
     }
 
-    /** Creates a GetMultiTileRequest */
+    /** Creates a GetMultiTileRequest, signature kept for now. */
     public GetTileRequest createGetTileRequest() {
 
         URL url;
@@ -224,32 +224,6 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
         GetTileRequest request =
                 ((WMTSSpecification) specification)
                         .createGetMultiTileRequest(url, props, capabilities, this.getHTTPClient());
-
-        if (headers != null) {
-            request.getHeaders().putAll(headers);
-        }
-        return request;
-    }
-
-    /** Creates a GetSingleTileRequest */
-    public GetTileRequest createGetTileRequest(WMTSServiceType type) {
-
-        OperationType getTile = capabilities.getRequest().getGetTile();
-        if (getTile == null) {
-            type = WMTSServiceType.REST;
-        }
-
-        URL url;
-        if (WMTSServiceType.KVP.equals(type)) {
-            url = findURL(getTile);
-        } else {
-            type = WMTSServiceType.REST;
-            url = serverURL;
-        }
-
-        GetSingleTileRequest request =
-                ((WMTSSpecification) specification)
-                        .createGetTileRequest(url, type, this.getHTTPClient());
 
         if (headers != null) {
             request.getHeaders().putAll(headers);

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
@@ -145,7 +145,7 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
     }
 
     /**
-     * Set up the WebMapTileServer with the given capabilities. Using the default http client.
+     * Set up the WebMapTileServer with the given capabilities, using a custom http client.
      *
      * @param capabilities
      * @throws ServiceException

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
@@ -36,6 +36,7 @@ import org.geotools.ows.wms.response.GetFeatureInfoResponse;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
 import org.geotools.ows.wmts.model.WMTSServiceType;
 import org.geotools.ows.wmts.request.GetTileRequest;
+import org.geotools.ows.wmts.response.GetTileResponse;
 import org.geotools.referencing.CRS;
 import org.geotools.tile.Tile;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -140,10 +141,19 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
      * @throws IOException
      */
     public WebMapTileServer(WMTSCapabilities capabilities) throws ServiceException, IOException {
-        super(
-                capabilities.getRequest().getGetCapabilities().getGet(),
-                HTTPClientFinder.createClient(),
-                capabilities);
+        this(capabilities, HTTPClientFinder.createClient());
+    }
+
+    /**
+     * Set up the WebMapTileServer with the given capabilities. Using the default http client.
+     *
+     * @param capabilities
+     * @throws ServiceException
+     * @throws IOException
+     */
+    public WebMapTileServer(WMTSCapabilities capabilities, HTTPClient httpClient)
+            throws ServiceException, IOException {
+        super(capabilities.getRequest().getGetCapabilities().getGet(), httpClient, capabilities);
         setupType();
     }
 
@@ -183,6 +193,12 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
     /** */
     public Set<Tile> issueRequest(GetTileRequest tileRequest) throws ServiceException {
         return tileRequest.getTiles();
+    }
+
+    /** The new issueRequest, which gives a GetTileResponse in response for a GetTileRequest. */
+    public GetTileResponse issueRequestForTileResponse(GetTileRequest tileRequest)
+            throws IOException, ServiceException {
+        return (GetTileResponse) internalIssueRequest(tileRequest);
     }
 
     /** @return */

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
@@ -150,7 +150,7 @@ public class WMTSTileService extends TileService {
             case KVP:
                 return WMTSHelper.appendQueryString(
                         templateURL,
-                        WMTSSpecification.GetTileRequest.getKVPparams(
+                        WMTSSpecification.GetMultiTileRequest.getKVPparams(
                                 layerName, styleName, tileMatrixSet, "image/png"));
             case REST:
                 templateURL = WMTSHelper.replaceToken(templateURL, "layer", layerName);

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSCoverageReader.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSCoverageReader.java
@@ -293,7 +293,7 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
             }
 
             getTileRequest().setCRS(gridEnvelope.getCoordinateReferenceSystem());
-            Set<Tile> responses = wmts.issueRequest(getTileRequest());
+            Set<Tile> responses = getTileRequest().getTiles();
             if (responses.isEmpty()) {
                 if (LOGGER.isLoggable(Level.FINE))
                     LOGGER.fine("Found 0 tiles in " + requestedEnvelope);

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -67,14 +67,6 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     public static final String FORMAT = "Format";
 
-    public static final String TILECOL = "TileCol";
-
-    public static final String TILEROW = "TileRow";
-
-    public static final String TILEMATRIX = "TileMatrix";
-
-    public static final String TILEMATRIXSET = "TileMatrixSet";
-
     private final HTTPClient client;
 
     protected WMTSLayer layer = null;
@@ -102,6 +94,14 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
     private final Map<String, String> headers = new HashMap<>();
 
     private String format = null;
+
+    private String tileMatrixSet = null;
+
+    private String tileMatrix = null;
+
+    private Integer tileRow = null;
+
+    private Integer tileCol = null;
 
     /**
      * Constructs a GetMapRequest. The data passed in represents valid values that can be used.
@@ -153,6 +153,42 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
     @Override
     public void setFormat(String format) {
         this.format = format;
+    }
+
+    @Override
+    public void setTileMatrixSet(String tileMatrixSet) {
+        this.tileMatrixSet = tileMatrixSet;
+    }
+
+    protected String getTileMatrixSet() {
+        return tileMatrixSet;
+    }
+
+    @Override
+    public void setTileMatrix(String tileMatrix) {
+        this.tileMatrix = tileMatrix;
+    }
+
+    public String getTileMatrix() {
+        return tileMatrix;
+    }
+
+    @Override
+    public void setTileRow(Integer tileRow) {
+        this.tileRow = tileRow;
+    }
+
+    protected Integer getTileRow() {
+        return tileRow;
+    }
+
+    @Override
+    public void setTileCol(Integer tileCol) {
+        this.tileCol = tileCol;
+    }
+
+    protected Integer getTileCol() {
+        return tileCol;
     }
 
     @Override
@@ -312,7 +348,7 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
                     if (LOGGER.isLoggable(Level.FINE)) {
                         LOGGER.fine("selected matrix set:" + matrixSet.getIdentifier());
                     }
-                    setProperty(TILEMATRIXSET, matrixSet.getIdentifier());
+                    setTileMatrixSet(matrixSet.getIdentifier());
                     retMatrixSet = matrixSet;
 
                     break;
@@ -333,7 +369,7 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
                     if (LOGGER.isLoggable(Level.FINE)) {
                         LOGGER.fine("defaulting matrix set:" + matrix.getIdentifier());
                     }
-                    setProperty(TILEMATRIXSET, matrix.getIdentifier());
+                    setTileMatrixSet(matrix.getIdentifier());
                     retMatrixSet = matrix;
 
                     break;

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -17,9 +17,10 @@
 
 package org.geotools.ows.wmts.request;
 
-import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -27,11 +28,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.geotools.data.ows.Response;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.http.HTTPClient;
 import org.geotools.http.HTTPClientFinder;
-import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
 import org.geotools.ows.wms.StyleImpl;
 import org.geotools.ows.wmts.WMTSHelper;
@@ -62,9 +61,11 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     static WMTSTileFactory factory = new WMTSTileFactory();
 
-    public static final String LAYER = "Layer";
+    public static final String LAYER = "layer";
 
-    public static final String STYLE = "Style";
+    public static final String STYLE = "style";
+
+    public static final String FORMAT = "format";
 
     public static final String TILECOL = "TileCol";
 
@@ -100,7 +101,7 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     private final Map<String, String> headers = new HashMap<>();
 
-    private String format;
+    private String format = null;
 
     /**
      * Constructs a GetMapRequest. The data passed in represents valid values that can be used.
@@ -124,12 +125,6 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
     @Override
     protected void initRequest() {
         setProperty(REQUEST, "GetTile");
-    }
-
-    @Override
-    public Response createResponse(HTTPResponse response) throws ServiceException, IOException {
-        // TODO Auto-generated method stub
-        return null;
     }
 
     @Override
@@ -263,7 +258,20 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
                 }
             }
         } else {
-            return super.getFinalURL();
+            try {
+                if (layer != null) {
+                    setProperty(LAYER, URLEncoder.encode(layer.getName(), "UTF-8"));
+                }
+                if (styleName != null) {
+                    setProperty(STYLE, URLEncoder.encode(styleName, "UTF-8"));
+                }
+                if (format != null) {
+                    setProperty(FORMAT, URLEncoder.encode(format, "UTF-8"));
+                }
+                return super.getFinalURL();
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException("Missing encoding for UTF-8.", e);
+            }
         }
     }
 

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -61,11 +61,11 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     static WMTSTileFactory factory = new WMTSTileFactory();
 
-    public static final String LAYER = "layer";
+    public static final String LAYER = "Layer";
 
-    public static final String STYLE = "style";
+    public static final String STYLE = "Style";
 
-    public static final String FORMAT = "format";
+    public static final String FORMAT = "Format";
 
     public static final String TILECOL = "TileCol";
 

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/GetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/GetTileRequest.java
@@ -42,6 +42,14 @@ public interface GetTileRequest extends Request {
 
     void setFormat(String format);
 
+    void setTileMatrixSet(String tileMatrixSet);
+
+    void setTileMatrix(String tileMatrix);
+
+    void setTileRow(Integer tileRow);
+
+    void setTileCol(Integer tileCol);
+
     Set<Tile> getTiles() throws ServiceException;
 
     void setRequestedHeight(int height);

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/response/GetTileResponse.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/response/GetTileResponse.java
@@ -16,23 +16,51 @@
  */
 package org.geotools.ows.wmts.response;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URL;
 import org.geotools.data.ows.Response;
 import org.geotools.http.HTTPResponse;
+import org.geotools.image.io.ImageIOExt;
 import org.geotools.ows.ServiceException;
 import org.geotools.ows.wmts.model.WMTSServiceType;
 
-/** @author ian */
+/**
+ * Represents the response of a tile request.
+ *
+ * <p>In most cases this is a image, but it can also be a file like kml with reference to an image.
+ * In such cases the content-type / responseStream must be used. Error-situations is managed in the
+ * same manner as other OWS responses.
+ *
+ * @author ian
+ */
 public class GetTileResponse extends Response {
+
     private WMTSServiceType type;
 
     private URL requestURL;
 
+    private final BufferedImage tileImage;
+
+    /**
+     * Constructor of GetTileResponse. Reads the image if the content-type is set to image. Other
+     * content-types should use the responseStream.
+     */
     public GetTileResponse(HTTPResponse httpResponse, WMTSServiceType wmtsServiceType)
             throws ServiceException, IOException {
         super(httpResponse);
         this.setType(wmtsServiceType);
+
+        String format = httpResponse.getContentType();
+        if (format.startsWith("image")) {
+            try {
+                tileImage = ImageIOExt.readBufferedImage(httpResponse.getResponseStream());
+            } finally {
+                httpResponse.dispose();
+            }
+        } else {
+            tileImage = null;
+        }
     }
 
     /** @return the type */
@@ -53,5 +81,10 @@ public class GetTileResponse extends Response {
     /** @param requestURL the requestURL to set */
     public void setRequestURL(URL requestURL) {
         this.requestURL = requestURL;
+    }
+
+    /** The tile image in cases where content-type is set to image. */
+    public BufferedImage getTileImage() {
+        return tileImage;
     }
 }

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
@@ -26,7 +26,6 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.Map;
 import java.util.Set;
 import org.geotools.TestData;
@@ -37,9 +36,10 @@ import org.geotools.http.HTTPResponse;
 import org.geotools.http.MockHttpClient;
 import org.geotools.http.MockHttpResponse;
 import org.geotools.ows.wms.Layer;
+import org.geotools.ows.wmts.WMTSSpecification.GetSingleTileRequest;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
 import org.geotools.ows.wmts.model.WMTSLayer;
-import org.geotools.ows.wmts.request.AbstractGetTileRequest;
+import org.geotools.ows.wmts.model.WMTSServiceType;
 import org.geotools.ows.wmts.request.GetTileRequest;
 import org.geotools.ows.wmts.response.GetTileResponse;
 import org.geotools.referencing.CRS;
@@ -274,19 +274,17 @@ public class WebMapTileServerTest {
                 new MockHttpResponse(TestData.file(null, "world.png"), "image/png"));
 
         WebMapTileServer server = new WebMapTileServer(capabilities, httpClient);
-        GetTileRequest request = server.createGetTileRequest();
+        GetSingleTileRequest request =
+                (GetSingleTileRequest) server.createGetTileRequest(WMTSServiceType.KVP);
         request.setLayer(server.getCapabilities().getLayer("spearfish"));
         request.setStyle("default");
         request.setFormat("image/png");
+        request.setTileMatrixSet("EPSG:4326");
+        request.setTileMatrix("EPSG:4326:0");
+        request.setTileRow(0);
+        request.setTileCol(0);
 
-        request.setProperty(
-                AbstractGetTileRequest.TILEMATRIXSET, URLEncoder.encode("EPSG:4326", "UTF-8"));
-        request.setProperty(
-                AbstractGetTileRequest.TILEMATRIX, URLEncoder.encode("EPSG:4326:0", "UTF-8"));
-        request.setProperty(AbstractGetTileRequest.TILEROW, "0");
-        request.setProperty(AbstractGetTileRequest.TILECOL, "0");
-
-        GetTileResponse response = server.issueRequestForTileResponse(request);
+        GetTileResponse response = server.issueRequest(request);
         BufferedImage tileImage = response.getTileImage();
         Assert.assertNotNull(tileImage);
     }

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSCoverageReaderTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSCoverageReaderTest.java
@@ -250,7 +250,7 @@ public class WMTSCoverageReaderTest {
         assertNotNull(grid);
         GetTileRequest mapRequest = wcr.getTileRequest();
         mapRequest.setCRS(grid.getCoordinateReferenceSystem());
-        Set<Tile> responses = wcr.wmts.issueRequest(mapRequest);
+        Set<Tile> responses = mapRequest.getTiles();
         for (Tile t : responses) {
             /*System.out.println(t);
             // System.out.println(t.getTileIdentifier() + " " + t.getExtent());*/

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSCoverageReaderTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSCoverageReaderTest.java
@@ -103,7 +103,7 @@ public class WMTSCoverageReaderTest {
         assertThat(
                 "Expect format=image/jpeg in the request url",
                 url.toString(),
-                containsString("format=image%2Fjpeg"));
+                containsString("Format=image%2Fjpeg"));
     }
 
     @Test

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/LantmaterietWMTSServerOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/LantmaterietWMTSServerOnlineTest.java
@@ -213,7 +213,7 @@ public class LantmaterietWMTSServerOnlineTest extends OnlineTestCase {
         request.setCRS(crs);
         request.setRequestedBBox(requested);
 
-        return wmts.issueRequest(request);
+        return request.getTiles();
     }
 
     private RenderedImage getRenderImageResult(

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/RestWMTSOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/RestWMTSOnlineTest.java
@@ -138,7 +138,7 @@ public class RestWMTSOnlineTest extends OnlineTestCase {
         request.setRequestedBBox(re);
 
         // System.out.println(request.getFinalURL());
-        Set<Tile> responses = wmts.issueRequest(request);
+        Set<Tile> responses = request.getTiles();
         assertFalse(responses.isEmpty());
         for (Tile response : responses) {
             // System.out.println("Content Type: " + response.getContentType());

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/WebMapTileServerOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/WebMapTileServerOnlineTest.java
@@ -124,7 +124,7 @@ public class WebMapTileServerOnlineTest extends OnlineTestCase {
         request.setRequestedBBox(re);
 
         // System.out.println(request.getFinalURL());
-        Set<Tile> responses = wmts.issueRequest(request);
+        Set<Tile> responses = request.getTiles();
         assertFalse(responses.isEmpty());
         for (Tile response : responses) {
             // System.out.println("Content Type: " + response.getContentType());

--- a/modules/library/http/src/test/java/org/geotools/http/MockHttpClient.java
+++ b/modules/library/http/src/test/java/org/geotools/http/MockHttpClient.java
@@ -140,7 +140,9 @@ public class MockHttpClient extends AbstractHttpClient {
             }
             return Arrays.stream(url.getQuery().split("&"))
                     .map(s -> s.split("="))
-                    .collect(Collectors.toMap(o -> decode(o[0]), o -> decode(o[1])));
+                    .collect(
+                            Collectors.toMap(
+                                    o -> decode(o[0]), o -> (o.length == 2 ? decode(o[1]) : "")));
         }
 
         private static String decode(final String encoded) {


### PR DESCRIPTION
[![GEOT-7028](https://badgen.net/badge/JIRA/GEOT-7028/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7028) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I've added a function issueRequestForTileResponse to org.geotools.ows.wmts.WebMapTileServer. The name isn't in accordance with the usual OWS server instances, but that's because of the original issueRequest that returns a Set of Tile's. This is unfortunate, but before we can deprecate and change the return, we must find an alternative solution. This signature is also used within GeoServer.

In addition I've changed GetTileResponse so that it tries to read the image of the response.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->