### PR TITLE
[GEOT-7031] Elasticsearch geohash process can fail with NPE in invertQuery

### DIFF
--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/GeoHashGridProcess.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/GeoHashGridProcess.java
@@ -164,31 +164,32 @@ public class GeoHashGridProcess implements VectorProcess {
 
         final BBOXRemovingFilterVisitor visitor = new BBOXRemovingFilterVisitor();
         Filter filter = (Filter) targetQuery.getFilter().accept(visitor, null);
-        final String geometryName = visitor.getGeometryPropertyName();
-        if (geometryName != null) {
-            final BBOX bbox;
-            try {
-                if (envelope.getCoordinateReferenceSystem() != null) {
-                    envelope = envelope.transform(DefaultGeographicCRS.WGS84, false);
-                }
-                bbox =
-                        FILTER_FACTORY.bbox(
-                                geometryName,
-                                envelope.getMinX(),
-                                envelope.getMinY(),
-                                envelope.getMaxX(),
-                                envelope.getMaxY(),
-                                "EPSG:4326");
-            } catch (Exception e) {
-                throw new ProcessException("Unable to create bbox filter for feature source", e);
-            }
-            filter =
-                    (Filter)
-                            FILTER_FACTORY
-                                    .and(filter, bbox)
-                                    .accept(new SimplifyingFilterVisitor(), null);
-            targetQuery.setFilter(filter);
+        String geometryName = visitor.getGeometryPropertyName();
+        if (geometryName == null) {
+            geometryName = "";
         }
+        final BBOX bbox;
+        try {
+            if (envelope.getCoordinateReferenceSystem() != null) {
+                envelope = envelope.transform(DefaultGeographicCRS.WGS84, false);
+            }
+            bbox =
+                    FILTER_FACTORY.bbox(
+                            geometryName,
+                            envelope.getMinX(),
+                            envelope.getMinY(),
+                            envelope.getMaxX(),
+                            envelope.getMaxY(),
+                            "EPSG:4326");
+        } catch (Exception e) {
+            throw new ProcessException("Unable to create bbox filter for feature source", e);
+        }
+        filter =
+                (Filter)
+                        FILTER_FACTORY
+                                .and(filter, bbox)
+                                .accept(new SimplifyingFilterVisitor(), null);
+        targetQuery.setFilter(filter);
 
         final List<PropertyName> properties = new ArrayList<>();
         properties.add(FILTER_FACTORY.property("_aggregation"));

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessTest.java
@@ -199,6 +199,31 @@ public class GeoHashGridProcessTest {
         checkInternal(coverage, fineDelta);
     }
 
+    /**
+     * StreamingRenderer does not necessarily include a BBOX filter in the query, as it uses the
+     * layer definition query. The area of interest is provided as part of the invertQuery
+     * parameters instead.
+     */
+    @Test
+    public void testInvertQueryNoBBOX() {
+        Filter filter = ff.bbox("geom", 0, 0, 0, 0, "EPSG:4326");
+        ReferencedEnvelope env = new ReferencedEnvelope(0, 1, 2, 3, DefaultGeographicCRS.WGS84);
+        Query query = new Query();
+        query.setFilter(filter);
+        Query queryOut = process.invertQuery(env, query, null);
+        assertEquals(ff.bbox("geom", 0, 2, 1, 3, "EPSG:4326"), queryOut.getFilter());
+    }
+
+    /** A NPE occurred when the filter did not contain a BBOX filter */
+    @Test
+    public void testInvertQueryNPE() {
+        ReferencedEnvelope env = new ReferencedEnvelope(0, 1, 2, 3, DefaultGeographicCRS.WGS84);
+        Query query = new Query();
+        query.setFilter(Filter.INCLUDE);
+        Query queryOut = process.invertQuery(env, query, null);
+        assertEquals(ff.bbox("", 0, 2, 1, 3, "EPSG:4326"), queryOut.getFilter());
+    }
+
     @Test
     public void testInvertQuery() {
         Filter filter = ff.bbox("geom", 0, 0, 0, 0, "EPSG:4326");


### PR DESCRIPTION
[![GEOT-7031](https://badgen.net/badge/JIRA/GEOT-7031/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7031) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->