### PR TITLE
Some small improvements to geopackage documentation

### DIFF
--- a/docs/user/library/data/geopackage.rst
+++ b/docs/user/library/data/geopackage.rst
@@ -108,7 +108,7 @@ A GeoPackage with a feature entry can be created using the following low level c
 
 Note:
 
-* Direct access to additional features and extensions, such as ``createSpatialIndex(entry)`` above
+* This example shows direct access to additional features and extensions, such as the ``createSpatialIndex(entry)`` discussed above.
 * GeoPackage requires that features are stored in XYZM order, the featureCollection used as the initial contents will be written to disk in this order.
 
 Once created, the features in the entry can be read using a SimpleFeatureReader:

--- a/docs/user/library/data/geopackage.rst
+++ b/docs/user/library/data/geopackage.rst
@@ -16,7 +16,7 @@ References:
 
 **Maven**
 
-::
+.. code-block:: xml
 
    <dependency>
       <groupId>org.geotools</groupId>
@@ -25,31 +25,54 @@ References:
     </dependency>
 
 
-DataStore Connection Parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+DataStore API
+^^^^^^^^^^^^^
 
-============== ============================================
-Parameter      Description
-============== ============================================
-``dbtype``     Must be the string ``geopkg``
-``database``   The database to connect to
-``user``       User name (optional)
-============== ============================================
+GeoTools provides direct access to JDBCDataStore implementation for accessing feature contents as expressed in the specification:
 
-Access
-^^^^^^
+> A GeoPackage with a ``gpkg_contents`` table row with a "features" data_type SHALL contain a ``gpkg_geometry_columns`` table per Table 5 and ``gpkg_geometry_columns`` Table Definition SQL.
 
-Example use::
+Spatial index is supported with the use of ``gpkg_rtree_index``.
+
+The ``JDBCDataStore.createVirtualTable`` functionality is not supported (as the ``gpkg_geometry_columns`` information is not available for ad-hoc SQL queries).
+
+Connection Parameters
+'''''''''''''''''''''
+
+.. list-table:: Connection Parameters
+   :widths: 30 79
+   :header-rows: 1
+
+   * - Parameter
+     - Quantity
+   * - ``dbtype``
+     - Must be the string ``geopkg``
+   * - ``database``
+     - The database to connect to
+   * - ``read_only``
+     - Use Boolean.TRUE to open in read-only mode (optional)
+   * - ``user``
+     - User name (optional)
+   * - ``memory map size``
+     - SQLite memory map size in MB
+
+Feature Access
+''''''''''''''
+
+Example use:
+
+.. code-block:: java
   
-  Map params = new HashMap();
-  params.put("dbtype", "geopkg");
-  params.put("database", "test.gkpg");
+   Map params = new HashMap();
+   params.put("dbtype", "geopkg");
+   params.put("database", "test.gkpg");
   
-  DataStore datastore = DataStoreFinder.getDataStore(params);
+   DataStore datastore = DataStoreFinder.getDataStore(params);
 
+Care should be taken when using `DataStore.create( schema )` as the GeoPackage specification requires features to be stored in XYZM order.
 
-High level coverage reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+GridCoverage API
+^^^^^^^^^^^^^^^^
 
 The high level coverage reader can access all tile entries found in the package, exposing each one as
 a separate coverage.
@@ -63,8 +86,13 @@ a separate coverage.
         parameters[0] = new Parameter<GridGeometry2D>(AbstractGridFormat.READ_GRIDGEOMETRY2D, gg);
         GridCoverage2D gc = reader.read("World_Lakes", parameters);  
 
-Adding a feature entry using the low level API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+GeoPackage API
+^^^^^^^^^^^^^^
+
+In addition to the GeoTools DataStore and GridCoverage access a low-level API is provided to directly manage the contents of a GeoPackage.
+
+Adding a feature entry
+^^^^^^^^^^^^^^^^^^^^^^
 
 A GeoPackage with a feature entry can be created using the following low level code:
 
@@ -73,10 +101,15 @@ A GeoPackage with a feature entry can be created using the following low level c
         GeoPackage geopkg = new GeoPackage(File.createTempFile("geopkg", "db", new File("target")));
         geopkg.init();
         
-        ShapefileDataStore shp = ...
-
         FeatureEntry entry = new FeatureEntry();
-        geopkg.add(entry, shp.getFeatureSource(), null);
+        entry.setDescription("Cities of the world");
+        geopkg.add(entry, featureCollection);
+        geopkg.createSpatialIndex(entry);
+
+Note:
+
+* Direct access to additional features and extensions, such as ``createSpatialIndex(entry)`` above
+* GeoPackage requires that features are stored in XYZM order, the featureCollection used as the initial contents will be written to disk in this order.
 
 Once created, the features in the entry can be read using a SimpleFeatureReader:
         
@@ -90,8 +123,8 @@ Once created, the features in the entry can be read using a SimpleFeatureReader:
 
 The parallel ``writer`` method can be used to grab a SimpleFeatureWriter to modify existing features.
 
-Adding a tile entry using the low level API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding a tile entry
+^^^^^^^^^^^^^^^^^^^
 
 A GeoPackage with a tile entry can be created using the following low level code:
 
@@ -107,7 +140,6 @@ A GeoPackage with a tile entry can be created using the following low level code
         e.getTileMatricies().add(new TileMatrix(1, 2, 2, 256, 256, 0.1, 0.1));
 
         geopkg.create(e);
-        assertTileEntry(e);
 
         List<Tile> tiles = new ArrayList();
         tiles.add(new Tile(0,0,0,new byte[]{...}));
@@ -131,3 +163,25 @@ Tile can then be read back using a ``TileReader``, as follows (the zoom and row/
             }
         }
 
+Using GeoPackage Extensions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The GeoPackage specification is modular using the concepts of extensions to support additional functionality.
+
+* ``GeoPkgExtension`` - base class for geopackage extensions
+* ``GeoPkgExtensionFactory`` - used to advertise additional extensions provided by client code
+
+The GeoPackage module supports the following extensions:
+
+* ``GeoPkgMetadataExtension`` - Use ``geopkg_metadata`` and and ``geopkg_metadata_reference`` to store metadata.
+* ``GeoPkgSchemaExtension`` - Allows additional description of table columns.
+
+GeoPackageProcessRequest
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+This java bean (and xml bindings) is used to support the GeoServer WPS GeoPackage process which supports the creation of GeoPackages with additional extensions.
+
+* ``GeoPackageProcessRequest.FeatureLayer``
+* ``GeoPackageProcessRequest.TileLayer``
+
+These classes cannot directly be used by GeoTools code.

--- a/docs/user/library/data/geopackage.rst
+++ b/docs/user/library/data/geopackage.rst
@@ -173,7 +173,7 @@ The GeoPackage specification is modular using the concepts of extensions to supp
 
 The GeoPackage module supports the following extensions:
 
-* ``GeoPkgMetadataExtension`` - Use ``geopkg_metadata`` and and ``geopkg_metadata_reference`` to store metadata.
+* ``GeoPkgMetadataExtension`` - Uses ``geopkg_metadata`` and and ``geopkg_metadata_reference`` to store metadata.
 * ``GeoPkgSchemaExtension`` - Allows additional description of table columns.
 
 GeoPackageProcessRequest

--- a/docs/user/library/data/geopackage.rst
+++ b/docs/user/library/data/geopackage.rst
@@ -48,13 +48,25 @@ Connection Parameters
    * - ``dbtype``
      - Must be the string ``geopkg``
    * - ``database``
-     - The database to connect to
+     - The database filename to connect to (either complete path or relative path).
    * - ``read_only``
      - Use Boolean.TRUE to open in read-only mode (optional)
-   * - ``user``
-     - User name (optional)
    * - ``memory map size``
      - SQLite memory map size in MB
+
+Use ``read-only`` for best performance, allowing SQLite to ignore the complexity of transactions.
+
+The ``database`` parameter above is specified as a path to the GeoPackage database. If using a relative path a base directory can be provided to the ``GeoPkgDataStoreFactory`` instance prior to use:
+
+.. code-block:: java
+   
+   for( DataStoreFactorySPI factory : DataStoreFinder.getAvailableDataStores() ){
+      if( factory instanceof GeoPkgDataStoreFactory){
+          GeoPkgDataStoreFactory geopkgFactory = (GeoPkgDataStoreFactory) factory;
+          geopkgFactory.setBaseDirectory( directory );
+      }
+   }
+
 
 Feature Access
 ''''''''''''''
@@ -66,6 +78,7 @@ Example use:
    Map params = new HashMap();
    params.put("dbtype", "geopkg");
    params.put("database", "test.gkpg");
+   params.put("read-only", true);
   
    DataStore datastore = DataStoreFinder.getDataStore(params);
 
@@ -80,6 +93,7 @@ a separate coverage.
 .. code-block:: java
 
         GeoPackageReader reader = new GeoPackageReader(getClass().getResource("world_lakes.gpkg"), null);
+        
         System.out.println(Arrays.asList(reader.getGridCoverageNames()));
         GeneralParameterValue[] parameters = new GeneralParameterValue[1];
         GridGeometry2D gg = new GridGeometry2D(new GridEnvelope2D(new Rectangle(500,500)), new ReferencedEnvelope(0,180.0,-85.0,0,WGS_84));
@@ -108,7 +122,7 @@ A GeoPackage with a feature entry can be created using the following low level c
 
 Note:
 
-* This example shows direct access to additional features and extensions, such as the ``createSpatialIndex(entry)`` discussed above.
+* This example shows direct access to additional features and extensions, such as the ``createSpatialIndex(entry)`` above.
 * GeoPackage requires that features are stored in XYZM order, the featureCollection used as the initial contents will be written to disk in this order.
 
 Once created, the features in the entry can be read using a SimpleFeatureReader:
@@ -121,7 +135,7 @@ Once created, the features in the entry can be read using a SimpleFeatureReader:
           }
         }
 
-The parallel ``writer`` method can be used to grab a SimpleFeatureWriter to modify existing features.
+The parallel ``writer`` method can be used to acquire a SimpleFeatureWriter to modify existing features.
 
 Adding a tile entry
 ^^^^^^^^^^^^^^^^^^^
@@ -166,7 +180,7 @@ Tile can then be read back using a ``TileReader``, as follows (the zoom and row/
 Using GeoPackage Extensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The GeoPackage specification is modular using the concepts of extensions to support additional functionality.
+The GeoPackage specification is modular using the concepts of extensions to support additional functionality:
 
 * ``GeoPkgExtension`` - base class for geopackage extensions
 * ``GeoPkgExtensionFactory`` - used to advertise additional extensions provided by client code

--- a/docs/user/library/data/geopackage.rst
+++ b/docs/user/library/data/geopackage.rst
@@ -44,7 +44,7 @@ Connection Parameters
    :header-rows: 1
 
    * - Parameter
-     - Quantity
+     - Description
    * - ``dbtype``
      - Must be the string ``geopkg``
    * - ``database``


### PR DESCRIPTION
Follow up to https://github.com/geotools/geotools/pull/3740 with some improvements to geopackage documentation.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->