### PR TITLE
[GEOT-7171]: Remove iterator from Create (Since it's not used)

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/RenderedSampleDimension.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/RenderedSampleDimension.java
@@ -23,8 +23,6 @@ import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
 import javax.measure.Unit;
-import javax.media.jai.iterator.RectIter;
-import javax.media.jai.iterator.RectIterFactory;
 import org.geotools.coverage.Category;
 import org.geotools.coverage.GridSampleDimension;
 import org.geotools.coverage.TypeMap;
@@ -125,16 +123,7 @@ final class RenderedSampleDimension extends GridSampleDimension {
                  */
                 if (defaultSD == null) {
                     defaultSD = new GridSampleDimension[numBands];
-                    create(
-                            name,
-                            RectIterFactory.create(image, null),
-                            image.getSampleModel(),
-                            null,
-                            null,
-                            null,
-                            null,
-                            defaultSD,
-                            null);
+                    create(name, image.getSampleModel(), null, null, null, null, defaultSD, null);
                 }
                 sd = defaultSD[i];
             }
@@ -175,24 +164,14 @@ final class RenderedSampleDimension extends GridSampleDimension {
             final Color[][] colors,
             final RenderingHints hints) {
         final GridSampleDimension[] dst = new GridSampleDimension[raster.getNumBands()];
-        create(
-                name,
-                (min == null || max == null) ? RectIterFactory.create(raster, null) : null,
-                raster.getSampleModel(),
-                min,
-                max,
-                units,
-                colors,
-                dst,
-                hints);
+        create(name, raster.getSampleModel(), min, max, units, colors, dst, hints);
         return dst;
     }
 
     /**
-     * Creates a set of sample dimensions for the data backing the given iterator.
+     * Creates a set of sample dimensions for the data
      *
      * @param name The name for data (e.g. "Elevation").
-     * @param iterator The iterator through the raster data, or {@code null}.
      * @param model The image or raster sample model.
      * @param min The minimal value, or {@code null} for computing it automatically.
      * @param max The maximal value, or {@code null} for computing it automatically.
@@ -210,7 +189,6 @@ final class RenderedSampleDimension extends GridSampleDimension {
      */
     private static void create(
             final CharSequence name,
-            final RectIter iterator,
             final SampleModel model,
             double[] min,
             double[] max,


### PR DESCRIPTION
[![GEOT-7171](https://badgen.net/badge/JIRA/GEOT-7171/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7171) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Clean up the creation method. RectIterator is never used. remove it.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->