### PR TITLE
[GEOT-7093] WMTSCoverageReader shouldn't have instance variables for single requests

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSMapLayer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSMapLayer.java
@@ -99,6 +99,7 @@ public class WMTSMapLayer extends GridReaderLayer {
     }
 
     /** Returns the {@link WebMapTileServer} used by this layer */
+    @Deprecated
     public WebMapTileServer getWebMapServer() {
         return getReader().wmts;
     }
@@ -109,6 +110,7 @@ public class WMTSMapLayer extends GridReaderLayer {
     }
 
     /** Returns last GetMap request performed by this layer */
+    @Deprecated
     public GetTileRequest getLastGetMap() {
         return getReader().getTileRequest();
     }
@@ -127,6 +129,7 @@ public class WMTSMapLayer extends GridReaderLayer {
         return rawTime;
     }
 
+    /** Set request Time the way the server wants it */
     public void setRawTime(String rawTime) {
         this.rawTime = rawTime;
         getReader().setRequestedTime(rawTime);

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -313,7 +313,7 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine("request CRS " + (requestCRS == null ? "NULL" : requestCRS.getName()));
         }
-        if (requestCRS == null) {
+        if (requestCRS == null && srs != null) {
             try {
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine("request CRS decoding" + srs);
@@ -326,6 +326,13 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
                 }
                 throw new RuntimeException(e);
             }
+        }
+        if (requestCRS == null && requestedBBox != null) {
+            requestCRS = requestedBBox.getCoordinateReferenceSystem();
+        }
+
+        if (requestCRS == null) {
+            throw new ServiceException("CRS or SRS wasn't set for this GetTileRequest.");
         }
 
         // See if the layer supports the requested SRS. Matching against the SRS rather than the

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSCoverageReaderTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSCoverageReaderTest.java
@@ -50,6 +50,7 @@ import org.geotools.http.MockHttpClient;
 import org.geotools.http.MockHttpResponse;
 import org.geotools.ows.ServiceException;
 import org.geotools.ows.wmts.WebMapTileServer;
+import org.geotools.ows.wmts.map.WMTSCoverageReader.TileRequest;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
 import org.geotools.ows.wmts.model.WMTSLayer;
 import org.geotools.ows.wmts.request.AbstractGetTileRequest;
@@ -245,9 +246,9 @@ public class WMTSCoverageReaderTest {
         ReferencedEnvelope bbox = new ReferencedEnvelope(5, 12, 45, 49, CRS.decode("EPSG:4326"));
         int width = 400;
         int height = 200;
-        ReferencedEnvelope grid = wcr.initTileRequest(bbox, width, height, null);
-        assertNotNull(grid);
-        GetTileRequest mapRequest = wcr.getTileRequest();
+        TileRequest request = wcr.initTileRequest(bbox, width, height, null);
+        assertNotNull(request);
+        GetTileRequest mapRequest = request.createTileRequest();
         String templateURL = ((AbstractGetTileRequest) mapRequest).getTemplateUrl();
         assertEquals(
                 "https://maps.wien.gv.at/basemap/bmaphidpi/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpeg",
@@ -259,14 +260,11 @@ public class WMTSCoverageReaderTest {
 
         int width = 400;
         int height = 200;
-        ReferencedEnvelope grid = wcr.initTileRequest(bbox, width, height, null);
-        assertNotNull(grid);
-        GetTileRequest mapRequest = wcr.getTileRequest();
-        mapRequest.setCRS(grid.getCoordinateReferenceSystem());
+        TileRequest request = wcr.initTileRequest(bbox, width, height, null);
+        assertNotNull(request);
+        GetTileRequest mapRequest = request.createTileRequest();
         Set<Tile> responses = mapRequest.getTiles();
         for (Tile t : responses) {
-            /*System.out.println(t);
-            // System.out.println(t.getTileIdentifier() + " " + t.getExtent());*/
             assertNotNull(t);
         }
         return responses;

--- a/modules/extension/xsd/xsd-wmts/src/main/java/org/geotools/wmts/bindings/TileMatrixLimitsBinding.java
+++ b/modules/extension/xsd/xsd-wmts/src/main/java/org/geotools/wmts/bindings/TileMatrixLimitsBinding.java
@@ -131,7 +131,7 @@ public class TileMatrixLimitsBinding extends AbstractComplexEMFBinding {
     }
 
     private static BigInteger toBigInt(Object o) {
-        return BigInteger.valueOf(((Integer) o).longValue());
+        return BigInteger.valueOf(((Number) o).longValue());
     }
 
     @Override


### PR DESCRIPTION
[![GEOT-7093](https://badgen.net/badge/JIRA/GEOT-7093/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7093) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

A little rewrite of previous PR that introduced a lot of instance variables and public getters that are related to a single request. Even though this class would easily been used to serve several requests. Maybe even in parallel.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->