### PR TITLE
[25.x][GEOT-7051] ContourProcess doesn't extract GridCoverage2D NoData properties

### DIFF
--- a/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/ContourProcess.java
+++ b/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/ContourProcess.java
@@ -17,6 +17,7 @@
  */
 package org.geotools.process.raster;
 
+import it.geosolutions.jaiext.range.NoDataContainer;
 import java.awt.geom.AffineTransform;
 import java.awt.image.RenderedImage;
 import java.util.ArrayList;
@@ -190,6 +191,11 @@ public class ContourProcess implements RasterProcess {
 
         // get the list of nodata, if any
         List<Object> noDataList = new ArrayList<>();
+        NoDataContainer noDataProperty =
+                org.geotools.coverage.util.CoverageUtilities.getNoDataProperty(gc2d);
+        if (noDataProperty != null) {
+            noDataList.add(noDataProperty.getAsSingleValue());
+        }
         for (GridSampleDimension sd : gc2d.getSampleDimensions()) {
             // grab all the explicit nodata
             final double[] sdNoData = sd.getNoDataValues();

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/ContourProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/ContourProcessTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import it.geosolutions.jaiext.range.NoDataContainer;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
@@ -315,5 +316,29 @@ public class ContourProcessTest {
         // bug would be significantly higher.
         double area = width * height;
         assertEquals(0.0025, whiteSamples / area, 0.0005);
+    }
+
+    @Test
+    public void testContourWithNoDataProperty() {
+        // Create a coverage with a NoData value only in the properties.
+        ReferencedEnvelope envelope = new ReferencedEnvelope(0, 3, 0, 3, null);
+        float[][] matrix = {{0, 0, 0}, {0, 9999, 0}, {0, 0, 0}};
+        GridCoverage2D cov = covFactory.create("coverage", matrix, envelope);
+        Map<Object, Object> properties = new HashMap<>();
+        properties.put(NoDataContainer.GC_NODATA, new NoDataContainer(9999));
+        cov =
+                covFactory.create(
+                        cov.getName(),
+                        cov.getRenderedImage(),
+                        cov.getEnvelope(),
+                        cov.getSampleDimensions(),
+                        null,
+                        properties);
+        SimpleFeatureCollection fc =
+                process.execute(cov, 0, new double[] {20}, null, null, null, null, null);
+        // Before fix, the NoData value will be interpolated and create a contour.
+        // After fix, the NoData value will be ignored so there will be no contours.
+        assertNotNull(fc);
+        assertTrue(fc.isEmpty());
     }
 }


### PR DESCRIPTION
[![GEOT-7051](https://badgen.net/badge/JIRA/GEOT-7051/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7051) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

25.x backport for https://github.com/geotools/geotools/pull/3736

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->