### PR TITLE
Updating to imageio-ext 1.3.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -476,7 +476,7 @@
     <test.forkMode>once</test.forkMode>
     <test.args></test.args>
     <src.output>${basedir}/target</src.output>
-    <imageio.ext.version>1.3.12</imageio.ext.version>
+    <imageio.ext.version>1.3.13</imageio.ext.version>
     <jts.version>1.18.2</jts.version>
     <jaiext.version>1.1.23</jaiext.version>
     <netcdf.version>4.6.15</netcdf.version>


### PR DESCRIPTION
Simple update to imageio-ext-1.3.13 including 
better support for S3 COG (IAM Roles support) and libdeflate plugin.