### PR TITLE
ElasticSearch dynamic grid enhancements

### DIFF
--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStoreFactory.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStoreFactory.java
@@ -183,7 +183,7 @@ public class ElasticDataStoreFactory implements DataStoreFactorySpi {
                     Long.class,
                     "Hint for Geohash grid size (nrow*ncol)",
                     false,
-                    10000L);
+                    65536L); // number of pixels in a 256*256 tile
 
     public static final Param GRID_THRESHOLD =
             new Param(

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticFeatureSource.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticFeatureSource.java
@@ -133,6 +133,9 @@ public class ElasticFeatureSource extends ContentFeatureSource {
             final String docType = dataStore.getDocType(entry.getName());
             final boolean scroll = !useSortOrPagination(query) && dataStore.getScrollEnabled();
             final ElasticRequest searchRequest = prepareSearchRequest(query, scroll);
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("Search request: " + searchRequest);
+            }
             final ElasticResponse sr =
                     dataStore.getClient().search(dataStore.getIndexName(), docType, searchRequest);
             if (LOGGER.isLoggable(Level.FINE)) {
@@ -291,7 +294,6 @@ public class ElasticFeatureSource extends ContentFeatureSource {
                 gridThreshold = (Double) ElasticDataStoreFactory.GRID_THRESHOLD.getDefaultValue();
             }
             final int precision = GeohashUtil.computePrecision(envelope, gridSize, gridThreshold);
-            LOGGER.fine("Updating GeoHash grid aggregation precision to " + precision);
             GeohashUtil.updateGridAggregationPrecision(aggregations, precision);
             searchRequest.setAggregations(aggregations);
             searchRequest.setSize(0);

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticRequest.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticRequest.java
@@ -108,4 +108,26 @@ class ElasticRequest {
     public void addField(String field) {
         this.fields.add(field);
     }
+
+    @Override
+    public String toString() {
+        return "ElasticRequest{"
+                + "query="
+                + query
+                + ", aggregations="
+                + aggregations
+                + ", size="
+                + size
+                + ", from="
+                + from
+                + ", scroll="
+                + scroll
+                + ", sorts="
+                + sorts
+                + ", sourceIncludes="
+                + sourceIncludes
+                + ", fields="
+                + fields
+                + '}';
+    }
 }

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
@@ -16,7 +16,6 @@
  */
 package org.geotools.data.elasticsearch;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.collect.ImmutableList;
@@ -28,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Logger;
 import org.geotools.data.Query;
 import org.geotools.data.elasticsearch.date.DateFormat;
@@ -1314,20 +1314,24 @@ class FilterToElastic implements FilterVisitor, ExpressionVisitor {
                     }
                 }
                 if (entry.getKey().equalsIgnoreCase("a")) {
-                    final ObjectMapper mapper = new ObjectMapper();
-                    final TypeReference<Map<String, Map<String, Map<String, Object>>>> type =
-                            new TypeReference<Map<String, Map<String, Map<String, Object>>>>() {};
-                    final String value = entry.getValue();
-                    try {
-                        this.aggregations = mapper.readValue(value, type);
-                    } catch (Exception e) {
-                        try {
-                            this.aggregations =
-                                    mapper.readValue(ElasticParserUtil.urlDecode(value), type);
-                        } catch (Exception e2) {
-                            throw new FilterToElasticException("Unable to parse aggregation", e);
-                        }
-                    }
+                    this.aggregations = GeohashUtil.parseAggregation(entry.getValue());
+
+                    // map default geometry to actual underlying field name, if it was left empty
+                    // (e.g, automatic grid definition in GeoHashProcess, it does not have
+                    // access to the geometry name in general)
+                    Optional.ofNullable(aggregations)
+                            .map(a -> a.get("agg"))
+                            .map(a -> a.get("geohash_grid"))
+                            .ifPresent(
+                                    m -> {
+                                        if ("".equals(m.get("field"))) {
+                                            m.put(
+                                                    "field",
+                                                    featureType
+                                                            .getGeometryDescriptor()
+                                                            .getLocalName());
+                                        }
+                                    });
                 }
             }
         }

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
@@ -1322,18 +1322,15 @@ class FilterToElastic implements FilterVisitor, ExpressionVisitor {
                     Optional.ofNullable(aggregations)
                             .map(a -> a.get("agg"))
                             .map(a -> a.get("geohash_grid"))
-                            .ifPresent(
-                                    m -> {
-                                        if ("".equals(m.get("field"))) {
-                                            m.put(
-                                                    "field",
-                                                    featureType
-                                                            .getGeometryDescriptor()
-                                                            .getLocalName());
-                                        }
-                                    });
+                            .ifPresent(this::setGeometryField);
                 }
             }
+        }
+    }
+
+    private void setGeometryField(Map<String, Object> m) {
+        if ("".equals(m.get("field"))) {
+            m.put("field", featureType.getGeometryDescriptor().getLocalName());
         }
     }
 

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/GeohashUtil.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/GeohashUtil.java
@@ -16,18 +16,26 @@
  */
 package org.geotools.data.elasticsearch;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.davidmoten.geo.GeoHash;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Envelope;
 
-class GeohashUtil {
+public class GeohashUtil {
+
+    static final ObjectMapper MAPPER = new ObjectMapper();
+    static final Logger LOGGER = Logging.getLogger(GeohashUtil.class);
 
     public static int computePrecision(Envelope envelope, long size, double threshold) {
         return computePrecision(envelope, size, threshold, 1);
     }
 
     private static int computePrecision(Envelope envelope, long size, double threshold, int n) {
-        return computeSize(envelope, n) / size > threshold
+        return computeSize(envelope, n) / size >= threshold
                 ? n
                 : computePrecision(envelope, size, threshold, n + 1);
     }
@@ -37,10 +45,43 @@ class GeohashUtil {
         return area / (GeoHash.widthDegrees(n) * GeoHash.heightDegrees(n));
     }
 
+    /**
+     * Updates the precision in the aggregation to the given value, but only if it's missing or if
+     * it's higher than the provided value (for safety)
+     */
     public static void updateGridAggregationPrecision(
             Map<String, Map<String, Map<String, Object>>> aggregations, int precision) {
         aggregations.values().stream()
                 .filter(a -> a.containsKey("geohash_grid"))
-                .forEach(a -> a.get("geohash_grid").put("precision", precision));
+                .forEach(a -> updateAggregatePrecision(precision, a));
+    }
+
+    private static void updateAggregatePrecision(
+            int precision, Map<String, Map<String, Object>> a) {
+        Map<String, Object> grid = a.get("geohash_grid");
+        Object foundPrecision = grid.get("precision");
+        if (!(foundPrecision instanceof Number)
+                || ((Number) foundPrecision).intValue() > precision) {
+            LOGGER.log(
+                    Level.FINE,
+                    "Updating aggregation precision from " + foundPrecision + " to " + precision);
+            grid.put("precision", precision);
+        }
+    }
+
+    public static Map<String, Map<String, Map<String, Object>>> parseAggregation(
+            String definition) {
+
+        final TypeReference<Map<String, Map<String, Map<String, Object>>>> type =
+                new TypeReference<Map<String, Map<String, Map<String, Object>>>>() {};
+        try {
+            return MAPPER.readValue(definition, type);
+        } catch (Exception e) {
+            try {
+                return MAPPER.readValue(ElasticParserUtil.urlDecode(definition), type);
+            } catch (Exception e2) {
+                throw new FilterToElasticException("Unable to parse aggregation", e);
+            }
+        }
     }
 }

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/ElasticBucketVisitor.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/ElasticBucketVisitor.java
@@ -33,15 +33,12 @@ public class ElasticBucketVisitor implements FeatureAttributeVisitor {
     private List<Map<String, Object>> buckets;
     private String aggregationDefinition;
     private String queryDefinition;
-    private Boolean nativeOnly;
     private Expression expr;
 
-    public ElasticBucketVisitor(
-            String aggregationDefinition, String queryDefinition, Boolean nativeOnly) {
+    public ElasticBucketVisitor(String aggregationDefinition, String queryDefinition) {
         this.buckets = new ArrayList<>();
         this.aggregationDefinition = aggregationDefinition;
         this.queryDefinition = queryDefinition;
-        this.nativeOnly = nativeOnly;
         FilterFactory factory = CommonFactoryFinder.getFilterFactory(null);
         expr = factory.property("_aggregation");
     }
@@ -75,14 +72,6 @@ public class ElasticBucketVisitor implements FeatureAttributeVisitor {
 
     public void setQueryDefinition(String queryDefinition) {
         this.queryDefinition = queryDefinition;
-    }
-
-    public Boolean getNativeOnly() {
-        return nativeOnly;
-    }
-
-    public void setNativeOnly(Boolean nativeOnly) {
-        this.nativeOnly = nativeOnly;
     }
 
     @Override

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/GeoHashGridProcess.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/process/elasticsearch/GeoHashGridProcess.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.process.elasticsearch;
 
+import static com.github.davidmoten.geo.GeoHash.widthDegrees;
+
+import com.github.davidmoten.geo.GeoHash;
 import java.util.ArrayList;
 import java.util.List;
 import org.geotools.coverage.grid.GridCoverage2D;
@@ -36,6 +39,8 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.expression.PropertyName;
 import org.opengis.filter.spatial.BBOX;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.operation.TransformException;
 import org.opengis.util.ProgressListener;
 
 @SuppressWarnings("unused")
@@ -81,7 +86,7 @@ public class GeoHashGridProcess implements VectorProcess {
                             name = "gridStrategy",
                             description = "GeoHash grid strategy",
                             defaultValue = "Basic",
-                            min = 1)
+                            min = 0)
                     String gridStrategy,
             @DescribeParameter(
                             name = "gridStrategyArgs",
@@ -113,7 +118,8 @@ public class GeoHashGridProcess implements VectorProcess {
                     Integer argOutputHeight,
             @DescribeParameter(
                             name = "aggregationDefinition",
-                            description = "Native Elasticsearch Aggregation definition")
+                            description = "Native Elasticsearch Aggregation definition",
+                            min = 0)
                     String aggregationDefinition,
             @DescribeParameter(
                             name = "queryDefinition",
@@ -129,6 +135,12 @@ public class GeoHashGridProcess implements VectorProcess {
             throws ProcessException {
 
         try {
+            // setup sane defaults for aggregation definition, if missing
+            if (aggregationDefinition == null)
+                aggregationDefinition =
+                        defaultAggregation(
+                                argOutputEnv, argOutputWidth, argOutputHeight, obsFeatures);
+
             // construct and populate grid
             final GeoHashGrid geoHashGrid =
                     Strategy.valueOf(gridStrategy.toUpperCase()).createNewInstance();
@@ -158,6 +170,37 @@ public class GeoHashGridProcess implements VectorProcess {
         } catch (Exception e) {
             throw new ProcessException("Error executing GeoHashGridProcess", e);
         }
+    }
+
+    String defaultAggregation(
+            ReferencedEnvelope envelope,
+            Integer width,
+            Integer height,
+            SimpleFeatureCollection obsFeatures)
+            throws FactoryException, TransformException {
+        ReferencedEnvelope wgse = envelope.transform(DefaultGeographicCRS.WGS84, true);
+        double cellw = wgse.getWidth() / width;
+        double cellh = wgse.getHeight() / height;
+
+        // find out which GeoHash precision best fits the target width and height, we need
+        // something just a little bit more precise
+        int precision = 0;
+        double ghw = 0, ghh = 0;
+        for (; precision <= GeoHash.MAX_HASH_LENGTH; precision++) {
+            ghw = widthDegrees(precision);
+            ghh = GeoHash.heightDegrees(precision);
+            if (ghw <= cellw && ghh <= cellh) break;
+        }
+        // stick with a lower precision, number of cells goes up by a factor of 32 for
+        // each precision level
+        if (precision > 1 && (ghw != cellw || ghh != cellh)) {
+            precision = precision - 1;
+        }
+
+        // having the precision, compute the aggregation definition
+        return "{\"agg\": {\"geohash_grid\": {\"size\": 65536, \"field\": \"\", \"precision\": "
+                + precision
+                + "}}}";
     }
 
     public Query invertQuery(

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticTestSupport.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticTestSupport.java
@@ -96,19 +96,19 @@ public class ElasticTestSupport {
 
     static final int SOURCE_SRID = 4326;
 
-    String host;
+    protected String host;
 
-    int port;
+    protected int port;
 
-    String indexName;
+    protected String indexName;
 
-    ElasticDataStore dataStore;
+    protected ElasticDataStore dataStore;
 
-    ElasticFeatureSource featureSource;
+    protected ElasticFeatureSource featureSource;
 
-    ElasticLayerConfiguration config;
+    protected ElasticLayerConfiguration config;
 
-    ElasticClient client;
+    protected ElasticClient client;
 
     @Before
     public void beforeTest() throws Exception {
@@ -217,7 +217,7 @@ public class ElasticTestSupport {
         return params;
     }
 
-    void init() throws Exception {
+    protected void init() throws Exception {
         DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
         init("active");
     }

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticViewParametersFilterIT.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticViewParametersFilterIT.java
@@ -115,10 +115,11 @@ public class ElasticViewParametersFilterIT extends ElasticTestSupport {
         ElasticBucketVisitor elasticBucketVisitor =
                 new ElasticBucketVisitor(
                         "{\"agg\": {\"geohash_grid\": {\"field\": \"geo\", \"precision\": 3}}}",
-                        null,
-                        false);
+                        null);
         featureSource.accepts(q, elasticBucketVisitor, null);
         List<Map<String, Object>> buckets = elasticBucketVisitor.getBuckets();
-        assertEquals(9, buckets.size());
+        // all 11 features in the store accounted for
+        assertEquals(10, buckets.size());
+        assertEquals(11, buckets.stream().mapToInt(b -> (int) b.get("doc_count")).sum());
     }
 }

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/GeohashUtilTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/GeohashUtilTest.java
@@ -81,9 +81,9 @@ public class GeohashUtilTest {
     }
 
     @Test
-    public void updatePrecision() {
+    public void updatePrecisionLower() {
         final Map<String, Object> geohashGridAgg =
-                new HashMap<>(ImmutableMap.of("field", "name", "precision", 0));
+                new HashMap<>(ImmutableMap.of("field", "name", "precision", 4));
         final Map<String, Map<String, Map<String, Object>>> aggregations =
                 ImmutableMap.of("first", ImmutableMap.of("geohash_grid", geohashGridAgg));
         final Map<String, Object> expected =
@@ -91,6 +91,21 @@ public class GeohashUtilTest {
                         "first",
                         ImmutableMap.of(
                                 "geohash_grid", ImmutableMap.of("field", "name", "precision", 2)));
+        GeohashUtil.updateGridAggregationPrecision(aggregations, 2);
+        assertEquals(expected, aggregations);
+    }
+
+    @Test
+    public void updatePrecisionHigher() {
+        final Map<String, Object> geohashGridAgg =
+                new HashMap<>(ImmutableMap.of("field", "name", "precision", 1));
+        final Map<String, Map<String, Map<String, Object>>> aggregations =
+                ImmutableMap.of("first", ImmutableMap.of("geohash_grid", geohashGridAgg));
+        final Map<String, Object> expected =
+                ImmutableMap.of(
+                        "first",
+                        ImmutableMap.of(
+                                "geohash_grid", ImmutableMap.of("field", "name", "precision", 1)));
         GeohashUtil.updateGridAggregationPrecision(aggregations, 2);
         assertEquals(expected, aggregations);
     }

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessIT.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessIT.java
@@ -1,0 +1,157 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.process.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferFloat;
+import java.awt.image.RenderedImage;
+import java.util.stream.IntStream;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.data.elasticsearch.ElasticTestSupport;
+import org.geotools.data.store.ContentFeatureCollection;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.junit.Test;
+import org.opengis.geometry.Envelope;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+public class GeoHashGridProcessIT extends ElasticTestSupport {
+
+    @Test
+    public void testAutomaticAggregation() throws Exception {
+        init();
+
+        ContentFeatureCollection features = featureSource.getFeatures();
+        String aggregationDefinition = null;
+        GridCoverage2D grid =
+                new GeoHashGridProcess()
+                        .execute(
+                                features,
+                                "Basic",
+                                null,
+                                null,
+                                null,
+                                null,
+                                false,
+                                new ReferencedEnvelope(
+                                        -180, 180, -90, 90, DefaultGeographicCRS.WGS84),
+                                360,
+                                180,
+                                aggregationDefinition /* agg definition */,
+                                null,
+                                null);
+        // automatic aggregation should have created a geohash with precision
+        assertNotNull(grid);
+        // precision = 3 has been chosen, level 4 would have too many cells
+        RenderedImage ri = grid.getRenderedImage();
+        assertEquals(256, ri.getWidth());
+        assertEquals(128, ri.getHeight());
+    }
+
+    @Test
+    public void testValues() throws Exception {
+        init();
+
+        // force it to a small grid that's easy to check
+        ContentFeatureCollection features = featureSource.getFeatures();
+        String aggregationDefinition = null;
+        GridCoverage2D grid =
+                new GeoHashGridProcess()
+                        .execute(
+                                features,
+                                "Basic",
+                                null,
+                                null,
+                                null,
+                                null,
+                                false,
+                                new ReferencedEnvelope(
+                                        -180, 180, -90, 90, DefaultGeographicCRS.WGS84),
+                                8,
+                                4,
+                                aggregationDefinition /* agg definition */,
+                                null,
+                                null);
+        // automatic aggregation should have created a geohash with precision
+        assertNotNull(grid);
+        // precision = 1 has been chosen
+        RenderedImage ri = grid.getRenderedImage();
+        assertEquals(8, ri.getWidth());
+        assertEquals(4, ri.getHeight());
+        // check data type and extract array
+        assertEquals(DataBuffer.TYPE_FLOAT, ri.getData().getTransferType());
+        float[] data = ((DataBufferFloat) ri.getData().getDataBuffer()).getData();
+        // all 11 values are in geohash "s", fifth cell of the second row
+        for (int i = 0; i < data.length; i++) {
+            if (i == 12) assertEquals(11, data[i], 0f);
+            else assertEquals(0, data[i], 0f);
+        }
+    }
+
+    @Test
+    public void testReprojected() throws Exception {
+        init();
+
+        ReferencedEnvelope base =
+                new ReferencedEnvelope(-50, 50, -50, 50, DefaultGeographicCRS.WGS84);
+        CoordinateReferenceSystem webMercator = CRS.decode("EPSG:3857", true);
+        ReferencedEnvelope transformed = base.transform(webMercator, true);
+
+        ContentFeatureCollection features = featureSource.getFeatures();
+        String aggregationDefinition = null;
+        GridCoverage2D grid =
+                new GeoHashGridProcess()
+                        .execute(
+                                features,
+                                "Basic",
+                                null,
+                                null,
+                                null,
+                                null,
+                                false,
+                                transformed,
+                                12,
+                                12,
+                                aggregationDefinition /* agg definition */,
+                                null,
+                                null);
+        assertNotNull(grid);
+        // the output is a GeoHash grid, always in WGS84
+        assertEquals(DefaultGeographicCRS.WGS84, grid.getCoordinateReferenceSystem2D());
+        // Locked on precision 2 containing the data (with a bit of padding due to reprojection)
+        // At precision 2 cells are 11.25 by 5.625 degrees
+        Envelope envelope = grid.getEnvelope();
+        assertEquals(-67.5, envelope.getMinimum(0), 0d);
+        assertEquals(-56.25, envelope.getMinimum(1), 0d);
+        assertEquals(56.25, envelope.getMaximum(0), 0d);
+        assertEquals(56.25, envelope.getMaximum(1), 0d);
+        // smaller area, smaller grid (at precision 2 cells are rectangular)
+        RenderedImage ri = grid.getRenderedImage();
+        assertEquals(11, ri.getWidth());
+        assertEquals(20, ri.getHeight());
+        // check data type and extract array
+        assertEquals(DataBuffer.TYPE_FLOAT, ri.getData().getTransferType());
+        float[] data = ((DataBufferFloat) ri.getData().getDataBuffer()).getData();
+        // at this precision data is spread out in various cells, let's check the total
+        int matches = (int) IntStream.range(0, data.length).mapToDouble(i -> data[i]).sum();
+        assertEquals(11, matches);
+    }
+}

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessTest.java
@@ -25,7 +25,6 @@ import com.github.davidmoten.geo.LatLong;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.awt.geom.Point2D;
-import java.util.List;
 import java.util.Map;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.data.Query;
@@ -38,7 +37,6 @@ import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Envelope;
-import org.opengis.coverage.grid.GridCoverage;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.referencing.FactoryException;
@@ -97,27 +95,13 @@ public class GeoHashGridProcessTest {
                 new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
         int width = 8;
         int height = 4;
-        int pixelsPerCell = 1;
         String strategy = "Basic";
         Float scaleMin = 0f;
 
         GridCoverage2D coverage =
                 process.execute(
-                        features,
-                        pixelsPerCell,
-                        strategy,
-                        null,
-                        null,
-                        scaleMin,
-                        null,
-                        false,
-                        envelope,
-                        width,
-                        height,
-                        null,
-                        "",
-                        false,
-                        null);
+                        features, strategy, null, null, scaleMin, null, false, envelope, width,
+                        height, null, "", null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -128,27 +112,13 @@ public class GeoHashGridProcessTest {
                 new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
         int width = 16;
         int height = 8;
-        int pixelsPerCell = 1;
         String strategy = "Basic";
         Float scaleMin = 0f;
 
         GridCoverage2D coverage =
                 process.execute(
-                        features,
-                        pixelsPerCell,
-                        strategy,
-                        null,
-                        null,
-                        scaleMin,
-                        null,
-                        false,
-                        envelope,
-                        width,
-                        height,
-                        null,
-                        "",
-                        false,
-                        null);
+                        features, strategy, null, null, scaleMin, null, false, envelope, width,
+                        height, null, "", null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -159,27 +129,13 @@ public class GeoHashGridProcessTest {
                 new ReferencedEnvelope(-168.75, 168.75, -78.75, 78.75, DefaultGeographicCRS.WGS84);
         int width = 16;
         int height = 8;
-        int pixelsPerCell = 1;
         String strategy = "Basic";
         Float scaleMin = 0f;
 
         GridCoverage2D coverage =
                 process.execute(
-                        features,
-                        pixelsPerCell,
-                        strategy,
-                        null,
-                        null,
-                        scaleMin,
-                        null,
-                        false,
-                        envelope,
-                        width,
-                        height,
-                        null,
-                        "",
-                        false,
-                        null);
+                        features, strategy, null, null, scaleMin, null, false, envelope, width,
+                        height, null, "", null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -190,27 +146,13 @@ public class GeoHashGridProcessTest {
                 new ReferencedEnvelope(-168.75, 168.75, -78.75, 78.75, DefaultGeographicCRS.WGS84);
         int width = 900;
         int height = 600;
-        int pixelsPerCell = 1;
         String strategy = "Basic";
         Float scaleMin = 0f;
 
         GridCoverage2D coverage =
                 process.execute(
-                        features,
-                        pixelsPerCell,
-                        strategy,
-                        null,
-                        null,
-                        scaleMin,
-                        null,
-                        false,
-                        envelope,
-                        width,
-                        height,
-                        null,
-                        "",
-                        false,
-                        null);
+                        features, strategy, null, null, scaleMin, null, false, envelope, width,
+                        height, null, "", null);
         checkInternal(coverage, fineDelta);
     }
 
@@ -243,12 +185,6 @@ public class GeoHashGridProcessTest {
         }
 
         return -1;
-    }
-
-    private GridCoverage2D unwrapToNative(GridCoverage2D coverage) {
-        List<GridCoverage> source = coverage.getSources();
-        if (source != null & source.size() == 1) return (GridCoverage2D) source.get(0);
-        return coverage;
     }
 
     /**

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridProcessTest.java
@@ -25,8 +25,11 @@ import com.github.davidmoten.geo.LatLong;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.awt.geom.Point2D;
+import java.util.List;
+import java.util.Map;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.data.Query;
+import org.geotools.data.elasticsearch.GeohashUtil;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -35,10 +38,13 @@ import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Envelope;
+import org.opengis.coverage.grid.GridCoverage;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
+import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CRSAuthorityFactory;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.TransformException;
 
 public class GeoHashGridProcessTest {
 
@@ -108,7 +114,7 @@ public class GeoHashGridProcessTest {
                         envelope,
                         width,
                         height,
-                        "",
+                        null,
                         "",
                         false,
                         null);
@@ -139,7 +145,7 @@ public class GeoHashGridProcessTest {
                         envelope,
                         width,
                         height,
-                        "",
+                        null,
                         "",
                         false,
                         null);
@@ -170,7 +176,7 @@ public class GeoHashGridProcessTest {
                         envelope,
                         width,
                         height,
-                        "",
+                        null,
                         "",
                         false,
                         null);
@@ -201,11 +207,48 @@ public class GeoHashGridProcessTest {
                         envelope,
                         width,
                         height,
-                        "",
+                        null,
                         "",
                         false,
                         null);
         checkInternal(coverage, fineDelta);
+    }
+
+    @Test
+    public void testAutomaticDefinition() throws FactoryException, TransformException {
+        ReferencedEnvelope envelope =
+                new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
+
+        assertEquals(1, getPrecision(process.defaultAggregation(envelope, 8, 4, features)));
+        assertEquals(1, getPrecision(process.defaultAggregation(envelope, 16, 8, features)));
+        assertEquals(2, getPrecision(process.defaultAggregation(envelope, 32, 32, features)));
+        assertEquals(2, getPrecision(process.defaultAggregation(envelope, 128, 128, features)));
+        assertEquals(3, getPrecision(process.defaultAggregation(envelope, 256, 128, features)));
+        assertEquals(3, getPrecision(process.defaultAggregation(envelope, 720, 360, features)));
+    }
+
+    private int getPrecision(String definition) throws FactoryException, TransformException {
+        Map<String, Map<String, Map<String, Object>>> aggregation =
+                GeohashUtil.parseAggregation(definition);
+        Map<String, Map<String, Object>> aggMap = aggregation.get("agg");
+        if (aggMap != null) {
+            Map<String, Object> geohashMap = aggMap.get("geohash_grid");
+            if (geohashMap != null) {
+                if (geohashMap.get("precision") != null) {
+                    if (geohashMap.get("precision") instanceof Integer) {
+                        return (Integer) geohashMap.get("precision");
+                    }
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private GridCoverage2D unwrapToNative(GridCoverage2D coverage) {
+        List<GridCoverage> source = coverage.getSources();
+        if (source != null & source.size() == 1) return (GridCoverage2D) source.get(0);
+        return coverage;
     }
 
     /**

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/process/elasticsearch/GeoHashGridTest.java
@@ -55,7 +55,6 @@ public class GeoHashGridTest {
             TestUtil.createAggBucket(AGG_KEY, AGG_RESULTS);
     private static final String aggregationDefinition = "";
     private static final String queryDefinition = "";
-    private static final Boolean nativeOnly = false;
 
     private SimpleFeatureCollection features;
 
@@ -85,8 +84,7 @@ public class GeoHashGridTest {
                                                         10)))));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-360, 180, -90, 90, DefaultGeographicCRS.WGS84);
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         assertEquals(GeoHash.widthDegrees(1), geohashGrid.getCellWidth(), 1e-10);
         assertEquals(GeoHash.heightDegrees(1), geohashGrid.getCellHeight(), 1e-10);
         assertEquals(
@@ -116,8 +114,7 @@ public class GeoHashGridTest {
                         ImmutableList.of(ImmutableMap.of("_aggregation", aggregation)));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(360, 540, -90, 90, DefaultGeographicCRS.WGS84);
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         assertEquals(GeoHash.widthDegrees(1), geohashGrid.getCellWidth(), 1e-10);
         assertEquals(GeoHash.heightDegrees(1), geohashGrid.getCellHeight(), 1e-10);
         assertEquals(
@@ -147,8 +144,7 @@ public class GeoHashGridTest {
                         ImmutableList.of(ImmutableMap.of("_aggregation", aggregation)));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         assertEquals(GeoHash.widthDegrees(1), geohashGrid.getCellWidth(), 1e-10);
         assertEquals(GeoHash.heightDegrees(1), geohashGrid.getCellHeight(), 1e-10);
         assertEquals(
@@ -192,8 +188,7 @@ public class GeoHashGridTest {
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84);
         geohashGrid.setScale(new RasterScale(5f, 10f));
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         assertEquals(GeoHash.widthDegrees(1), geohashGrid.getCellWidth(), 1e-10);
         assertEquals(GeoHash.heightDegrees(1), geohashGrid.getCellHeight(), 1e-10);
         assertEquals(
@@ -233,8 +228,7 @@ public class GeoHashGridTest {
                         -30240971.96,
                         30240971.96,
                         CRS.decode("EPSG:3857"));
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
 
         assertEquals(
                 new ReferencedEnvelope(-180, 180, -90, 90, DefaultGeographicCRS.WGS84),
@@ -246,8 +240,7 @@ public class GeoHashGridTest {
         features = new DefaultFeatureCollection();
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         IntStream.range(0, geohashGrid.getGrid().length)
                 .forEach(
                         i ->
@@ -264,8 +257,7 @@ public class GeoHashGridTest {
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
         geohashGrid.setEmptyCellValue(emptyCellValue);
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         int bound = geohashGrid.getGrid().length;
         for (int i = 0; i < bound; i++) {
             int bound1 = geohashGrid.getGrid()[i].length;
@@ -281,8 +273,7 @@ public class GeoHashGridTest {
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
         geohashGrid.setEmptyCellValue(null);
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         int bound = geohashGrid.getGrid().length;
         for (int row = 0; row < bound; row++) {
             int bound1 = geohashGrid.getGrid()[row].length;
@@ -299,8 +290,7 @@ public class GeoHashGridTest {
                         ImmutableList.of(ImmutableMap.of("aString", UUID.randomUUID().toString())));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         IntStream.range(0, geohashGrid.getGrid().length)
                 .forEach(
                         i ->
@@ -320,8 +310,7 @@ public class GeoHashGridTest {
                         ImmutableList.of(ImmutableMap.of("_aggregation", aggregation)));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         IntStream.range(0, geohashGrid.getGrid().length)
                 .forEach(
                         i ->
@@ -343,8 +332,7 @@ public class GeoHashGridTest {
                                                         "key", "invalid", "doc_count", 10)))));
         ReferencedEnvelope envelope =
                 new ReferencedEnvelope(-180, 180, -90, 90, CRS.decode("EPSG:4326"));
-        geohashGrid.initalize(
-                envelope, features, aggregationDefinition, queryDefinition, nativeOnly);
+        geohashGrid.initalize(envelope, features, aggregationDefinition, queryDefinition);
         IntStream.range(0, geohashGrid.getGrid().length)
                 .forEach(
                         i ->


### PR DESCRIPTION
A few changes to make ES grid generation more convenient, less prone to security dodging attacks, and have it better align on screen, especially when using tiled displays:

* [[GEOT-7118](https://osgeo-org.atlassian.net/browse/GEOT-7118)] Allow GeoHashGridProcess to default the grid aggregation definition
* [[GEOT-7119](https://osgeo-org.atlassian.net/browse/GEOT-7119)] Clean up GeoHashGridProcessParameters, make it work properly with tiling


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->