### PR TITLE
[GEOT-7154] Sphinx build failure with extlinks (new warnings in Sphinx build) (26.x)

### DIFF
--- a/.github/workflows/linux_jdk11.yml
+++ b/.github/workflows/linux_jdk11.yml
@@ -22,11 +22,13 @@ jobs:
         key: gt-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           gt-maven-
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
     - uses: BSFishy/pip-action@v1
       with:
         packages: |
-          sphinx
+          sphinx==4.5.0
           requests
     - name: Disable checksum offloading
       # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760

--- a/.github/workflows/linux_jdk8.yml
+++ b/.github/workflows/linux_jdk8.yml
@@ -22,11 +22,13 @@ jobs:
         key: gt-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           gt-maven-
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
     - uses: BSFishy/pip-action@v1
       with:
         packages: |
-          sphinx
+          sphinx==4.5.0
           requests
     - name: Disable checksum offloading
       # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760

--- a/docs/common.py
+++ b/docs/common.py
@@ -27,13 +27,13 @@ import datetime
 extensions = ['sphinx.ext.todo','sphinx.ext.extlinks']
 
 extlinks = { 
-    'wiki': ('https://github.com/geotools/geotools/wiki/%s',''),
-    'website': ('https://geotools.org/%s',''),
-    'geoserver': ('https://docs.geoserver.org/latest/en/user/%s',''),
-    'developer': ('https://docs.geotools.org/latest/developer/%s',''),
-    'user': ('https://docs.geotools.org/maintenance/userguide/%s',''),
-    'api': ('https://docs.geotools.org/maintenance/javadocs',''),
-    'geot': ('https://osgeo-org.atlassian.net/browse/GEOT-%s','GEOT-')
+    'wiki': ('https://github.com/geotools/geotools/wiki/%s', None),
+    'website': ('https://geotools.org/%s', None),
+    'geoserver': ('https://docs.geoserver.org/latest/en/user/%s', None),
+    'developer': ('https://docs.geotools.org/latest/developer/%s', None),
+    'user': ('https://docs.geotools.org/latest/userguide/%s', None),
+    'api': ('https://docs.geotools.org/latest/javadocs/%s', None),
+    'geot': ('https://osgeo-org.atlassian.net/browse/GEOT-%s','GEOT-%s')
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
[![GEOT-7154](https://badgen.net/badge/JIRA/GEOT-7154/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7154) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->