### PR TITLE
[GEOT-7102] ElasticSearch plugin move aggregation creation from view parameters to Rendering Transformation parameter (26.x)

### DIFF
--- a/modules/unsupported/elasticsearch/pom.xml
+++ b/modules/unsupported/elasticsearch/pom.xml
@@ -165,6 +165,10 @@
       <artifactId>gt-geojsondatastore</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
@@ -34,6 +34,7 @@ import org.geotools.data.Query;
 import org.geotools.data.geojson.GeoJSONWriter;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.Capabilities;
+import org.geotools.process.elasticsearch.ElasticBucketVisitor;
 import org.geotools.util.ConverterFactory;
 import org.geotools.util.Converters;
 import org.geotools.util.factory.Hints;
@@ -1275,9 +1276,15 @@ class FilterToElastic implements FilterVisitor, ExpressionVisitor {
     void addViewParams(Query query) {
         if (query.getHints() != null
                 && query.getHints().get(Hints.VIRTUAL_TABLE_PARAMETERS) != null) {
+            throw new UnsupportedOperationException(
+                    "Viewparams not supported with Elasticsearch queries.");
+        }
+        if (query.getHints() != null
+                && query.getHints().get(ElasticBucketVisitor.ES_AGGREGATE_BUCKET) != null) {
             @SuppressWarnings("unchecked")
             Map<String, String> parameters =
-                    (Map<String, String>) query.getHints().get(Hints.VIRTUAL_TABLE_PARAMETERS);
+                    (Map<String, String>)
+                            query.getHints().get(ElasticBucketVisitor.ES_AGGREGATE_BUCKET);
 
             boolean nativeOnly = false;
             for (final Map.Entry<String, String> entry : parameters.entrySet()) {

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/ElasticBucketVisitor.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/ElasticBucketVisitor.java
@@ -1,0 +1,92 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.process.elasticsearch;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.visitor.FeatureAttributeVisitor;
+import org.geotools.util.factory.Hints;
+import org.opengis.feature.Feature;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.expression.Expression;
+
+/** Visitor to generate Elastic aggregate buckets or native queries */
+public class ElasticBucketVisitor implements FeatureAttributeVisitor {
+    public static final Hints.ClassKey ES_AGGREGATE_BUCKET = new Hints.ClassKey(Map.class);
+    private List<Map<String, Object>> buckets;
+    private String aggregationDefinition;
+    private String queryDefinition;
+    private Boolean nativeOnly;
+    private Expression expr;
+
+    public ElasticBucketVisitor(
+            String aggregationDefinition, String queryDefinition, Boolean nativeOnly) {
+        this.buckets = new ArrayList<>();
+        this.aggregationDefinition = aggregationDefinition;
+        this.queryDefinition = queryDefinition;
+        this.nativeOnly = nativeOnly;
+        FilterFactory factory = CommonFactoryFinder.getFilterFactory(null);
+        expr = factory.property("_aggregation");
+    }
+
+    @Override
+    public void visit(Feature feature) {
+        throw new RuntimeException(
+                "The ElasticBucketVisitor is only for Elasticsearch data sources "
+                        + "and is not designed to work in memory.");
+    }
+
+    public List<Map<String, Object>> getBuckets() {
+        return buckets;
+    }
+
+    public void setBuckets(List<Map<String, Object>> buckets) {
+        this.buckets = buckets;
+    }
+
+    public String getAggregationDefinition() {
+        return aggregationDefinition;
+    }
+
+    public void setAggregationDefinition(String aggregationDefinition) {
+        this.aggregationDefinition = aggregationDefinition;
+    }
+
+    public String getQueryDefinition() {
+        return queryDefinition;
+    }
+
+    public void setQueryDefinition(String queryDefinition) {
+        this.queryDefinition = queryDefinition;
+    }
+
+    public Boolean getNativeOnly() {
+        return nativeOnly;
+    }
+
+    public void setNativeOnly(Boolean nativeOnly) {
+        this.nativeOnly = nativeOnly;
+    }
+
+    @Override
+    public List<Expression> getExpressions() {
+        return Arrays.asList(expr);
+    }
+}

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/GeoHashGridProcess.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/GeoHashGridProcess.java
@@ -111,6 +111,20 @@ public class GeoHashGridProcess implements VectorProcess {
                             name = "outputHeight",
                             description = "Height of output raster in pixels")
                     Integer argOutputHeight,
+            @DescribeParameter(
+                            name = "aggregationDefinition",
+                            description = "Native Elasticsearch Aggregation definition")
+                    String aggregationDefinition,
+            @DescribeParameter(
+                            name = "queryDefinition",
+                            description = "Native Elasticsearch Query definition",
+                            min = 0)
+                    String queryDefinition,
+            @DescribeParameter(
+                            name = "nativeOnly",
+                            description = "Use native Elasticsearch query and ignore other filters",
+                            min = 0)
+                    Boolean nativeOnly,
             ProgressListener monitor)
             throws ProcessException {
 
@@ -121,7 +135,8 @@ public class GeoHashGridProcess implements VectorProcess {
             geoHashGrid.setParams(gridStrategyArgs);
             geoHashGrid.setEmptyCellValue(emptyCellValue);
             geoHashGrid.setScale(new RasterScale(scaleMin, scaleMax, useLog));
-            geoHashGrid.initalize(argOutputEnv, obsFeatures);
+            geoHashGrid.initalize(
+                    argOutputEnv, obsFeatures, aggregationDefinition, queryDefinition, nativeOnly);
             // convert to grid coverage
             final GridCoverage2D nativeCoverage = geoHashGrid.toGridCoverage2D();
 

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFilterTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFilterTest.java
@@ -42,6 +42,7 @@ import org.geotools.feature.AttributeTypeBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.process.elasticsearch.ElasticBucketVisitor;
 import org.geotools.temporal.object.DefaultInstant;
 import org.geotools.temporal.object.DefaultPeriod;
 import org.geotools.temporal.object.DefaultPosition;
@@ -174,7 +175,7 @@ public class ElasticFilterTest {
 
         parameters = new HashMap<>();
         final Hints hints = new Hints();
-        hints.put(Hints.VIRTUAL_TABLE_PARAMETERS, parameters);
+        hints.put(ElasticBucketVisitor.ES_AGGREGATE_BUCKET, parameters);
         query = new Query();
         query.setHints(hints);
 

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessTest.java
@@ -111,6 +111,9 @@ public class GeoHashGridProcessTest {
                         envelope,
                         width,
                         height,
+                        "",
+                        "",
+                        false,
                         null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
@@ -139,6 +142,9 @@ public class GeoHashGridProcessTest {
                         envelope,
                         width,
                         height,
+                        "",
+                        "",
+                        false,
                         null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
@@ -167,6 +173,9 @@ public class GeoHashGridProcessTest {
                         envelope,
                         width,
                         height,
+                        "",
+                        "",
+                        false,
                         null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
@@ -195,6 +204,9 @@ public class GeoHashGridProcessTest {
                         envelope,
                         width,
                         height,
+                        "",
+                        "",
+                        false,
                         null);
         checkInternal(coverage, fineDelta);
     }

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridTest.java
@@ -53,6 +53,9 @@ public class GeoHashGridTest {
             TestUtil.createMetricBucket(DOC_COUNT, METRIC_KEY, VALUE_KEY, VALUE);
     private static final Map<String, Object> AGG_BUCKET =
             TestUtil.createAggBucket(AGG_KEY, AGG_RESULTS);
+    private static final String aggregationDefinition = "";
+    private static final String queryDefinition = "";
+    private static final Boolean nativeOnly = false;
 
     private SimpleFeatureCollection features;
 
@@ -82,7 +85,8 @@ public class GeoHashGridTest {
                                                         10)))));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-360, 180, -90, 90, DefaultGeographicCRS.WGS84);
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
         assertEquals(GeoHash.widthDegrees(1), geohashGrid.getCellWidth(), 1e-10);
         assertEquals(GeoHash.heightDegrees(1), geohashGrid.getCellHeight(), 1e-10);
         assertEquals(
@@ -114,7 +118,8 @@ public class GeoHashGridTest {
                                                         10)))));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(360, 540, -90, 90, DefaultGeographicCRS.WGS84);
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
         assertEquals(GeoHash.widthDegrees(1), geohashGrid.getCellWidth(), 1e-10);
         assertEquals(GeoHash.heightDegrees(1), geohashGrid.getCellHeight(), 1e-10);
         assertEquals(
@@ -146,7 +151,8 @@ public class GeoHashGridTest {
                                                         10)))));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
         assertEquals(GeoHash.widthDegrees(1), geohashGrid.getCellWidth(), 1e-10);
         assertEquals(GeoHash.heightDegrees(1), geohashGrid.getCellHeight(), 1e-10);
         assertEquals(
@@ -192,7 +198,8 @@ public class GeoHashGridTest {
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
         geohashGrid.setScale(new RasterScale(5f, 10f));
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
         assertEquals(GeoHash.widthDegrees(1), geohashGrid.getCellWidth(), 1e-10);
         assertEquals(GeoHash.heightDegrees(1), geohashGrid.getCellHeight(), 1e-10);
         assertEquals(
@@ -234,7 +241,8 @@ public class GeoHashGridTest {
                         -30240971.96,
                         30240971.96,
                         CRS.decode("EPSG:3857"));
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
 
         assertEquals(
                 new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84),
@@ -246,7 +254,8 @@ public class GeoHashGridTest {
         features = new DefaultFeatureCollection();
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
         IntStream.range(0, geohashGrid.getGrid().length)
                 .forEach(
                         i ->
@@ -263,17 +272,15 @@ public class GeoHashGridTest {
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
         geohashGrid.setEmptyCellValue(emptyCellValue);
-        geohashGrid.initalize(envelope, features);
-        IntStream.range(0, geohashGrid.getGrid().length)
-                .forEach(
-                        row ->
-                                IntStream.range(0, geohashGrid.getGrid()[row].length)
-                                        .forEach(
-                                                column ->
-                                                        assertEquals(
-                                                                emptyCellValue,
-                                                                geohashGrid.getGrid()[row][column],
-                                                                0.0)));
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        int bound = geohashGrid.getGrid().length;
+        for (int i = 0; i < bound; i++) {
+            int bound1 = geohashGrid.getGrid()[i].length;
+            for (int column = 0; column < bound1; column++) {
+                assertEquals(emptyCellValue, geohashGrid.getGrid()[i][column], 0.0);
+            }
+        }
     }
 
     @Test
@@ -282,17 +289,15 @@ public class GeoHashGridTest {
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
         geohashGrid.setEmptyCellValue(null);
-        geohashGrid.initalize(envelope, features);
-        IntStream.range(0, geohashGrid.getGrid().length)
-                .forEach(
-                        row ->
-                                IntStream.range(0, geohashGrid.getGrid()[row].length)
-                                        .forEach(
-                                                column ->
-                                                        assertEquals(
-                                                                0.0,
-                                                                geohashGrid.getGrid()[row][column],
-                                                                0.0)));
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        int bound = geohashGrid.getGrid().length;
+        for (int row = 0; row < bound; row++) {
+            int bound1 = geohashGrid.getGrid()[row].length;
+            for (int column = 0; column < bound1; column++) {
+                assertEquals(0.0, geohashGrid.getGrid()[row][column], 0.0);
+            }
+        }
     }
 
     @Test
@@ -302,7 +307,8 @@ public class GeoHashGridTest {
                         ImmutableList.of(ImmutableMap.of("aString", UUID.randomUUID().toString())));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
         IntStream.range(0, geohashGrid.getGrid().length)
                 .forEach(
                         i ->
@@ -326,7 +332,8 @@ public class GeoHashGridTest {
                                                                 new LatLong(-89.9, -179.9), 1))))));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
         IntStream.range(0, geohashGrid.getGrid().length)
                 .forEach(
                         i ->
@@ -348,7 +355,8 @@ public class GeoHashGridTest {
                                                         "key", "invalid", "doc_count", 10)))));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-        geohashGrid.initalize(envelope, features);
+        geohashGrid.initalize(
+                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
         IntStream.range(0, geohashGrid.getGrid().length)
                 .forEach(
                         i ->


### PR DESCRIPTION
[![GEOT-7102](https://badgen.net/badge/JIRA/GEOT-7102/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7102) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->