### PR TITLE
[GEOT-7011] GeoPackage.add(FeatureEntry, SimpleFeatureCollection) forced to XY order

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
@@ -56,6 +56,7 @@ import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureReader;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureWriter;
+import org.geotools.data.store.ReprojectingFeatureCollection;
 import org.geotools.filter.identity.FeatureIdImpl;
 import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.Geometries;
@@ -82,6 +83,7 @@ import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.filter.Filter;
 import org.opengis.filter.identity.Identifier;
 import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.ReferenceIdentifier;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.sqlite.Function;
 import org.sqlite.SQLiteConfig;
@@ -796,6 +798,38 @@ public class GeoPackage implements Closeable {
     }
 
     /**
+     * According to GeoPKG spec, the coordinates MUST be in XY order. If this FC is in YX format, we
+     * reproject to the equivalent XY project.
+     *
+     * <p>If already XY, return the input FC.
+     *
+     * @param fc underlying feature collection
+     * @return feature collection which is has axis order in XY (NORTH_EAST)
+     */
+    public static SimpleFeatureCollection forceXY(SimpleFeatureCollection fc) {
+        CoordinateReferenceSystem sourceCRS = fc.getSchema().getCoordinateReferenceSystem();
+        if ((CRS.getAxisOrder(sourceCRS) == CRS.AxisOrder.EAST_NORTH)
+                || (CRS.getAxisOrder(sourceCRS) == CRS.AxisOrder.INAPPLICABLE)) {
+            return fc;
+        }
+
+        for (ReferenceIdentifier identifier : sourceCRS.getIdentifiers()) {
+            try {
+                String _identifier = identifier.toString();
+                CoordinateReferenceSystem flippedCRS = CRS.decode(_identifier, true);
+                if (CRS.getAxisOrder(flippedCRS) == CRS.AxisOrder.EAST_NORTH) {
+                    ReprojectingFeatureCollection result =
+                            new ReprojectingFeatureCollection(fc, flippedCRS);
+                    return result;
+                }
+            } catch (Exception e) {
+                // couldn't flip - try again
+            }
+        }
+        return fc;
+    }
+
+    /**
      * Adds a new feature dataset to the geopackage.
      *
      * @param entry Contains metadata about the feature entry.
@@ -806,6 +840,8 @@ public class GeoPackage implements Closeable {
     public void add(FeatureEntry entry, SimpleFeatureCollection collection) throws IOException {
         FeatureEntry e = new FeatureEntry();
         e.init(entry);
+
+        collection = forceXY(collection);
 
         if (e.getBounds() == null) {
             e.setBounds(collection.getBounds());

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
@@ -806,7 +806,7 @@ public class GeoPackage implements Closeable {
      * @param fc underlying feature collection
      * @return feature collection which is has axis order in XY (NORTH_EAST)
      */
-    public static SimpleFeatureCollection forceXY(SimpleFeatureCollection fc) {
+    static SimpleFeatureCollection forceXY(SimpleFeatureCollection fc) {
         CoordinateReferenceSystem sourceCRS = fc.getSchema().getCoordinateReferenceSystem();
         if ((CRS.getAxisOrder(sourceCRS) == CRS.AxisOrder.EAST_NORTH)
                 || (CRS.getAxisOrder(sourceCRS) == CRS.AxisOrder.INAPPLICABLE)) {

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -16,11 +16,7 @@
  */
 package org.geotools.geopkg;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
@@ -97,6 +93,7 @@ import org.opengis.filter.FilterFactory;
 import org.opengis.filter.identity.Identifier;
 import org.opengis.parameter.GeneralParameterValue;
 import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.sqlite.SQLiteConfig;
 
 public class GeoPackageTest {
@@ -1122,5 +1119,83 @@ public class GeoPackageTest {
         FeatureEntry entry = new FeatureEntry();
         geopkg.add(entry, shp.getFeatureSource(), null);
         assertTableExists("bugsites");
+    }
+
+    // if the FC already is XY, then forceXY does nothing (should return same FC)
+    @Test
+    public void testForceXY_alreadyXY() throws Exception {
+
+        String wkt_xy =
+                "GEOGCS[\"WGS 84\", \n"
+                        + "  DATUM[\"World Geodetic System 1984\", \n"
+                        + "    SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], \n"
+                        + "    AUTHORITY[\"EPSG\",\"6326\"]], \n"
+                        + "  PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], \n"
+                        + "  UNIT[\"degree\", 0.017453292519943295], \n"
+                        + "  AXIS[\"Geodetic latitude\", EAST], \n"
+                        + "  AXIS[\"Geodetic longitude\", NORTH], \n"
+                        + "  AUTHORITY[\"EPSG\",\"4326\"]]";
+
+        CoordinateReferenceSystem crs_yx = CRS.parseWKT(wkt_xy);
+        assertEquals(CRS.getAxisOrder(crs_yx), CRS.AxisOrder.EAST_NORTH);
+
+        SimpleFeatureType simpleFeatureTypeXY =
+                DataUtilities.createType("testcase", "id:String,pointProperty:Point:srid=4326");
+        simpleFeatureTypeXY =
+                DataUtilities.createSubType(simpleFeatureTypeXY, null, crs_yx); // set CRS
+
+        SimpleFeature sfXY =
+                DataUtilities.createFeature(simpleFeatureTypeXY, "fid1=test|POINT(0 1)");
+        SimpleFeatureCollection fcXY = DataUtilities.collection(sfXY);
+
+        SimpleFeatureCollection fcXY2 = GeoPackage.forceXY(fcXY);
+
+        assertEquals(
+                CRS.getAxisOrder(fcXY2.getSchema().getCoordinateReferenceSystem()),
+                CRS.AxisOrder.EAST_NORTH);
+        assertSame(fcXY2, fcXY);
+    }
+
+    // if underlying data is YX, result should be XY
+    @Test
+    public void testForceXY_simpleFlip() throws Exception {
+        // create a FeatureCollection that is advertised as YX
+        String wkt_yx =
+                "GEOGCS[\"WGS 84\", \n"
+                        + "  DATUM[\"World Geodetic System 1984\", \n"
+                        + "    SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], \n"
+                        + "    AUTHORITY[\"EPSG\",\"6326\"]], \n"
+                        + "  PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], \n"
+                        + "  UNIT[\"degree\", 0.017453292519943295], \n"
+                        + "  AXIS[\"Geodetic longitude\", NORTH], \n"
+                        + "  AXIS[\"Geodetic latitude\", EAST], \n"
+                        + "  AUTHORITY[\"EPSG\",\"4326\"]]";
+        CoordinateReferenceSystem crs_yx = CRS.parseWKT(wkt_yx);
+        assertEquals(CRS.getAxisOrder(crs_yx), CRS.AxisOrder.NORTH_EAST);
+
+        SimpleFeatureType simpleFeatureTypeYX =
+                DataUtilities.createType("testcase", "id:String,pointProperty:Point:srid=4326");
+        simpleFeatureTypeYX =
+                DataUtilities.createSubType(simpleFeatureTypeYX, null, crs_yx); // set CRS
+
+        SimpleFeature sfYX =
+                DataUtilities.createFeature(simpleFeatureTypeYX, "fid1=test|POINT(0 1)");
+        SimpleFeatureCollection fcYX = DataUtilities.collection(sfYX);
+
+        // xform
+        SimpleFeatureCollection fcXY = GeoPackage.forceXY(fcYX);
+
+        assertEquals(
+                CRS.getAxisOrder(fcXY.getSchema().getCoordinateReferenceSystem()),
+                CRS.AxisOrder.EAST_NORTH);
+
+        SimpleFeature sfXY = fcXY.features().next();
+
+        // verify geometry is actually XY
+        Coordinate coordinate = ((Geometry) sfYX.getDefaultGeometry()).getCoordinate();
+        Coordinate coordinateYX = ((Geometry) sfXY.getDefaultGeometry()).getCoordinate();
+
+        assertEquals(coordinate.x, coordinateYX.y, 0);
+        assertEquals(coordinate.y, coordinateYX.x, 0);
     }
 }

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -1123,8 +1123,9 @@ public class GeoPackageTest {
 
     // if the FC already is XY, then forceXY does nothing (should return same FC)
     @Test
-    public void testForceXY_alreadyXY() throws Exception {
+    public void testForceXYAlreadyXY() throws Exception {
 
+        // standard EPSG:4326 in EAST_NORTH format (XY)
         String wkt_xy =
                 "GEOGCS[\"WGS 84\", \n"
                         + "  DATUM[\"World Geodetic System 1984\", \n"
@@ -1158,8 +1159,9 @@ public class GeoPackageTest {
 
     // if underlying data is YX, result should be XY
     @Test
-    public void testForceXY_simpleFlip() throws Exception {
+    public void testForceXYSimpleFlip() throws Exception {
         // create a FeatureCollection that is advertised as YX
+        // standard EPSG:4326 in NORTH_EAST format (YX)
         String wkt_yx =
                 "GEOGCS[\"WGS 84\", \n"
                         + "  DATUM[\"World Geodetic System 1984\", \n"

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -16,7 +16,12 @@
  */
 package org.geotools.geopkg;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.awt.Graphics2D;
 import java.awt.Rectangle;


### PR DESCRIPTION
[![GEOT-7011](https://badgen.net/badge/JIRA/GEOT-7011/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7011) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is a port of a fix proposed here https://github.com/geoserver/geoserver/pull/5558 for the geopackage output format. 

Feedback from @groldan indicated the fix could be better applied directly in the GeoPackage API.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue: [ in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). ](https://osgeo-org.atlassian.net/browse/GEOT-7011)
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->