### PR TITLE
[GEOT-7070] In CQL2 "id" is not a reserved word

### DIFF
--- a/modules/unsupported/cql2/src/main/jjtree/CQL2Grammar.jjt
+++ b/modules/unsupported/cql2/src/main/jjtree/CQL2Grammar.jjt
@@ -112,7 +112,6 @@ TOKEN [IGNORE_CASE]:  /* keywords */
    < UNKNOWN: "unknown"> |
    < LIKE: "like" > |
    < BETWEEN: "between"> |
-   < ID: "id" > |
    < IN: "in" > |
    < IS: "is" > |
    < NULL: "null" > |

--- a/modules/unsupported/cql2/src/test/java/org/geotools/filter/text/cql_2/CQL2Test.java
+++ b/modules/unsupported/cql2/src/test/java/org/geotools/filter/text/cql_2/CQL2Test.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.filter.text.cql_2;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.awt.Color;
@@ -27,6 +28,7 @@ import org.geotools.filter.IsNullImpl;
 import org.geotools.filter.text.cql2.CQL;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.FilterECQLSample;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opengis.filter.And;
@@ -36,6 +38,7 @@ import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.Not;
 import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsBetween;
+import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsGreaterThan;
 import org.opengis.filter.PropertyIsLessThan;
 import org.opengis.filter.PropertyIsLike;
@@ -351,5 +354,29 @@ public class CQL2Test {
 
         actual = CQL2.toCQL2(function);
         assertEquals("color literals", expected, actual);
+    }
+
+    @Test
+    public void idEquality() throws CQLException {
+        Filter filter = CQL2.toFilter("id = 'abcd'");
+        assertThat(filter, CoreMatchers.instanceOf(PropertyIsEqualTo.class));
+        PropertyIsEqualTo pet = (PropertyIsEqualTo) filter;
+        assertThat(pet.getExpression1(), CoreMatchers.instanceOf(PropertyName.class));
+        PropertyName pn = (PropertyName) pet.getExpression1();
+        assertEquals("id", pn.getPropertyName());
+    }
+
+    @Test
+    public void idInChoices() throws CQLException {
+        Filter filter = CQL2.toFilter("id in ('abcd', 'efg')");
+        assertThat(filter, CoreMatchers.instanceOf(Or.class));
+        Or or = (Or) filter;
+        assertEquals(2, or.getChildren().size());
+        assertThat(or.getChildren().get(0), CoreMatchers.instanceOf(PropertyIsEqualTo.class));
+        assertThat(or.getChildren().get(1), CoreMatchers.instanceOf(PropertyIsEqualTo.class));
+        PropertyIsEqualTo pet = (PropertyIsEqualTo) or.getChildren().get(0);
+        assertThat(pet.getExpression1(), CoreMatchers.instanceOf(PropertyName.class));
+        PropertyName pn = (PropertyName) pet.getExpression1();
+        assertEquals("id", pn.getPropertyName());
     }
 }


### PR DESCRIPTION
See ticket.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
