### PR TITLE
[GEOT-7035] Add ability to provide the desired database type name when creating a schema in JDBC stores

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -3249,8 +3249,20 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
 
         for (int i = 0; i < descriptors.size(); i++) {
             AttributeDescriptor ad = descriptors.get(i);
+            Object nativeTypeName = ad.getUserData().get(JDBC_NATIVE_TYPENAME);
+            if (nativeTypeName instanceof String) {
+                sqlTypeNames[i] = (String) nativeTypeName;
+                continue;
+            }
+
             Class clazz = ad.getType().getBinding();
-            Integer sqlType = dialect.getSQLType(ad);
+            Integer sqlType;
+            Object nativeType = ad.getUserData().get(JDBC_NATIVE_TYPE);
+            if (nativeType instanceof Integer) {
+                sqlType = (Integer) nativeType;
+            } else {
+                sqlType = dialect.getSQLType(ad);
+            }
 
             if (sqlType == null) {
                 sqlType = getMapping(clazz);

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreOnlineTest.java
@@ -22,10 +22,14 @@ import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureWriter;
 import org.geotools.data.Query;
@@ -162,6 +166,59 @@ public abstract class JDBCDataStoreOnlineTest extends JDBCTestSupport {
             } catch (Exception e) {
             }
         }
+    }
+
+    public void testCreateSchemaWithNativeTypename() throws Exception {
+        assertLargeText(b -> b.userData(JDBCDataStore.JDBC_NATIVE_TYPENAME, getCLOBTypeName()));
+    }
+
+    /**
+     * Used by testCreateSchemaWithNativeTypename. Allows database specific overrides, defaults to
+     * <code>CLOB</code>
+     */
+    protected String getCLOBTypeName() {
+        return "CLOB";
+    }
+
+    public void testCreateSchemaWithNativeType() throws Exception {
+        assertLargeText(b -> b.userData(JDBCDataStore.JDBC_NATIVE_TYPE, Types.CLOB));
+    }
+
+    private void assertLargeText(Consumer<SimpleFeatureTypeBuilder> stringCustomizer)
+            throws FactoryException, IOException {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        String typeName = tname("ft2");
+        builder.setName(typeName);
+        builder.setNamespaceURI(dataStore.getNamespaceURI());
+        builder.setCRS(CRS.decode("EPSG:4326"));
+        builder.add(aname("geometry"), Geometry.class);
+        builder.nillable(false).add(aname("intProperty"), Integer.class);
+        // database can process this name (also tried going from Type.CLOB to a name,
+        // but for example postgresql does have a mapping for it
+        String stringProperty = aname("stringProperty");
+        stringCustomizer.accept(builder);
+        builder.add(stringProperty, String.class);
+
+        SimpleFeatureType featureType = builder.buildFeatureType();
+        dataStore.createSchema(featureType);
+
+        // cannot get a consistent type response from different databases, but it should be able
+        // to hold a very large string without cutting it
+        String largeString = RandomStringUtils.random(Short.MAX_VALUE + 1, true, false);
+        try (FeatureWriter<SimpleFeatureType, SimpleFeature> w =
+                dataStore.getFeatureWriter(typeName, Transaction.AUTO_COMMIT)) {
+            w.hasNext();
+
+            SimpleFeature f = w.next();
+            f.setAttribute(1, 123);
+            f.setAttribute(2, largeString);
+            w.write();
+        }
+
+        // table was just created, it only has one feature inside, no need for a filter
+        SimpleFeatureCollection fc = dataStore.getFeatureSource(typeName).getFeatures();
+        SimpleFeature test = DataUtilities.first(fc);
+        assertEquals(largeString, test.getAttribute(stringProperty));
     }
 
     public void testRemoveSchema() throws Exception {

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -265,6 +265,9 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
         // but will allow GeoTools to handle some usual java.sql.Types
         // not mapped to raw SQL types by org.sqlite.jdbc3.JDBC3DatabaseMetaData.getTypeInfo()
 
+        // Strings
+        overrides.put(Types.CLOB, "TEXT");
+
         // Numbers
         overrides.put(Types.BOOLEAN, "BOOLEAN");
         overrides.put(Types.TINYINT, "TINYINT");

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialect.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialect.java
@@ -375,6 +375,7 @@ public class MySQLDialect extends SQLDialect {
     @Override
     public void registerSqlTypeToSqlTypeNameOverrides(Map<Integer, String> overrides) {
         overrides.put(Types.BOOLEAN, "BOOL");
+        overrides.put(Types.CLOB, "TEXT");
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreOnlineTest.java
@@ -34,4 +34,10 @@ public class MySQLDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
     public void testCreateSchemaWithConstraints() throws Exception {
         // MySql does not complain if the string is too long, so we cannot run this test
     }
+
+    @Override
+    protected String getCLOBTypeName() {
+        // CLOB is supported in MySQL 8 but not in 5
+        return "TEXT";
+    }
 }

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/jndi/MySQLDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/jndi/MySQLDataStoreOnlineTest.java
@@ -11,4 +11,10 @@ public class MySQLDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
     protected JDBCTestSetup createTestSetup() {
         return new JDBCJNDITestSetup(new MySQLTestSetup());
     }
+
+    @Override
+    protected String getCLOBTypeName() {
+        // CLOB is supported in MySQL 8 but not in 5
+        return "TEXT";
+    }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -1070,6 +1070,7 @@ public class PostGISDialect extends BasicSQLDialect {
         overrides.put(Types.VARCHAR, "VARCHAR");
         overrides.put(Types.BOOLEAN, "BOOL");
         overrides.put(Types.BLOB, "BYTEA");
+        overrides.put(Types.CLOB, "TEXT");
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreOnlineTest.java
@@ -25,4 +25,9 @@ public class PostgisDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
     protected JDBCTestSetup createTestSetup() {
         return new PostGISTestSetup();
     }
+
+    @Override
+    protected String getCLOBTypeName() {
+        return "TEXT";
+    }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisDataStoreOnlineTest.java
@@ -25,4 +25,9 @@ public class PostgisDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
     protected JDBCTestSetup createTestSetup() {
         return new PostGISPSTestSetup();
     }
+
+    @Override
+    protected String getCLOBTypeName() {
+        return "TEXT";
+    }
 }

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
@@ -174,6 +174,7 @@ public class SQLServerDialect extends BasicSQLDialect {
         // force varchar, if not it will default to nvarchar which won't support length restrictions
         overrides.put(Types.VARCHAR, "varchar");
         overrides.put(Types.BLOB, "varbinary");
+        overrides.put(Types.CLOB, "text");
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDataStoreOnlineTest.java
@@ -25,4 +25,9 @@ public class SQLServerDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
     protected JDBCTestSetup createTestSetup() {
         return new SQLServerTestSetup();
     }
+
+    @Override
+    protected String getCLOBTypeName() {
+        return "TEXT";
+    }
 }


### PR DESCRIPTION
[![GEOT-7035](https://badgen.net/badge/JIRA/GEOT-7035/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7035) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->