### PR TITLE
[GEOT-7185] Tolerate empty Online Resource in Service definition

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/WMSComplexTypes.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/WMSComplexTypes.java
@@ -5243,14 +5243,19 @@ public class WMSComplexTypes {
                 throws SAXException, OperationNotSupportedException {
 
             if (value != null && value.length >= 1) {
-                try {
-                    return new URL((String) value[value.length - 1].getValue());
-                } catch (MalformedURLException e1) {
+                if (value[value.length - 1].getValue() != null) {
+                    try {
+                        return new URL((String) value[value.length - 1].getValue());
+                    } catch (MalformedURLException e1) {
+                    }
                 }
             }
 
             String href = attrs.getValue("", "href");
             href = href != null ? href : attrs.getValue(XLinkSchema.NAMESPACE.toString(), "href");
+            if (href == null) {
+                return null;
+            }
             try {
                 return new URL(href);
             } catch (MalformedURLException e) {

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSComplexTypesTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSComplexTypesTest.java
@@ -111,4 +111,30 @@ public class WMSComplexTypesTest {
         // invalid xlink URL will cause most online resources to be null
         Assert.assertNull(legendURL);
     }
+
+    @Test
+    public void testEmptyOnlineResourceServiceDef() throws Exception {
+
+        File getCaps = TestData.file(this, "1.3.0Capabilities_EmptyOnlineResource.xml");
+        URL getCapsURL = getCaps.toURI().toURL();
+        Map<String, Object> hints = new HashMap<>();
+        hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+        Object object = null;
+
+        try {
+            object = DocumentFactory.getInstance(getCapsURL.openStream(), hints, Level.WARNING);
+        } catch (NullPointerException e) {
+            Assert.fail("Parsing document with empty xlink URL should not cause NPE");
+        }
+
+        Assert.assertTrue("Capabilities failed to parse", object instanceof WMSCapabilities);
+
+        WMSCapabilities capabilities = (WMSCapabilities) object;
+
+        Assert.assertEquals(capabilities.getVersion(), "1.3.0");
+        Assert.assertEquals(capabilities.getService().getName(), "WMS");
+        Assert.assertEquals(capabilities.getService().getTitle(), "World Map");
+        // empty Service OnlineResource element should be null, preventing npe
+        Assert.assertNull(capabilities.getService().getOnlineResource());
+    }
 }

--- a/modules/extension/wms/src/test/resources/org/geotools/ows/wms/xml/test/test-data/1.3.0Capabilities_EmptyOnlineResource.xml
+++ b/modules/extension/wms/src/test/resources/org/geotools/ows/wms/xml/test/test-data/1.3.0Capabilities_EmptyOnlineResource.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms capabilities_1_3_0.xsd">
+	<!-- Service Metadata -->
+	<Service>
+		<!-- The WMT-defined name for this type of service -->
+		<Name>WMS</Name>
+		<!-- Human-readable title for pick lists -->
+		<Title>World Map</Title>
+		<!-- Narrative description providing additional information -->
+		<Abstract>None</Abstract>
+		<!-- Online resource is sometimes empty, WMS 1.3.0 spec declares it may be used, but not required -->
+		<OnlineResource/>
+		<!-- Contact information -->
+		<ContactInformation>
+			<ContactPersonPrimary>
+				<ContactPerson></ContactPerson>
+				<ContactOrganization></ContactOrganization>
+			</ContactPersonPrimary>
+			<ContactPosition>None</ContactPosition>
+			<ContactAddress>
+				<AddressType>None</AddressType>
+				<Address>None</Address>
+				<City>None</City>
+				<StateOrProvince>None</StateOrProvince>
+				<PostCode>None</PostCode>
+				<Country>None</Country>
+			</ContactAddress>
+			<ContactVoiceTelephone>None</ContactVoiceTelephone>
+			<ContactElectronicMailAddress></ContactElectronicMailAddress>
+		</ContactInformation>
+		<!-- Fees or access constraints imposed. -->
+		<Fees>none</Fees>
+		<AccessConstraints>none</AccessConstraints>
+		<LayerLimit>40</LayerLimit>
+		<MaxWidth>2000</MaxWidth>
+		<MaxHeight>2000</MaxHeight>
+	</Service>
+	<Capability>
+		<Request>
+			<GetCapabilities>
+				<Format>text/xml</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+						<Post>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Post>
+					</HTTP>
+				</DCPType>
+			</GetCapabilities>
+			<GetMap>
+				<Format>image/gif</Format>
+				<Format>image/png</Format>
+				<Format>image/jpeg</Format>
+				<Format>image/bmp</Format>
+				<Format>image/swf</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<!-- The URL here for invoking GetCapabilities using HTTP GET
+            is only a prefix to which a query string is appended. -->
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetMap>
+			<GetFeatureInfo>
+				<Format>text/xml</Format>
+				<Format>text/plain</Format>
+				<Format>text/html</Format>
+				<Format>text/swf</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetFeatureInfo>
+		</Request>
+		<Exception>
+			<Format>XML</Format>
+			<Format>INIMAGE</Format>
+			<Format>BLANK</Format>
+		</Exception>
+		<Layer>
+			<Title>World Map</Title>
+			<CRS>CRS:84</CRS>
+			<!-- all layers are available in at least this CRS -->
+			<EX_GeographicBoundingBox>
+				<westBoundLongitude>-180</westBoundLongitude>
+				<eastBoundLongitude>180</eastBoundLongitude>
+				<southBoundLatitude>-90</southBoundLatitude>
+				<northBoundLatitude>90</northBoundLatitude>
+			</EX_GeographicBoundingBox>
+			<BoundingBox CRS="CRS:84" minx="-184" miny="-90.0000000017335" maxx="180" maxy="90"/>
+			<Layer queryable="1" opaque="1">
+				<Name>Bathymetry</Name>
+				<Title>Bathymetry</Title>
+				<BoundingBox CRS="CRS:84" minx="-180" miny="-90" maxx="180" maxy="90"/>
+				<Attribution>
+					<Title>test</Title>
+					<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.example.com"/>
+					<LogoURL height="100" width="100">
+						<Format>image/png</Format>
+						<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.osgeo.org/sites/all/themes/osgeo/logo.png"/>
+					</LogoURL>
+				</Attribution>
+				<MetadataURL type="FGDC">
+					<Format>text/html</Format>
+					<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.example.com/?"/>
+				</MetadataURL>
+				<Style>
+					<Name>default</Name>
+					<Title>default</Title>
+					<LegendURL width="99" height="25">
+						<Format>image/png</Format>
+						<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.osgeo.org/sites/all/themes/osgeo/logo.png"/>
+					</LegendURL>
+				</Style>
+			</Layer>
+			<Layer queryable="1" opaque="0">
+				<Name>Countries</Name>
+				<Title>Countries</Title>
+				<BoundingBox CRS="CRS:84" minx="-184" miny="-90" maxx="180" maxy="85"/>
+				<Attribution>
+					<Title>test</Title>
+					<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.example.com"/>
+				</Attribution>
+			</Layer>
+			<Layer queryable="1" opaque="1">
+				<Name>Topography</Name>
+				<Title>Topography</Title>
+				<BoundingBox CRS="CRS:84" minx="-179.999999999999" miny="-90.0000000017335" maxx="179.999999996401" maxy="89.9999999999998"/>
+				<Attribution>
+					<Title>test</Title>
+				</Attribution>			
+			</Layer>
+			<Layer queryable="0" opaque="1">
+				<Name>Hillshading</Name>
+				<Title>Hillshading</Title>
+				<BoundingBox CRS="CRS:84" minx="-179.999999999999" miny="-90.0000000017335" maxx="179.999999996401" maxy="89.9999999999998"/>
+				<Attribution>
+      				<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.example.com"/>
+					<LogoURL>
+						<Format>image/png</Format>
+						<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.osgeo.org/sites/all/themes/osgeo/logo.png"/>
+					</LogoURL>				
+				</Attribution>			
+			</Layer>
+			<Layer queryable="1" opaque="0">
+				<Name>Builtup areas</Name>
+				<Title>Builtup areas</Title>
+				<BoundingBox CRS="CRS:84" minx="-180" miny="-55" maxx="180" maxy="75"/>
+				<MaxScaleDenominator>5000000</MaxScaleDenominator>
+			</Layer>
+		</Layer>
+	</Capability>
+</WMS_Capabilities>
+


### PR DESCRIPTION
[![GEOT-7185](https://badgen.net/badge/JIRA/GEOT-7185/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7185) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Signed-off-by: mtcarto <morgan.thomps@gmail.com>

Parsing of an WMS 1.3.0 capabilities document  containing an empty OnlineResource element can cause a MalformedUrl error to be thrown when parsing. 
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->