### PR TITLE
[GEOT-7105] Handling NumberFormatException in DateParser for GeoJSON parser.

### DIFF
--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/DateParser.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/DateParser.java
@@ -93,7 +93,7 @@ class DateParser {
         for (FastDateFormat format : formats) {
             try {
                 return format.parse(text);
-            } catch (ParseException e) {
+            } catch (ParseException | NumberFormatException e) {
                 if (LOGGER.isLoggable(Level.FINEST))
                     LOGGER.log(
                             Level.FINEST,

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/DateParserTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/DateParserTest.java
@@ -1,0 +1,14 @@
+package org.geotools.data.geojson;
+
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class DateParserTest {
+
+    @Test
+    public void testLongNumberString() {
+        DateParser p = new DateParser();
+        assertNull(p.parse("903425011324"));
+    }
+}


### PR DESCRIPTION
[![GEOT-7105](https://badgen.net/badge/JIRA/GEOT-7105/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7105) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The GeoJSON parser attempts to parse incoming data as a date, and is meant to skip data it can't parse. WHen it encounters a string that is a integral number that is bigger than an int, but fits in a long, it instead fails with an exception.
  

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).