### PR TITLE
[27.x backport] [GEOT-7173] Oracle DataStore - Allow configuring time out properties for login and socket connection (#3955)

### DIFF
--- a/docs/user/library/jdbc/oracle.rst
+++ b/docs/user/library/jdbc/oracle.rst
@@ -69,6 +69,18 @@ Advanced
 |                       | the bounds are configured right in the tables  |
 |                       | default is false                               |
 +-----------------------+------------------------------------------------+
+|  ``Login timemout``   | Specifies the timeout for opening              |
+|                       | an Oracle JDBC connection (seconds)            |
++-----------------------+------------------------------------------------+
+|  ``Socket connection``| Specifies the timeout when connecting          |
+|      ``timeout``      | a socket to the database listener              |
+|                       | (milliseconds)                                 |
++-----------------------+------------------------------------------------+
+|``Outbound connection``| Specifies the timeout when negotiating         |
+|     ``timeout``       | a session with the database listener           |
+|                       | (milliseconds)                                 |
++-----------------------+------------------------------------------------+
+
 
 Example use::
   

--- a/modules/plugin/jdbc/jdbc-oracle/pom.xml
+++ b/modules/plugin/jdbc/jdbc-oracle/pom.xml
@@ -60,8 +60,17 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-jdbc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-dbcp</groupId>
+      <artifactId>commons-dbcp</artifactId>
     </dependency>
   </dependencies>
 

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleNGDataStoreFactory.java
@@ -21,11 +21,17 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import org.apache.commons.dbcp.BasicDataSource;
 import org.geotools.data.Parameter;
 import org.geotools.data.Transaction;
+import org.geotools.data.jdbc.datasource.DBCPDataSource;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
+import org.geotools.util.logging.Logging;
 
 /**
  * Oracle data store factory.
@@ -93,6 +99,38 @@ public class OracleNGDataStoreFactory extends JDBCDataStoreFactory {
                     "Get data bounds quickly from MDSYS.USER_SDO_GEOM_METADATA or MDSYS.ALL_SDO_GEOM_METADATA table",
                     false,
                     Boolean.FALSE);
+
+    /** parameter for specify the login timeout. */
+    public static final Param LOGIN_TIMEOUT =
+            new Param(
+                    "Login Timeout (s)",
+                    Integer.class,
+                    "Specifies the timeout for opening an Oracle JDBC connection (seconds)",
+                    false);
+
+    /** Specifies the socket connection timeout to the database. */
+    public static final Param CONNECTION_TIMEOUT =
+            new Param(
+                    "Socket connection timeout (ms)",
+                    Integer.class,
+                    "Specifies the timeout when connecting a socket to the database listener (milliseconds)",
+                    false);
+
+    /** Specifies the timeout when negotiating a session with the database. */
+    public static final Param OUTBOUND_CONNECTION_TIMEOUT =
+            new Param(
+                    "Outbound connection timeout (ms)",
+                    Integer.class,
+                    "Specifies the timeout when negotiating a session with the database listener (milliseconds)",
+                    false);
+
+    static final String LOGIN_TIMEOUT_NAME = "oracle.jdbc.loginTimeout";
+
+    static final String CONN_TIMEOUT_NAME = "oracle.net.CONNECT_TIMEOUT";
+
+    static final String OUTBOUND_TIMEOUT_NAME = "oracle.net.OUTBOUND_CONNECT_TIMEOUT";
+
+    static final Logger LOGGER = Logging.getLogger(OracleNGDataStoreFactory.class);
 
     @Override
     protected SQLDialect createSQLDialect(JDBCDataStore dataStore) {
@@ -164,6 +202,21 @@ public class OracleNGDataStoreFactory extends JDBCDataStoreFactory {
         Boolean metadateBbox = (Boolean) METADATA_BBOX.lookUp(params);
         dialect.setMetadataBboxEnabled(Boolean.TRUE.equals(metadateBbox));
 
+        DataSource source = getDataSource(dataStore);
+        if (source instanceof BasicDataSource) {
+            Integer loginTimeout = (Integer) LOGIN_TIMEOUT.lookUp(params);
+            Integer connectionTimeout = (Integer) CONNECTION_TIMEOUT.lookUp(params);
+            Integer outboundConnTimeout = (Integer) OUTBOUND_CONNECTION_TIMEOUT.lookUp(params);
+            BasicDataSource basicSource = (BasicDataSource) source;
+            if (loginTimeout != null)
+                basicSource.addConnectionProperty(LOGIN_TIMEOUT_NAME, loginTimeout.toString());
+            if (connectionTimeout != null)
+                basicSource.addConnectionProperty(CONN_TIMEOUT_NAME, connectionTimeout.toString());
+            if (outboundConnTimeout != null)
+                basicSource.addConnectionProperty(
+                        OUTBOUND_TIMEOUT_NAME, outboundConnTimeout.toString());
+        }
+
         if (dataStore.getFetchSize() <= 0) {
             // Oracle is dead slow with the fetch size at 0, let's have a sane default
             dataStore.setFetchSize(200);
@@ -182,6 +235,21 @@ public class OracleNGDataStoreFactory extends JDBCDataStoreFactory {
             dataStore.closeSafe(cx);
         }
         return dataStore;
+    }
+
+    private DataSource getDataSource(JDBCDataStore dataStore) {
+        DataSource source = dataStore.getDataSource();
+        if (source instanceof DBCPDataSource) {
+            try {
+                source = source.unwrap(BasicDataSource.class);
+            } catch (SQLException e) {
+                LOGGER.log(
+                        Level.SEVERE,
+                        "Error while unwrapping the DataSource before setting connection timeout properties. ",
+                        e);
+            }
+        }
+        return source;
     }
 
     @Override
@@ -220,6 +288,9 @@ public class OracleNGDataStoreFactory extends JDBCDataStoreFactory {
         parameters.put(DBTYPE.key, DBTYPE);
         parameters.put(GEOMETRY_METADATA_TABLE.key, GEOMETRY_METADATA_TABLE);
         parameters.put(METADATA_BBOX.key, METADATA_BBOX);
+        parameters.put(LOGIN_TIMEOUT.key, LOGIN_TIMEOUT);
+        parameters.put(CONNECTION_TIMEOUT.key, CONNECTION_TIMEOUT);
+        parameters.put(OUTBOUND_CONNECTION_TIMEOUT.key, OUTBOUND_CONNECTION_TIMEOUT);
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleJNDIDataSourceOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/test/java/org/geotools/data/oracle/OracleJNDIDataSourceOnlineTest.java
@@ -17,6 +17,10 @@
 
 package org.geotools.data.oracle;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.JDBCJNDIDataSourceOnlineTest;
 import org.geotools.jdbc.JDBCJNDITestSetup;
 
@@ -35,5 +39,22 @@ public class OracleJNDIDataSourceOnlineTest extends JDBCJNDIDataSourceOnlineTest
     @Override
     protected OracleNGDataStoreFactory getDataStoreFactory() {
         return new OracleNGDataStoreFactory();
+    }
+
+    /** Make sure the JNDI factory exposes all the extra params that the non JNDI one exposes */
+    @Override
+    public void testExtraParams() {
+        List<String> baseParams = getBaseParams();
+        List<String> standardParams = getParamKeys(getDataStoreFactory());
+        standardParams.remove(JDBCDataStoreFactory.VALIDATECONN.key);
+        standardParams.remove(JDBCDataStoreFactory.MAX_OPEN_PREPARED_STATEMENTS.key);
+        standardParams.remove(OracleNGDataStoreFactory.LOGIN_TIMEOUT.key);
+        standardParams.remove(OracleNGDataStoreFactory.CONNECTION_TIMEOUT.key);
+        standardParams.remove(OracleNGDataStoreFactory.OUTBOUND_CONNECTION_TIMEOUT.key);
+        standardParams.removeAll(baseParams);
+        List<String> baseJndiParams = getBaseJNDIParams();
+        List<String> jndiParams = getParamKeys(getJNDIStoreFactory());
+        jndiParams.removeAll(baseJndiParams);
+        assertEquals(standardParams, jndiParams);
     }
 }


### PR DESCRIPTION
[![GEOT-7173](https://badgen.net/badge/JIRA/GEOT-7173/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7173) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* [GEOT-7173] Oracle DataStore - Allow configuring time out properties for login and socket connection

* review feedback

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->