### PR TITLE
[26.x backport][GEOT-7030] Missing YSLD support for rule vendor options

### DIFF
--- a/docs/user/extension/ysld.rst
+++ b/docs/user/extension/ysld.rst
@@ -254,6 +254,7 @@ Rule definition:
       zoom: [<min>,<max>]
       symbolizers:
       - <symbolizers>
+      x-inclusion: <text>
 
 Line symbolizer definition:
 

--- a/modules/extension/ysld/src/main/java/org/geotools/ysld/encode/RuleEncoder.java
+++ b/modules/extension/ysld/src/main/java/org/geotools/ysld/encode/RuleEncoder.java
@@ -82,6 +82,7 @@ public class RuleEncoder extends YsldEncodeHandler<Rule> {
         }
 
         put("symbolizers", new SymbolizersEncoder(rule));
+        vendorOptions(rule.getOptions());
     }
 
     String toStringOrNull(double d, String nullKeyword) {

--- a/modules/extension/ysld/src/main/java/org/geotools/ysld/parse/RuleParser.java
+++ b/modules/extension/ysld/src/main/java/org/geotools/ysld/parse/RuleParser.java
@@ -85,6 +85,7 @@ public class RuleParser extends YsldParseHandler {
             }
 
             context.push(r, "symbolizers", new SymbolizersParser(rule, factory));
+            rule.getOptions().putAll(Util.vendorOptions(r));
         }
     }
 

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeCookbookTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeCookbookTest.java
@@ -620,6 +620,46 @@ public class YsldEncodeCookbookTest {
     }
 
     @Test
+    public void testPointWithRuleVendorOption() throws Exception {
+        // <UserStyle>
+        //   <Title>Simple Point With Rule Vendor Option</Title>
+        //   <FeatureTypeStyle>
+        //     <Rule>
+        //       <PointSymbolizer>
+        //         <Graphic>
+        //           <Mark>
+        //             <WellKnownName>circle</WellKnownName>
+        //             <Fill>
+        //               <CssParameter name="fill">#FF0000</CssParameter>
+        //             </Fill>
+        //           </Mark>
+        //           <Size>6</Size>
+        //         </Graphic>
+        //       </PointSymbolizer>
+        //       <VendorOption name="inclusion">mapOnly</VendorOption>
+        //     </Rule>
+        //     <Rule>
+        //       <PointSymbolizer>
+        //         <Graphic>
+        //           <ExternalGraphic>
+        //              <OnlineResource xlink:type="simple" xlink:href="smileyface.png" />
+        //             <Format>image/png</Format>
+        //           </ExternalGraphic>
+        //           <Size>20</Size>
+        //         </Graphic>
+        //       </PointSymbolizer>
+        //       <VendorOption name="inclusion">legendOnly</VendorOption>
+        //     </Rule>
+        //   </FeatureTypeStyle>
+        // </UserStyle>
+        YamlMap style = encode("point", "rule-option.sld");
+        YamlMap rule1 = style.seq("feature-styles").map(0).seq("rules").map(0);
+        assertEquals("mapOnly", rule1.str("x-inclusion"));
+        YamlMap rule2 = style.seq("feature-styles").map(0).seq("rules").map(1);
+        assertEquals("legendOnly", rule2.str("x-inclusion"));
+    }
+
+    @Test
     public void testLineSimple() throws Exception {
         //    <UserStyle>
         //      <Title>SLD Cook Book: Simple Line</Title>

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeTest.java
@@ -1814,4 +1814,19 @@ public class YsldEncodeTest {
         Tuple map = iterator.next();
         assertEquals("('#E20374',1.0,1,Lorem Ipsum (magenta = covered))", map.toString());
     }
+
+    @Test
+    public void testRuleVendorOption() throws Exception {
+        PointSymbolizer p = CommonFactoryFinder.getStyleFactory().createPointSymbolizer();
+        FeatureTypeStyle fts = fts(p);
+        fts.rules().get(0).getOptions().put("foo", "bar");
+
+        StringWriter out = new StringWriter();
+        Ysld.encode(sld(fts), out);
+
+        YamlMap obj = new YamlMap(YamlUtil.getSafeYaml().load(out.toString()));
+        YamlMap result = obj.seq("feature-styles").map(0).seq("rules").map(0);
+
+        assertEquals("bar", result.str("x-foo"));
+    }
 }

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseCookbookTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseCookbookTest.java
@@ -19,12 +19,14 @@ package org.geotools.ysld.parse;
 
 import static org.geotools.ysld.Ysld.transform;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 
 import java.awt.Color;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.List;
 import java.util.Map;
 import org.geotools.filter.Filters;
 import org.geotools.filter.text.ecql.ECQL;
@@ -602,6 +604,45 @@ public class YsldParseCookbookTest {
         assertEquals(0, Filters.asInt(placement.getDisplacement().getDisplacementX()));
         assertEquals(25, Filters.asInt(placement.getDisplacement().getDisplacementY()));
         assertEquals(-45, Filters.asInt(placement.getRotation()));
+    }
+
+    @Test
+    public void testPointWithRuleVendorOption() throws Exception {
+        // <UserStyle>
+        //   <Title>Simple Point With Rule Vendor Option</Title>
+        //   <FeatureTypeStyle>
+        //     <Rule>
+        //       <PointSymbolizer>
+        //         <Graphic>
+        //           <Mark>
+        //             <WellKnownName>circle</WellKnownName>
+        //             <Fill>
+        //               <CssParameter name="fill">#FF0000</CssParameter>
+        //             </Fill>
+        //           </Mark>
+        //           <Size>6</Size>
+        //         </Graphic>
+        //       </PointSymbolizer>
+        //       <VendorOption name="inclusion">mapOnly</VendorOption>
+        //     </Rule>
+        //     <Rule>
+        //       <PointSymbolizer>
+        //         <Graphic>
+        //           <ExternalGraphic>
+        //              <OnlineResource xlink:type="simple" xlink:href="smileyface.png" />
+        //             <Format>image/png</Format>
+        //           </ExternalGraphic>
+        //           <Size>20</Size>
+        //         </Graphic>
+        //       </PointSymbolizer>
+        //       <VendorOption name="inclusion">legendOnly</VendorOption>
+        //     </Rule>
+        //   </FeatureTypeStyle>
+        // </UserStyle>
+        Style style = parse("point", "rule-option.sld");
+        List<Rule> rules = style.featureTypeStyles().get(0).rules();
+        assertThat(rules.get(0).getOptions(), hasEntry("inclusion", "mapOnly"));
+        assertThat(rules.get(1).getOptions(), hasEntry("inclusion", "legendOnly"));
     }
 
     @Test

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
@@ -2302,4 +2302,12 @@ public class YsldParseTest {
             assertThat(e.getMessage(), containsString("could not determine a constructor"));
         }
     }
+
+    @Test
+    public void testRuleVendorOption() throws Exception {
+        String yaml = "feature-styles:\n" + "- rules:\n" + "  - x-foo: bar";
+        StyledLayerDescriptor sld = Ysld.parse(yaml);
+        Rule rule = SLD.rules(SLD.defaultStyle(sld))[0];
+        assertThat(rule.getOptions(), hasEntry("foo", "bar"));
+    }
 }

--- a/modules/extension/ysld/src/test/resources/org/geotools/ysld/sld/point/rule-option.sld
+++ b/modules/extension/ysld/src/test/resources/org/geotools/ysld/sld/point/rule-option.sld
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Rule Vendor Option</Name>
+    <UserStyle>
+      <Title>Simple Point With Rule Vendor Option</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <VendorOption name="inclusion">mapOnly</VendorOption>
+        </Rule>
+        <Rule>
+          <PointSymbolizer>
+            <Graphic>
+              <ExternalGraphic>
+                 <OnlineResource xlink:type="simple" xlink:href="smileyface.png" />
+                <Format>image/png</Format>
+              </ExternalGraphic>
+              <Size>20</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <VendorOption name="inclusion">legendOnly</VendorOption>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOT-7030](https://badgen.net/badge/JIRA/GEOT-7030/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7030) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport of https://github.com/geotools/geotools/pull/3694

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->