### PR TITLE
[GEOT-6888] PostGIS - fixed columns lengths when using prepared statements (27.x)

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
@@ -334,4 +334,9 @@ public class PostGISPSDialect extends PreparedStatementSQLDialect {
     public boolean canGroupOnGeometry() {
         return delegate.canGroupOnGeometry();
     }
+
+    @Override
+    public int getDefaultVarcharSize() {
+        return delegate.getDefaultVarcharSize();
+    }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostGISPSTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostGISPSTestSetup.java
@@ -33,4 +33,10 @@ public class PostGISPSTestSetup extends PostGISTestSetup {
         dialect.setLooseBBOXEnabled(false);
         dataStore.setSQLDialect(dialect);
     }
+
+    @Override
+    protected void setUpData() throws Exception {
+        super.setUpData();
+        runSafe("DROP TABLE \"varchartest\"");
+    }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisDataStoreOnlineTest.java
@@ -47,7 +47,6 @@ public class PostgisDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
      */
     @Test
     public void testDefaultVarcharSize() throws Exception {
-        dataStore.removeSchema("varchartest");
         dataStore.createSchema(DataUtilities.createType("varchartest", "stringProperty:String"));
 
         SimpleFeatureType simpleFeatureType = dataStore.getSchema(tname("varchartest"));
@@ -63,6 +62,5 @@ public class PostgisDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
                     "column size should be larger than 255 (default) but was " + columnSize,
                     columnSize > 255);
         }
-        dataStore.removeSchema("varchartest");
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisDataStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisDataStoreOnlineTest.java
@@ -16,8 +16,18 @@
  */
 package org.geotools.data.postgis.ps;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.Transaction;
 import org.geotools.jdbc.JDBCDataStoreOnlineTest;
 import org.geotools.jdbc.JDBCTestSetup;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
 
 public class PostgisDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
 
@@ -29,5 +39,30 @@ public class PostgisDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
     @Override
     protected String getCLOBTypeName() {
         return "TEXT";
+    }
+
+    /**
+     * verifies that the column width of a varchar column is larger than 255 if length is not
+     * specified. See <a href="https://osgeo-org.atlassian.net/browse/GEOT-6888">GEOT-6888</a>.
+     */
+    @Test
+    public void testDefaultVarcharSize() throws Exception {
+        dataStore.removeSchema("varchartest");
+        dataStore.createSchema(DataUtilities.createType("varchartest", "stringProperty:String"));
+
+        SimpleFeatureType simpleFeatureType = dataStore.getSchema(tname("varchartest"));
+        assertNotNull(simpleFeatureType);
+        try (Transaction t = new DefaultTransaction("metadata");
+                Connection cx = dataStore.getConnection(t);
+                ResultSet rs =
+                        cx.getMetaData().getColumns(null, null, "varchartest", "stringProperty")) {
+
+            rs.absolute(1);
+            int columnSize = rs.getInt("COLUMN_SIZE");
+            assertTrue(
+                    "column size should be larger than 255 (default) but was " + columnSize,
+                    columnSize > 255);
+        }
+        dataStore.removeSchema("varchartest");
     }
 }


### PR DESCRIPTION
[![GEOT-6888](https://badgen.net/badge/JIRA/GEOT-6888/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6888) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

backports #3893 to 27.x

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->