### PR TITLE
Revert "[GEOT-7048] Upgrade NetCDF to 4.6.19"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
     <imageio.ext.version>1.3.11</imageio.ext.version>
     <jts.version>1.18.2</jts.version>
     <jaiext.version>1.1.21</jaiext.version>
-    <netcdf.version>4.6.19</netcdf.version>
+    <netcdf.version>4.6.15</netcdf.version>
     <commons-beanutils.version>1.9.2</commons-beanutils.version>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>
     <jt.version>1.6.0</jt.version>


### PR DESCRIPTION
[![GEOT-7048](https://badgen.net/badge/JIRA/GEOT-7048/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7048) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Reverts geotools/geotools#3728

Due to WCS netcdf-out build failures. See details in relevant GS Revert PR:
https://github.com/geoserver/geoserver/pull/5584