### PR TITLE
[GEOT-7053] TransformFeatureCollection visitor delegation can result in infinite recursion

### DIFF
--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureCollection.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureCollection.java
@@ -39,7 +39,6 @@ import org.geotools.util.logging.Logging;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.expression.Expression;
@@ -282,11 +281,7 @@ class TransformFeatureCollection extends AbstractFeatureCollection {
 
     protected void delegateVisitor(FeatureVisitor visitor, ProgressListener progress)
             throws IOException {
-        Name typeName = transformer.getSource().getName();
         Query txQuery = transformer.transformQuery(query);
-        source.getDataStore()
-                .getFeatureSource(typeName)
-                .getFeatures(txQuery)
-                .accepts(visitor, progress);
+        transformer.getSource().getFeatures(txQuery).accepts(visitor, progress);
     }
 }

--- a/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformFeatureCollectionTest.java
+++ b/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformFeatureCollectionTest.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import org.geotools.data.DataAccess;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.Query;
@@ -34,8 +33,6 @@ import org.geotools.util.logging.Logging;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengis.feature.FeatureVisitor;
-import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.opengis.util.ProgressListener;
@@ -47,7 +44,6 @@ public class TransformFeatureCollectionTest {
 
     static class TransformFeatureStoreWrapper extends TransformFeatureStore {
 
-        private DataStore datastore;
         private boolean passedDown = false;
 
         class TransformFeatureCollectionWrapper extends TransformFeatureCollection {
@@ -72,12 +68,6 @@ public class TransformFeatureCollectionTest {
                 DataStore datastore)
                 throws IOException {
             super(store, name, definitions);
-            this.datastore = datastore;
-        }
-
-        @Override
-        public DataAccess<SimpleFeatureType, SimpleFeature> getDataStore() {
-            return datastore;
         }
 
         @Override


### PR DESCRIPTION
[![GEOT-7053](https://badgen.net/badge/JIRA/GEOT-7053/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7053) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->