### PR TITLE
[GEOT-7149] WKTWriter2 failing with negative numbers in some locales

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/WKTWriter2.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/WKTWriter2.java
@@ -109,6 +109,7 @@ public class WKTWriter2 extends WKTWriter {
         // specify decimal separator explicitly to avoid problems in other locales
         DecimalFormatSymbols symbols = new DecimalFormatSymbols();
         symbols.setDecimalSeparator('.');
+        symbols.setMinusSign('-');
         String fmtString = "0" + (decimalPlaces > 0 ? "." : "") + stringOfChar('#', decimalPlaces);
         return new DecimalFormat(fmtString, symbols);
     }

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/WKTWriter2Test.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/WKTWriter2Test.java
@@ -18,6 +18,7 @@ package org.geotools.geometry.jts;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Locale;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
@@ -85,6 +86,19 @@ public class WKTWriter2Test {
                         + "COMPOUNDCURVE ((6 10, 10 1, 14 10), CIRCULARSTRING (14 10, 10 14, 6 10)), COMPOUNDCURVE ((13 10, 10 2, 7 10), CIRCULARSTRING (7 10, 10 13, 13 10))), "
                         + "CURVEPOLYGON (COMPOUNDCURVE ((106 110, 110 101, 114 110), CIRCULARSTRING (114 110, 110 114, 106 110))))");
         testRoundTrip("MULTISURFACE EMPTY");
+    }
+
+    @Test
+    public void treatingNegativeNumbersInNorwegianLocale() throws Exception {
+        Locale defLocale = Locale.getDefault();
+        try {
+            Locale norLocale = new Locale("nb");
+            Locale.setDefault(norLocale);
+            testRoundTrip(
+                    "CURVEPOLYGON (CIRCULARSTRING (143.62025166838282 -30.037497356076827, 142.92857147299705 -32.75101196874403, 143.62025166838282 -30.037497356076827))");
+        } finally {
+            Locale.setDefault(defLocale);
+        }
     }
 
     private void testRoundTrip(String wkt, String expectedWkt) throws ParseException {


### PR DESCRIPTION
[![GEOT-7149](https://badgen.net/badge/JIRA/GEOT-7149/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7149) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added setting to DecimalFormat for Norwegian locale (and other's).

And also a test that is somewhat hard to run. The existing tests are failing for me in a JDK >8 without the change.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->