### PR TITLE
[GEOT-7061] GrowableInternationalString.getLocales() is fixed to the values of its first invocation

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/GrowableInternationalString.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/GrowableInternationalString.java
@@ -41,6 +41,8 @@ import org.opengis.util.InternationalString;
  * added}, but existing strings can't be removed or modified. This behavior is a compromise between
  * making constructionss easier, and being suitable for use in immutable objects.
  *
+ * <p>This class is mutable and not thread-safe.
+ *
  * @since 2.1
  * @version $Id$
  * @author Martin Desruisseaux (IRD)
@@ -61,12 +63,6 @@ public class GrowableInternationalString extends AbstractInternationalString
      * and values are {@link String}s.
      */
     private Map<Locale, String> localMap;
-
-    /**
-     * An unmodifiable view of the entry set in {@link #localMap}. This is the set of locales
-     * defined in this international string. Will be constructed only when first requested.
-     */
-    private transient Set<Locale> localSet;
 
     /**
      * Constructs an initially empty international string. Localized strings can been added using
@@ -262,13 +258,15 @@ public class GrowableInternationalString extends AbstractInternationalString
     /**
      * Returns the set of locales defined in this international string.
      *
+     * <p>The returned set may contain a {@code null} object, signifying there's a "default" value
+     * (as created wither through the {@link
+     * GrowableInternationalString#GrowableInternationalString(String) single-string} constructor,
+     * or with a {@code null} "locale" parameter to {@link #add(Locale, String)}
+     *
      * @return The set of locales.
      */
-    public synchronized Set<Locale> getLocales() {
-        if (localSet == null) {
-            localSet = Collections.unmodifiableSet(localMap.keySet());
-        }
-        return localSet;
+    public Set<Locale> getLocales() {
+        return Collections.unmodifiableSet(localMap.keySet());
     }
 
     /**

--- a/modules/library/metadata/src/test/java/org/geotools/util/GrowableInternationalStringTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/GrowableInternationalStringTest.java
@@ -2,7 +2,11 @@ package org.geotools.util;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 import org.junit.Test;
 
 public class GrowableInternationalStringTest {
@@ -36,5 +40,24 @@ public class GrowableInternationalStringTest {
         assertEquals(2, newGrowable.getLocales().size());
         assertEquals("english text", newGrowable.toString(Locale.ENGLISH));
         assertEquals("default text", newGrowable.toString(null));
+    }
+
+    @Test
+    public void testGetLocales() {
+        GrowableInternationalString gi18ns = new GrowableInternationalString();
+        assertEquals(Collections.emptySet(), gi18ns.getLocales());
+
+        gi18ns.add(null, "default value");
+        assertEquals(Collections.singleton(null), gi18ns.getLocales());
+
+        gi18ns.add(Locale.CANADA_FRENCH, "ca-FR value");
+        assertEquals(newSet(null, Locale.CANADA_FRENCH), gi18ns.getLocales());
+
+        gi18ns.add(Locale.GERMAN, "de value");
+        assertEquals(newSet(null, Locale.CANADA_FRENCH, Locale.GERMAN), gi18ns.getLocales());
+    }
+
+    private Set<Locale> newSet(Locale... locales) {
+        return new HashSet<>(Arrays.asList(locales));
     }
 }


### PR DESCRIPTION
[![GEOT-7061](https://badgen.net/badge/JIRA/GEOT-7061/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7061) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`GrowableInternationalString.getLocales():Set<Locale>`
will always return the values it had when it was first called,
regardless of having called
`GrowableInternationalString.add(Locale, String)` afterwards.

This is because the set of Locales is held in an instance variable
initialized when `getLocales()` is first called, and never updated.

Moreover, it doesn't even make sense to cache them.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->