### PR TITLE
[GEOT-5911] MongoDB CQL_Filter not working anymore (and some other issue)

### DIFF
--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFilterSplitter.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFilterSplitter.java
@@ -51,15 +51,21 @@ public class MongoFilterSplitter extends PostPreProcessFilterSplittingVisitor {
         Expression expression1 = filter.getExpression1();
         Expression expression2 = filter.getExpression2();
         if ((expression1 instanceof JsonSelectFunction
-                        || expression1 instanceof JsonSelectAllFunction)
-                && expression2 instanceof Literal) {
-            preStack.push(filter);
+                || expression1 instanceof JsonSelectAllFunction)) {
+            if (expression2 instanceof Literal) {
+                preStack.push(filter);
+            } else {
+                postStack.push(filter);
+            }
         } else if ((expression2 instanceof JsonSelectFunction
-                        || expression2 instanceof JsonSelectAllFunction)
-                && expression1 instanceof Literal) {
-            preStack.push(filter);
+                || expression2 instanceof JsonSelectAllFunction)) {
+            if (expression1 instanceof Literal) {
+                preStack.push(filter);
+            } else {
+                postStack.push(filter);
+            }
         } else {
-            postStack.push(filter);
+            super.visitBinaryComparisonOperator(filter);
         }
     }
 

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterSplitterTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterSplitterTest.java
@@ -1,0 +1,83 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2015, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2014-2015, Boundless
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+/** @author hans.yperman@vliz.be */
+package org.geotools.data.mongodb;
+
+import org.geotools.data.mongodb.geojson.GeoJSONMongoTestSetup;
+import org.geotools.data.store.ContentEntry;
+import org.geotools.feature.NameImpl;
+import org.geotools.filter.text.ecql.ECQL;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+
+public class FilterSplitterTest extends MongoTestSupport {
+
+    public FilterSplitterTest() throws Exception {
+        super(new GeoJSONMongoTestSetup());
+    }
+
+    @Test
+    public void testProperty() throws Exception {
+        checkSplitter("a=1", "a=1", "INCLUDE");
+    }
+
+    @Test
+    public void testAndMongoOnly() throws Exception {
+        checkSplitter("a=1 AND b=1", "a=1 AND b=1", "INCLUDE");
+    }
+
+    @Test
+    public void testAndSplit() throws Exception {
+        // FIXME: CQL.toFilter(before) has wrong date format
+        checkSplitter(
+                "a=1 AND b BEFORE 1980-09-03T00:00:00", "a=1", "b BEFORE 1980-09-03T00:00:00");
+    }
+
+    @Test
+    public void testJSonSelect() throws Exception {
+        // jsonSelect is only supported by mongo if the other side is a literal
+        checkSplitter("jsonSelect('a')=1", "jsonSelect('a')=1", "INCLUDE");
+        checkSplitter("1=jsonSelect('a')", "1=jsonSelect('a')", "INCLUDE");
+        checkSplitter("jsonSelect('a')=a", "INCLUDE", "jsonSelect('a')=a");
+        checkSplitter("a=jsonSelect('a')", "INCLUDE", "a=jsonSelect('a')");
+    }
+
+    @Test
+    public void testLike() throws Exception {
+        checkSplitter("a like '%'", "a like '%'", "INCLUDE");
+        checkSplitter("(a+b) like '%'", "INCLUDE", "(a+b) like '%'");
+    }
+
+    /**
+     * @param beforeSplit The input to the splitter
+     * @param toMongo The part of the filter given to mongodb
+     * @param toPostprocess The part of the filter done by postprocessing
+     * @throws Exception
+     */
+    private void checkSplitter(String beforeSplit, String toMongo, String toPostprocess)
+            throws Exception {
+        // FIXME getCountInternal ignores the toPostprocess, is this correct?
+        connect();
+        ContentEntry entry = new ContentEntry(dataStore, new NameImpl("ft1"));
+        MongoFeatureSource source = new MongoFeatureSource(entry, null, null);
+        Filter[] split = source.splitFilter(ECQL.toFilter(beforeSplit));
+        Assert.assertEquals(ECQL.toFilter(toMongo), split[0]);
+        Assert.assertEquals(ECQL.toFilter(toPostprocess), split[1]);
+    }
+}

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -79,13 +79,13 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
         assertEquals(1, source.getCount(q));
         assertEquals(
-                new ReferencedEnvelope(2d, 0d, 2d, 0d, DefaultGeographicCRS.WGS84),
+                new ReferencedEnvelope(2d, 2d, 2d, 2d, DefaultGeographicCRS.WGS84),
                 source.getBounds(q));
 
         SimpleFeatureCollection features = source.getFeatures(q);
         try (SimpleFeatureIterator it = features.features()) {
             assertTrue(it.hasNext());
-            assertFeature(it.next(), 0);
+            assertFeature(it.next(), 2);
         }
     }
 
@@ -165,13 +165,13 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
         assertEquals(2, source.getCount(q));
         assertEquals(
-                new ReferencedEnvelope(0d, 2d, 0d, 2d, DefaultGeographicCRS.WGS84),
+                new ReferencedEnvelope(1d, 2d, 1d, 2d, DefaultGeographicCRS.WGS84),
                 source.getBounds(q));
 
         SimpleFeatureCollection features = source.getFeatures(q);
         try (SimpleFeatureIterator it = features.features()) {
             assertTrue(it.hasNext());
-            assertFeature(it.next(), 0);
+            assertFeature(it.next(), 1);
         }
 
         // test again passing Date object as literal
@@ -183,11 +183,11 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
         assertEquals(2, source.getCount(q));
         assertEquals(
-                new ReferencedEnvelope(0d, 2d, 0d, 2d, DefaultGeographicCRS.WGS84),
+                new ReferencedEnvelope(1d, 2d, 1d, 2d, DefaultGeographicCRS.WGS84),
                 source.getBounds(q));
         try (SimpleFeatureIterator it = source.getFeatures(q).features()) {
             assertTrue(it.hasNext());
-            assertFeature(it.next(), 0);
+            assertFeature(it.next(), 1);
         }
 
         // test no-match filter
@@ -213,7 +213,7 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
         assertEquals(1, source.getCount(q));
         assertEquals(
-                new ReferencedEnvelope(0d, 2d, 0d, 2d, DefaultGeographicCRS.WGS84),
+                new ReferencedEnvelope(0d, 0d, 0d, 0d, DefaultGeographicCRS.WGS84),
                 source.getBounds(q));
 
         SimpleFeatureCollection features = source.getFeatures(q);


### PR DESCRIPTION
[![GEOT-5911](https://badgen.net/badge/JIRA/GEOT-5911/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-5911) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

FIXED GEOT-5911 and some others, mongodb splitter bug
  
3 existing unit tests did invalid checks, and fixing the splitter made them fail:
e.g. testEqualToFilter:  The result contained points 0 1 2 but should only contain 2 as the test does equals to "two"

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
   Let me know if you want this
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
   Sorry this is wrong and I don't seem to manage  to get it fixed.  github newby :-(
- [ ] Bug fixes and small new features are presented as a single commit.
   A second commit appeared when I synced with upstream. github newby :-(
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->