### PR TITLE
[GEOT-7072] Allow empty string element value for parsing simple types in gt-xsd to avoid NumberFormatException

### DIFF
--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSBooleanBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSBooleanBinding.java
@@ -17,6 +17,7 @@
 package org.geotools.xs.bindings;
 
 import javax.xml.namespace.QName;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.xs.XS;
 import org.geotools.xsd.InstanceComponent;
 import org.geotools.xsd.SimpleBinding;
@@ -96,8 +97,9 @@ public class XSBooleanBinding implements SimpleBinding {
             return Boolean.TRUE;
         } else if ("0".equals(value) || "false".equals(value)) {
             return Boolean.FALSE;
+        } else if (StringUtils.isBlank((String) value)) {
+            return null;
         }
-
         throw new IllegalArgumentException("boolean indeterminate from  '" + value + "'");
     }
 

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDateBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDateBinding.java
@@ -19,6 +19,7 @@ package org.geotools.xs.bindings;
 import java.sql.Date;
 import java.util.Calendar;
 import javax.xml.namespace.QName;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.xml.impl.DatatypeConverterImpl;
 import org.geotools.xs.XS;
 import org.geotools.xs.XSUtils;
@@ -101,6 +102,7 @@ public class XSDateBinding implements SimpleBinding {
      */
     @Override
     public java.sql.Date parse(InstanceComponent instance, Object value) throws Exception {
+        if (StringUtils.isBlank((String) value)) return null;
         Calendar calendar = DatatypeConverterImpl.getInstance().parseDate((String) value);
         return new java.sql.Date(calendar.getTimeInMillis());
     }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDateTimeBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDateTimeBinding.java
@@ -105,7 +105,7 @@ public class XSDateTimeBinding implements SimpleBinding {
     @Override
     public Timestamp parse(InstanceComponent instance, Object value) throws Exception {
         String str = (String) value;
-        if (StringUtils.isEmpty(str)) return null;
+        if (StringUtils.isBlank(str)) return null;
         Calendar calendar = DatatypeConverterImpl.getInstance().parseDateTime(str, true);
         Timestamp dateTime = new Timestamp(calendar.getTimeInMillis());
         return dateTime;

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDecimalBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDecimalBinding.java
@@ -19,6 +19,7 @@ package org.geotools.xs.bindings;
 import java.math.BigDecimal;
 import java.util.Calendar;
 import javax.xml.namespace.QName;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.xs.XS;
 import org.geotools.xsd.InstanceComponent;
 import org.geotools.xsd.SimpleBinding;
@@ -108,6 +109,8 @@ public class XSDecimalBinding implements SimpleBinding {
 
         if (text.startsWith("+")) {
             text = text.substring(1);
+        } else if (StringUtils.isBlank(text)) {
+            return null;
         }
 
         BigDecimal decimal = new BigDecimal(text);

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDoubleBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSDoubleBinding.java
@@ -17,6 +17,7 @@
 package org.geotools.xs.bindings;
 
 import javax.xml.namespace.QName;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.xs.XS;
 import org.geotools.xsd.InstanceComponent;
 import org.geotools.xsd.SimpleBinding;
@@ -101,8 +102,7 @@ public class XSDoubleBinding implements SimpleBinding {
         if ("INF".equals(value)) {
             return Double.valueOf(Double.POSITIVE_INFINITY);
         }
-
-        return Double.valueOf((String) value);
+        return StringUtils.isBlank((String) value) ? null : Double.valueOf((String) value);
     }
 
     /**

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSFloatBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSFloatBinding.java
@@ -17,6 +17,7 @@
 package org.geotools.xs.bindings;
 
 import javax.xml.namespace.QName;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.xs.XS;
 import org.geotools.xsd.InstanceComponent;
 import org.geotools.xsd.SimpleBinding;
@@ -103,7 +104,7 @@ public class XSFloatBinding implements SimpleBinding {
             return Float.valueOf(Float.POSITIVE_INFINITY);
         }
 
-        return Float.valueOf(text);
+        return StringUtils.isBlank(text) ? null : Float.valueOf(text);
     }
 
     /**

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSIntegerBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSIntegerBinding.java
@@ -18,6 +18,7 @@ package org.geotools.xs.bindings;
 
 import java.math.BigInteger;
 import javax.xml.namespace.QName;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.xs.XS;
 import org.geotools.xsd.InstanceComponent;
 import org.geotools.xsd.SimpleBinding;
@@ -92,7 +93,7 @@ public class XSIntegerBinding implements SimpleBinding {
             string = string.substring(1);
         }
 
-        return new BigInteger(string);
+        return StringUtils.isBlank((String) value) ? null : new BigInteger(string);
     }
 
     /**

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSLongBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSLongBinding.java
@@ -17,6 +17,7 @@
 package org.geotools.xs.bindings;
 
 import javax.xml.namespace.QName;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.xs.XS;
 import org.geotools.xsd.InstanceComponent;
 import org.geotools.xsd.SimpleBinding;
@@ -91,7 +92,7 @@ public class XSLongBinding implements SimpleBinding {
     public Object parse(InstanceComponent instance, Object value) throws Exception {
         String text = (String) value;
 
-        if (text == null || text.length() == 0) {
+        if (StringUtils.isBlank(text)) {
             return null;
         }
 

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSTimeBinding.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xs/bindings/XSTimeBinding.java
@@ -20,6 +20,7 @@ import java.sql.Time;
 import java.util.Calendar;
 import java.util.TimeZone;
 import javax.xml.namespace.QName;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.xml.impl.DatatypeConverterImpl;
 import org.geotools.xs.XS;
 import org.geotools.xsd.InstanceComponent;
@@ -101,6 +102,7 @@ public class XSTimeBinding implements SimpleBinding {
      */
     @Override
     public Time parse(InstanceComponent instance, Object value) throws Exception {
+        if (StringUtils.isBlank((String) value)) return null;
         Calendar calTime = DatatypeConverterImpl.getInstance().parseTime((String) value);
         Time time = new Time(calTime.getTimeInMillis());
         return time;

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/TestSchema.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/TestSchema.java
@@ -161,7 +161,15 @@ public abstract class TestSchema {
      */
     public void validateValues(String given, Object expected) throws Exception {
         Object result = strategy.parse(element(given, qname), given);
-        Assert.assertEquals(expected, result);
+        validateValues(result, expected);
+    }
+
+    protected void validateValues(Object result, Object expected) throws Exception {
+        if (null == expected) {
+            Assert.assertNull(result);
+        } else {
+            Assert.assertEquals(expected, result);
+        }
     }
 
     /** Each subclass must indicate which kind of QName they wish to operate against. */

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSBooleanStrategyTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSBooleanStrategyTest.java
@@ -54,4 +54,14 @@ public class XSBooleanStrategyTest extends TestSchema {
     protected QName getQName() {
         return XS.BOOLEAN;
     }
+
+    /**
+     * GEOT-7072: Non-comformant WFS implementations tend to send empty elements (e.g. {@code
+     * <value></value>})
+     */
+    @Test
+    public void testParseEmptyStringAsNull() throws Exception {
+        validateValues("", null);
+        validateValues("\t", null);
+    }
 }

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSDateTimeStrategyTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSDateTimeStrategyTest.java
@@ -188,6 +188,26 @@ public class XSDateTimeStrategyTest extends TestSchema {
         assertEquals("2011-10-24T10:53:31.999Z", encoded);
     }
 
+    /**
+     * GEOT-7072: Non-comformant WFS implementations tend to send empty elements (e.g. {@code
+     * <value></value>})
+     */
+    @Test
+    public void testParseEmptyStringAsNull() throws Exception {
+        validateValues(XS.DATE, "", null);
+        validateValues(XS.DATE, "\t", null);
+        validateValues(XS.TIME, "", null);
+        validateValues(XS.TIME, "\t", null);
+        validateValues(XS.DATETIME, "", null);
+        validateValues(XS.DATETIME, "\t", null);
+    }
+
+    public void validateValues(QName qname, String given, Object expected) throws Exception {
+        SimpleBinding strategy = (SimpleBinding) stratagy(qname);
+        Object result = strategy.parse(element(given, qname), given);
+        super.validateValues(result, expected);
+    }
+
     private void testEncodeCalendar(Calendar cal, QName qname, String expected) throws Exception {
         Encoder encoder = new Encoder(new TestConfiguration());
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSDecimalStrategyTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSDecimalStrategyTest.java
@@ -17,6 +17,7 @@
 package org.geotools.xs.bindings;
 
 import java.math.BigDecimal;
+import javax.xml.namespace.QName;
 import org.eclipse.xsd.XSDElementDeclaration;
 import org.eclipse.xsd.XSDMaxExclusiveFacet;
 import org.eclipse.xsd.XSDMaxInclusiveFacet;
@@ -31,12 +32,20 @@ import org.eclipse.xsd.impl.XSDMinExclusiveFacetImpl;
 import org.eclipse.xsd.impl.XSDMinInclusiveFacetImpl;
 import org.eclipse.xsd.impl.XSDSimpleTypeDefinitionImpl;
 import org.eclipse.xsd.impl.XSDTotalDigitsFacetImpl;
+import org.geotools.xs.TestSchema;
+import org.geotools.xs.XS;
 import org.geotools.xsd.ElementInstance;
 import org.geotools.xsd.impl.ElementImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class XSDecimalStrategyTest {
+public class XSDecimalStrategyTest extends TestSchema {
+
+    @Override
+    protected QName getQName() {
+        return XS.DECIMAL;
+    }
+
     /*
      * Test method for 'org.geotools.xml.strategies.xs.XSDecimalStrategy.parse(Element, Node[], Object)'
      */
@@ -86,6 +95,16 @@ public class XSDecimalStrategyTest {
         //		} catch (ValidationException e) {
         //
         //		}
+    }
+
+    /**
+     * GEOT-7072: Non-comformant WFS implementations tend to send empty elements (e.g. {@code
+     * <value></value>})
+     */
+    @Test
+    public void testParseEmptyStringAsNull() throws Exception {
+        validateValues("", null);
+        validateValues("\t", null);
     }
 
     public void validateValues(

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSDoubleStrategyTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSDoubleStrategyTest.java
@@ -56,4 +56,14 @@ public class XSDoubleStrategyTest extends TestSchema {
     protected QName getQName() {
         return XS.DOUBLE;
     }
+
+    /**
+     * GEOT-7072: Non-comformant WFS implementations tend to send empty elements (e.g. {@code
+     * <value></value>})
+     */
+    @Test
+    public void testParseEmptyStringAsNull() throws Exception {
+        validateValues("", null);
+        validateValues("\t", null);
+    }
 }

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSFloatStrategyTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSFloatStrategyTest.java
@@ -53,4 +53,14 @@ public class XSFloatStrategyTest extends TestSchema {
     protected QName getQName() {
         return XS.FLOAT;
     }
+
+    /**
+     * GEOT-7072: Non-comformant WFS implementations tend to send empty elements (e.g. {@code
+     * <value></value>})
+     */
+    @Test
+    public void testParseEmptyStringAsNull() throws Exception {
+        validateValues("", null);
+        validateValues("\t", null);
+    }
 }

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSIntegerStrategyTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSIntegerStrategyTest.java
@@ -41,4 +41,14 @@ public class XSIntegerStrategyTest extends TestSchema {
     protected QName getQName() {
         return XS.INTEGER;
     }
+
+    /**
+     * GEOT-7072: Non-comformant WFS implementations tend to send empty elements (e.g. {@code
+     * <value></value>})
+     */
+    @Test
+    public void testParseEmptyStringAsNull() throws Exception {
+        validateValues("", null);
+        validateValues("\t", null);
+    }
 }

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSLongStrategyTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSLongStrategyTest.java
@@ -44,4 +44,14 @@ public class XSLongStrategyTest extends TestSchema {
     protected QName getQName() {
         return XS.LONG;
     }
+
+    /**
+     * GEOT-7072: Non-comformant WFS implementations tend to send empty elements (e.g. {@code
+     * <value></value>})
+     */
+    @Test
+    public void testParseEmptyStringAsNull() throws Exception {
+        validateValues("", null);
+        validateValues("\t", null);
+    }
 }


### PR DESCRIPTION
[![GEOT-7072](https://badgen.net/badge/JIRA/GEOT-7072/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7072) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Allow empty string element value for parsing simple types in gt-xsd to avoid NumberFormatException.

gt-xsd version of [GEOT-3350](https://osgeo-org.atlassian.net/browse/GEOT-3350), an old bug report over gt-xml.

Non-conformant WFS implementations tend to emit empty elements for null values, instead of the appropriate GML  Nil/Null, or omitting the xml element.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->