### PR TITLE
[GEOT-7076] Enable to use curly braces out of env variable definition

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/SessionCommandListenerTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/SessionCommandListenerTest.java
@@ -118,18 +118,22 @@ public class SessionCommandListenerTest {
     @Test
     public void testOneExpandVariablesIsReplaced() throws Exception {
         SessionCommandsListener listener =
-                new SessionCommandsListener(
-                        "call startSession('${user}')", "call endSession('${user,joe}')");
+                new SessionCommandsListener("call startSession('${user}')", null);
 
         // check borrow
         EnvFunction.setLocalValue("user", "abcde");
         listener.onBorrow(store, conn);
         assertEquals(1, conn.commands.size());
         assertEquals("call startSession('abcde')", conn.commands.get(0));
-        conn.commands.clear();
+    }
+
+    // this tests checks the same of previos but for the release connection sql script
+    @Test
+    public void testReleaseConnectionsScript() throws Exception {
+        SessionCommandsListener listener =
+                new SessionCommandsListener(null, "call endSession('${user,joe}')");
 
         // check release
-        EnvFunction.clearLocalValues();
         listener.onRelease(store, conn);
         assertEquals(1, conn.commands.size());
         assertEquals("call endSession('joe')", conn.commands.get(0));
@@ -143,7 +147,8 @@ public class SessionCommandListenerTest {
     }
 
     @After
-    public void clearCommands() {
+    public void clearResources() {
+        EnvFunction.clearLocalValues();
         conn.commands.clear();
     }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/SessionCommandListenerTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/SessionCommandListenerTest.java
@@ -7,6 +7,7 @@ import com.mockrunner.mock.jdbc.MockStatement;
 import java.util.ArrayList;
 import java.util.List;
 import org.geotools.filter.function.EnvFunction;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -89,7 +90,6 @@ public class SessionCommandListenerTest {
         listener.onBorrow(store, conn);
         assertEquals(1, conn.commands.size());
         assertEquals("call startSession('select user1, x.x from 1')", conn.commands.get(0));
-        conn.commands.clear();
     }
 
     @Test
@@ -98,8 +98,6 @@ public class SessionCommandListenerTest {
         listener.onBorrow(store, conn);
         assertEquals(1, conn.commands.size());
         assertEquals("select true from 1", conn.commands.get(0));
-
-        conn.commands.clear();
     }
 
     @Test
@@ -115,7 +113,6 @@ public class SessionCommandListenerTest {
         assertEquals(
                 "select set_config('my.userString', substring('user11111', 'user#\"[0-9]{5}#\"%', '#'), false) ",
                 conn.commands.get(0));
-        conn.commands.clear();
     }
 
     @Test
@@ -136,7 +133,6 @@ public class SessionCommandListenerTest {
         listener.onRelease(store, conn);
         assertEquals(1, conn.commands.size());
         assertEquals("call endSession('joe')", conn.commands.get(0));
-        conn.commands.clear();
     }
 
     @Test
@@ -144,6 +140,10 @@ public class SessionCommandListenerTest {
         Assert.assertThrows(
                 IllegalArgumentException.class,
                 () -> new SessionCommandsListener("select ${user from 1)", null));
+    }
+
+    @After
+    public void clearCommands() {
         conn.commands.clear();
     }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/SessionCommandListenerTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/SessionCommandListenerTest.java
@@ -1,13 +1,13 @@
 package org.geotools.jdbc;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import com.mockrunner.mock.jdbc.MockConnection;
 import com.mockrunner.mock.jdbc.MockStatement;
 import java.util.ArrayList;
 import java.util.List;
 import org.geotools.filter.function.EnvFunction;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class SessionCommandListenerTest {
@@ -78,7 +78,48 @@ public class SessionCommandListenerTest {
     }
 
     @Test
-    public void testExpandVariables() throws Exception {
+    public void testTwoExpandVariablesAreReplaced() throws Exception {
+        SessionCommandsListener listener =
+                new SessionCommandsListener(
+                        "call startSession('select ${user}, ${version} from 1')", null);
+
+        // check borrow
+        EnvFunction.setLocalValue("user", "user1");
+        EnvFunction.setLocalValue("version", "x.x");
+        listener.onBorrow(store, conn);
+        assertEquals(1, conn.commands.size());
+        assertEquals("call startSession('select user1, x.x from 1')", conn.commands.get(0));
+        conn.commands.clear();
+    }
+
+    @Test
+    public void testValidSqlWhenNoVariable() throws Exception {
+        SessionCommandsListener listener = new SessionCommandsListener("select true from 1", null);
+        listener.onBorrow(store, conn);
+        assertEquals(1, conn.commands.size());
+        assertEquals("select true from 1", conn.commands.get(0));
+
+        conn.commands.clear();
+    }
+
+    @Test
+    public void testValidSqlUsingCurlyBracketsOutOfAVariableDefinition() throws Exception {
+        SessionCommandsListener listener =
+                new SessionCommandsListener(
+                        "select set_config('my.userString', substring('${GSUSER}', 'user#\"[0-9]{5}#\"%', '#'), false) ",
+                        null);
+
+        EnvFunction.setLocalValue("GSUSER", "user11111");
+        listener.onBorrow(store, conn);
+        assertEquals(1, conn.commands.size());
+        assertEquals(
+                "select set_config('my.userString', substring('user11111', 'user#\"[0-9]{5}#\"%', '#'), false) ",
+                conn.commands.get(0));
+        conn.commands.clear();
+    }
+
+    @Test
+    public void testOneExpandVariablesIsReplaced() throws Exception {
         SessionCommandsListener listener =
                 new SessionCommandsListener(
                         "call startSession('${user}')", "call endSession('${user,joe}')");
@@ -99,12 +140,10 @@ public class SessionCommandListenerTest {
     }
 
     @Test
-    public void testInvalid() throws Exception {
-        try {
-            new SessionCommandsListener("startSession('${user')", null);
-            fail("This should have failed, the syntax is not valid");
-        } catch (IllegalArgumentException e) {
-            // fine
-        }
+    public void testInvalidVariableDefinitionMissingClosingBracket() throws Exception {
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> new SessionCommandsListener("select ${user from 1)", null));
+        conn.commands.clear();
     }
 }


### PR DESCRIPTION
[![GEOT-7076](https://badgen.net/badge/JIRA/GEOT-7076/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7076) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOT-7076] Enable to use curly brackets out of env variable definitions in sql start/release scripts
  
There is a bug in stored start/stop session custom sql script. When the script has a closing bracket char '}' out of a env variable definition, the script is treated as invalid and then it cannot use the db connection at all.

This commit reverts such a limitation and adds some more test cases for valid/invalid sql start/stop connection scripts

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).