### PR TITLE
[GEOT-7124] WMTSCoverageReader isNativelySupported should check for equality in CRS rather than SRS

### DIFF
--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSMapLayerTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSMapLayerTest.java
@@ -27,7 +27,9 @@ import org.geotools.ows.wmts.WebMapTileServer;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
 import org.geotools.ows.wmts.model.WMTSLayer;
 import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.test.TestData;
+import org.junit.Assert;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.parameter.GeneralParameterValue;
@@ -51,5 +53,15 @@ public class WMTSMapLayerTest {
         CoordinateReferenceSystem crs =
                 (CoordinateReferenceSystem) ((ParameterValue) params[0]).getValue();
         assertEquals(CRS.decode("EPSG:3857"), crs);
+    }
+
+    @Test
+    public void testNativelySupported() throws Exception {
+        WMTSCapabilities capa = WMTSTestUtils.createCapabilities("getcapa_kvp.xml");
+        URL url = new URL("http://localhost:8080/geoserver/gwc/service/wmts?");
+        WebMapTileServer server = new WebMapTileServer(url, capa);
+        WMTSMapLayer mapLayer = new WMTSMapLayer(server, capa.getLayer("tasmania"));
+        boolean wgs84supported = mapLayer.isNativelySupported(DefaultGeographicCRS.WGS84);
+        Assert.assertTrue(wgs84supported);
     }
 }


### PR DESCRIPTION
[![GEOT-7124](https://badgen.net/badge/JIRA/GEOT-7124/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7124) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I would like to see a more robust method to determine whether the coordinate reference system is supported natively by the server.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->