### PR TITLE
Removed double semicolon at the end of line

### DIFF
--- a/modules/ogc/net.opengis.wcs/src/net/opengis/wcs10/impl/DescribeCoverageTypeImpl.java
+++ b/modules/ogc/net.opengis.wcs/src/net/opengis/wcs10/impl/DescribeCoverageTypeImpl.java
@@ -149,7 +149,7 @@ public class DescribeCoverageTypeImpl extends EObjectImpl implements DescribeCov
 	 * @generated NOT
 	 * @ordered
 	 */
-	protected Map extendedProperties = new HashMap();;
+	protected Map extendedProperties = new HashMap();
 
 				/**
 	 * <!-- begin-user-doc -->

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterLayerRequest.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterLayerRequest.java
@@ -101,7 +101,7 @@ public class RasterLayerRequest {
     RasterManager rasterManager;
 
     private Color inputTransparentColor =
-            AbstractGridFormat.INPUT_TRANSPARENT_COLOR.getDefaultValue();;
+            AbstractGridFormat.INPUT_TRANSPARENT_COLOR.getDefaultValue();
 
     private boolean blend = ImageMosaicFormat.FADING.getDefaultValue();
 
@@ -109,7 +109,7 @@ public class RasterLayerRequest {
     private MergeBehavior mergeBehavior = MergeBehavior.getDefault();
 
     private Color outputTransparentColor =
-            ImageMosaicFormat.OUTPUT_TRANSPARENT_COLOR.getDefaultValue();;
+            ImageMosaicFormat.OUTPUT_TRANSPARENT_COLOR.getDefaultValue();
 
     /**
      * Max number of tiles that this plugin will load.

--- a/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/RasterLayerRequest.java
+++ b/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/RasterLayerRequest.java
@@ -108,7 +108,7 @@ class RasterLayerRequest {
      */
     private boolean empty;
 
-    private Color inputTransparentColor = JP2KFormat.INPUT_TRANSPARENT_COLOR.getDefaultValue();;
+    private Color inputTransparentColor = JP2KFormat.INPUT_TRANSPARENT_COLOR.getDefaultValue();
 
     private AffineTransform requestedGridToWorld;
 

--- a/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojsonstore/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -76,7 +76,7 @@ public class GeoJSONReader implements AutoCloseable {
 
     private JsonParser parser;
 
-    private static JsonFactory factory = new JsonFactory();;
+    private static JsonFactory factory = new JsonFactory();
 
     private SimpleFeatureType schema;
 

--- a/modules/unsupported/swing/src/test/java/org/geotools/swing/dialog/JFileImageChooserTest.java
+++ b/modules/unsupported/swing/src/test/java/org/geotools/swing/dialog/JFileImageChooserTest.java
@@ -65,7 +65,7 @@ public class JFileImageChooserTest extends GraphicsTestBase<DialogFixture, Dialo
 
     private static final Class<? extends Component> DIALOG_CLASS = JFileImageChooser.class;
 
-    private static final ExecutorService executor = Executors.newSingleThreadExecutor();;
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
     private static List<String> readerFileSuffixes;
     private static List<String> writerFileSuffixes;
 


### PR DESCRIPTION
Hi

I have found some lines of codes with a double semicolon at the end. No impact on baseline

ciao
matteo
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).