### PR TITLE
[GEOT-7058] WMTS documentation and examples - updates

### DIFF
--- a/docs/src/main/java/org/geotools/wfs/ReadWFSKommuner.java
+++ b/docs/src/main/java/org/geotools/wfs/ReadWFSKommuner.java
@@ -4,18 +4,9 @@
  *
  *    (C) 2021, Open Source Geospatial Foundation (OSGeo)
  *
- *    This library is free software; you can redistribute it and/or
- *    modify it under the terms of the GNU Lesser General Public
- *    License as published by the Free Software Foundation;
- *    version 2.1 of the License.
- *
- *    This library is distributed in the hope that it will be useful,
- *    but WITHOUT ANY WARRANTY; without even the implied warranty of
- *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *    Lesser General Public License for more details.
- *
+ *    This file is hereby placed into the Public Domain. This means anyone is
+ *    free to do whatever they wish with this file. Use it well and enjoy!
  */
-
 package org.geotools.wfs;
 
 import java.io.IOException;

--- a/docs/src/main/java/org/geotools/wmts/WMTSCoverage.java
+++ b/docs/src/main/java/org/geotools/wmts/WMTSCoverage.java
@@ -4,16 +4,8 @@
  *
  *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
  *
- *    This library is free software; you can redistribute it and/or
- *    modify it under the terms of the GNU Lesser General Public
- *    License as published by the Free Software Foundation;
- *    version 2.1 of the License.
- *
- *    This library is distributed in the hope that it will be useful,
- *    but WITHOUT ANY WARRANTY; without even the implied warranty of
- *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *    Lesser General Public License for more details.
- *
+ *    This file is hereby placed into the Public Domain. This means anyone is
+ *    free to do whatever they wish with this file. Use it well and enjoy!
  */
 
 package org.geotools.wmts;
@@ -48,7 +40,6 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  */
 public class WMTSCoverage {
 
-    private static final double[] LOMFJORDBOTNEN_EXTENT = {17.0697, 18.1937, 79.3052, 79.4667};
     private static final String WMTS_ORTOFOTO_URL =
             "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Ortofoto_Svalbard_WMTS_25833/MapServer/WMTS/1.0.0/WMTSCapabilities.xml";
 
@@ -59,18 +50,14 @@ public class WMTSCoverage {
         }
 
         File resultFile = new File(args[0]);
-
+        // start wmtsCoverage example
         WebMapTileServer wmts = new WebMapTileServer(new URL(WMTS_ORTOFOTO_URL));
         WMTSLayer layer = wmts.getCapabilities().getLayerList().get(0);
         WMTSCoverageReader reader = new WMTSCoverageReader(wmts, layer);
 
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(
-                        LOMFJORDBOTNEN_EXTENT[0],
-                        LOMFJORDBOTNEN_EXTENT[1],
-                        LOMFJORDBOTNEN_EXTENT[2],
-                        LOMFJORDBOTNEN_EXTENT[3],
-                        DefaultGeographicCRS.WGS84);
+                        17.0697, 18.1937, 79.3052, 79.4667, DefaultGeographicCRS.WGS84);
 
         CoordinateReferenceSystem upsCrs = CRS.decode("EPSG:32661");
         ReferencedEnvelope upsExtent =
@@ -93,5 +80,6 @@ public class WMTSCoverage {
         GeneralParameterValue[] parameters = new GeneralParameterValue[] {readGG};
         GridCoverage2D coverage = reader.read(parameters);
         ImageIO.write(coverage.getRenderedImage(), "png", resultFile);
+        // end wmtsCoverage example
     }
 }

--- a/docs/src/main/java/org/geotools/wmts/WMTSDownloader.java
+++ b/docs/src/main/java/org/geotools/wmts/WMTSDownloader.java
@@ -4,16 +4,8 @@
  *
  *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
  *
- *    This library is free software; you can redistribute it and/or
- *    modify it under the terms of the GNU Lesser General Public
- *    License as published by the Free Software Foundation;
- *    version 2.1 of the License.
- *
- *    This library is distributed in the hope that it will be useful,
- *    but WITHOUT ANY WARRANTY; without even the implied warranty of
- *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *    Lesser General Public License for more details.
- *
+ *    This file is hereby placed into the Public Domain. This means anyone is
+ *    free to do whatever they wish with this file. Use it well and enjoy!
  */
 package org.geotools.wmts;
 
@@ -60,7 +52,7 @@ public class WMTSDownloader {
             throw new IllegalArgumentException("You must provide the path to a root folder.");
         }
         rootFolder = new File(args[0]);
-
+        // start wmtsTileService example
         WebMapTileServer server = new WebMapTileServer(new URL(serverUrl));
         System.out.println("Layers:");
         server.getCapabilities()
@@ -85,5 +77,6 @@ public class WMTSDownloader {
             BufferedImage image = tile.getBufferedImage();
             ImageIO.write(image, "png", new File(rootFolder, tile.getId() + ".png"));
         }
+        // end wmtsTileService example
     }
 }

--- a/docs/src/main/java/org/geotools/wmts/WMTSMapViewer.java
+++ b/docs/src/main/java/org/geotools/wmts/WMTSMapViewer.java
@@ -4,16 +4,8 @@
  *
  *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
  *
- *    This library is free software; you can redistribute it and/or
- *    modify it under the terms of the GNU Lesser General Public
- *    License as published by the Free Software Foundation;
- *    version 2.1 of the License.
- *
- *    This library is distributed in the hope that it will be useful,
- *    but WITHOUT ANY WARRANTY; without even the implied warranty of
- *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *    Lesser General Public License for more details.
- *
+ *    This file is hereby placed into the Public Domain. This means anyone is
+ *    free to do whatever they wish with this file. Use it well and enjoy!
  */
 package org.geotools.wmts;
 
@@ -45,6 +37,7 @@ public class WMTSMapViewer {
     public static void main(String[] args) throws Exception {
         URL serverURL = showChooseWMTS();
 
+        // start wmtsMapViewer example
         WebMapTileServer server = new WebMapTileServer(serverURL);
         List<WMTSLayer> layers = server.getCapabilities().getLayerList();
 
@@ -57,6 +50,8 @@ public class WMTSMapViewer {
         map.addLayer(mapLayer);
 
         JMapFrame.showMap(map);
+        // end wmtsMapViewer example
+
     }
 
     private static URL showChooseWMTS() {

--- a/docs/user/extension/wmts/index.rst
+++ b/docs/user/extension/wmts/index.rst
@@ -20,9 +20,6 @@ WebMapTileServer
 
 The client code takes care of version negotiation, and even a few server specific wrinkles for you. It is based on the functionality of AbstractOpenWebService, and handles the requests: GetCapabilities and GetTile.
 
-The client code is fairly slick in that it takes care of version negotiation (inheriting functionalities from AbstractOpenWebService),
-and even a few server specific wrinkles for you.
-
 This page contains examples how how to connect and use the GeoTools WebMapTileServer class. WebMapTileServer acts as a proxy
 for a remote "Web Map Tile Server" and can be used to examine and retrieve published information in the forms of descriptive Java beans, and raw images.
 
@@ -204,24 +201,10 @@ WMTSTileService
 This class builds on the functionality of TileService. The main difference between a WMTS and a TileService is that a given WMTS layer might not cover all of the matrix set.
 This is handled through matrix set links given by the configuration of each layer.
 
-.. code-block:: java
-
-  String serverUrl = "https://opencache.statkart.no/gatekeeper/gk/gk.open_wmts";
-  WebMapTileServer server = new WebMapTileServer(new URL(serverUrl));
-  WMTSLayer layer = server.getCapabilities().getLayer("norges_grunnkart");
-  TileMatrixSet matrixSet = server.getCapabilities().getMatrixSet("EPSG:32632");
-
-  ReferencedEnvelope = new ReferencedEnvelope(595042, 611310, 6645322, 6661883, 
-              matrixSet.getCoordinateReferenceSystem());
-  double scaleFactor = 100000.0;
-
-  WMTSTileService service = new WMTSTileService(serverUrl, WMTSServiceType.KVP, 
-              layer, null, matrixSet);
-  Set<Tile> tiles = service.findTilesInExtent(extent, zoomLevel, true, 100);
-  for (Tile tile : tiles) {
-    BufferedImage image = tile.getBufferedImage();
-    ImageIO.write(image, "png", new File(tile.getId() + ".png"))
-  }
+.. literalinclude:: /../src/main/java/org/geotools/wmts/WMTSDownloader.java
+  :language: java
+  :start-after: // start wmtsTileService example
+  :end-before: // end wmtsTileService example
 
 
 WMTSCoverageReader
@@ -230,48 +213,20 @@ WMTSCoverageReader
 These classes is based on a WebMapTileServer and is useful for exporting or displaying maps from a WMTS server. 
 For export we treat the tiles as a coverage with the WMTSCoverageReader, and use ImageIO to write the rendered image.
 
-.. code-block:: java
-
-  String serverUrl = "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Ortofoto_Svalbard_WMTS_25833/MapServer/WMTS/1.0.0/WMTSCapabilities.xml";
-
-  WebMapTileServer server = new WebMapTileServer(new URL(serverUrl));
-  WMTSLayer layer = server.getCapabilities().getLayerList().get(0);
-
-  WMTSCoverageReader reader = new WMTSCoverageReader(server, layer);
-
-  ReferencedEnvelope envelope = new ReferencedEnvelope(..., ...., ...., ...., CRS.decode("EPSG:....");
-  int width = ...;
-  int height = ...;
-
-  Parameter<GridGeometry2D> readGG =
-                (Parameter<GridGeometry2D>)
-                        AbstractGridFormat.READ_GRIDGEOMETRY2D.createValue();
-        readGG.setValue(new GridGeometry2D(new GridEnvelope2D(new Rectangle(width, height)), envelope));
-
-  GridCoverage2D coverage = reader.read(new GeneralParameterValue [] { readGG });
-  ImageIO.write(coverage.getRenderedImage(), "png", new File(....));
-		
+.. literalinclude:: /../src/main/java/org/geotools/wmts/WMTSCoverage.java
+  :language: java
+  :start-after: // start wmtsCoverage example
+  :end-before: // end wmtsCoverage example	
 
 WMTSMapLayer
 ------------
 
 To display the WMTS within a map we would use WMTSMapLayer in a similar way.
 
-
-.. code-block:: java
-
-  String serverUrl = "https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Ortofoto_Svalbard_WMTS_25833/MapServer/WMTS/1.0.0/WMTSCapabilities.xml";
-
-  WebMapTileServer server = new WebMapTileServer(new URL(serverUrl));
-  WMTSLayer layer = server.getCapabilities().getLayerList().get(0);
-
-  MapContent map = new MapContent();
-  map.setTitle(server.getCapabilities().getService().getTitle());
-
-  WMTSMapLayer mapLayer = new WMTSMapLayer(server, layer);
-  map.addLayer(mapLayer);
-
-  JMapFrame.showMap(map);
+.. literalinclude:: /../src/main/java/org/geotools/wmts/WMTSMapViewer.java
+  :language: java
+  :start-after: // start wmtsMapViewer example
+  :end-before: // end wmtsMapViewer example
 
 
 In addition it's possible to use the TileLayer class of gt-tile-client with a WMTSTileService as input.


### PR DESCRIPTION
[![GEOT-7058](https://badgen.net/badge/JIRA/GEOT-7058/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7058) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Based on input of @jodygarnett 

Changed headers and using literalinclude for code examples

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [X] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->