### PR TITLE
[GEOT-7087] Followup to number_format change

### DIFF
--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v2_0/storedquery/ParameterTypeFactoryTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v2_0/storedquery/ParameterTypeFactoryTest.java
@@ -18,6 +18,7 @@ package org.geotools.data.wfs.internal.v2_0.storedquery;
 
 import static org.junit.Assert.assertEquals;
 
+import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +41,8 @@ public class ParameterTypeFactoryTest {
     FeatureTypeInfoImpl featureType;
     StoredQueryConfiguration config;
     StoredQueryDescriptionType desc;
+
+    private final char DC = DecimalFormatSymbols.getInstance().getDecimalSeparator();
 
     @Before
     public void setup() {
@@ -190,7 +193,7 @@ public class ParameterTypeFactoryTest {
 
         ParameterType tmp = params.get(0);
         assertEquals("foo", tmp.getName());
-        assertEquals("3.0", tmp.getValue());
+        assertEquals("3" + DC + "0", tmp.getValue());
     }
 
     // Test that bbox parameters from the context are mapped appropriately
@@ -225,19 +228,19 @@ public class ParameterTypeFactoryTest {
         // the order is not paramount, though
         ParameterType tmp = params.get(0);
         assertEquals("param1", tmp.getName());
-        assertEquals("-10.0", tmp.getValue());
+        assertEquals("-10" + DC + "0", tmp.getValue());
 
         tmp = params.get(1);
         assertEquals("param2", tmp.getName());
-        assertEquals("-5.0", tmp.getValue());
+        assertEquals("-5" + DC + "0", tmp.getValue());
 
         tmp = params.get(2);
         assertEquals("param3", tmp.getName());
-        assertEquals("10.0", tmp.getValue());
+        assertEquals("10" + DC + "0", tmp.getValue());
 
         tmp = params.get(3);
         assertEquals("param4", tmp.getName());
-        assertEquals("5.0", tmp.getValue());
+        assertEquals("5" + DC + "0", tmp.getValue());
     }
 
     private ParameterExpressionType createParam(String name) {
@@ -337,6 +340,6 @@ public class ParameterTypeFactoryTest {
 
         ParameterType tmp = params.get(0);
         assertEquals("foo", tmp.getName());
-        assertEquals("3.0,10", tmp.getValue());
+        assertEquals("3" + DC + "0,10", tmp.getValue());
     }
 }


### PR DESCRIPTION
[![GEOT-7087](https://badgen.net/badge/JIRA/GEOT-7087/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7087) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I discovered some test failures in gt-wfs-ng as a consequence of the change of default locale in the number_format function. This will only be visible when using a locale with a different decimal separator.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->