### PR TITLE
[GEOT-7182] TransformFeatureSource can lose paging information while transforming query

### DIFF
--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/Transformer.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/Transformer.java
@@ -252,9 +252,6 @@ class Transformer {
 
         // can we support the required sorting?
         QueryCapabilities caps = source.getQueryCapabilities();
-        if (query.getStartIndex() != null && !caps.isJoiningSupported()) {
-            txQuery.setStartIndex(null);
-        }
         if (query.getSortBy() != null && !caps.supportsSorting(txQuery.getSortBy())) {
             txQuery.setSortBy(null);
         }
@@ -269,6 +266,7 @@ class Transformer {
         // if the wrapped store cannot apply offsets we have to remove them too
         if (!caps.isOffsetSupported()) {
             txQuery.setStartIndex(null);
+            txQuery.setMaxFeatures(Query.DEFAULT_MAX);
         }
 
         return txQuery;

--- a/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformerTest.java
+++ b/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformerTest.java
@@ -38,4 +38,19 @@ public class TransformerTest extends AbstractTransformTest {
         assertEquals(1, transformedQuery.getSortBy().length);
         assertEquals("state_name", transformedQuery.getSortBy()[0].getPropertyName().toString());
     }
+
+    @Test
+    public void testTransformedPaging() throws Exception {
+        TransformFeatureSource transformedSource = (TransformFeatureSource) transformWithRename();
+
+        Query query = new Query(Query.ALL);
+        query.setStartIndex(10);
+        query.setMaxFeatures(5);
+
+        Query transformedQuery = transformedSource.transformer.transformQuery(query);
+        assertNotNull(transformedQuery);
+        assertNotNull(transformedQuery.getStartIndex());
+        assertEquals(10, transformedQuery.getStartIndex().intValue());
+        assertEquals(5, transformedQuery.getMaxFeatures());
+    }
 }


### PR DESCRIPTION
[![GEOT-7182](https://badgen.net/badge/JIRA/GEOT-7182/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7182) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->