### PR TITLE
[GEOT-7074] SLD or CSS filter rules using a non existent attribute named 'type' causes a generic ClassCastException

### DIFF
--- a/modules/extension/complex/src/test/java/org/geotools/filter/attribute/extractor/FilterAttributeExtractorTest.java
+++ b/modules/extension/complex/src/test/java/org/geotools/filter/attribute/extractor/FilterAttributeExtractorTest.java
@@ -1,56 +1,55 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
 package org.geotools.filter.attribute.extractor;
 
-import static org.geotools.feature.FakeTypes.ANYSIMPLETYPE_TYPE;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import org.geotools.feature.NameImpl;
+import java.util.HashSet;
+import java.util.Set;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
-import org.geotools.feature.simple.SimpleFeatureTypeImpl;
-import org.geotools.feature.type.AttributeDescriptorImpl;
-import org.geotools.feature.type.AttributeTypeImpl;
-import org.geotools.feature.type.Types;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.FilterAttributeExtractor;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.feature.type.AttributeDescriptor;
-import org.opengis.feature.type.AttributeType;
-import org.xml.sax.helpers.NamespaceSupport;
 
 public class FilterAttributeExtractorTest {
 
     @Test
     public void testNonExistingAttributeEvaluatesToAttributeDescriptor() throws Exception {
-        List<AttributeDescriptor> schema = new ArrayList<>();
-        AttributeType doubleType =
-                new AttributeTypeImpl(
-                        new NameImpl("http://www.w3.org/2001/XMLSchema", "double"),
-                        Double.class,
-                        false,
-                        false,
-                        Collections.emptyList(),
-                        ANYSIMPLETYPE_TYPE,
-                        null);
-        schema.add(
-                new AttributeDescriptorImpl(
-                        doubleType, Types.typeName("pointOne"), 0, 1, false, null));
-        schema.add(
-                new AttributeDescriptorImpl(
-                        doubleType, Types.typeName("pointTwo"), 0, 1, false, null));
 
-        SimpleFeatureType type =
-                new SimpleFeatureTypeImpl(
-                        Types.typeName("GeometryContainer"), schema, null, false, null, null, null);
+        SimpleFeatureTypeBuilder sftb = new SimpleFeatureTypeBuilder();
+        sftb.setName("twoDoublesFeatureType");
+        sftb.add("pointOne", Double.class);
+        sftb.add("pointTwo", Double.class);
+        SimpleFeatureType type = sftb.buildFeatureType();
+
         Feature feature = SimpleFeatureBuilder.build(type, new Object[] {5.0, 2.5}, null);
         FilterAttributeExtractor fae = new FilterAttributeExtractor(type);
-        NamespaceSupport nss = new NamespaceSupport();
-        nss.declarePrefix("ogc", "http://www.opengis.net/ogc");
-        nss.declarePrefix("gml", "http://www.opengis.net/gml");
-        nss.declarePrefix("sld", "http://www.opengis.net/sld");
-        Assert.assertNotNull(fae.visit(new AttributeExpressionImpl("type", nss), feature));
+
+        // the next call to fae.visit used to throw a ClassCastException, here it is ensured is not
+        // anymore thrown
+        Assert.assertNotNull(fae.visit(new AttributeExpressionImpl("type"), feature));
+
+        Set<String> attributeTypesDescriptorsNames = new HashSet<>();
+        attributeTypesDescriptorsNames.add("type");
+        // checking that there is the there is a "type" AttributeDescriptor
+        Assert.assertEquals(
+                attributeTypesDescriptorsNames,
+                fae.visit(new AttributeExpressionImpl("type"), feature));
     }
 }

--- a/modules/extension/complex/src/test/java/org/geotools/filter/attribute/extractor/FilterAttributeExtractorTest.java
+++ b/modules/extension/complex/src/test/java/org/geotools/filter/attribute/extractor/FilterAttributeExtractorTest.java
@@ -1,0 +1,56 @@
+package org.geotools.filter.attribute.extractor;
+
+import static org.geotools.feature.FakeTypes.ANYSIMPLETYPE_TYPE;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.geotools.feature.NameImpl;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeImpl;
+import org.geotools.feature.type.AttributeDescriptorImpl;
+import org.geotools.feature.type.AttributeTypeImpl;
+import org.geotools.feature.type.Types;
+import org.geotools.filter.AttributeExpressionImpl;
+import org.geotools.filter.FilterAttributeExtractor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opengis.feature.Feature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.AttributeType;
+import org.xml.sax.helpers.NamespaceSupport;
+
+public class FilterAttributeExtractorTest {
+
+    @Test
+    public void testNonExistingAttributeEvaluatesToAttributeDescriptor() throws Exception {
+        List<AttributeDescriptor> schema = new ArrayList<>();
+        AttributeType doubleType =
+                new AttributeTypeImpl(
+                        new NameImpl("http://www.w3.org/2001/XMLSchema", "double"),
+                        Double.class,
+                        false,
+                        false,
+                        Collections.emptyList(),
+                        ANYSIMPLETYPE_TYPE,
+                        null);
+        schema.add(
+                new AttributeDescriptorImpl(
+                        doubleType, Types.typeName("pointOne"), 0, 1, false, null));
+        schema.add(
+                new AttributeDescriptorImpl(
+                        doubleType, Types.typeName("pointTwo"), 0, 1, false, null));
+
+        SimpleFeatureType type =
+                new SimpleFeatureTypeImpl(
+                        Types.typeName("GeometryContainer"), schema, null, false, null, null, null);
+        Feature feature = SimpleFeatureBuilder.build(type, new Object[] {5.0, 2.5}, null);
+        FilterAttributeExtractor fae = new FilterAttributeExtractor(type);
+        NamespaceSupport nss = new NamespaceSupport();
+        nss.declarePrefix("ogc", "http://www.opengis.net/ogc");
+        nss.declarePrefix("gml", "http://www.opengis.net/gml");
+        nss.declarePrefix("sld", "http://www.opengis.net/sld");
+        Assert.assertNotNull(fae.visit(new AttributeExpressionImpl("type", nss), feature));
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/filter/FilterAttributeExtractor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/FilterAttributeExtractor.java
@@ -113,7 +113,7 @@ public class FilterAttributeExtractor extends DefaultFilterVisitor {
             // evaluate against the feature type instead of using straight name
             // since the path from the property name may be an XPath or a
             // namespace prefixed string
-            AttributeDescriptor type = (AttributeDescriptor) expression.evaluate(featureType);
+            AttributeDescriptor type = expression.evaluate(featureType, AttributeDescriptor.class);
             if (type != null) {
                 attributeNames.add(type.getLocalName());
             } else {


### PR DESCRIPTION
[![GEOT-7074](https://badgen.net/badge/JIRA/GEOT-7074/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7074) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOT-7074] SLD or CSS filter rules using a non existent attribute named 'type' causes a generic ClassCastException instead of a specific exception with the right message

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).