### PR TITLE
[GEOT-7147] Add support for missing CSS label vendor options (27.x)

### DIFF
--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
@@ -197,7 +197,7 @@ public class CssTranslator {
             new HashMap<String, String>() {
                 {
                     put("label-padding", TextSymbolizer.SPACE_AROUND_KEY);
-                    put("label-group", "group");
+                    put("label-group", TextSymbolizer.GROUP_KEY);
                     put("label-max-displacement", TextSymbolizer.MAX_DISPLACEMENT_KEY);
                     put("label-min-group-distance", TextSymbolizer.MIN_GROUP_DISTANCE_KEY);
                     put("label-repeat", TextSymbolizer.LABEL_REPEAT_KEY);
@@ -216,9 +216,12 @@ public class CssTranslator {
                     put("label-fit-goodness", TextSymbolizer.GOODNESS_OF_FIT_KEY);
                     put("label-kerning", TextSymbolizer.KERNING_KEY);
                     put("label-polygon-align", TextSymbolizer.POLYGONALIGN_KEY);
-                    put("shield-resize", "graphic-resize");
-                    put("shield-margin", "graphic-margin");
+                    put("label-partials", TextSymbolizer.PARTIALS_KEY);
+                    put("label-displacement-mode", TextSymbolizer.DISPLACEMENT_MODE_KEY);
+                    put("shield-resize", TextSymbolizer.GRAPHIC_RESIZE_KEY);
+                    put("shield-margin", TextSymbolizer.GRAPHIC_MARGIN_KEY);
                     put("shield-placement", TextSymbolizer.GRAPHIC_PLACEMENT_KEY);
+                    put("font-shrink-size-min", TextSymbolizer.FONT_SHRINK_SIZE_MIN);
                 }
             };
 

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
@@ -562,6 +562,36 @@ public class TranslatorSyntheticTest extends CssBaseTest {
     }
 
     @Test
+    public void labelPartials() throws Exception {
+        String css = "* { label: 'test'; label-partials: true}";
+        Style style = translate(css);
+        Rule rule = assertSingleRule(style);
+        TextSymbolizer2 ts = assertSingleSymbolizer(rule, TextSymbolizer2.class);
+        assertLiteral("test", ts.getLabel());
+        assertEquals("true", ts.getOptions().get(TextSymbolizer.PARTIALS_KEY));
+    }
+
+    @Test
+    public void labelDisplacementMode() throws Exception {
+        String css = "* { label: 'test'; label-displacement-mode: 'N,E,W,S'}";
+        Style style = translate(css);
+        Rule rule = assertSingleRule(style);
+        TextSymbolizer2 ts = assertSingleSymbolizer(rule, TextSymbolizer2.class);
+        assertLiteral("test", ts.getLabel());
+        assertEquals("N,E,W,S", ts.getOptions().get(TextSymbolizer.DISPLACEMENT_MODE_KEY));
+    }
+
+    @Test
+    public void labelShrink() throws Exception {
+        String css = "* { label: 'test'; font-shrink-size-min: 5}";
+        Style style = translate(css);
+        Rule rule = assertSingleRule(style);
+        TextSymbolizer2 ts = assertSingleSymbolizer(rule, TextSymbolizer2.class);
+        assertLiteral("test", ts.getLabel());
+        assertEquals("5", ts.getOptions().get(TextSymbolizer.FONT_SHRINK_SIZE_MIN));
+    }
+
+    @Test
     public void rasterBasic() throws Exception {
         String css = "* { raster-channels: auto;}";
         Style style = translate(css);


### PR DESCRIPTION
[![GEOT-7147](https://badgen.net/badge/JIRA/GEOT-7147/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7147) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->