### PR TITLE
[GEOT-7076] Enable to use curly braces out of env variable definitions in sql start/release scripts 26.x

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/SessionCommandsListener.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/SessionCommandsListener.java
@@ -158,11 +158,7 @@ public class SessionCommandsListener implements ConnectionLifecycleListener {
                 // mark the beginning and skip the next character
                 inEnvVariable = true;
                 i++;
-            } else if (curr == '}') {
-                if (!inEnvVariable)
-                    throw new IllegalArgumentException(
-                            "Already found a ${ sequence before the one at " + (i + 1));
-
+            } else if (curr == '}' && inEnvVariable) {
                 if (sb.length() == 0)
                     throw new IllegalArgumentException(
                             "Invalid empty environment variable reference ${} at " + (i - 1));
@@ -189,6 +185,7 @@ public class SessionCommandsListener implements ConnectionLifecycleListener {
                 expressions.add(env);
                 sb.setLength(0);
                 inEnvVariable = false;
+
             } else {
                 sb.append(curr);
             }


### PR DESCRIPTION
[![GEOT-7076](https://badgen.net/badge/JIRA/GEOT-7076/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7076) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backported from #3798

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).