### PR TITLE
[GEOT-7088] Fix shapefile resource leaks

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/IndexManager.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/IndexManager.java
@@ -372,6 +372,7 @@ class IndexManager {
         if (!shpFiles.isLocal()) {
             return null;
         }
+        FileSystemIndexStore idxStore = null;
         URL treeURL = shpFiles.acquireRead(QIX, writer);
         try {
             File treeFile = URLs.urlToFile(treeURL);
@@ -380,14 +381,14 @@ class IndexManager {
                 return null;
             }
 
-            try {
-                FileSystemIndexStore idxStore = new FileSystemIndexStore(treeFile);
-                return idxStore.load(store.shpManager.openIndexFile(), store.isMemoryMapped());
-            } catch (IOException e) {
-                throw new StoreException(e);
-            }
+            idxStore = new FileSystemIndexStore(treeFile, shpFiles);
         } finally {
             shpFiles.unlockRead(treeURL, writer);
+        }
+        try {
+            return idxStore.load(store.shpManager.openIndexFile(), store.isMemoryMapped());
+        } catch (IOException e) {
+            throw new StoreException(e);
         }
     }
 

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -502,6 +502,7 @@ class ShapefileFeatureSource extends ContentFeatureSource {
                     crs = prj.getCoordinateReferenceSystem();
                 }
             } catch (FactoryException fe) {
+                LOGGER.log(Level.FINE, "Error reading prj file", fe);
                 crs = null;
             }
 

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -502,7 +502,11 @@ class ShapefileFeatureSource extends ContentFeatureSource {
                     crs = prj.getCoordinateReferenceSystem();
                 }
             } catch (FactoryException fe) {
-                LOGGER.log(Level.FINE, "Error reading prj file", fe);
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.log(
+                            Level.FINER,
+                            "Ignoring invalid prj file and moving on: " + fe.getMessage());
+                }
                 crs = null;
             }
 

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileSetManager.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileSetManager.java
@@ -115,6 +115,7 @@ class ShapefileSetManager implements FileReader {
                 }
             } catch (IOException e) {
                 // could happen if cpg file does not exist remotely
+                LOGGER.log(Level.FINE, "Error reading cpg file", e);
             }
         }
 
@@ -128,6 +129,7 @@ class ShapefileSetManager implements FileReader {
             }
         } catch (IOException e) {
             // could happen if dbf file does not exist
+            LOGGER.log(Level.FINE, "Error reading dbf file", e);
             return null;
         }
     }
@@ -152,6 +154,7 @@ class ShapefileSetManager implements FileReader {
             return new PrjFileReader(shpFiles.getReadChannel(PRJ, this));
         } catch (IOException e) {
             // could happen if prj file does not exist remotely
+            LOGGER.log(Level.FINE, "Error reading prj file", e);
             return null;
         }
     }
@@ -174,6 +177,7 @@ class ShapefileSetManager implements FileReader {
             return new IndexFile(shpFiles, store.isMemoryMapped());
         } catch (IOException e) {
             // could happen if shx file does not exist remotely
+            LOGGER.log(Level.FINE, "Error reading shx file", e);
             return null;
         }
     }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileSetManager.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileSetManager.java
@@ -115,7 +115,11 @@ class ShapefileSetManager implements FileReader {
                 }
             } catch (IOException e) {
                 // could happen if cpg file does not exist remotely
-                LOGGER.log(Level.FINE, "Error reading cpg file", e);
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.log(
+                            Level.FINER,
+                            "Ignoring invalid cpg file and moving on: " + e.getMessage());
+                }
             }
         }
 
@@ -129,7 +133,10 @@ class ShapefileSetManager implements FileReader {
             }
         } catch (IOException e) {
             // could happen if dbf file does not exist
-            LOGGER.log(Level.FINE, "Error reading dbf file", e);
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.log(
+                        Level.FINER, "Ignoring invalid dbf file and moving on: " + e.getMessage());
+            }
             return null;
         }
     }
@@ -154,7 +161,10 @@ class ShapefileSetManager implements FileReader {
             return new PrjFileReader(shpFiles.getReadChannel(PRJ, this));
         } catch (IOException e) {
             // could happen if prj file does not exist remotely
-            LOGGER.log(Level.FINE, "Error reading prj file", e);
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.log(
+                        Level.FINER, "Ignoring invalid prj file and moving on: " + e.getMessage());
+            }
             return null;
         }
     }
@@ -177,7 +187,10 @@ class ShapefileSetManager implements FileReader {
             return new IndexFile(shpFiles, store.isMemoryMapped());
         } catch (IOException e) {
             // could happen if shx file does not exist remotely
-            LOGGER.log(Level.FINE, "Error reading shx file", e);
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.log(
+                        Level.FINER, "Ignoring invalid shx file and moving on: " + e.getMessage());
+            }
             return null;
         }
     }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileReader.java
@@ -183,7 +183,7 @@ public class DbaseFileReader implements FileReader, Closeable {
         this.channel = dbfChannel;
         boolean initialized = false;
         try {
-            init(useMemoryMappedBuffer, charset, timeZone);
+            doInit(useMemoryMappedBuffer, charset, timeZone);
             initialized = true;
         } finally {
             if (!initialized) {
@@ -196,7 +196,7 @@ public class DbaseFileReader implements FileReader, Closeable {
         }
     }
 
-    private void init(boolean useMemoryMappedBuffer, Charset charset, TimeZone timeZone)
+    private void doInit(boolean useMemoryMappedBuffer, Charset charset, TimeZone timeZone)
             throws IOException {
         this.stringCharset = charset == null ? Charset.defaultCharset() : charset;
         TimeZone calTimeZone = timeZone == null ? TimeZone.getDefault() : timeZone;

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileReader.java
@@ -181,6 +181,23 @@ public class DbaseFileReader implements FileReader, Closeable {
             final TimeZone timeZone)
             throws IOException {
         this.channel = dbfChannel;
+        boolean initialized = false;
+        try {
+            init(useMemoryMappedBuffer, charset, timeZone);
+            initialized = true;
+        } finally {
+            if (!initialized) {
+                try {
+                    close();
+                } catch (IOException e) {
+                    // do nothing
+                }
+            }
+        }
+    }
+
+    private void init(boolean useMemoryMappedBuffer, Charset charset, TimeZone timeZone)
+            throws IOException {
         this.stringCharset = charset == null ? Charset.defaultCharset() : charset;
         TimeZone calTimeZone = timeZone == null ? TimeZone.getDefault() : timeZone;
         this.calendar = Calendar.getInstance(calTimeZone, Locale.US);

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidReader.java
@@ -65,9 +65,25 @@ public class IndexedFidReader implements FIDReader, FileReader, AutoCloseable {
     }
 
     private void init(ShpFiles shpFiles, ReadableByteChannel in) throws IOException {
+        this.readChannel = in;
+        boolean initialized = false;
+        try {
+            init(shpFiles);
+            initialized = true;
+        } finally {
+            if (!initialized) {
+                try {
+                    close();
+                } catch (IOException e) {
+                    // do nothing
+                }
+            }
+        }
+    }
+
+    private void init(ShpFiles shpFiles) throws IOException {
         this.typeName = shpFiles.getTypeName() + ".";
         this.fidBuilder = new StringBuilder(typeName);
-        this.readChannel = in;
         streamLogger.open();
         getHeader(shpFiles);
 

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/fid/IndexedFidReader.java
@@ -68,7 +68,7 @@ public class IndexedFidReader implements FIDReader, FileReader, AutoCloseable {
         this.readChannel = in;
         boolean initialized = false;
         try {
-            init(shpFiles);
+            doInit(shpFiles);
             initialized = true;
         } finally {
             if (!initialized) {
@@ -81,7 +81,7 @@ public class IndexedFidReader implements FIDReader, FileReader, AutoCloseable {
         }
     }
 
-    private void init(ShpFiles shpFiles) throws IOException {
+    private void doInit(ShpFiles shpFiles) throws IOException {
         this.typeName = shpFiles.getTypeName() + ".";
         this.fidBuilder = new StringBuilder(typeName);
         streamLogger.open();

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/FileSystemIndexStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/FileSystemIndexStore.java
@@ -182,7 +182,7 @@ public class FileSystemIndexStore implements FileReader, IndexStore {
                 fis = new FileInputStream(file);
                 channel = fis.getChannel();
             }
-            QuadTree tree = load(fis, channel, indexfile, useMemoryMapping);
+            QuadTree tree = doLoad(fis, channel, indexfile, useMemoryMapping);
             initialized = true;
             return tree;
         } catch (IOException e) {
@@ -212,7 +212,7 @@ public class FileSystemIndexStore implements FileReader, IndexStore {
         }
     }
 
-    private QuadTree load(
+    private QuadTree doLoad(
             FileInputStream fis, FileChannel channel, IndexFile indexfile, boolean useMemoryMapping)
             throws IOException {
         IndexHeader header = new IndexHeader(channel);

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/FileSystemIndexStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/index/quadtree/fs/FileSystemIndexStore.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.data.shapefile.index.quadtree.fs;
 
+import static org.geotools.data.shapefile.files.ShpFileType.QIX;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -26,6 +28,8 @@ import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geotools.data.shapefile.files.FileReader;
+import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.shapefile.index.quadtree.IndexStore;
 import org.geotools.data.shapefile.index.quadtree.Node;
 import org.geotools.data.shapefile.index.quadtree.QuadTree;
@@ -34,16 +38,24 @@ import org.geotools.data.shapefile.shp.IndexFile;
 import org.locationtech.jts.geom.Envelope;
 
 /** @author Tommaso Nolli */
-public class FileSystemIndexStore implements IndexStore {
+public class FileSystemIndexStore implements FileReader, IndexStore {
     private static final Logger LOGGER =
             org.geotools.util.logging.Logging.getLogger(FileSystemIndexStore.class);
     private File file;
     private byte byteOrder;
+    private ShpFiles shpFiles;
 
     /** Constructor. The byte order defaults to NEW_MSB_ORDER */
     public FileSystemIndexStore(File file) {
         this.file = file;
         this.byteOrder = IndexHeader.NEW_MSB_ORDER;
+    }
+
+    /** Constructor. The byte order defaults to NEW_MSB_ORDER */
+    public FileSystemIndexStore(File file, ShpFiles shpFiles) {
+        this.file = file;
+        this.byteOrder = IndexHeader.NEW_MSB_ORDER;
+        this.shpFiles = shpFiles;
     }
 
     /** Constructor */
@@ -155,54 +167,91 @@ public class FileSystemIndexStore implements IndexStore {
     @Override
     @SuppressWarnings("PMD.CloseResource") // channel is managed in the returned value
     public QuadTree load(IndexFile indexfile, boolean useMemoryMapping) throws StoreException {
-        QuadTree tree = null;
-
+        boolean initialized = false;
+        FileInputStream fis = null;
+        FileChannel channel = null;
         try {
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.finest("Opening QuadTree " + this.file.getCanonicalPath());
             }
-
-            final FileInputStream fis = new FileInputStream(file);
-            final FileChannel channel = fis.getChannel();
-
-            IndexHeader header = new IndexHeader(channel);
-
-            ByteOrder order = byteToOrder(header.getByteOrder());
-            ByteBuffer buf = ByteBuffer.allocate(8);
-            buf.order(order);
-            channel.read(buf);
-            ((Buffer) buf).flip();
-
-            tree =
-                    new QuadTree(buf.getInt(), buf.getInt(), indexfile) {
-                        @Override
-                        public void insert(int recno, Envelope bounds) {
-                            throw new UnsupportedOperationException("File quadtrees are immutable");
-                        }
-
-                        @Override
-                        public boolean trim() {
-                            return false;
-                        }
-
-                        @Override
-                        public void close() throws StoreException {
-                            super.close();
-                            try {
-                                channel.close();
-                                fis.close();
-                            } catch (IOException e) {
-                                throw new StoreException(e);
-                            }
-                        }
-                    };
-
-            tree.setRoot(FileSystemNode.readNode(0, null, channel, order, useMemoryMapping));
-
-            LOGGER.finest("QuadTree opened");
+            if (shpFiles != null) {
+                // the QIX file must be a local file for this class to be used so cast is safe
+                channel = (FileChannel) shpFiles.getReadChannel(QIX, this);
+            } else {
+                // just for backwards compatibility
+                fis = new FileInputStream(file);
+                channel = fis.getChannel();
+            }
+            QuadTree tree = load(fis, channel, indexfile, useMemoryMapping);
+            initialized = true;
+            return tree;
         } catch (IOException e) {
             throw new StoreException(e);
+        } finally {
+            if (!initialized) {
+                try {
+                    indexfile.close();
+                } catch (IOException e) {
+                    // do nothing
+                }
+                try {
+                    if (channel != null) {
+                        channel.close();
+                    }
+                } catch (IOException e) {
+                    // do nothing
+                }
+                try {
+                    if (fis != null) {
+                        fis.close();
+                    }
+                } catch (IOException e) {
+                    // do nothing
+                }
+            }
         }
+    }
+
+    private QuadTree load(
+            FileInputStream fis, FileChannel channel, IndexFile indexfile, boolean useMemoryMapping)
+            throws IOException {
+        IndexHeader header = new IndexHeader(channel);
+
+        ByteOrder order = byteToOrder(header.getByteOrder());
+        ByteBuffer buf = ByteBuffer.allocate(8);
+        buf.order(order);
+        channel.read(buf);
+        ((Buffer) buf).flip();
+
+        QuadTree tree =
+                new QuadTree(buf.getInt(), buf.getInt(), indexfile) {
+                    @Override
+                    public void insert(int recno, Envelope bounds) {
+                        throw new UnsupportedOperationException("File quadtrees are immutable");
+                    }
+
+                    @Override
+                    public boolean trim() {
+                        return false;
+                    }
+
+                    @Override
+                    public void close() throws StoreException {
+                        super.close();
+                        try {
+                            channel.close();
+                            if (fis != null) {
+                                fis.close();
+                            }
+                        } catch (IOException e) {
+                            throw new StoreException(e);
+                        }
+                    }
+                };
+
+        tree.setRoot(FileSystemNode.readNode(0, null, channel, order, useMemoryMapping));
+
+        LOGGER.finest("QuadTree opened");
 
         return tree;
     }
@@ -241,5 +290,10 @@ public class FileSystemIndexStore implements IndexStore {
     /** @param byteOrder The byteOrder to set. */
     public void setByteOrder(byte byteOrder) {
         this.byteOrder = byteOrder;
+    }
+
+    @Override
+    public String id() {
+        return getClass().getName();
     }
 }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileReader.java
@@ -209,7 +209,7 @@ public class ShapefileReader implements FileReader, Closeable {
 
     private final Record record = new Record();
 
-    private final boolean randomAccessEnabled;
+    private boolean randomAccessEnabled;
 
     private boolean useMemoryMappedBuffer;
 
@@ -261,12 +261,9 @@ public class ShapefileReader implements FileReader, Closeable {
             boolean onlyRandomAccess)
             throws IOException, ShapefileException {
         this.channel = shapefileFiles.getReadChannel(ShpFileType.SHP, this);
-        this.useMemoryMappedBuffer = useMemoryMapped;
-        streamLogger.open();
-        randomAccessEnabled = channel instanceof FileChannel;
         boolean initialized = false;
         try {
-            init(shapefileFiles, strict, gf, onlyRandomAccess);
+            doInit(shapefileFiles, strict, useMemoryMapped, gf, onlyRandomAccess);
             initialized = true;
         } finally {
             if (!initialized) {
@@ -279,9 +276,16 @@ public class ShapefileReader implements FileReader, Closeable {
         }
     }
 
-    private void init(
-            ShpFiles shapefileFiles, boolean strict, GeometryFactory gf, boolean onlyRandomAccess)
+    private void doInit(
+            ShpFiles shapefileFiles,
+            boolean strict,
+            boolean useMemoryMapped,
+            GeometryFactory gf,
+            boolean onlyRandomAccess)
             throws IOException, ShapefileException {
+        this.useMemoryMappedBuffer = useMemoryMapped;
+        streamLogger.open();
+        randomAccessEnabled = channel instanceof FileChannel;
         if (!onlyRandomAccess) {
             try {
                 shxReader = new IndexFile(shapefileFiles, this.useMemoryMappedBuffer);

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/ShapefileReader.java
@@ -264,6 +264,24 @@ public class ShapefileReader implements FileReader, Closeable {
         this.useMemoryMappedBuffer = useMemoryMapped;
         streamLogger.open();
         randomAccessEnabled = channel instanceof FileChannel;
+        boolean initialized = false;
+        try {
+            init(shapefileFiles, strict, gf, onlyRandomAccess);
+            initialized = true;
+        } finally {
+            if (!initialized) {
+                try {
+                    close();
+                } catch (IOException e) {
+                    // do nothing
+                }
+            }
+        }
+    }
+
+    private void init(
+            ShpFiles shapefileFiles, boolean strict, GeometryFactory gf, boolean onlyRandomAccess)
+            throws IOException, ShapefileException {
         if (!onlyRandomAccess) {
             try {
                 shxReader = new IndexFile(shapefileFiles, this.useMemoryMappedBuffer);

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDescriptorLeakTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDescriptorLeakTest.java
@@ -1,0 +1,184 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.shapefile;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+import org.geotools.TestData;
+import org.geotools.data.DataSourceException;
+import org.geotools.data.shapefile.files.ShpFileType;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.util.URLs;
+import org.geotools.util.factory.GeoTools;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.spatial.BBOX;
+
+public class ShapefileDescriptorLeakTest {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testFileDescriptorLeakInvalidShp() throws IOException {
+        // leak existed before GEOT-7088 fix for any shapefile with an invalid .shp file
+        ShapefileDataStore store = createTestDataStore(ShpFileType.SHP);
+        try {
+            assertThrows(
+                    BufferUnderflowException.class, () -> store.getFeatureSource().getFeatures());
+            // verify that all opened file channels were closed
+            assertEquals(0, store.shpFiles.numberOfLocks());
+        } finally {
+            store.dispose();
+        }
+        // file deletion will fail if there are open file descriptors
+        FileUtils.deleteDirectory(folder.getRoot());
+    }
+
+    @Test
+    public void testFileDescriptorLeakInvalidDbf() throws IOException {
+        // leak existed before GEOT-7088 fix for any shapefile with an invalid .dbf file
+        ShapefileDataStore store = createTestDataStore(ShpFileType.DBF);
+        try {
+            assertNotNull(store.getFeatureSource().getFeatures());
+            // verify that all opened file channels were closed
+            assertEquals(0, store.shpFiles.numberOfLocks());
+        } finally {
+            store.dispose();
+        }
+        // file deletion will fail if there are open file descriptors
+        FileUtils.deleteDirectory(folder.getRoot());
+    }
+
+    @Test
+    public void testFileDescriptorLeakInvalidShx() throws IOException {
+        // leak did not exist
+        ShapefileDataStore store = createTestDataStore(ShpFileType.SHX);
+        try {
+            assertNotNull(store.getFeatureSource().getFeatures());
+            // verify that all opened file channels were closed
+            assertEquals(0, store.shpFiles.numberOfLocks());
+        } finally {
+            store.dispose();
+        }
+        // file deletion will fail if there are open file descriptors
+        FileUtils.deleteDirectory(folder.getRoot());
+    }
+
+    @Test
+    public void testFileDescriptorLeakInvalidPrj() throws IOException {
+        // leak did not exist
+        ShapefileDataStore store = createTestDataStore(ShpFileType.PRJ);
+        try {
+            assertNotNull(store.getFeatureSource().getFeatures());
+            // verify that all opened file channels were closed
+            assertEquals(0, store.shpFiles.numberOfLocks());
+        } finally {
+            store.dispose();
+        }
+        // file deletion will fail if there are open file descriptors
+        FileUtils.deleteDirectory(folder.getRoot());
+    }
+
+    @Test
+    public void testFileDescriptorLeakInvalidQix() throws IOException {
+        // leak did not exist
+        ShapefileDataStore store = createTestDataStore(ShpFileType.QIX);
+        try {
+            // load the features with a spatial filter
+            FilterFactory ff = CommonFactoryFinder.getFilterFactory(GeoTools.getDefaultHints());
+            BBOX bbox = ff.bbox("", -180, -90, 180, 90, null);
+            SimpleFeatureCollection features =
+                    store.getFeatureSource().getFeatures().subCollection(bbox);
+            RuntimeException exception =
+                    assertThrows(RuntimeException.class, () -> features.features());
+            assertThat(exception.getCause(), instanceOf(DataSourceException.class));
+            // verify that all opened file channels were closed
+            assertEquals(0, store.shpFiles.numberOfLocks());
+        } finally {
+            store.dispose();
+        }
+        // file deletion will fail if there are open file descriptors
+        FileUtils.deleteDirectory(folder.getRoot());
+    }
+
+    @Test
+    public void testFileDescriptorLeakInvalidFix() throws IOException {
+        // leak existed before GEOT-7088 fix for any shapefile with an invalid .fix file
+        ShapefileDataStore store = createTestDataStore(ShpFileType.FIX);
+        try {
+            SimpleFeatureCollection features = store.getFeatureSource().getFeatures();
+            RuntimeException exception =
+                    assertThrows(RuntimeException.class, () -> features.features());
+            assertThat(exception.getCause(), instanceOf(IOException.class));
+            // verify that all opened file channels were closed
+            assertEquals(0, store.shpFiles.numberOfLocks());
+        } finally {
+            store.dispose();
+        }
+        // file deletion will fail if there are open file descriptors
+        FileUtils.deleteDirectory(folder.getRoot());
+    }
+
+    @Test
+    public void testFileDescriptorLeakInvalidCpg() throws IOException {
+        // leak did not exist
+        ShapefileDataStore store = createTestDataStore(ShpFileType.CPG);
+        try {
+            store.setTryCPGFile(true);
+            assertNotNull(store.getFeatureSource().getFeatures());
+            // verify that all opened file channels were closed
+            assertEquals(0, store.shpFiles.numberOfLocks());
+        } finally {
+            store.dispose();
+        }
+        // file deletion will fail if there are open file descriptors
+        FileUtils.deleteDirectory(folder.getRoot());
+    }
+
+    private ShapefileDataStore createTestDataStore(ShpFileType type) throws IOException {
+        // copy the valid test shapefile to a temp directory
+        String dstName = "invalid-" + type.extension;
+        copyFile(dstName, ShpFileType.DBF);
+        copyFile(dstName, ShpFileType.SHP);
+        copyFile(dstName, ShpFileType.SHX);
+        // put invalid contents into the file to test
+        File testFile = new File(folder.getRoot(), dstName + type.extensionWithPeriod);
+        FileUtils.write(testFile, "0", StandardCharsets.UTF_8);
+        // create the data store
+        File shapeFile = new File(folder.getRoot(), dstName + ShpFileType.SHP.extensionWithPeriod);
+        return new ShapefileDataStore(URLs.fileToUrl(shapeFile));
+    }
+
+    private void copyFile(String dstName, ShpFileType type) throws IOException {
+        File srcFile =
+                TestData.file(this, "empty-shapefile/empty-shapefile" + type.extensionWithPeriod);
+        File dstFile = new File(folder.getRoot(), dstName + type.extensionWithPeriod);
+        FileUtils.copyFile(srcFile, dstFile);
+    }
+}


### PR DESCRIPTION
[![GEOT-7088](https://badgen.net/badge/JIRA/GEOT-7088/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7088) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR fixes file descriptor leaks when reading shapefiles with invalid files for certain file formats.  Some debug logging was added for cases where exceptions from invalid files were being swallowed even when there was no leak.  This PR also fixes read locks on QIX files not being properly tracked so GeoTools wouldn't report the QIX files as being open even though they were still open.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->