### PR TITLE
[GEOT-7187] MockHTTPResponse cannot be replayed, will only work once

### DIFF
--- a/modules/library/http/src/test/java/org/geotools/http/MockHttpResponseTest.java
+++ b/modules/library/http/src/test/java/org/geotools/http/MockHttpResponseTest.java
@@ -1,0 +1,43 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.http;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class MockHttpResponseTest {
+
+    private static final byte[] THE_RESPONSE = {1, 2, 3};
+
+    @Test
+    public void testReplay() throws IOException {
+        byte[] payload = new byte[THE_RESPONSE.length];
+        HTTPResponse response = new MockHttpResponse(THE_RESPONSE, "application/octet-stream");
+        readAndCompare(payload, response);
+        readAndCompare(payload, response);
+    }
+
+    private void readAndCompare(byte[] payload, HTTPResponse response) throws IOException {
+        try (InputStream is = response.getResponseStream()) {
+            is.read(payload);
+            assertArrayEquals(THE_RESPONSE, payload);
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-7187](https://badgen.net/badge/JIRA/GEOT-7187/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7187) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Allow the same request to be played more than once.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->