### PR TITLE
Fix for ImageWorker

### DIFF
--- a/modules/library/coverage/src/test/java/org/geotools/image/ImageWorkerTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/image/ImageWorkerTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2006-2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2006-2021, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -2451,5 +2451,14 @@ public final class ImageWorkerTest extends GridProcessingTestBase {
         Histogram histogram = iw.getHistogram(new int[] {1}, minimums, maximums);
         Histogram histogram2 = iw.getHistogram(new int[] {1}, minimums, maximums);
         assertEquals(histogram.getBins(0)[0], histogram2.getBins(0)[0]);
+    }
+
+    @Test(expected = Test.None.class /* No IllegalArgumentException */)
+    public void testReattachScaledAlphaChannel() {
+        BufferedImage bi = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_GRAY);
+        ImageWorker iw = new ImageWorker(bi);
+        RenderingHints hints = new RenderingHints(null);
+        hints.put(JAI.KEY_IMAGE_LAYOUT, new ImageLayout(0, 0, 1, 1));
+        iw.prepareForScaledAlphaChannel(bi, hints, bi.getColorModel(), bi.getSampleModel());
     }
 }


### PR DESCRIPTION
A lot of my data is raster data with alpha-channel. About 2% fail when serving them through the tile server at some resolutions.  I can't produce a small, self-contained example, unfortunately. But I have tracked it down and it seems the alpha-channel is rendered separately from the rest of the image and is "allergic" to 0-size tile-width. This is the way I fixed it in 21.1 (verified in my environment). If necessary, I can give you the stack trace from the logs, the AWT class doesn't like 0.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

I wasn't able to create a Jira issue, because the Attlassian license limit was reached, or so it said. The issue was discussed on the mailing list a few weeks ago, Jody Garnett was involved. If you need a signed contribution agreement, I can forward that, but I consider the issue minor enough not to do so at this point in time.