### PR TITLE
Make GeoJSON store usable in all GeoServer modules

### DIFF
--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFilterTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFilterTest.java
@@ -648,15 +648,15 @@ public class ElasticFilterTest {
 
     @Test
     public void testGeoShapeBboxFilter() {
-        BBOX filter = ff.bbox("geom", 0., 0., 1.1, 1.1, "EPSG:4326");
-        List<List<Double>> coords = new ArrayList<>();
-        coords.add(ImmutableList.of(0., 0.));
-        coords.add(ImmutableList.of(0., 1.1));
+        BBOX filter = ff.bbox("geom", 0, 0, 1.1, 1.1, "EPSG:4326");
+        List<List<Number>> coords = new ArrayList<>();
+        coords.add(ImmutableList.of(0, 0));
+        coords.add(ImmutableList.of(0, 1.1));
         coords.add(ImmutableList.of(1.1, 1.1));
-        coords.add(ImmutableList.of(1.1, 0.));
-        coords.add(ImmutableList.of(0., 0.));
+        coords.add(ImmutableList.of(1.1, 0));
+        coords.add(ImmutableList.of(0, 0));
         // vertices in reverse order
-        final List<List<Double>> reverseCoords =
+        final List<List<Number>> reverseCoords =
                 ImmutableList.of(
                         coords.get(0), coords.get(3), coords.get(2), coords.get(1), coords.get(4));
         Map<String, Object> expected =
@@ -693,8 +693,8 @@ public class ElasticFilterTest {
     public void testGeoShapeIntersectsFilter() throws CQLException {
         Intersects filter =
                 (Intersects) ECQL.toFilter("INTERSECTS(\"geom\", LINESTRING(0 0,1.1 1.1))");
-        List<List<Double>> coords = new ArrayList<>();
-        coords.add(ImmutableList.of(0., 0.));
+        List<List<Number>> coords = new ArrayList<>();
+        coords.add(ImmutableList.of(0, 0));
         coords.add(ImmutableList.of(1.1, 1.1));
         Map<String, Object> expected =
                 ImmutableMap.of(
@@ -750,8 +750,8 @@ public class ElasticFilterTest {
     public void testGeoShapeIntersectsFilterReversed() throws CQLException {
         Intersects filter =
                 (Intersects) ECQL.toFilter("INTERSECTS(LINESTRING(0 0,1.1 1.1), \"geom\")");
-        List<List<Double>> coords = new ArrayList<>();
-        coords.add(ImmutableList.of(0., 0.));
+        List<List<Number>> coords = new ArrayList<>();
+        coords.add(ImmutableList.of(0, 0));
         coords.add(ImmutableList.of(1.1, 1.1));
         Map<String, Object> expected =
                 ImmutableMap.of(
@@ -782,15 +782,15 @@ public class ElasticFilterTest {
     @Test
     public void testAndWithBbox() {
         And filter =
-                ff.and(ff.id(ff.featureId("id1")), ff.bbox("geom", 0., 0., 1.1, 1.1, "EPSG:4326"));
-        List<List<Double>> coords = new ArrayList<>();
-        coords.add(ImmutableList.of(0., 0.));
-        coords.add(ImmutableList.of(0., 1.1));
+                ff.and(ff.id(ff.featureId("id1")), ff.bbox("geom", 0, 0, 1.1, 1.1, "EPSG:4326"));
+        List<List<Number>> coords = new ArrayList<>();
+        coords.add(ImmutableList.of(0, 0));
+        coords.add(ImmutableList.of(0, 1.1));
         coords.add(ImmutableList.of(1.1, 1.1));
-        coords.add(ImmutableList.of(1.1, 0.));
-        coords.add(ImmutableList.of(0., 0.));
+        coords.add(ImmutableList.of(1.1, 0));
+        coords.add(ImmutableList.of(0, 0));
         // vertices in reverse order
-        List<List<Double>> reverseCoords =
+        List<List<Number>> reverseCoords =
                 ImmutableList.of(
                         coords.get(0), coords.get(3), coords.get(2), coords.get(1), coords.get(4));
         Map<String, Object> expected =
@@ -985,8 +985,8 @@ public class ElasticFilterTest {
         Filter filter =
                 ECQL.toFilter(
                         "time > \"1970-01-01\" and INTERSECTS(\"geom\", LINESTRING(0 0,1.1 1.1))");
-        List<List<Double>> coords = new ArrayList<>();
-        coords.add(ImmutableList.of(0., 0.));
+        List<List<Number>> coords = new ArrayList<>();
+        coords.add(ImmutableList.of(0, 0));
         coords.add(ImmutableList.of(1.1, 1.1));
         Map<String, Object> expected =
                 ImmutableMap.of(

--- a/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule.java
+++ b/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule.java
@@ -50,7 +50,7 @@ public class JtsModule extends SimpleModule {
     private GeometrySerializer geometrySerializer;
 
     public JtsModule(int maxDecimals) {
-        this(new GeometryFactory(), maxDecimals, 1, RoundingMode.HALF_UP);
+        this(new GeometryFactory(), maxDecimals, 0, RoundingMode.HALF_UP);
     }
 
     public JtsModule() {

--- a/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule.java
+++ b/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule.java
@@ -47,10 +47,14 @@ public class JtsModule extends SimpleModule {
     /** serialVersionUID */
     private static final long serialVersionUID = 3387512874441967803L;
 
+    public static int DEFAULT_MAX_DECIMALS = 4;
+    public static int DEFAULT_MIN_DECIMALS = 0;
+    public static RoundingMode DEFAULT_ROUND_MODE = RoundingMode.HALF_UP;
+
     private GeometrySerializer geometrySerializer;
 
     public JtsModule(int maxDecimals) {
-        this(new GeometryFactory(), maxDecimals, 0, RoundingMode.HALF_UP);
+        this(new GeometryFactory(), maxDecimals, DEFAULT_MIN_DECIMALS, DEFAULT_ROUND_MODE);
     }
 
     public JtsModule() {
@@ -58,7 +62,7 @@ public class JtsModule extends SimpleModule {
     }
 
     public JtsModule(GeometryFactory geometryFactory) {
-        this(geometryFactory, 4, 1, RoundingMode.HALF_UP);
+        this(geometryFactory, DEFAULT_MAX_DECIMALS, DEFAULT_MIN_DECIMALS, DEFAULT_ROUND_MODE);
     }
 
     public JtsModule(
@@ -71,28 +75,25 @@ public class JtsModule extends SimpleModule {
         geometrySerializer = new GeometrySerializer(minDecimals, maxDecimals, rounding);
         addSerializer(Geometry.class, geometrySerializer);
         GenericGeometryParser genericGeometryParser = new GenericGeometryParser(geometryFactory);
-        addDeserializer(Geometry.class, new GeometryDeserializer<Geometry>(genericGeometryParser));
-        addDeserializer(
-                Point.class, new GeometryDeserializer<Point>(new PointParser(geometryFactory)));
+        addDeserializer(Geometry.class, new GeometryDeserializer<>(genericGeometryParser));
+        addDeserializer(Point.class, new GeometryDeserializer<>(new PointParser(geometryFactory)));
         addDeserializer(
                 MultiPoint.class,
-                new GeometryDeserializer<MultiPoint>(new MultiPointParser(geometryFactory)));
+                new GeometryDeserializer<>(new MultiPointParser(geometryFactory)));
         addDeserializer(
                 LineString.class,
-                new GeometryDeserializer<LineString>(new LineStringParser(geometryFactory)));
+                new GeometryDeserializer<>(new LineStringParser(geometryFactory)));
         addDeserializer(
                 MultiLineString.class,
-                new GeometryDeserializer<MultiLineString>(
-                        new MultiLineStringParser(geometryFactory)));
+                new GeometryDeserializer<>(new MultiLineStringParser(geometryFactory)));
         addDeserializer(
-                Polygon.class,
-                new GeometryDeserializer<Polygon>(new PolygonParser(geometryFactory)));
+                Polygon.class, new GeometryDeserializer<>(new PolygonParser(geometryFactory)));
         addDeserializer(
                 MultiPolygon.class,
-                new GeometryDeserializer<MultiPolygon>(new MultiPolygonParser(geometryFactory)));
+                new GeometryDeserializer<>(new MultiPolygonParser(geometryFactory)));
         addDeserializer(
                 GeometryCollection.class,
-                new GeometryDeserializer<GeometryCollection>(
+                new GeometryDeserializer<>(
                         new GeometryCollectionParser(geometryFactory, genericGeometryParser)));
     }
 

--- a/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule3D.java
+++ b/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule3D.java
@@ -50,7 +50,11 @@ public class JtsModule3D extends SimpleModule {
     }
 
     public JtsModule3D(GeometryFactory geometryFactory) {
-        this(geometryFactory, 4, 1, RoundingMode.HALF_UP);
+        this(
+                geometryFactory,
+                JtsModule.DEFAULT_MAX_DECIMALS,
+                JtsModule.DEFAULT_MIN_DECIMALS,
+                JtsModule.DEFAULT_ROUND_MODE);
     }
 
     public JtsModule3D(
@@ -64,28 +68,25 @@ public class JtsModule3D extends SimpleModule {
 
         addSerializer(Geometry.class, new GeometrySerializer(minDecimals, maxDecimals, rounding));
         GenericGeometryParser genericGeometryParser = new GenericGeometryParser(geometryFactory);
-        addDeserializer(Geometry.class, new GeometryDeserializer<Geometry>(genericGeometryParser));
-        addDeserializer(
-                Point.class, new GeometryDeserializer<Point>(new PointParser(geometryFactory)));
+        addDeserializer(Geometry.class, new GeometryDeserializer<>(genericGeometryParser));
+        addDeserializer(Point.class, new GeometryDeserializer<>(new PointParser(geometryFactory)));
         addDeserializer(
                 MultiPoint.class,
-                new GeometryDeserializer<MultiPoint>(new MultiPointParser(geometryFactory)));
+                new GeometryDeserializer<>(new MultiPointParser(geometryFactory)));
         addDeserializer(
                 LineString.class,
-                new GeometryDeserializer<LineString>(new LineStringParser(geometryFactory)));
+                new GeometryDeserializer<>(new LineStringParser(geometryFactory)));
         addDeserializer(
                 MultiLineString.class,
-                new GeometryDeserializer<MultiLineString>(
-                        new MultiLineStringParser(geometryFactory)));
+                new GeometryDeserializer<>(new MultiLineStringParser(geometryFactory)));
         addDeserializer(
-                Polygon.class,
-                new GeometryDeserializer<Polygon>(new PolygonParser(geometryFactory)));
+                Polygon.class, new GeometryDeserializer<>(new PolygonParser(geometryFactory)));
         addDeserializer(
                 MultiPolygon.class,
-                new GeometryDeserializer<MultiPolygon>(new MultiPolygonParser(geometryFactory)));
+                new GeometryDeserializer<>(new MultiPolygonParser(geometryFactory)));
         addDeserializer(
                 GeometryCollection.class,
-                new GeometryDeserializer<GeometryCollection>(
+                new GeometryDeserializer<>(
                         new GeometryCollectionParser(geometryFactory, genericGeometryParser)));
     }
 

--- a/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/parsers/BaseParser.java
+++ b/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/parsers/BaseParser.java
@@ -26,7 +26,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 /** Created by mihaildoronin on 11/11/15. */
 public class BaseParser {
 
-    protected GeometryFactory geometryFactory;
+    protected final GeometryFactory geometryFactory;
 
     public BaseParser(GeometryFactory geometryFactory) {
         this.geometryFactory = geometryFactory;

--- a/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/serialization/GeometrySerializer.java
+++ b/modules/unsupported/geojsonstore/src/main/java/com/bedatadriven/jackson/datatype/jts/serialization/GeometrySerializer.java
@@ -53,15 +53,17 @@ public class GeometrySerializer extends JsonSerializer<Geometry> {
 
     private RoundingMode roundingMode = RoundingMode.HALF_UP;
     NumberFormat format = NumberFormat.getNumberInstance(Locale.ENGLISH);
-    /** Maximum number of decimal places (see https://xkcd.com/2170/ before changing it) */
-    int maximumFractionDigits = 4;
 
-    int minimumFractionDigits = 1;
+    int maximumFractionDigits;
+
+    int minimumFractionDigits;
 
     public GeometrySerializer(int minDecimals, int maxDecimals, RoundingMode rounding) {
-        format.setMinimumFractionDigits(minimumFractionDigits);
-        format.setMaximumFractionDigits(maximumFractionDigits);
-        format.setRoundingMode(roundingMode);
+        this.maximumFractionDigits = maxDecimals;
+        this.minimumFractionDigits = minDecimals;
+        format.setMinimumFractionDigits(minDecimals);
+        format.setMaximumFractionDigits(maxDecimals);
+        format.setRoundingMode(rounding);
     }
 
     @Override

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -49,6 +49,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.collection.ListFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -199,16 +200,13 @@ public class GeoJSONReader implements AutoCloseable {
         }
     }
 
-    /**
-     * Parses and returns a single feature from the source
-     */
+    /** Parses and returns a single feature from the source */
     public SimpleFeature getFeature() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JtsModule());
         ObjectNode node = mapper.readTree(parser);
         return getNextFeature(node);
     }
-
 
     /**
      * Parses all features in the source and returns them as an in-memory feature collection with a
@@ -468,7 +466,7 @@ public class GeoJSONReader implements AutoCloseable {
      * @return
      * @throws IOException
      */
-    public FeatureIterator<SimpleFeature> getIterator() throws IOException {
+    public SimpleFeatureIterator getIterator() throws IOException {
         if (!isConnected()) {
             LOGGER.fine("trying to read an unconnected data stream");
             return new DefaultFeatureCollection(null, null).features();
@@ -516,7 +514,7 @@ public class GeoJSONReader implements AutoCloseable {
         }
     }
 
-    private class GeoJsonIterator implements FeatureIterator<SimpleFeature>, AutoCloseable {
+    private class GeoJsonIterator implements SimpleFeatureIterator, AutoCloseable {
         /** @throws IOException */
         ObjectMapper mapper = new ObjectMapper();
 

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -109,6 +109,10 @@ public class GeoJSONReader implements AutoCloseable {
         parser = factory.createParser(is);
     }
 
+    public GeoJSONReader(String json) throws IOException {
+        parser = factory.createParser(json);
+    }
+
     /**
      * Returns true if the parser is trying to convert string formatted as dates into
      * java.util.Date, false otherwise. Defaults to true.

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -47,6 +47,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.FilenameUtils;
 import org.geotools.data.DataUtilities;
+import org.geotools.data.collection.ListFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.FeatureIterator;
@@ -227,9 +228,12 @@ public class GeoJSONReader implements AutoCloseable {
                     nFeatures.add(feature);
                 }
             }
-            return DataUtilities.collection(nFeatures);
+            features = nFeatures;
         }
-        return DataUtilities.collection(features);
+        // a GeoJSON feature collection has an array of features -> it's an ordered entity
+        // so we should return the features in the same order we got them, cannot use
+        // DefaultFeatureCollectin, but an order preserving collection instead
+        return new ListFeatureCollection(schema, features);
     }
 
     /** */

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -200,6 +200,17 @@ public class GeoJSONReader implements AutoCloseable {
     }
 
     /**
+     * Parses and returns a single feature from the source
+     */
+    public SimpleFeature getFeature() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JtsModule());
+        ObjectNode node = mapper.readTree(parser);
+        return getNextFeature(node);
+    }
+
+
+    /**
      * Parses all features in the source and returns them as an in-memory feature collection with a
      * stable {@link FeatureType}. In order to stream use {@link #getIterator()} instead.
      *

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
@@ -77,6 +77,7 @@ public class GeoJSONWriter implements AutoCloseable {
     public static final FastDateFormat DEFAULT_DATE_FORMATTER =
             FastDateFormat.getInstance(DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
 
+    /** Maximum number of decimal places (see https://xkcd.com/2170/ before changing it) */
     private int maxDecimals = 4;
 
     private OutputStream out;

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
@@ -107,6 +107,12 @@ public class GeoJSONWriter implements AutoCloseable {
     private boolean singleFeature = false;
     private FastDateFormat dateFormatter = DEFAULT_DATE_FORMATTER;
 
+    /**
+     * Prepares a writer over the target output stream.
+     *
+     * @param outputStream
+     * @throws IOException
+     */
     public GeoJSONWriter(OutputStream outputStream) throws IOException {
         // force the output CRS to be long, lat as required by spec
         CRSAuthorityFactory cFactory = CRS.getAuthorityFactory(true);
@@ -166,6 +172,12 @@ public class GeoJSONWriter implements AutoCloseable {
         generator.writeEndArray();
     }
 
+    /**
+     * Writes a single feature onto the output.
+     *
+     * @param currentFeature
+     * @throws IOException
+     */
     public void write(SimpleFeature currentFeature) throws IOException {
         if (!initalised) {
             initialise();
@@ -352,6 +364,7 @@ public class GeoJSONWriter implements AutoCloseable {
         this.encodeFeatureBounds = encodeFeatureCollectionBounds;
     }
 
+    /** Utility encoding a single JTS geometry in GeoJSON, and returning it as a string */
     public static String toGeoJSON(Geometry geometry) {
         ObjectMapper lMapper = new ObjectMapper();
         lMapper.registerModule(new JtsModule());
@@ -363,10 +376,7 @@ public class GeoJSONWriter implements AutoCloseable {
         return "";
     }
 
-    /**
-     * @param f
-     * @return
-     */
+    /** Utility encoding a single {@link SimpleFeature}, and returning it as a string */
     public static String toGeoJSON(SimpleFeature f) {
         JsonFactory factory = new JsonFactory();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -379,10 +389,7 @@ public class GeoJSONWriter implements AutoCloseable {
         return new String(out.toByteArray());
     }
 
-    /**
-     * @param fc
-     * @return
-     */
+    /** Utility encoding a @link {@link SimpleFeatureCollection}}, and returning it as a string */
     public static String toGeoJSON(SimpleFeatureCollection fc) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (GeoJSONWriter writer = new GeoJSONWriter(out);
@@ -402,7 +409,7 @@ public class GeoJSONWriter implements AutoCloseable {
         return new String(out.toByteArray());
     }
 
-    /** @param b */
+    /** Set to true to encode the feature collection CRS field. Defaults to false. */
     public void setEncodeFeatureCollectionCRS(boolean b) {
         encodeFeatureCollectionCRS = b;
     }
@@ -412,6 +419,11 @@ public class GeoJSONWriter implements AutoCloseable {
         return encodeFeatureCollectionCRS;
     }
 
+    /**
+     * Returns the max number of decimals used for encoding
+     *
+     * @return
+     */
     public int getMaxDecimals() {
         return maxDecimals;
     }
@@ -427,10 +439,8 @@ public class GeoJSONWriter implements AutoCloseable {
         maxDecimals = number;
         module.setMaxDecimals(number);
     }
-    /**
-     * @param features
-     * @throws IOException
-     */
+
+    /** Encodes the whole feature collection onto the output */
     public void writeFeatureCollection(SimpleFeatureCollection features) throws IOException {
         // the collection might be empty, but we still need the wrapper JSON
         // for a collection to be generated
@@ -449,7 +459,10 @@ public class GeoJSONWriter implements AutoCloseable {
         bounds = bbox;
     }
 
-    /** Returns true if the JSON is going to be pretty-printed, false otherwise */
+    /**
+     * Returns true if the generated JSON is for a single feature, without a feature collection
+     * wrapper around it.
+     */
     public boolean isSingleFeature() {
         return singleFeature;
     }

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/ObjectMapperFactory.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/ObjectMapperFactory.java
@@ -1,0 +1,46 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.geojson;
+
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Support class providing {@link com.fasterxml.jackson.databind.ObjectMapper} instances configured
+ * with the desired settings.
+ */
+class ObjectMapperFactory {
+
+    private static ObjectMapper DEFAULT_MAPPER;
+
+    static {
+        DEFAULT_MAPPER = new ObjectMapper();
+        DEFAULT_MAPPER.registerModule(new JtsModule());
+    }
+
+    /**
+     * Returns an {@link ObjectMapper} set up to parse JTS geometries, with the default settings.
+     * See also {@link JtsModule#DEFAULT_MAX_DECIMALS}, {@link JtsModule#DEFAULT_MIN_DECIMALS} and
+     * {@link JtsModule#DEFAULT_ROUND_MODE}. It is to be noticed, the settings above only affects
+     * writing, so the default mapper should be used for all read operations.
+     *
+     * @return
+     */
+    public static ObjectMapper getDefaultMapper() {
+        return DEFAULT_MAPPER;
+    }
+}

--- a/modules/unsupported/geojsonstore/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
+++ b/modules/unsupported/geojsonstore/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.core.Is.is;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
+import java.math.RoundingMode;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -45,10 +46,23 @@ public abstract class BaseJtsModuleTest<T extends Geometry> {
     @Before
     public void setup() {
         mapper = new ObjectMapper();
-        mapper.registerModule(new JtsModule());
+        mapper.registerModule(
+                new JtsModule(
+                        new GeometryFactory(),
+                        getMaxDecimals(),
+                        getMinDecimals(),
+                        RoundingMode.HALF_UP));
         writer = mapper.writer();
         geometry = createGeometry();
         geometryAsGeoJson = createGeometryAsGeoJson();
+    }
+
+    protected int getMaxDecimals() {
+        return 4;
+    }
+
+    protected int getMinDecimals() {
+        return 1;
     }
 
     protected abstract Class<T> getType();
@@ -77,6 +91,6 @@ public abstract class BaseJtsModuleTest<T extends Geometry> {
         String json = writer.writeValueAsString(geom);
 
         Geometry regeom = mapper.readerFor(Geometry.class).readValue(json);
-        assertThat(geom.equalsExact(regeom, 0.0001), is(true));
+        assertThat(geom.equalsExact(regeom, Math.pow(10, -getMaxDecimals())), is(true));
     }
 }

--- a/modules/unsupported/geojsonstore/src/test/java/com/bedatadriven/jackson/datatype/jts/PointTest.java
+++ b/modules/unsupported/geojsonstore/src/test/java/com/bedatadriven/jackson/datatype/jts/PointTest.java
@@ -20,11 +20,33 @@ package com.bedatadriven.jackson.datatype.jts;
  *
  */
 
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Point;
 
 /** Created by mihaildoronin on 11/11/15. */
+@RunWith(Parameterized.class)
 public class PointTest extends BaseJtsModuleTest<Point> {
+
+    int maxDecimals;
+
+    public PointTest(int maxDecimals) {
+        this.maxDecimals = maxDecimals;
+    }
+
+    @Override
+    public int getMaxDecimals() {
+        return maxDecimals;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> precisions() {
+        return Arrays.asList(new Object[][] {{1}, {2}, {3}, {4}, {5}, {6}, {7}});
+    }
+
     @Override
     protected Class<Point> getType() {
         return Point.class;
@@ -32,7 +54,26 @@ public class PointTest extends BaseJtsModuleTest<Point> {
 
     @Override
     protected String createGeometryAsGeoJson() {
-        return "{\"type\":\"Point\",\"coordinates\":[1.2346,2.3457]}";
+        switch (maxDecimals) {
+            case 0:
+                return "{\"type\":\"Point\",\"coordinates\":[1,2]}";
+            case 1:
+                return "{\"type\":\"Point\",\"coordinates\":[1.2,2.3]}";
+            case 2:
+                return "{\"type\":\"Point\",\"coordinates\":[1.23,2.35]}";
+            case 3:
+                return "{\"type\":\"Point\",\"coordinates\":[1.235,2.346]}";
+            case 4:
+                return "{\"type\":\"Point\",\"coordinates\":[1.2346,2.3457]}";
+            case 5:
+                return "{\"type\":\"Point\",\"coordinates\":[1.23457,2.34568]}";
+            case 6:
+                return "{\"type\":\"Point\",\"coordinates\":[1.234568,2.345679]}";
+            case 7:
+                return "{\"type\":\"Point\",\"coordinates\":[1.2345678,2.3456789]}";
+            default:
+                throw new RuntimeException("Unexpected precision");
+        }
     }
 
     @Override

--- a/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONDataStoreTest.java
+++ b/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONDataStoreTest.java
@@ -18,7 +18,6 @@ package org.geotools.data.geojson;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
@@ -31,6 +30,7 @@ import org.geotools.test.TestData;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
@@ -86,21 +86,22 @@ public class GeoJSONDataStoreTest {
         GeoJSONDataStore fds = new GeoJSONDataStore(url);
         String type = fds.getNames().get(0).getLocalPart();
         Query query = new Query(type);
+        Class<?> lastGeometryBinding = null;
         try (FeatureReader<SimpleFeatureType, SimpleFeature> reader =
                 fds.getFeatureReader(query, null)) {
             SimpleFeatureType schema = reader.getFeatureType();
-            assertTrue(
-                    Geometry.class.isAssignableFrom(
-                            schema.getGeometryDescriptor().getType().getBinding()));
             assertNotNull(schema);
             int count = 0;
             while (reader.hasNext()) {
-                reader.next();
+                SimpleFeature sf = reader.next();
+                lastGeometryBinding =
+                        sf.getFeatureType().getGeometryDescriptor().getType().getBinding();
                 count++;
             }
 
             assertEquals(7, count);
         }
+        assertEquals(Geometry.class, lastGeometryBinding);
     }
 
     // An ogr written file
@@ -116,9 +117,7 @@ public class GeoJSONDataStoreTest {
                 fds.getFeatureReader(query, null)) {
             SimpleFeatureType schema = reader.getFeatureType();
             // System.out.println(schema);
-            assertTrue(
-                    Geometry.class.isAssignableFrom(
-                            schema.getGeometryDescriptor().getType().getBinding()));
+            assertEquals(Point.class, schema.getGeometryDescriptor().getType().getBinding());
             assertNotNull(schema);
             int count = 0;
             while (reader.hasNext()) {

--- a/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderRunner.java
+++ b/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderRunner.java
@@ -16,8 +16,6 @@
  */
 package org.geotools.data.geojson;
 
-import org.geotools.util.logging.Logging;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
@@ -27,13 +25,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geotools.util.logging.Logging;
 
 /** Not a test class, but a load test that can be used to profile the module */
 public class GeoJSONReaderRunner {
 
     static final Logger LOGGER = Logging.getLogger(GeoJSONReaderRunner.class);
-    
-    
+
     File source;
     int threads = Runtime.getRuntime().availableProcessors() * 2;
     int count = threads * 10;
@@ -64,7 +62,7 @@ public class GeoJSONReaderRunner {
             try (FileInputStream fos = new FileInputStream(source);
                     GeoJSONReader reader = new GeoJSONReader(fos)) {
                 reader.getFeatures();
-                
+
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Failed to read GeoJSON", e);
             }
@@ -72,10 +70,14 @@ public class GeoJSONReaderRunner {
         }
     }
 
+    @SuppressWarnings("PMD.SystemPrintln")
     public static void main(String[] args) throws Exception {
-        File source =
-                new File(
-                        "/home/aaime/devel/gisData/Natural_Earth_quick_start/10m_cultural/ne_10m_admin_1_states_provinces_lines.json");
+        if (args.length != 1) {
+            System.out.println(GeoJSONReaderRunner.class.getSimpleName() + " <file>");
+            System.exit(-1);
+        }
+
+        File source = new File(args[0]);
         long start = System.currentTimeMillis();
         GeoJSONReaderRunner runner = new GeoJSONReaderRunner(source);
         runner.execute();

--- a/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderRunner.java
+++ b/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderRunner.java
@@ -1,0 +1,85 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.geojson;
+
+import org.geotools.util.logging.Logging;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Not a test class, but a load test that can be used to profile the module */
+public class GeoJSONReaderRunner {
+
+    static final Logger LOGGER = Logging.getLogger(GeoJSONReaderRunner.class);
+    
+    
+    File source;
+    int threads = Runtime.getRuntime().availableProcessors() * 2;
+    int count = threads * 10;
+
+    public GeoJSONReaderRunner(File source) {
+        this.source = source;
+        if (!source.exists()) throw new RuntimeException("File does not exist");
+    }
+
+    public void execute() throws Exception {
+        List<Callable<Void>> runners = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            runners.add(new ParsingCallable());
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            executor.invokeAll(runners);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private class ParsingCallable implements Callable<Void> {
+
+        @Override
+        public Void call() throws Exception {
+            try (FileInputStream fos = new FileInputStream(source);
+                    GeoJSONReader reader = new GeoJSONReader(fos)) {
+                reader.getFeatures();
+                
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Failed to read GeoJSON", e);
+            }
+            return null;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        File source =
+                new File(
+                        "/home/aaime/devel/gisData/Natural_Earth_quick_start/10m_cultural/ne_10m_admin_1_states_provinces_lines.json");
+        long start = System.currentTimeMillis();
+        GeoJSONReaderRunner runner = new GeoJSONReaderRunner(source);
+        runner.execute();
+        long end = System.currentTimeMillis();
+        System.out.println("Time to execute: " + (end - start) / 1000d);
+    }
+}

--- a/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
+++ b/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.opengis.feature.Property;
@@ -110,6 +111,9 @@ public class GeoJSONReaderTest {
         try (GeoJSONReader reader = new GeoJSONReader(new ByteArrayInputStream(input.getBytes()))) {
             SimpleFeatureCollection features = reader.getFeatures();
             assertNotNull(features);
+            assertEquals(
+                    Point.class,
+                    features.getSchema().getGeometryDescriptor().getType().getBinding());
             assertEquals("wrong number of features read", 9, features.size());
             List<SimpleFeature> list = DataUtilities.list(features);
             // order preserving, since a GeoJSON collection is ordered
@@ -287,6 +291,7 @@ public class GeoJSONReaderTest {
         WKTReader wkt = new WKTReader();
         assertEquals(wkt.read("POINT (0.1 0.1)"), f.getDefaultGeometry());
         assertEquals(wkt.read("LINESTRING (1.1 1.2, 1.3 1.4)"), f.getAttribute("otherGeometry"));
+        assertEquals(Point.class, f.getType().getGeometryDescriptor().getType().getBinding());
     }
 
     @Test
@@ -321,6 +326,7 @@ public class GeoJSONReaderTest {
         SimpleFeature feature = GeoJSONReader.parseFeature(geojson);
         assertEquals(true, feature.getAttribute("boolTrue"));
         assertEquals(false, feature.getAttribute("boolFalse"));
+        assertEquals(Point.class, feature.getType().getGeometryDescriptor().getType().getBinding());
     }
 
     @Test

--- a/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
+++ b/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
@@ -108,9 +108,14 @@ public class GeoJSONReaderTest {
                         + "}";
 
         try (GeoJSONReader reader = new GeoJSONReader(new ByteArrayInputStream(input.getBytes()))) {
-            FeatureCollection features = reader.getFeatures();
+            SimpleFeatureCollection features = reader.getFeatures();
             assertNotNull(features);
             assertEquals("wrong number of features read", 9, features.size());
+            List<SimpleFeature> list = DataUtilities.list(features);
+            // order preserving, since a GeoJSON collection is ordered
+            assertEquals("Trento", list.get(0).getAttribute("CITY"));
+            assertEquals("St Paul", list.get(1).getAttribute("CITY"));
+            assertEquals("Bangkok", list.get(2).getAttribute("CITY"));
         }
     }
 

--- a/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
+++ b/modules/unsupported/geojsonstore/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
@@ -81,7 +81,7 @@ public class GeoJSONReaderTest {
             expected.put("CITY", "Trento");
             expected.put("NUMBER", null);
             expected.put("YEAR", null);
-            expected.put("the_geom", gf.createPoint(new Coordinate(11.117, 46.067)));
+            expected.put("geometry", gf.createPoint(new Coordinate(11.117, 46.067)));
             SimpleFeature first = DataUtilities.first(features);
             for (Property prop : first.getProperties()) {
                 assertEquals(expected.get(prop.getName().getLocalPart()), prop.getValue());


### PR DESCRIPTION
This is a set of changes I've added to allow GeoJSONStore be used as a replacement for gt-geojson in GeoServer. 
It's really a follow up to "[GEOT-6887] Bring GeoJsonWriter/GeoJsonReader on par with gt-geojson", could use the same Jira ticket or a new one.

Also sneaked in a performance improvement and [started looking into a more significant one](https://github.com/FasterXML/jackson-core/issues/346) that will require some Jackson changes.

@ianturton could use your review.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->