### PR TITLE
[GEOT-7164] Make it easier to move mosaics of NetCDF around (26.x backport)

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/AncillaryFileManager.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/AncillaryFileManager.java
@@ -326,20 +326,18 @@ public class AncillaryFileManager implements FileSetManager {
      */
     private File lookupFile(String filePath, String baseName, AuxiliaryFileType type) {
         // CASE 1: file externally provided
-        File file = null;
         if (filePath != null) {
-            file = new File(filePath);
-            if (!file.exists() || !file.canRead()) {
-                file = null;
+            // absolute path?
+            File file = new File(filePath);
+            if (file.exists() && file.canRead()) return file;
+            // findable relative path?
+            if (!file.isAbsolute()) {
+                file = new File(parentDirectory, filePath);
+                if (file.exists() && file.canRead()) return file;
             }
         }
-        if (file != null) {
-            return file;
-        } else {
-            file = type.lookup(baseName, parentDirectory, destinationDir);
-        }
-
-        return file;
+        // CASE 2, default lookup
+        return type.lookup(baseName, parentDirectory, destinationDir);
     }
 
     private static boolean cutExtension(String extension) {

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -16,7 +16,11 @@
  */
 package org.geotools.coverage.io.netcdf;
 
+import static org.geotools.coverage.util.CoverageUtilities.loadPropertiesFromURL;
 import static org.geotools.gce.imagemosaic.Utils.FF;
+import static org.geotools.gce.imagemosaic.Utils.Prop.AUXILIARY_DATASTORE_FILE;
+import static org.geotools.gce.imagemosaic.Utils.Prop.AUXILIARY_FILE;
+import static org.geotools.util.URLs.fileToUrl;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
@@ -94,7 +98,6 @@ import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.test.TestData;
-import org.geotools.util.URLs;
 import org.geotools.util.factory.Hints;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -897,7 +900,7 @@ public class NetCDFMosaicReaderTest {
                 "TimeAttribute=time\n"
                         + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n";
         //  + "PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](time)\n";
-        indexer += Prop.AUXILIARY_FILE + "=" + "hdf5Coverage2D.xml";
+        indexer += AUXILIARY_FILE + "=" + "hdf5Coverage2D.xml";
         FileUtils.writeStringToFile(new File(mosaic, "indexer.properties"), indexer, "UTF-8");
 
         // simply test if the mosaic can be read without exceptions
@@ -1015,7 +1018,7 @@ public class NetCDFMosaicReaderTest {
                 "TimeAttribute=time\n"
                         + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n"
                         + "PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](time)\n";
-        indexer += Prop.AUXILIARY_FILE + "=" + "GOME2.NO2_new.xml";
+        indexer += AUXILIARY_FILE + "=" + "GOME2.NO2_new.xml";
         FileUtils.writeStringToFile(new File(mosaic, "indexer.properties"), indexer, "UTF-8");
 
         String timeregex = "regex=[0-9]{8}";
@@ -1094,7 +1097,7 @@ public class NetCDFMosaicReaderTest {
                 "TimeAttribute=time\n"
                         + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n"
                         + "PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](time)\n";
-        indexer += Prop.AUXILIARY_FILE + "=" + "GOME2.NO2.xml";
+        indexer += AUXILIARY_FILE + "=" + "GOME2.NO2.xml";
         FileUtils.writeStringToFile(new File(mosaic, "indexer.properties"), indexer, "UTF-8");
 
         String timeregex = "regex=[0-9]{8}";
@@ -1198,7 +1201,7 @@ public class NetCDFMosaicReaderTest {
                 "TimeAttribute=time\n"
                         + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n"
                         + "PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](time)\n";
-        indexer += Prop.AUXILIARY_FILE + "=" + "GOME2.NO2.xml";
+        indexer += AUXILIARY_FILE + "=" + "GOME2.NO2.xml";
         FileUtils.writeStringToFile(new File(mosaic, "indexer.properties"), indexer, "UTF-8");
 
         String timeregex = "regex=[0-9]{8}";
@@ -1294,7 +1297,7 @@ public class NetCDFMosaicReaderTest {
                 "TimeAttribute=time\n"
                         + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n"
                         + "PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](time)\n";
-        indexer += Prop.AUXILIARY_FILE + "=" + "GOME2.NO2.xml\n";
+        indexer += AUXILIARY_FILE + "=" + "GOME2.NO2.xml\n";
 
         // Setting RelativePath behavior
         indexer += Prop.ABSOLUTE_PATH + "=" + "false";
@@ -1325,7 +1328,7 @@ public class NetCDFMosaicReaderTest {
                 props.load(inStream);
             }
             // Before the fix, the AuxiliaryFile was always an absolute path
-            assertEquals(auxFileName, props.getProperty(Prop.AUXILIARY_FILE));
+            assertEquals(auxFileName, props.getProperty(AUXILIARY_FILE));
         } finally {
             if (reader != null) {
                 try {
@@ -1352,7 +1355,7 @@ public class NetCDFMosaicReaderTest {
         String indexer =
                 "TimeAttribute=time\n"
                         + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n";
-        indexer += Prop.AUXILIARY_FILE + "=" + "O3-NO2.xml";
+        indexer += AUXILIARY_FILE + "=" + "O3-NO2.xml";
         FileUtils.writeStringToFile(new File(mosaic, "indexer.properties"), indexer, "UTF-8");
 
         // the datastore.properties file is also mandatory...
@@ -1404,7 +1407,7 @@ public class NetCDFMosaicReaderTest {
                 "TimeAttribute=time\n"
                         + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n"
                         + "PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](time)\n";
-        indexer += Prop.AUXILIARY_FILE + "=" + "DUMMYGOME2.xml";
+        indexer += AUXILIARY_FILE + "=" + "DUMMYGOME2.xml";
         FileUtils.writeStringToFile(new File(mosaic, "indexer.properties"), indexer, "UTF-8");
 
         String timeregex = "regex=[0-9]{8}";
@@ -1476,7 +1479,7 @@ public class NetCDFMosaicReaderTest {
                 "TimeAttribute=time\n"
                         + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n"
                         + "PropertyCollectors=TimestampFileNameExtractorSPI[timeregex](time)\n";
-        indexer += Prop.AUXILIARY_FILE + "=" + "DUMMYGOME2.xml";
+        indexer += AUXILIARY_FILE + "=" + "DUMMYGOME2.xml";
         FileUtils.writeStringToFile(new File(mosaic, "indexer.properties"), indexer, "UTF-8");
 
         String timeregex = "regex=[0-9]{8}";
@@ -1587,7 +1590,7 @@ public class NetCDFMosaicReaderTest {
     @Test
     public void testMultiCoverage() throws Exception {
         File testDir = tempFolder.newFolder("multi-coverage");
-        URL testUrl = URLs.fileToUrl(testDir);
+        URL testUrl = fileToUrl(testDir);
         FileUtils.copyDirectory(TestData.file(this, "multi-coverage"), testDir);
         ImageMosaicReader reader = null;
         try {
@@ -1700,7 +1703,7 @@ public class NetCDFMosaicReaderTest {
 
     private File[] runNO2Removal(String folder, Hints hints) throws IOException {
         File testDir = tempFolder.newFolder(folder);
-        URL testUrl = URLs.fileToUrl(testDir);
+        URL testUrl = fileToUrl(testDir);
         FileUtils.copyDirectory(TestData.file(this, "gome"), testDir);
         ImageMosaicReader reader = null;
         try {
@@ -1740,7 +1743,7 @@ public class NetCDFMosaicReaderTest {
         FileUtils.deleteQuietly(netcdfAux);
 
         File testDir = tempFolder.newFolder(folder);
-        URL testUrl = URLs.fileToUrl(testDir);
+        URL testUrl = fileToUrl(testDir);
         FileUtils.copyDirectory(TestData.file(this, "poliaux"), testDir);
         ImageMosaicReader reader = null;
         PropertyIsLike locationFilter = FF.like(FF.property("location"), "*Poli1*");
@@ -1789,6 +1792,61 @@ public class NetCDFMosaicReaderTest {
         assertEquals(0, store.getFeatureSource("O3").getFeatures(locationFilter).size());
     }
 
+    @Test
+    public void testAuxiliaryFileRelativeReference() throws Exception {
+        String folder = "poliaux-relative";
+        File testDir = tempFolder.newFolder(folder);
+        FileUtils.copyDirectory(TestData.file(this, "poliaux"), testDir);
+
+        // create and perform checks in original directory
+        ImageMosaicReader reader = null;
+        try {
+            reader = new ImageMosaicReader(fileToUrl(testDir));
+            assertNotNull(reader);
+
+            // force full init and creation of all config files
+            reader.read("NO2", NO_DEFERRED_LOADING_PARAMS).dispose(true);
+            reader.read("O3", NO_DEFERRED_LOADING_PARAMS).dispose(true);
+
+            // check that the per store property files use relative references
+            Properties no2 = loadPropertiesFromURL(fileToUrl(new File(testDir, "NO2.properties")));
+            assertEquals("_polyphemus.xml", no2.getProperty(AUXILIARY_FILE));
+            assertEquals("netcdf_datastore.properties", no2.getProperty(AUXILIARY_DATASTORE_FILE));
+
+            Properties o3 = loadPropertiesFromURL(fileToUrl(new File(testDir, "O3.properties")));
+            assertEquals("_polyphemus.xml", o3.getProperty(AUXILIARY_FILE));
+            assertEquals("netcdf_datastore.properties", o3.getProperty(AUXILIARY_DATASTORE_FILE));
+        } finally {
+            if (reader != null) {
+                reader.dispose();
+            }
+        }
+
+        // copy the folder, make sure the reader works there too
+        File testDir2 = tempFolder.newFolder(folder + "2");
+        FileUtils.copyDirectory(testDir, testDir2);
+        try {
+            reader = new ImageMosaicReader(fileToUrl(testDir2));
+            assertNotNull(reader);
+
+            // check reads are still working as expected (no exceptions, there is actual data)
+            float[] pixel = new float[1];
+            GridCoverage2D no2 = reader.read("NO2", NO_DEFERRED_LOADING_PARAMS);
+            no2.evaluate(new Point2D.Double(12, 47), pixel);
+            assertEquals(0.92, pixel[0], 0.01);
+            no2.dispose(true);
+
+            GridCoverage2D o3 = reader.read("O3", NO_DEFERRED_LOADING_PARAMS);
+            o3.evaluate(new Point2D.Double(12, 47), pixel);
+            assertEquals(56.25, pixel[0], 0.01);
+            o3.dispose(true);
+        } finally {
+            if (reader != null) {
+                reader.dispose();
+            }
+        }
+    }
+
     /** Cleanup granules metadata, fully */
     @Test
     public void testMultiCoverageCleanupMetadataInAuxDB() throws Exception {
@@ -1800,7 +1858,7 @@ public class NetCDFMosaicReaderTest {
         FileUtils.deleteQuietly(netcdfAux);
 
         File testDir = tempFolder.newFolder(folder);
-        URL testUrl = URLs.fileToUrl(testDir);
+        URL testUrl = fileToUrl(testDir);
         FileUtils.copyDirectory(TestData.file(this, "poliaux"), testDir);
         ImageMosaicReader reader = null;
         PropertyIsLike locationFilter = FF.like(FF.property("location"), "*Poli1*");
@@ -1854,7 +1912,7 @@ public class NetCDFMosaicReaderTest {
     @Test
     public void testGranuleSourceFileView() throws Exception {
         File testDir = tempFolder.newFolder("multi-coverage-fileview");
-        URL testUrl = URLs.fileToUrl(testDir);
+        URL testUrl = fileToUrl(testDir);
         FileUtils.copyDirectory(TestData.file(this, "multi-coverage"), testDir);
         ImageMosaicReader reader = new ImageMosaicReader(testUrl);
         try {

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicConfigHandler.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicConfigHandler.java
@@ -867,49 +867,24 @@ public class ImageMosaicConfigHandler {
             final String rootMosaicDir) {
         final boolean isAbsolutePath =
                 Boolean.parseBoolean(configuration.getParameter(Prop.ABSOLUTE_PATH));
-        hints =
-                updateHints(
-                        ancillaryFile,
-                        isAbsolutePath,
-                        rootMosaicDir,
-                        configuration,
-                        hints,
-                        Utils.AUXILIARY_FILES_PATH);
-        hints =
-                updateHints(
-                        datastoreFile,
-                        isAbsolutePath,
-                        rootMosaicDir,
-                        configuration,
-                        hints,
-                        Utils.AUXILIARY_DATASTORE_PATH);
+        hints = updateHints(ancillaryFile, configuration, hints, Utils.AUXILIARY_FILES_PATH);
+        hints = updateHints(datastoreFile, configuration, hints, Utils.AUXILIARY_DATASTORE_PATH);
+        // the ND readers use the parentDir in case the path was not absolute
+        if (!isAbsolutePath) {
+            hints.put(Utils.PARENT_DIR, rootMosaicDir);
+        }
         hints = updateRepositoryHints(configuration, hints);
         setReader(hints, true);
     }
 
     private Hints updateHints(
-            String filePath,
-            boolean isAbsolutePath,
-            String rootMosaicDir,
-            CatalogBuilderConfiguration configuration,
-            Hints hints,
-            Key key) {
-        String updatedFilePath = null;
+            String filePath, CatalogBuilderConfiguration configuration, Hints hints, Key key) {
         if (filePath != null) {
-            if (isAbsolutePath && !filePath.startsWith(rootMosaicDir)) {
-                updatedFilePath = rootMosaicDir + File.separatorChar + filePath;
-            } else {
-                updatedFilePath = filePath;
-            }
-
             if (hints != null) {
-                hints.put(key, updatedFilePath);
+                hints.put(key, filePath);
             } else {
-                hints = new Hints(key, updatedFilePath);
+                hints = new Hints(key, filePath);
                 configuration.setHints(hints);
-            }
-            if (!isAbsolutePath) {
-                hints.put(Utils.PARENT_DIR, rootMosaicDir);
             }
         }
         return hints;

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterManager.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterManager.java
@@ -1115,10 +1115,7 @@ public class RasterManager implements Cloneable {
                         new RenderingHints(Utils.AUXILIARY_DATASTORE_PATH, auxiliaryDatastorePath));
                 update = true;
             }
-            if (update
-                    && (configuration.getCatalogConfigurationBean().getPathType()
-                            != PathType.ABSOLUTE)
-                    && !hints.containsKey(Utils.PARENT_DIR)) {
+            if (update && !hints.containsKey(Utils.PARENT_DIR)) {
                 String parentDir = null;
                 if (parentReader.parentDirectory != null) {
                     parentDir = parentReader.parentDirectory.getAbsolutePath();
@@ -1128,7 +1125,7 @@ public class RasterManager implements Cloneable {
                         parentDir = ((File) source).getAbsolutePath();
                     }
                 }
-                hints.add(new RenderingHints(Utils.PARENT_DIR, parentDir));
+                if (parentDir != null) hints.add(new RenderingHints(Utils.PARENT_DIR, parentDir));
             }
         }
     }


### PR DESCRIPTION
[![GEOT-7164](https://badgen.net/badge/JIRA/GEOT-7164/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7164) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->