### PR TITLE
[GEOT-7049] Crop operation should preserve the ROI among the coverage properties

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Crop.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Crop.java
@@ -636,10 +636,11 @@ public class Crop extends Operation2D {
             // //
             ImageWorker worker = new ImageWorker();
             java.awt.Polygon rasterSpaceROI = null;
-            double[] background =
-                    destnodata != null
-                            ? destnodata
-                            : CoverageUtilities.getBackgroundValues(sourceCoverage);
+
+            double[] background = destnodata;
+            if (background == null)
+                background = CoverageUtilities.getBackgroundValues(sourceCoverage);
+
             String operatioName = null;
             if (!isSimpleTransform || cropROI != null) {
                 // /////////////////////////////////////////////////////////////////////
@@ -757,7 +758,12 @@ public class Crop extends Operation2D {
             if (sourceProperties != null && !sourceProperties.isEmpty()) {
                 properties = new HashMap<>(sourceProperties);
             }
-            if (rasterSpaceROI != null || internalROI != null) {
+            if (worker.getROI() != null && !worker.getROI().contains(croppedImage.getBounds())) {
+                if (properties == null) {
+                    properties = new HashMap<>();
+                }
+                CoverageUtilities.setROIProperty(properties, worker.getROI());
+            } else if (rasterSpaceROI != null || internalROI != null) {
                 ROI finalROI = null;
                 if (rasterSpaceROI != null) {
                     finalROI = getAsROI(JTS.toPolygon(rasterSpaceROI));


### PR DESCRIPTION
[![GEOT-7049](https://badgen.net/badge/JIRA/GEOT-7049/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7049) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->