### PR TITLE
[GEOT-7144] ElasticSearch query return no data, when source filtering is enabled, and attributes have been renamed

### DIFF
--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticFeatureSource.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticFeatureSource.java
@@ -39,6 +39,7 @@ import org.locationtech.jts.geom.Envelope;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.sort.SortOrder;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -253,8 +254,14 @@ public class ElasticFeatureSource extends ContentFeatureSource {
 
         if (dataStore.isSourceFilteringEnabled()) {
             if (query.getProperties() != Query.ALL_PROPERTIES) {
+                SimpleFeatureType schema = getSchema();
                 for (String property : query.getPropertyNames()) {
-                    searchRequest.addSourceInclude(property);
+                    AttributeDescriptor descriptor = schema.getDescriptor(property);
+                    if (descriptor != null) {
+                        final String sourceName =
+                                (String) descriptor.getUserData().get(ElasticConstants.FULL_NAME);
+                        searchRequest.addSourceInclude(sourceName);
+                    }
                 }
             } else {
                 // add source includes


### PR DESCRIPTION
[![GEOT-7144](https://badgen.net/badge/JIRA/GEOT-7144/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7144) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->