### PR TITLE
[GEOT-7073] GeoPackage store fails to use spatial indexes when multiple BBOX filters are used at the same time (26.x)

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -830,7 +830,7 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
                                 envelope.getMaxX(),
                                 envelope.getMaxY(),
                                 null);
-                split[0] = ff.and(split[0], bbox);
+                split[0] = Filter.INCLUDE.equals(split[0]) ? bbox : ff.and(split[0], bbox);
 
                 return split;
             }
@@ -857,7 +857,7 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
             }
             // check if geometris
             if (ad instanceof GeometryDescriptor) {
-                if (geometryAttribute != null) {
+                if (geometryAttribute != null && !geometryAttribute.equals(ad)) {
                     // two different attributes found
                     return null;
                 }

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDialectTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDialectTest.java
@@ -1,0 +1,54 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.geopkg;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.jdbc.JDBCDataStore;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.opengis.filter.And;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.spatial.BBOX;
+
+public class GeoPkgDialectTest {
+
+    @Test
+    public void testMultiBBOX() throws Exception {
+        File lakes0 = new File("./src/test/resources/org/geotools/geopkg/lakes_srs_0.gpkg");
+        Map<String, File> params = Collections.singletonMap("database", lakes0);
+        JDBCDataStore store = new GeoPkgDataStoreFactory().createDataStore(params);
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        BBOX bboxDefault = ff.bbox("", 0, 0, 10, 10, null);
+        BBOX bboxExplicit = ff.bbox("geom", 5, 5, 15, 15, null);
+        And and = ff.and(bboxDefault, bboxExplicit);
+
+        // should run an equivalent bbox direclty on the index, and the and in memory
+        Filter[] split = store.getSQLDialect().splitFilter(and, store.getSchema("lakes_null"));
+        assertThat(split[0], CoreMatchers.instanceOf(BBOX.class));
+        assertEquals(and, split[1]);
+        BBOX sqlbox = (BBOX) split[0];
+        assertEquals(new ReferencedEnvelope(5, 10, 5, 10, null), sqlbox.getBounds());
+    }
+}


### PR DESCRIPTION
[![GEOT-7073](https://badgen.net/badge/JIRA/GEOT-7073/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7073) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main 
# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->