### PR TITLE
[GEOT-7145] WMTSCoverageReader using WMTSTileService directly

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/Layer.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/Layer.java
@@ -222,9 +222,11 @@ public class Layer implements Comparable<Layer> {
         return allBoundingBoxesCache;
     }
 
+    /** Sets the layers bounding box */
     public void setBoundingBoxes(CRSEnvelope boundingBox) {
         this.boundingBoxes.clear();
         this.boundingBoxes.add(boundingBox);
+        clearCache();
     }
 
     /**

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
@@ -63,6 +63,10 @@ public class WMTSSpecification extends Specification {
 
     public static final String WMTS_VERSION = "1.0.0";
 
+    public static final String DIMENSION_TIME = "time";
+
+    public static final String DIMENSION_ELEVATION = "elevation";
+
     /** */
     public WMTSSpecification() {}
 
@@ -97,6 +101,36 @@ public class WMTSSpecification extends Specification {
         return new GetMultiTileRequest(server, props, caps, client);
     }
 
+    /**
+     * Returns the properties for KVP WMTS, as well as placeholder's for the specific parameters of
+     * GetTile. Values passed in are expected to be already encoded appropriately for use in URLs.
+     * See {@link WMTSHelper#encodeParameter(String)}
+     *
+     * @param layerString layer
+     * @param styleString style
+     * @param tileMatrixSetName tilematrixSet name
+     * @param format format
+     * @return a hashmap containing the properties for the KVP WMTS including placeholders for
+     *     specific parameters of GetTile
+     * @see WMTSHelper#encodeParameter(String)
+     */
+    public static HashMap<String, String> getKVPparams(
+            String layerString, String styleString, String tileMatrixSetName, String format) {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("service", "WMTS");
+        params.put("version", WMTS_VERSION);
+        params.put("request", "GetTile");
+        params.put("layer", layerString);
+        params.put("style", styleString);
+        params.put("format", format);
+        params.put("tilematrixset", tileMatrixSetName);
+        params.put("TileMatrix", "{TileMatrix}");
+        params.put("TileCol", "{TileCol}");
+        params.put("TileRow", "{TileRow}");
+
+        return params;
+    }
+
     /** @deprecated Avoid usage of this - change to GetMultiTileRequest */
     @Deprecated
     public static class GetTileRequest extends GetMultiTileRequest {
@@ -117,6 +151,7 @@ public class WMTSSpecification extends Specification {
     }
 
     /** GetMultiTileRequest - used for getting a Set of tiles */
+    @Deprecated
     public static class GetMultiTileRequest extends AbstractGetTileRequest {
 
         private static Logger LOGGER = Logging.getLogger(GetMultiTileRequest.class);
@@ -246,6 +281,7 @@ public class WMTSSpecification extends Specification {
          *     specific parameters of GetTile
          * @see WMTSHelper#encodeParameter(String)
          */
+        @Deprecated
         public static HashMap<String, String> getKVPparams(
                 String layerString, String styleString, String tileMatrixSetName, String format) {
             HashMap<String, String> params = new HashMap<>();
@@ -304,15 +340,17 @@ public class WMTSSpecification extends Specification {
                         "Missing some properties for a proper GetTile-request.");
             }
 
-            String layerString = WMTSHelper.encodeParameter(layer.getName());
-            String styleString = WMTSHelper.encodeParameter(this.styleName);
-            String tileMatrixSetString = WMTSHelper.encodeParameter(this.getTileMatrixSet());
+            String layerEncoded = WMTSHelper.encodeParameter(layer.getName());
+            String styleEncoded = WMTSHelper.encodeParameter(this.styleName);
+            String formatEncoded = WMTSHelper.encodeParameter(this.getFormat());
+            String tileMatrixSetEncoded = WMTSHelper.encodeParameter(this.getTileMatrixSet());
+            String tileMatrixEncoded = WMTSHelper.encodeParameter(this.getTileMatrix());
 
-            this.setProperty("layer", layerString);
-            this.setProperty("style", styleString);
-            this.setProperty("format", this.getFormat());
-            this.setProperty("tilematrixset", tileMatrixSetString);
-            this.setProperty("TileMatrix", this.getTileMatrix());
+            this.setProperty("layer", layerEncoded);
+            this.setProperty("style", styleEncoded);
+            this.setProperty("format", formatEncoded);
+            this.setProperty("tilematrixset", tileMatrixSetEncoded);
+            this.setProperty("TileMatrix", tileMatrixEncoded);
             this.setProperty("TileCol", this.getTileCol().toString());
             this.setProperty("TileRow", this.getTileRow().toString());
             this.setProperty("time", this.getRequestedTime());

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileFactory.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileFactory.java
@@ -76,12 +76,15 @@ public class WMTSTileFactory extends TileFactory {
         return constrainToUpperLeftTile(matrixTile, zoomLevel, service);
     }
 
+    /**
+     * Returns the col and row min/max. Either as defined within layer or compute from matrixSet.
+     * Makes the WMTSTileService tolerante for server spec without TileMatrixSetLink for the layer.
+     */
     public static TileMatrixLimits getLimits(TileMatrixSetLink tmsl, TileMatrixSet tms, int z) {
-
-        List<TileMatrixLimits> limitsList = tmsl.getLimits();
         TileMatrixLimits limits;
 
-        if (limitsList != null && z < limitsList.size()) {
+        if (tmsl != null && z < tmsl.getLimits().size()) {
+            List<TileMatrixLimits> limitsList = tmsl.getLimits();
             limits = limitsList.get(z);
         } else {
             // no limits defined in layer; let's take all the defined tiles

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/TileMatrixSetLink.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/TileMatrixSetLink.java
@@ -32,7 +32,7 @@ public class TileMatrixSetLink {
 
     String identifier = "";
 
-    List<TileMatrixLimits> limits = new ArrayList<>();
+    final List<TileMatrixLimits> limits = new ArrayList<>();
 
     /** @return the identifier */
     public String getIdentifier() {
@@ -51,7 +51,8 @@ public class TileMatrixSetLink {
 
     /** @param limits the limits to set */
     public void setLimits(List<TileMatrixLimits> limits) {
-        this.limits = limits;
+        this.limits.clear();
+        this.limits.addAll(limits);
     }
 
     public void addLimit(TileMatrixLimits limit) {

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
@@ -257,11 +257,13 @@ public class WMTSCapabilities extends Capabilities {
                             .put(srs, new CRSEnvelope(wgs84Env.transform(tmsCRS, true)));
 
                 } catch (TransformException | FactoryException e) {
-                    if (LOGGER.isLoggable(Level.INFO))
-                        LOGGER.log(
-                                Level.INFO,
-                                "Not adding CRS " + srs + " for layer " + wmtsLayer.getName(),
-                                e);
+                    LOGGER.info(
+                            () -> {
+                                return "Not adding CRS "
+                                        + srs
+                                        + " for layer "
+                                        + wmtsLayer.getName();
+                            });
                 }
             }
         }

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/AbstractGetTileRequest.java
@@ -96,9 +96,9 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
 
     private String tileMatrix = null;
 
-    private Integer tileRow = null;
+    private Long tileRow = null;
 
-    private Integer tileCol = null;
+    private Long tileCol = null;
 
     /**
      * Constructs a GetMapRequest. The data passed in represents valid values that can be used.
@@ -182,33 +182,36 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
     }
 
     @Override
-    public void setTileRow(Integer tileRow) {
+    public void setTileRow(Long tileRow) {
         this.tileRow = tileRow;
     }
 
-    protected Integer getTileRow() {
+    protected Long getTileRow() {
         return tileRow;
     }
 
     @Override
-    public void setTileCol(Integer tileCol) {
+    public void setTileCol(Long tileCol) {
         this.tileCol = tileCol;
     }
 
-    protected Integer getTileCol() {
+    protected Long getTileCol() {
         return tileCol;
     }
 
+    @Deprecated
     @Override
     public void setRequestedHeight(int height) {
         this.requestedHeight = height;
     }
 
+    @Deprecated
     @Override
     public void setRequestedWidth(int width) {
         this.requestedWidth = width;
     }
 
+    @Deprecated
     @Override
     public void setRequestedBBox(ReferencedEnvelope requestedBBox) {
         this.requestedBBox = requestedBBox;
@@ -223,21 +226,25 @@ public abstract class AbstractGetTileRequest extends AbstractWMTSRequest impleme
         this.requestedTime = requestedTime;
     }
 
+    @Deprecated
     @Override
     public Map<String, String> getHeaders() {
         return headers;
     }
 
+    @Deprecated
     /** @return the crs */
     public CoordinateReferenceSystem getCrs() {
         return crs;
     }
 
+    @Deprecated
     @Override
     public void setCRS(CoordinateReferenceSystem coordinateReferenceSystem) {
         crs = coordinateReferenceSystem;
     }
 
+    @Deprecated
     /** Compute the set of tiles needed to generate the image. */
     @Override
     public Set<Tile> getTiles() throws ServiceException {

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/GetTileRequest.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/request/GetTileRequest.java
@@ -46,22 +46,32 @@ public interface GetTileRequest extends Request {
 
     void setTileMatrix(String tileMatrix);
 
-    void setTileRow(Integer tileRow);
+    void setTileRow(Long tileRow);
 
-    void setTileCol(Integer tileCol);
+    void setTileCol(Long tileCol);
 
+    @Deprecated
     Set<Tile> getTiles() throws ServiceException;
 
+    @Deprecated
     void setRequestedHeight(int height);
 
+    @Deprecated
     void setRequestedWidth(int width);
 
+    @Deprecated
     void setRequestedBBox(ReferencedEnvelope bbox);
 
     void setRequestedTime(String time);
 
+    @Deprecated
     void setCRS(CoordinateReferenceSystem coordinateReferenceSystem);
 
-    /** HTTP headers required for some WMTS * */
+    /**
+     * HTTP headers required for some WMTS *
+     *
+     * @deprecated Call WebMapTileServer.getHeaders()
+     */
+    @Deprecated
     Map<String, String> getHeaders();
 }

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WMTSTestUtils.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WMTSTestUtils.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileReader;
+import java.net.URL;
 import net.opengis.wmts.v_1.CapabilitiesType;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
 import org.geotools.test.TestData;
@@ -43,5 +44,12 @@ public class WMTSTestUtils {
 
         WMTSCapabilities capabilities = new WMTSCapabilities((CapabilitiesType) object);
         return capabilities;
+    }
+
+    public static WebMapTileServer createServer(URL serverUrl, String resourceName)
+            throws Exception {
+
+        WMTSCapabilities capa = createCapabilities(resourceName);
+        return new WebMapTileServer(serverUrl, capa);
     }
 }

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSMapLayerTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSMapLayerTest.java
@@ -38,6 +38,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 public class WMTSMapLayerTest {
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testConstructorSourceCRS() throws Exception {
         URL url = TestData.file(null, "geodata.nationaalgeoregister.nl.xml").toURI().toURL();
@@ -51,7 +52,7 @@ public class WMTSMapLayerTest {
         AttributeExpressionImpl xpath = new AttributeExpressionImpl("params");
         GeneralParameterValue[] params = xpath.evaluate(f, GeneralParameterValue[].class);
         CoordinateReferenceSystem crs =
-                (CoordinateReferenceSystem) ((ParameterValue) params[0]).getValue();
+                ((ParameterValue<CoordinateReferenceSystem>) params[0]).getValue();
         assertEquals(CRS.decode("EPSG:3857"), crs);
     }
 

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
@@ -95,13 +95,21 @@ public class WMTSCapabilitiesTest {
             Assert.assertEquals(7, tml3.getMincol());
             Assert.assertEquals(7, tml3.getMaxcol());
 
-            Assert.assertEquals("b_road", layers.get(1).getTitle());
-            Assert.assertEquals("meridian:b_road", layers.get(1).getName());
-            Assert.assertEquals("b_road_polyline", layers.get(20).getTitle());
-            Assert.assertEquals("meridian:b_road_polyline", layers.get(20).getName());
+            WMTSLayer layerRoad = layers.get(1);
+            WMTSLayer layerPoly = layers.get(20);
 
-            CRSEnvelope bbox = layers.get(1).getBoundingBoxes().get("EPSG:4326");
+            Assert.assertEquals("b_road", layerRoad.getTitle());
+            Assert.assertEquals("meridian:b_road", layerRoad.getName());
+            Assert.assertEquals(
+                    "Missing bounding box for layer b_road",
+                    3,
+                    layerRoad.getBoundingBoxes().size());
+            CRSEnvelope bbox = layerRoad.getBoundingBoxes().get("EPSG:4326");
             Assert.assertNotNull(bbox);
+
+            Assert.assertEquals("b_road_polyline", layerPoly.getTitle());
+            Assert.assertEquals("meridian:b_road_polyline", layerPoly.getName());
+
         } catch (Exception e) {
             java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
             if ((e.getMessage() != null) && e.getMessage().indexOf("timed out") > 0) {

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/LantmaterietWMTSServerOnlineTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/online/LantmaterietWMTSServerOnlineTest.java
@@ -305,6 +305,7 @@ public class LantmaterietWMTSServerOnlineTest extends WMTSOnlineTestCase {
             URL url = getClass().getResource("different_srs_def.png");
             ImageAssert.assertEquals(new File(url.toURI()), ri, 100);
         } finally {
+            CRS.reset("all");
             System.clearProperty("org.geotools.referencing.forceXY");
         }
     }


### PR DESCRIPTION
[![GEOT-7145](https://badgen.net/badge/JIRA/GEOT-7145/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7145) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The main purpose of the PR is to make the fetching of tiles from WMTSCoverageReader more obvious. This change will use a WMTSTileService that matches the selection of layer and crs, and then call WMTSTileService.findTilesInExtent directly.

In return this will make it possible to deprecate some of the functionality of GetTileRequest that didn't fit with the specification of WMTS.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->