### PR TITLE
[GEOT-7125] GetSingleTileRequest doesn't include TIME in url

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
@@ -290,7 +290,7 @@ public class WMTSSpecification extends Specification {
             this.setProperty("TileMatrix", this.getTileMatrix());
             this.setProperty("TileCol", this.getTileCol().toString());
             this.setProperty("TileRow", this.getTileRow().toString());
-
+            this.setProperty("time", this.getRequestedTime());
             return super.getFinalURL();
         }
 

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -211,6 +211,10 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
         this.requestedBBox = requestedBBox;
     }
 
+    protected String getRequestedTime() {
+        return requestedTime;
+    }
+
     @Override
     public void setRequestedTime(String requestedTime) {
         this.requestedTime = requestedTime;

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
@@ -355,6 +355,35 @@ public class WebMapTileServerTest {
         Assert.assertNotNull(tileImage);
     }
 
+    /** Check that TIME is set when requestedTime is set on GetTileRequest */
+    @Test
+    public void testIssueRequestWithTime() throws Exception {
+        WMTSCapabilities capabilities = createCapabilities("getcapa_kvp.xml");
+        MockHttpClient httpClient = new MockHttpClient();
+        URL serverUrl = new URL("http://localhost:8080/geoserver/gwc/service/wmts");
+
+        httpClient.expectGet(
+                new URL(
+                        "http://localhost:8080/geoserver/gwc/service/wmts?REQUEST=GetTile&VERSION=1.0.0&SERVICE=WMTS&type=KVP&"
+                                + "LAYER=spearfish&STYLE=default&FORMAT=image%2Fpng&TILEMATRIXSET=EPSG%3A4326&"
+                                + "TILEMATRIX=EPSG%3A4326%3A0&TILEROW=0&TILECOL=0&TIME=2020-01-01"),
+                new MockHttpResponse(TestData.file(null, "world.png"), "image/png"));
+
+        WebMapTileServer server = new WebMapTileServer(serverUrl, httpClient, capabilities);
+        GetSingleTileRequest request = (GetSingleTileRequest) server.createGetTileRequest(false);
+        request.setLayer(server.getCapabilities().getLayer("spearfish"));
+        request.setStyle("default");
+        request.setFormat("image/png");
+        request.setTileMatrixSet("EPSG:4326");
+        request.setTileMatrix("EPSG:4326:0");
+        request.setTileRow(0);
+        request.setTileCol(0);
+        request.setRequestedTime("2020-01-01");
+
+        GetTileResponse response = server.issueRequest(request);
+        Assert.assertNotNull(response.getTileImage());
+    }
+
     @Test
     public void testIssueRequestWithRestTileResponseWithImage() throws Exception {
         WMTSCapabilities capabilities = createCapabilities("basemapGetCapa.xml");


### PR DESCRIPTION
[![GEOT-7125](https://badgen.net/badge/JIRA/GEOT-7125/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7125) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I've discovered a bug within creating url for GetSingleTileRequest.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->