### PR TITLE
Updating GT to imageio-ext-1.4.1 (better support for S3 urls)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
     <test.args></test.args>
     <test.otherJVMParams></test.otherJVMParams>
     <src.output>${basedir}/target</src.output>
-    <imageio.ext.version>1.4.0</imageio.ext.version>
+    <imageio.ext.version>1.4.1</imageio.ext.version>
     <jts.version>1.18.2</jts.version>
     <jaiext.version>1.1.21</jaiext.version>
     <netcdf.version>4.6.15</netcdf.version>


### PR DESCRIPTION
Simple ImageIO-Ext dependency version upgrade for better support for S3 URLs
https://github.com/geosolutions-it/imageio-ext/issues/256