### PR TITLE
Fix user docs and website extlink errors caused by upgrade to sphinx-build

### DIFF
--- a/docs/build.xml
+++ b/docs/build.xml
@@ -73,16 +73,16 @@
 	</target>
 
 	<target name="sphinx-ignore-warnings" if="sphinx.available">
-        <echo message="Running sphinx-build -D release=${project.version} -q -j 2 -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+        <echo message="Running sphinx-build -D release=${project.version} -q -j auto -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
 		<exec executable="sphinx-build" failonerror="true" dir="${basedir}/${id}">
-			<arg line="-D release=${project.version} -q -j 2 -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+			<arg line="-D release=${project.version} -q -j auto -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
 		</exec>
 	</target>
     
     <target name="sphinx" if="sphinx.available">
-        <echo message="Running sphinx-build -D release=${project.version} -q -W -j 2 -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+        <echo message="Running sphinx-build -D release=${project.version} -q -W --keep-going -j auto -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
 		<exec executable="sphinx-build" failonerror="true" dir="${basedir}/${id}">
-			<arg line="-D release=${project.version} -q -W -j 2 -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+			<arg line="-D release=${project.version} -q -W --keep-going -j auto -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
 		</exec>
 	</target>
 

--- a/docs/user/library/coverage/netCDF.rst
+++ b/docs/user/library/coverage/netCDF.rst
@@ -9,4 +9,4 @@ Collections. It supports Forecast Model Run Collection Aggregations
 (FMRC) either through the NCML or Feature Collection syntax. It supports
 an unlimited amount of custom dimensions, including runtime.
 
-Further documentation is available in `the GeoServer project <https://docs.geoserver.org/latest/en/user/extensions/netcdf/netcdf.html#notes-on-supported-netcdfs>`_
+Further documentation is available in :geoserver:`the GeoServer project <extensions/netcdf/netcdf.html#notes-on-supported-netcdfs>`.

--- a/docs/user/welcome/upgrade.rst
+++ b/docs/user/welcome/upgrade.rst
@@ -775,7 +775,7 @@ GeoTools 10.0
 
 .. sidebar:: Wiki
 
-   * `GeoTools 10.0 <https://github.com/geotools/geotools/wiki/10.x>`_
+   * :wiki:`10.x`
 
    For background details on any API changes review the change proposals above.
 
@@ -795,7 +795,7 @@ GeoTools 9.0
 
 .. sidebar:: Wiki
 
-   * `GeoTools 9.0 <https://github.com/geotools/geotools/wiki/9.x>`_
+   * :wiki:`9.x`
 
    For background details on any API changes review the change proposals above.
 
@@ -972,7 +972,7 @@ GeoTools 8.0
 
 .. sidebar:: Wiki
 
-   * `GeoTools 8.0 <https://github.com/geotools/geotools/wiki/8.x>`_
+   * :wiki:`8.x`
 
    You are encouraged to review the change proposals for GeoTools 8.0 for background information
    on the following changes.
@@ -1112,7 +1112,7 @@ GeoTools 2.7
 
 .. sidebar:: Wiki
 
-   * `GeoTools 2.7.0 <https://github.com/geotools/geotools/wiki/2.7.x>`_
+   * :wiki:`2.7.x`
 
    You are encouraged to review the change proposals for GeoTools 2.7.0 for background information
    on the following changes.
@@ -1310,7 +1310,7 @@ GeoTools 2.6
 
 .. sidebar:: Wiki
 
-   * `GeoTools 2.6.0 <https://github.com/geotools/geotools/wiki/2.6.x>`_
+   * :wiki:`2.6.x`
 
    You are encouraged to review the change proposals for GeoTools 2.6.0 for background information
    on the following changes.
@@ -1526,7 +1526,7 @@ GeoTools 2.5
 
 .. sidebar:: Wiki
 
-   * `GeoTools 2.5.0 <https://github.com/geotools/geotools/wiki/2.5.x>`_
+   * :wiki:`2.5.x`
 
    You are encouraged to review the change proposals for GeoTools 2.5.0 for background information
    on the following changes.
@@ -1849,7 +1849,7 @@ GeoTools 2.4
 
 .. sidebar:: Wiki
 
-   * `GeoTools 2.4.0 <https://github.com/geotools/geotools/wiki/2.4.x>`_
+   * :wiki:`2.4.x`
 
    You are encouraged to review the change proposals for GeoTools 2.4.0 for background information
    on the following changes.

--- a/docs/web/about.rst
+++ b/docs/web/about.rst
@@ -16,7 +16,7 @@ Current :developer:`version <conventions/version.html>` information:
 * `26.x <http://sourceforge.net/projects/geotools/files/GeoTools%2026%20Releases/>`__: Stable
 * `25.x <http://sourceforge.net/projects/geotools/files/GeoTools%2025%20Releases/>`__: Maintenance
 
-GeoTools is used by a `number of projects <https://github.com/geotools/geotools/wiki/screenshots>`__
+GeoTools is used by a :wiki:`number of projects <screenshots>`
 including Web Feature Servers, Web Map Servers, and desktop applications.
 
 Open Source


### PR DESCRIPTION
Fix extlink warnings for geotools user docs, this should be backported.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->