### PR TITLE
[Backport 26.x] [GEOT-7162] Postgis Partition tests fail on postgres versions below 1…

### DIFF
--- a/modules/library/sample-data/src/main/java/org/geotools/test/OnlineTestCase.java
+++ b/modules/library/sample-data/src/main/java/org/geotools/test/OnlineTestCase.java
@@ -244,8 +244,6 @@ public abstract class OnlineTestCase extends TestCase {
                 fixture = null;
                 // leave some trace of the swallowed exception
                 java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
-
-                Assume.assumeTrue("Ignored because of exception: " + e.getMessage(), false);
             } else {
                 // do not swallow the exception
                 throw e;

--- a/modules/library/sample-data/src/main/java/org/geotools/test/OnlineTestCase.java
+++ b/modules/library/sample-data/src/main/java/org/geotools/test/OnlineTestCase.java
@@ -244,6 +244,8 @@ public abstract class OnlineTestCase extends TestCase {
                 fixture = null;
                 // leave some trace of the swallowed exception
                 java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
+
+                Assume.assumeTrue("Ignored because of exception: " + e.getMessage(), false);
             } else {
                 // do not swallow the exception
                 throw e;

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISPartitionedTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISPartitionedTest.java
@@ -17,9 +17,11 @@
 package org.geotools.data.postgis;
 
 import java.math.BigDecimal;
+import java.sql.Connection;
 import java.util.List;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.Query;
+import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -45,12 +47,22 @@ public class PostGISPartitionedTest extends JDBCTestSupport {
     }
 
     public void testTableExists() throws Exception {
+        try (Connection connection = dataStore.getConnection(Transaction.AUTO_COMMIT)) {
+            if (!setup.shouldRunTests(connection)) {
+                return;
+            }
+        }
         SimpleFeatureType schema = dataStore.getSchema(tname("customers"));
         assertEquals(String.class, schema.getDescriptor("status").getType().getBinding());
         assertEquals(BigDecimal.class, schema.getDescriptor("arr").getType().getBinding());
     }
 
     public void testReadAll() throws Exception {
+        try (Connection connection = dataStore.getConnection(Transaction.AUTO_COMMIT)) {
+            if (!setup.shouldRunTests(connection)) {
+                return;
+            }
+        }
         SimpleFeatureSource fs = dataStore.getFeatureSource(tname("customers"));
         FilterFactory ff = dataStore.getFilterFactory();
         Query q = new Query();
@@ -63,6 +75,11 @@ public class PostGISPartitionedTest extends JDBCTestSupport {
     }
 
     public void testInsertNew() throws Exception {
+        try (Connection connection = dataStore.getConnection(Transaction.AUTO_COMMIT)) {
+            if (!setup.shouldRunTests(connection)) {
+                return;
+            }
+        }
         // initial states, contains RECURRING AND REACTIVATED
         SimpleFeatureSource others = dataStore.getFeatureSource(tname("cust_others"));
         assertEquals(2, others.getCount(Query.ALL));

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISPartitionedTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISPartitionedTestSetup.java
@@ -1,12 +1,30 @@
 package org.geotools.data.postgis;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import org.geotools.jdbc.JDBCDelegatingTestSetup;
+import org.geotools.util.Version;
 
 @SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation") // not yet a JUnit4 test
 public class PostGISPartitionedTestSetup extends JDBCDelegatingTestSetup {
 
     protected PostGISPartitionedTestSetup() {
         super(new PostGISTestSetup());
+    }
+
+    public boolean isPgsqlVersionGreaterThanEqualTo(Version v) {
+
+        PostGISTestSetup postGISTestSetup = (PostGISTestSetup) delegate;
+
+        boolean var =
+                postGISTestSetup.pgsqlVersion != null
+                        && postGISTestSetup.pgsqlVersion.compareTo(v) >= 0;
+        return var;
+    }
+
+    @Override
+    public boolean shouldRunTests(Connection cx) throws SQLException {
+        return isPgsqlVersionGreaterThanEqualTo(new Version("11.0")) && delegate.shouldRunTests(cx);
     }
 
     @Override


### PR DESCRIPTION
[![GEOT-7162](https://badgen.net/badge/JIRA/GEOT-7162/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7162) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…1 (#3932)

* ignore Partition tests for PG < 11.0

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->