### PR TITLE
[GEOT-7150] Name of type in AttributeDescriptor are wrong

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/AttributeTypeBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/AttributeTypeBuilder.java
@@ -435,17 +435,6 @@ public class AttributeTypeBuilder {
         return type;
     }
 
-    protected String typeName() {
-        if (name == null) {
-            return Classes.getShortName(binding);
-        }
-        return name;
-    }
-
-    private InternationalString description() {
-        return description != null ? new SimpleInternationalString(description) : null;
-    }
-
     /**
      * Builds the geometry attribute type.
      *
@@ -468,22 +457,37 @@ public class AttributeTypeBuilder {
         return type;
     }
 
+    private Name name() {
+        if (name == null) {
+            name = Classes.getShortName(binding);
+        }
+        return separator == null
+                ? new NameImpl(namespaceURI, name)
+                : new NameImpl(namespaceURI, separator, name);
+    }
+
+    private InternationalString description() {
+        return description != null ? new SimpleInternationalString(description) : null;
+    }
+
     /**
      * Builds an attribute descriptor first building an attribute type from internal state.
      *
-     * <p>If {@link #crs} has been set via {@link #setCRS(CoordinateReferenceSystem)} the internal
-     * attribute type will be built via {@link #buildGeometryType()}, otherwise it will be built via
-     * {@link #buildType()}.
+     * <p>If {@link #crs} has been set via {@link #setCRS(CoordinateReferenceSystem)}, or {@link
+     * #binding} is of Geometry. The internal attribute type will be built via {@link
+     * #buildGeometryType()}, and {@link #buildDescriptor(String, GeometryType)} will be called.
      *
-     * <p>This method calls through to {@link #buildDescriptor(String, AttributeType)}.
+     * <p>Otherwise it will be built via {@link #buildType()}, and {@link #buildDescriptor(String,
+     * AttributeType)} will be called.
      *
      * @param name The name of the descriptor.
      * @see #buildDescriptor(String, AttributeType)
+     * @throws IllegalStateException If no binding is set
      */
     public AttributeDescriptor buildDescriptor(String name) {
-        setName(name);
-        if (binding == null)
+        if (binding == null) {
             throw new IllegalStateException("No binding has been provided for this attribute");
+        }
         if (crs != null || Geometry.class.isAssignableFrom(binding)) {
             return buildDescriptor(name, buildGeometryType());
         } else {
@@ -560,14 +564,6 @@ public class AttributeTypeBuilder {
             return 1;
         }
         return maxOccurs;
-    }
-
-    private Name name() {
-        if (separator == null) {
-            return new NameImpl(namespaceURI, typeName());
-        } else {
-            return new NameImpl(namespaceURI, separator, typeName());
-        }
     }
 
     private Object defaultValue() {

--- a/modules/library/sample-data/src/main/java/org/geotools/test/OnlineTestCase.java
+++ b/modules/library/sample-data/src/main/java/org/geotools/test/OnlineTestCase.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Properties;
 import junit.framework.TestCase; // NOPMD
 import junit.framework.TestResult;
+import org.junit.Assume;
 
 /**
  * Test support for test cases that require an "online" resource, such as an
@@ -243,7 +244,13 @@ public abstract class OnlineTestCase extends TestCase {
                 // disable the test
                 fixture = null;
                 // leave some trace of the swallowed exception
-                java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
+                java.util.logging.Logger.getGlobal()
+                        .log(
+                                java.util.logging.Level.INFO,
+                                "SetUp of test failed. Test ignored.",
+                                e);
+
+                Assume.assumeTrue("Ignorded because of exception: " + e.getMessage(), false);
             } else {
                 // do not swallow the exception
                 throw e;

--- a/modules/library/sample-data/src/main/java/org/geotools/test/OnlineTestCase.java
+++ b/modules/library/sample-data/src/main/java/org/geotools/test/OnlineTestCase.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import junit.framework.TestCase; // NOPMD
 import junit.framework.TestResult;
 import org.junit.Assume;
@@ -144,7 +146,7 @@ public abstract class OnlineTestCase extends TestCase {
                                     + fixtureId
                                     + " tests, resources not available: "
                                     + t.getMessage());
-                    java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", t);
+                    Logger.getGlobal().log(Level.INFO, "", t);
                     available = Boolean.FALSE;
                 }
                 online.put(fixtureId, available);
@@ -199,7 +201,7 @@ public abstract class OnlineTestCase extends TestCase {
                     FixtureUtilities.printSkipNotice(fixtureId, fixtureFile);
                 }
             } catch (Exception e) {
-                java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
+                Logger.getGlobal().log(Level.INFO, "", e);
             }
         }
     }
@@ -220,7 +222,7 @@ public abstract class OnlineTestCase extends TestCase {
             // System.out.println("Wrote example fixture file to " + exFixtureFile);
         } catch (IOException ioe) {
             // System.out.println("Unable to write out example fixture " + exFixtureFile);
-            java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", ioe);
+            Logger.getGlobal().log(Level.INFO, "", ioe);
         }
     }
     /**
@@ -244,11 +246,7 @@ public abstract class OnlineTestCase extends TestCase {
                 // disable the test
                 fixture = null;
                 // leave some trace of the swallowed exception
-                java.util.logging.Logger.getGlobal()
-                        .log(
-                                java.util.logging.Level.INFO,
-                                "SetUp of test failed. Test ignored.",
-                                e);
+                Logger.getGlobal().log(Level.INFO, "SetUp of test failed. Test ignored.", e);
 
                 Assume.assumeTrue("Ignorded because of exception: " + e.getMessage(), false);
             } else {

--- a/modules/plugin/csv/src/test/java/org/geotools/data/csv/parse/CSVLatLonStrategyTest.java
+++ b/modules/plugin/csv/src/test/java/org/geotools/data/csv/parse/CSVLatLonStrategyTest.java
@@ -60,7 +60,7 @@ public class CSVLatLonStrategyTest {
 
         GeometryDescriptor geometryDescriptor = featureType.getGeometryDescriptor();
         GeometryType geometryType = geometryDescriptor.getType();
-        assertEquals("Invalid geometry name", "location", geometryType.getName().getLocalPart());
+        assertEquals("Invalid geometry name", "Point", geometryType.getName().getLocalPart());
     }
 
     @Test

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicReaderTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicReaderTest.java
@@ -1435,7 +1435,7 @@ public class ImageMosaicReaderTest {
         final int granules = source.getCount(null);
         final SimpleFeatureType type = source.getSchema();
         assertEquals(
-                "SimpleFeatureTypeImpl time_domainsRanges identified extends polygonFeature(the_geom:MultiPolygon,location:location,time:time,endtime:endtime,date:date,lowz:lowz,highz:highz,loww:loww,highw:highw)",
+                "SimpleFeatureTypeImpl time_domainsRanges identified extends polygonFeature(the_geom:MultiPolygon,location:String,time:Date,endtime:Date,date:String,lowz:Integer,highz:Integer,loww:Integer,highw:Integer)",
                 type.toString());
         assertEquals(granules, 12);
 


### PR DESCRIPTION
[![GEOT-7150](https://badgen.net/badge/JIRA/GEOT-7150/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7150) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removed the setName call. Now the name of AttributeType would either be explicitly set, or it will be the name of the binding class.

The functions buildDescriptor shouldn't been a part of AttributeTypeBuilder rather they should have their own AttributeDescriptorBuilder.

There were just two tests that was written based on wrong type names.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->