### PR TITLE
[GEOT-7165] Failing to find CRS factory for ESRI:102017 with gt-epsg-extension at classpath

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -31,6 +31,7 @@ import org.opengis.geometry.MismatchedDimensionException;
 import org.opengis.geometry.MismatchedReferenceSystemException;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.cs.CoordinateSystem;
 import org.opengis.referencing.operation.CoordinateOperation;
 import org.opengis.referencing.operation.CoordinateOperationFactory;
 import org.opengis.referencing.operation.MathTransform;
@@ -743,8 +744,24 @@ public class ReferencedEnvelope extends Envelope
 
             buffer.append(getMinimum(i)).append(" : ").append(getMaximum(i));
         }
+        buffer.append(']');
 
-        return buffer.append(']').toString();
+        final CoordinateReferenceSystem crs = getCoordinateReferenceSystem();
+        if (crs != null) {
+            buffer.append(" ")
+                    .append(Classes.getShortClassName(crs))
+                    .append("[")
+                    .append(crs.getName())
+                    .append("]");
+            final CoordinateSystem cs = crs.getCoordinateSystem();
+            if (cs != null) {
+                for (int i = 0; i < cs.getDimension(); i++) {
+                    buffer.append(" ").append(cs.getAxis(i));
+                }
+            }
+        }
+
+        return buffer.toString();
     }
     /**
      * Factory method to create the correct ReferencedEnvelope.

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/DefaultAuthorityFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/DefaultAuthorityFactory.java
@@ -165,11 +165,11 @@ final class DefaultAuthorityFactory extends ThreadedAuthorityFactory
     @Override
     public CoordinateReferenceSystem createCoordinateReferenceSystem(String code)
             throws FactoryException {
-        if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.fine("Create CRS: " + code);
-        }
         if (code != null) {
             code = code.trim();
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("Create CRS with code:" + code);
+            }
             if (code.equalsIgnoreCase("WGS84(DD)")) {
                 return DefaultGeographicCRS.WGS84;
             }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/ThreadedAuthorityFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/ThreadedAuthorityFactory.java
@@ -665,7 +665,11 @@ public class ThreadedAuthorityFactory extends AbstractAuthorityFactory implement
             crs = (CoordinateReferenceSystem) cached;
         } else {
             crs = getBackingStore().createCoordinateReferenceSystem(code);
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer("Created CRS with code:" + code + "\n" + crs);
+            }
         }
+        LOGGER.fine(() -> "Using CRS[" + crs.getName() + "] for code:" + code);
         objectCache.put(key, crs);
         return crs;
     }

--- a/modules/plugin/epsg-extension/src/test/java/org/geotools/referencing/epsg/esri/EpsgFallbackTest.java
+++ b/modules/plugin/epsg-extension/src/test/java/org/geotools/referencing/epsg/esri/EpsgFallbackTest.java
@@ -24,6 +24,7 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.NamedIdentifier;
 import org.geotools.referencing.factory.epsg.FactoryUsingWKT;
 import org.junit.Assert;
+import org.junit.Test;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.ReferenceIdentifier;
 import org.opengis.referencing.crs.CRSAuthorityFactory;
@@ -45,7 +46,7 @@ public class EpsgFallbackTest {
      * A random CRS for fun. This CRS is defined in the {@linkplain DefaultFactory default EPSG
      * authority factory}.
      */
-    @org.junit.Test
+    @Test
     public void test26910() throws FactoryException {
         final String code = "EPSG:26910";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -58,7 +59,7 @@ public class EpsgFallbackTest {
      * UDIG requires this to work. This CRS is defined in the {@linkplain DefaultFactory default
      * EPSG authority factory}.
      */
-    @org.junit.Test
+    @Test
     public void test4326() throws FactoryException {
         final String code = "EPSG:4326";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -71,7 +72,7 @@ public class EpsgFallbackTest {
      * UDIG requires this to work. This CRS is defined in the {@linkplain DefaultFactory default
      * EPSG authority factory}.
      */
-    @org.junit.Test
+    @Test
     public void test4269() throws FactoryException {
         final String code = "EPSG:4269";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -81,7 +82,7 @@ public class EpsgFallbackTest {
     }
 
     /** UDIG requires this to work. This CRS is defined in {@code unnamed.properties}. */
-    @org.junit.Test
+    @Test
     public void test42102() throws FactoryException {
         final String code = "EPSG:42102";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -101,7 +102,7 @@ public class EpsgFallbackTest {
      * A random CRS for fun. This CRS is defined in the {@linkplain DefaultFactory default EPSG
      * authority factory}.
      */
-    @org.junit.Test
+    @Test
     public void test26910Lower() throws FactoryException {
         final String code = "epsg:26910";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -114,7 +115,7 @@ public class EpsgFallbackTest {
      * A random CRS for fun. This CRS is defined in the {@linkplain DefaultFactory default EPSG
      * authority factory}.
      */
-    @org.junit.Test
+    @Test
     public void test26986Lower() throws FactoryException {
         final String code = "epsg:26986";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -127,7 +128,7 @@ public class EpsgFallbackTest {
      * WFS requires this to work. This CRS is defined in the {@linkplain DefaultFactory default EPSG
      * authority factory}.
      */
-    @org.junit.Test
+    @Test
     public void test4326Lower() throws FactoryException {
         final String code = "epsg:4326";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -140,7 +141,7 @@ public class EpsgFallbackTest {
      * WFS requires this to work. This CRS is defined in the {@linkplain DefaultFactory default EPSG
      * authority factory}.
      */
-    @org.junit.Test
+    @Test
     public void test26742Lower() throws FactoryException {
         final String code = "epsg:26742";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -153,7 +154,7 @@ public class EpsgFallbackTest {
      * WFS requires this to work. This CRS is defined in the {@linkplain DefaultFactory default EPSG
      * authority factory}.
      */
-    @org.junit.Test
+    @Test
     public void test4269Lower() throws FactoryException {
         final String code = "epsg:4269";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -163,7 +164,7 @@ public class EpsgFallbackTest {
     }
 
     /** WFS requires this to work. This CRS is defined in {@code unnamed.properties}. */
-    @org.junit.Test
+    @Test
     public void test42304Lower() throws FactoryException {
         final String code = "epsg:42304";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -172,7 +173,7 @@ public class EpsgFallbackTest {
     }
 
     /** WFS requires this to work. This CRS is defined in {@code unnamed.properties}. */
-    @org.junit.Test
+    @Test
     public void test42102Lower() throws FactoryException {
         final String code = "epsg:42102";
         final CoordinateReferenceSystem crs = CRS.decode(code);
@@ -188,7 +189,7 @@ public class EpsgFallbackTest {
     }
 
     /** This CRS is defined in {@code esri.properties}. */
-    @org.junit.Test
+    @Test
     public void test54004() throws FactoryException {
         final CRSAuthorityFactory factory = CRS.getAuthorityFactory(false);
         final String code = "EPSG:54004";
@@ -207,13 +208,13 @@ public class EpsgFallbackTest {
     }
 
     /** Tests the obtention of various codes. */
-    @org.junit.Test
+    @Test
     public void testCodes() throws FactoryException {
         final CRSAuthorityFactory factory = CRS.getAuthorityFactory(false);
         final Collection codes = factory.getAuthorityCodes(ProjectedCRS.class);
         assertTrue(codes.contains("EPSG:3395")); // Defined in EPSG database
-        assertTrue(codes.contains("EPSG:54004")); // Defined in ESRI database
-        Assert.assertFalse(codes.contains("ESRI:54004"));
+        assertTrue(codes.contains("ESRI:54004")); // Defined in ESRI database
+        assertTrue(codes.contains("EPSG:54004")); // With EPSG as well
         assertTrue(codes.contains("EPSG:42304")); // Defined in unnamed database
         assertTrue(codes.contains("EPSG:26742")); // Defined in EPSG database
         assertTrue(codes.contains("EPSG:42102")); // Defined in unnamed database


### PR DESCRIPTION
[![GEOT-7165](https://badgen.net/badge/JIRA/GEOT-7165/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7165) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The main change is within the function createFallbacks where I split Citations with more than one Identifier (Like ESRI, EPSG) into singular Citations. That will make them reachable for both ESRI and EPSG.

Added some logging to dispose which crs is being used in each situation.

Fixed an assertion within a test that I mean is counterintuitive.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->