### PR TITLE
[GEOT-7169] When GeoJsonReader parses a complex nested object, it sho…

### DIFF
--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -327,6 +327,12 @@ public class GeoJSONReader implements AutoCloseable {
                             case STRING:
                                 vc = item.asText();
                                 break;
+                            case OBJECT:
+                                vc = item;
+                                break;
+                            case ARRAY:
+                                vc = item;
+                                break;
                             case NULL:
                                 vc = null;
                                 break;

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
@@ -418,4 +418,46 @@ public class GeoJSONReaderTest {
         assertEquals("abc", array.get(1));
         assertNull(array.get(2));
     }
+
+    @Test
+    public void testObjectInList() throws Exception {
+        String geojson =
+                "{"
+                        + "  'type': 'Feature',"
+                        + "  'id': 'feature.0',"
+                        + "  'properties': {"
+                        + "    'array': [{'a': 10}, {'b': 'foo'}]"
+                        + "   },"
+                        + "  'geometry': {"
+                        + "    'type': 'Point',"
+                        + "    'coordinates': [0.1, 0.1]"
+                        + "  }"
+                        + "}";
+        geojson = geojson.replace('\'', '"');
+        SimpleFeature feature = GeoJSONReader.parseFeature(geojson);
+        List array = (List) feature.getAttribute("array");
+        assertEquals(10, ((ObjectNode) array.get(0)).get("a").asDouble(), 0d);
+        assertEquals("foo", ((ObjectNode) array.get(1)).get("b").asText());
+    }
+
+    @Test
+    public void testObjectInObject() throws Exception {
+        String geojson =
+                "{"
+                        + "  'type': 'Feature',"
+                        + "  'id': 'feature.0',"
+                        + "  'properties': {"
+                        + "    'parent': {'child': {'a': 10, 'b': 'foo'}}"
+                        + "   },"
+                        + "  'geometry': {"
+                        + "    'type': 'Point',"
+                        + "    'coordinates': [0.1, 0.1]"
+                        + "  }"
+                        + "}";
+        geojson = geojson.replace('\'', '"');
+        SimpleFeature feature = GeoJSONReader.parseFeature(geojson);
+        ObjectNode parent = (ObjectNode) feature.getAttribute("parent");
+        assertEquals(10, ((ObjectNode) parent.get("child")).get("a").asDouble(), 0d);
+        assertEquals("foo", ((ObjectNode) parent.get("child")).get("b").asText());
+    }
 }


### PR DESCRIPTION
[![GEOT-7169](https://badgen.net/badge/JIRA/GEOT-7169/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7169) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…uld capture it as a Jackson JSONNode

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->