### PR TITLE
[GEOT-2063] PostGIS xy axis order

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
@@ -167,6 +167,9 @@ public abstract class SQLDialect {
     /** The datastore using the dialect */
     protected JDBCDataStore dataStore;
 
+    /** Used to influence the CRS axis ordering in {@link #createCRS(int, java.sql.Connection) }. */
+    protected boolean forceLongitudeFirst = false;
+
     /**
      * Creates the dialect.
      *
@@ -612,6 +615,9 @@ public abstract class SQLDialect {
      * Turns the specified srid into a {@link CoordinateReferenceSystem}, or returns <code>null
      * </code> if not possible.
      *
+     * <p>Note this implementation takes account of {@link #forceLongitudeFirst} which should be set
+     * when longitude first (XY) axis ordering is required.
+     *
      * <p>The implementation might just use <code>CRS.decode("EPSG:" + srid)</code>, but most
      * spatial databases will have their own SRS database that can be queried as well.
      *
@@ -624,7 +630,7 @@ public abstract class SQLDialect {
      */
     public CoordinateReferenceSystem createCRS(int srid, Connection cx) throws SQLException {
         try {
-            return CRS.decode("EPSG:" + srid);
+            return CRS.decode("EPSG:" + srid, forceLongitudeFirst);
         } catch (Exception e) {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreAPIOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreAPIOnlineTest.java
@@ -48,7 +48,6 @@ import org.geotools.filter.function.math.FilterFunction_ceil;
 import org.geotools.geometry.jts.LiteCoordinateSequence;
 import org.geotools.geometry.jts.LiteCoordinateSequenceFactory;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.CRS;
 import org.geotools.util.factory.Hints;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -69,7 +68,6 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 public abstract class JDBCDataStoreAPIOnlineTest extends JDBCTestSupport {
     private static final int LOCK_DURATION = 3600 * 1000; // one hour
     protected TestData td;
-    protected boolean forceLongitudeFirst = false;
 
     @Override
     protected void connect() throws Exception {
@@ -151,7 +149,7 @@ public abstract class JDBCDataStoreAPIOnlineTest extends JDBCTestSupport {
         String featureTypeName = tname("building");
 
         // create a featureType and write it to PostGIS
-        CoordinateReferenceSystem crs = CRS.decode("EPSG:4326", forceLongitudeFirst);
+        CoordinateReferenceSystem crs = decodeEPSG(4326);
 
         SimpleFeatureTypeBuilder ftb = new SimpleFeatureTypeBuilder();
         ftb.setName(featureTypeName);
@@ -915,7 +913,7 @@ public abstract class JDBCDataStoreAPIOnlineTest extends JDBCTestSupport {
         SimpleFeatureCollection some = road.getFeatures(td.rd12Filter);
         assertEquals(2, some.size());
 
-        ReferencedEnvelope e = new ReferencedEnvelope(CRS.decode("EPSG:4326", forceLongitudeFirst));
+        ReferencedEnvelope e = new ReferencedEnvelope(decodeEPSG(4326));
         e.include(td.roadFeatures[0].getBounds());
         e.include(td.roadFeatures[1].getBounds());
         //        assertEquals(e, some.getBounds());

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreOnlineTest.java
@@ -362,7 +362,7 @@ public abstract class JDBCDataStoreOnlineTest extends JDBCTestSupport {
      * but the wrapped geographic CRS is order dependent)
      */
     protected CoordinateReferenceSystem getUTMCRS() throws FactoryException {
-        return CRS.decode("EPSG:26713");
+        return decodeEPSG(26713);
     }
 
     public void testCreateSchemaFidColumn() throws Exception {

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceExposePkOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceExposePkOnlineTest.java
@@ -16,7 +16,6 @@
  */
 package org.geotools.jdbc;
 
-import org.geotools.referencing.CRS;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 /**
@@ -38,7 +37,7 @@ public abstract class JDBCFeatureSourceExposePkOnlineTest extends JDBCFeatureSou
         SimpleFeatureType schema = featureSource.getSchema();
         assertEquals(tname("ft1"), schema.getTypeName());
         assertEquals(dataStore.getNamespaceURI(), schema.getName().getNamespaceURI());
-        assertTrue(areCRSEqual(CRS.decode("EPSG:4326"), schema.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), schema.getCoordinateReferenceSystem()));
 
         assertEquals(5, schema.getAttributeCount());
         assertNotNull(schema.getDescriptor(aname("id")));

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureSourceOnlineTest.java
@@ -32,7 +32,6 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.function.FilterFunction_strToLowerCase;
 import org.geotools.geometry.jts.LiteCoordinateSequenceFactory;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.CRS;
 import org.geotools.util.factory.Hints;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -53,8 +52,6 @@ import org.opengis.filter.expression.Subtract;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
 import org.opengis.filter.spatial.BBOX;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 @SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation") // not yet a JUnit4 test
 public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
@@ -71,7 +68,7 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
         SimpleFeatureType schema = featureSource.getSchema();
         assertEquals(tname("ft1"), schema.getTypeName());
         assertEquals(dataStore.getNamespaceURI(), schema.getName().getNamespaceURI());
-        assertTrue(areCRSEqual(getWGS84(), schema.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), schema.getCoordinateReferenceSystem()));
 
         assertEquals(4, schema.getAttributeCount());
         assertNotNull(schema.getDescriptor(aname("geometry")));
@@ -87,7 +84,7 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
         assertEquals(2l, Math.round(bounds.getMaxX()));
         assertEquals(2l, Math.round(bounds.getMaxY()));
 
-        assertTrue(areCRSEqual(getWGS84(), bounds.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
     }
 
     public void testBoundsWithQuery() throws Exception {
@@ -104,7 +101,7 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
         assertEquals(1l, Math.round(bounds.getMaxX()));
         assertEquals(1l, Math.round(bounds.getMaxY()));
 
-        assertTrue(areCRSEqual(getWGS84(), bounds.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
     }
 
     public void testBoundsWithLimit() throws Exception {
@@ -117,7 +114,7 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
         assertEquals(1l, Math.round(bounds.getMaxX()));
         assertEquals(1l, Math.round(bounds.getMaxY()));
 
-        assertTrue(areCRSEqual(getWGS84(), bounds.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
     }
 
     public void testBoundsWithOffset() throws Exception {
@@ -130,12 +127,7 @@ public abstract class JDBCFeatureSourceOnlineTest extends JDBCTestSupport {
         assertEquals(2l, Math.round(bounds.getMaxX()));
         assertEquals(2l, Math.round(bounds.getMaxY()));
 
-        assertTrue(areCRSEqual(getWGS84(), bounds.getCoordinateReferenceSystem()));
-    }
-
-    /** Allows subclasses to use a axis order specific version of it */
-    protected CoordinateReferenceSystem getWGS84() throws FactoryException {
-        return CRS.decode("EPSG:4326");
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
     }
 
     public void testCount() throws Exception {

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGeneric3DOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGeneric3DOnlineTest.java
@@ -114,7 +114,7 @@ public abstract class JDBCGeneric3DOnlineTest extends JDBCTestSupport {
                                 + ":String");
         poly3DType.getGeometryDescriptor().getUserData().put(Hints.COORDINATE_DIMENSION, 3);
 
-        crs = CRS.decode("EPSG:" + getEpsgCode());
+        crs = decodeEPSG(getEpsgCode());
     }
 
     protected Integer getNativeSRID() {

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGeographyOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGeographyOnlineTest.java
@@ -189,8 +189,7 @@ public abstract class JDBCGeographyOnlineTest extends JDBCTestSupport {
         }
 
         ReferencedEnvelope env = dataStore.getFeatureSource(tname("geopoint")).getBounds();
-        ReferencedEnvelope expected =
-                new ReferencedEnvelope(-110, 0, 29, 49, CRS.decode("EPSG:4326"));
+        ReferencedEnvelope expected = new ReferencedEnvelope(-110, 0, 29, 49, decodeEPSG(4326));
         assertEquals(expected, env);
     }
 

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTestSupport.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCTestSupport.java
@@ -32,6 +32,7 @@ import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.NameImpl;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 import org.geotools.test.OnlineTestCase;
 import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Geometry;
@@ -42,6 +43,7 @@ import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.AttributeType;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.Name;
+import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
@@ -82,6 +84,9 @@ public abstract class JDBCTestSupport extends OnlineTestCase {
     protected JDBCTestSetup setup;
     protected JDBCDataStore dataStore;
     protected SQLDialect dialect;
+
+    /** Allows implementations to request a longitude first axis ordering for CRSs. */
+    protected boolean forceLongitudeFirst = false;
 
     @Override
     protected Properties createOfflineFixture() {
@@ -253,6 +258,14 @@ public abstract class JDBCTestSupport extends OnlineTestCase {
         }
 
         assertEquals(expected, actual);
+    }
+
+    /**
+     * Returns the {@link CoordinateReferenceSystem} denoted by epsgCode with an axis order taking
+     * into account the {@link #forceLongitudeFirst} setting.
+     */
+    protected CoordinateReferenceSystem decodeEPSG(int epsgCode) throws FactoryException {
+        return CRS.decode(String.format("EPSG:%d", epsgCode), forceLongitudeFirst);
     }
 
     protected boolean areCRSEqual(CoordinateReferenceSystem crs1, CoordinateReferenceSystem crs2) {

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgFeatureSourceOnlineTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgFeatureSourceOnlineTest.java
@@ -19,19 +19,15 @@ package org.geotools.geopkg;
 import org.geotools.data.Query;
 import org.geotools.jdbc.JDBCFeatureSourceOnlineTest;
 import org.geotools.jdbc.JDBCTestSetup;
-import org.geotools.referencing.CRS;
 import org.junit.Test;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsLike;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 public class GeoPkgFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest {
 
-    /** Allows subclasses to use a axis order specific version of it */
-    @Override
-    protected CoordinateReferenceSystem getWGS84() throws FactoryException {
-        return CRS.decode("EPSG:4326", true);
+    public GeoPkgFeatureSourceOnlineTest() {
+        super();
+        this.forceLongitudeFirst = true;
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -192,6 +192,8 @@ public class PostGISDialect extends BasicSQLDialect {
 
     public PostGISDialect(JDBCDataStore dataStore) {
         super(dataStore);
+        this.forceLongitudeFirst =
+                true; // PostGIS has an XY axis order, so forceLongitudeFirst is set.
     }
 
     boolean looseBBOXEnabled = false;

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGIS3DOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGIS3DOnlineTest.java
@@ -31,6 +31,10 @@ import org.opengis.feature.simple.SimpleFeature;
 
 public class PostGIS3DOnlineTest extends JDBC3DOnlineTest {
 
+    public PostGIS3DOnlineTest() {
+        this.forceLongitudeFirst = true;
+    }
+
     @Override
     protected JDBC3DTestSetup createTestSetup() {
         return new PostGIS3DTestSetup(new PostGISTestSetup());

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISFeatureSourceExposePkOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISFeatureSourceExposePkOnlineTest.java
@@ -21,6 +21,10 @@ import org.geotools.jdbc.JDBCTestSetup;
 
 public class PostGISFeatureSourceExposePkOnlineTest extends JDBCFeatureSourceExposePkOnlineTest {
 
+    public PostGISFeatureSourceExposePkOnlineTest() {
+        this.forceLongitudeFirst = true;
+    }
+
     @Override
     protected JDBCTestSetup createTestSetup() {
         return new PostGISTestSetup();

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISFeatureSourceOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISFeatureSourceOnlineTest.java
@@ -21,6 +21,8 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.JDBCFeatureSourceOnlineTest;
 import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.CRS.AxisOrder;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -31,6 +33,10 @@ import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.spatial.Intersects;
 
 public class PostGISFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest {
+
+    public PostGISFeatureSourceOnlineTest() {
+        this.forceLongitudeFirst = true;
+    }
 
     @Override
     protected JDBCTestSetup createTestSetup() {
@@ -121,5 +127,13 @@ public class PostGISFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest 
         SimpleFeatureType schema = dataStore.getSchema(tname("ft3"));
         GeometryDescriptor gd = schema.getGeometryDescriptor();
         assertTrue(areCRSEqual(decodeEPSG(4326), gd.getCoordinateReferenceSystem()));
+    }
+
+    public void testCrsIsLongitudeFirst() throws Exception {
+        SimpleFeatureType schema = dataStore.getSchema(tname("ft3"));
+        GeometryDescriptor gd = schema.getGeometryDescriptor();
+        assertTrue(areCRSEqual(decodeEPSG(4326), gd.getCoordinateReferenceSystem()));
+        // an explicit check to ensure we have a longitude first (XY) axis order.
+        assertEquals(AxisOrder.EAST_NORTH, CRS.getAxisOrder(gd.getCoordinateReferenceSystem()));
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISFeatureSourceOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISFeatureSourceOnlineTest.java
@@ -21,7 +21,6 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.JDBCFeatureSourceOnlineTest;
 import org.geotools.jdbc.JDBCTestSetup;
-import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -72,7 +71,7 @@ public class PostGISFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest 
         assertEquals(2l, Math.round(bounds.getMaxX()));
         assertEquals(2l, Math.round(bounds.getMaxY()));
 
-        assertTrue(areCRSEqual(CRS.decode("EPSG:4326"), bounds.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
     }
 
     public void testEstimatedBounds() throws Exception {
@@ -85,7 +84,7 @@ public class PostGISFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest 
         assertEquals(2l, Math.round(bounds.getMaxX()));
         assertEquals(2l, Math.round(bounds.getMaxY()));
 
-        assertTrue(areCRSEqual(CRS.decode("EPSG:4326"), bounds.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
     }
 
     public void testEstimatedBoundsWithQuery() throws Exception {
@@ -105,7 +104,7 @@ public class PostGISFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest 
         assertEquals(1l, Math.round(bounds.getMaxX()));
         assertEquals(1l, Math.round(bounds.getMaxY()));
 
-        assertTrue(areCRSEqual(CRS.decode("EPSG:4326"), bounds.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
     }
 
     public void testEstimatedBoundsWithLimit() throws Exception {
@@ -121,6 +120,6 @@ public class PostGISFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest 
     public void testSridFirstGeometry() throws Exception {
         SimpleFeatureType schema = dataStore.getSchema(tname("ft3"));
         GeometryDescriptor gd = schema.getGeometryDescriptor();
-        assertTrue(areCRSEqual(CRS.decode("EPSG:4326"), gd.getCoordinateReferenceSystem()));
+        assertTrue(areCRSEqual(decodeEPSG(4326), gd.getCoordinateReferenceSystem()));
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreAPIOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreAPIOnlineTest.java
@@ -29,6 +29,10 @@ import org.locationtech.jts.geom.Geometry;
 
 public class PostgisDataStoreAPIOnlineTest extends JDBCDataStoreAPIOnlineTest {
 
+    public PostgisDataStoreAPIOnlineTest() {
+        this.forceLongitudeFirst = true;
+    }
+
     @Override
     protected JDBCDataStoreAPITestSetup createTestSetup() {
         return new PostgisDataStoreAPITestSetup(new PostGISTestSetup());

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisDataStoreOnlineTest.java
@@ -21,6 +21,10 @@ import org.geotools.jdbc.JDBCTestSetup;
 
 public class PostgisDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
 
+    public PostgisDataStoreOnlineTest() {
+        this.forceLongitudeFirst = true;
+    }
+
     @Override
     protected JDBCTestSetup createTestSetup() {
         return new PostGISTestSetup();

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGeographyOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisGeographyOnlineTest.java
@@ -44,6 +44,10 @@ import org.opengis.filter.spatial.DWithin;
 
 public class PostgisGeographyOnlineTest extends JDBCGeographyOnlineTest {
 
+    public PostgisGeographyOnlineTest() {
+        this.forceLongitudeFirst = true;
+    }
+
     @Override
     protected JDBCGeographyTestSetup createTestSetup() {
         return new PostgisGeographyTestSetup(new PostGISTestSetup());

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisViewOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisViewOnlineTest.java
@@ -8,6 +8,10 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 public class PostgisViewOnlineTest extends JDBCViewOnlineTest {
 
+    public PostgisViewOnlineTest() {
+        this.forceLongitudeFirst = true;
+    }
+
     @Override
     protected JDBCViewTestSetup createTestSetup() {
         return new PostgisViewTestSetup();

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisViewOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisViewOnlineTest.java
@@ -18,6 +18,6 @@ public class PostgisViewOnlineTest extends JDBCViewOnlineTest {
         CoordinateReferenceSystem crs =
                 schema.getGeometryDescriptor().getCoordinateReferenceSystem();
         assertNotNull(crs);
-        assertTrue(CRS.equalsIgnoreMetadata(CRS.decode("EPSG:4326"), crs));
+        assertTrue(CRS.equalsIgnoreMetadata(decodeEPSG(4326), crs));
     }
 }


### PR DESCRIPTION
[![GEOT-2063](https://badgen.net/badge/JIRA/GEOT-2063/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-2063) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->