### PR TITLE
[GEOT-7177] Remove randomSupportedCRS from WMTSCoverageReader

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSCoverageReader.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSCoverageReader.java
@@ -105,9 +105,7 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
 
         // best guess at the format with a preference for PNG (since it's
         // normally transparent)
-        List<String> formats =
-                ((WMTSLayer) layer)
-                        .getFormats(); // wms2.getCapabilities().getRequest().getGetTile().getFormats();
+        List<String> formats = ((WMTSLayer) layer).getFormats();
         this.format = formats.iterator().next();
         for (String f : formats) {
             if ("image/png".equals(f)
@@ -131,7 +129,7 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
                     new String[] {"EPSG:4326", "WGS84", "CRS:84", "WGS 84", "WGS84(DD)"}) {
                 if (layer.getSrs().contains(preferred)) {
                     srsName = preferred;
-                    if (LOGGER.isLoggable(Level.INFO)) LOGGER.info("defaulting CRS to: " + srsName);
+                    LOGGER.info(() -> "defaulting CRS to: " + srsName);
                 }
             }
 
@@ -144,7 +142,7 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
                         CRS.decode(srs);
                         srsName = srs;
 
-                        if (LOGGER.isLoggable(Level.INFO)) LOGGER.info("setting CRS: " + srsName);
+                        LOGGER.info(() -> "setting CRS: " + srsName);
                         break;
                     } catch (Exception e) {
                         // it's fine, we could not decode that code
@@ -155,14 +153,13 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
             if (srsName == null) {
                 if (layer.getSrs().isEmpty()) {
                     // force 4326
-                    if (LOGGER.isLoggable(Level.INFO))
-                        LOGGER.info("adding default CRS to: " + srsName);
+                    LOGGER.info(() -> "adding default CRS to: " + srsName);
                     srsName = "EPSG:4326";
                     layer.getSrs().add(srsName);
                 } else {
                     // if not even that works we just take the first...
                     srsName = layer.getSrs().iterator().next();
-                    if (LOGGER.isLoggable(Level.INFO)) LOGGER.info("guessing CRS to: " + srsName);
+                    LOGGER.info(() -> "guessing CRS to: " + srsName);
                 }
             }
 
@@ -195,15 +192,13 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
         try {
             crs = CRS.decode(srsName);
         } catch (Exception e) {
-            LOGGER.log(
-                    Level.INFO,
+            LOGGER.info(
                     () ->
                             "Default srs ("
                                     + srsName
                                     + ") for layer ("
                                     + layer
-                                    + ") couldn't be decoded. "
-                                    + e.getMessage());
+                                    + ") couldn't be decoded.");
         }
         this.crs = crs;
         updateBounds();

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSCoverageReader.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSCoverageReader.java
@@ -192,13 +192,10 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
         try {
             crs = CRS.decode(srsName);
         } catch (Exception e) {
-            LOGGER.info(
-                    () ->
-                            "Default srs ("
-                                    + srsName
-                                    + ") for layer ("
-                                    + layer
-                                    + ") couldn't be decoded.");
+            LOGGER.log(
+                    Level.WARNING,
+                    "Default crs (" + srsName + ") for layer (" + layer + ") couldn't be set.",
+                    e);
         }
         this.crs = crs;
         updateBounds();


### PR DESCRIPTION
[![GEOT-7177](https://badgen.net/badge/JIRA/GEOT-7177/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7177) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

A little change to make it more clear which tileset being used when reprojecting a WMTS tile request.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->