### PR TITLE
Remove <repositories> section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1436,42 +1436,6 @@
     </dependency>
   </dependencies>
 
-  <!-- ================================================================== -->
-  <!--     Repositories. This is where Maven looks for dependencies. The  -->
-  <!--     Maven repository is implicit and doesn't need to be specified. -->
-  <!-- ================================================================== -->
-  <repositories>
-
-    <!-- Maven Central is assumed -->
-
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <!-- contains release (including third-party-dependences)                            -->
-      <!-- ucar (https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases) -->
-      <!-- geosolutions (http://maven.geo-solutions.it/)                                   -->
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>osgeo</id>
-      <name>OSGeo Nexus Release Repository</name>
-      <url>https://repo.osgeo.org/repository/release/</url>
-    </repository>
-
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>osgeo-snapshot</id>
-      <name>OSGeo Nexus Snapshot Repository</name>
-      <url>https://repo.osgeo.org/repository/snapshot/</url>
-    </repository>
-  </repositories>
-
   <!-- =========================================================== -->
   <!--     Plugin repositories.                                    -->
   <!--     This is where Maven looks for plugin dependencies.      -->


### PR DESCRIPTION
`<repositories>` should be defined in defined in a [settings.xml](https://maven.apache.org/settings.html).
This allows the geotools artifacts to work with proxy repositories.

---

I use a proxy repository to cache maven artifacts ([specifically Nexus](https://www.sonatype.com/products/nexus-repository)).
By defining `<repositories>` in you parent pom dependency downloads go directly through to repo.osgeo.org, and don't get cached.
[My use case is quite similar to the one described here.](https://stackoverflow.com/questions/20503829/how-do-you-configure-maven-to-ignore-repositories-specified-in-pom-files)

---

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] ~I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).~
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] ~Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).~
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).
