### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/modules/plugin/mongodb/pom.xml
+++ b/modules/plugin/mongodb/pom.xml
@@ -163,7 +163,7 @@
           <!--systemPropertyVariables>
             <embedmongo.port>${embedmongo.port}</embedmongo.port>
           </systemPropertyVariables-->
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
         </configuration>
       </plugin>
       <!--plugin>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
