### PR TITLE
Improve error messages and handle timestamp types from java.sql

### DIFF
--- a/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/FeatureConversions.java
+++ b/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/FeatureConversions.java
@@ -202,14 +202,20 @@ public class FeatureConversions {
                     isoDateTime = ((OffsetDateTime) value).toString();
                 } else if (value instanceof OffsetTime) {
                     isoDateTime = ((OffsetTime) value).toString();
+                } else if (value instanceof java.sql.Date) {
+                    isoDateTime = ((java.sql.Date) value).toString();
+                } else if (value instanceof java.sql.Time) {
+                    isoDateTime = ((java.sql.Time) value).toString();
+                } else if (value instanceof java.sql.Timestamp) {
+                    isoDateTime = ((java.sql.Timestamp) value).toString();
                 } else {
-                    throw new RuntimeException("Unknown date/time type " + type);
+                    throw new RuntimeException("Cannot handle datetime type " + value.getClass().getName());
                 }
                 writeString(target, isoDateTime);
             } else if (type == ColumnType.String) {
                 writeString(target, (String) value);
             } else {
-                throw new RuntimeException("Unknown type " + type);
+                throw new RuntimeException("Cannot handle type " + value.getClass().getName());
             }
         }
     }

--- a/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/HeaderMetaUtil.java
+++ b/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/HeaderMetaUtil.java
@@ -85,10 +85,13 @@ public class HeaderMetaUtil {
                     || binding.isAssignableFrom(LocalDate.class)
                     || binding.isAssignableFrom(LocalTime.class)
                     || binding.isAssignableFrom(OffsetDateTime.class)
-                    || binding.isAssignableFrom(OffsetTime.class))
+                    || binding.isAssignableFrom(OffsetTime.class)
+                    || binding.isAssignableFrom(java.sql.Date.class)
+                    || binding.isAssignableFrom(java.sql.Time.class)
+                    || binding.isAssignableFrom(java.sql.Timestamp.class))
                 column.type = ColumnType.DateTime;
             else if (binding.isAssignableFrom(String.class)) column.type = ColumnType.String;
-            else throw new RuntimeException("Unknown type");
+            else throw new RuntimeException("Cannot handle type " + binding.getName());
             columns.add(column);
         }
 


### PR DESCRIPTION
Before this fix you get this error if attempting to request data from fx. PostGIS that has timestamps:

<ServiceExceptionReport xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2.0" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/wfs/1.0.0/OGC-exception.xsd">
<ServiceException> java.lang.RuntimeException: Unknown type Unknown type </ServiceException>
</ServiceExceptionReport>