### PR TITLE
[GEOT-7170] StreamingRenderer might throw NPE with complex features when no default Geometry attribute is set

### DIFF
--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderableFeatureTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderableFeatureTest.java
@@ -1,0 +1,75 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.renderer.lite;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.awt.geom.AffineTransform;
+import org.geotools.feature.NameImpl;
+import org.geotools.geometry.jts.LiteShape2;
+import org.geotools.styling.Symbolizer;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.mockito.Mockito;
+import org.opengis.feature.Feature;
+import org.opengis.feature.Property;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.Name;
+import org.opengis.referencing.FactoryException;
+
+public class RenderableFeatureTest {
+
+    @Test
+    public void testNoDefGeometryComplexFeature() throws FactoryException {
+        // tests that a RenderableFeature doesn't thrown NPE when finding a geometry
+        // of a Complex feature if the Symbolizer has null geom attribute and the
+        // default geom of the Feature is null.
+        String ns = "namespace";
+        String gName = "geom";
+        Name name = new NameImpl(ns, gName);
+        Property property = Mockito.mock(Property.class);
+        Point point = new GeometryFactory().createPoint();
+        when(property.getValue()).thenReturn(point);
+        Feature feature = Mockito.mock(Feature.class);
+        FeatureType type = Mockito.mock(FeatureType.class);
+        GeometryDescriptor descriptor = Mockito.mock(GeometryDescriptor.class);
+        when(descriptor.getName()).thenReturn(name);
+        when(feature.getDefaultGeometryProperty()).thenReturn(null);
+        when(type.getGeometryDescriptor()).thenReturn(descriptor);
+        when(feature.getProperty(name)).thenReturn(property);
+        when(feature.getType()).thenReturn(type);
+        Symbolizer symbolizer = Mockito.mock(Symbolizer.class);
+        when(symbolizer.getGeometry()).thenReturn(null);
+        StreamingRenderer.RenderableFeature rf =
+                new StreamingRenderer().new RenderableFeature("layerId", false) {
+                    @Override
+                    public LiteShape2 getShape(
+                            Symbolizer symbolizer, AffineTransform at, Geometry g, boolean clone)
+                            throws FactoryException {
+                        assertEquals(point, g);
+                        return null;
+                    }
+                };
+        rf.setFeature(feature);
+        rf.getShape(symbolizer, null);
+    }
+}


### PR DESCRIPTION
[![GEOT-7170](https://badgen.net/badge/JIRA/GEOT-7170/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7170) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->