### PR TITLE
Improve usablity of STAC store for GetMap usage

### DIFF
--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -223,7 +223,7 @@ public class GeoJSONReader implements AutoCloseable {
         }
         ObjectMapper mapper = ObjectMapperFactory.getDefaultMapper();
         List<SimpleFeature> features = new ArrayList<>();
-        URL next = null;
+        ObjectNode next = null;
         Integer matched = null;
         builder = null;
         while (!parser.isClosed()) {
@@ -256,11 +256,7 @@ public class GeoJSONReader implements AutoCloseable {
                     ObjectNode node = mapper.readTree(parser);
                     JsonNode rel = node.get("rel");
                     if (rel != null && "next".equals(rel.textValue())) {
-                        JsonNode href = node.get("href");
-                        if (href != null) {
-                            next = new URL(href.textValue());
-                            break;
-                        }
+                        next = node;
                     }
                 }
             }
@@ -306,9 +302,14 @@ public class GeoJSONReader implements AutoCloseable {
 
         // if there is a next link, support paging
         if (next != null) {
-            return new PagingFeatureCollection(result, next, matched);
+            return getPagingFeatureCollection(result, matched, next);
         }
         return result;
+    }
+
+    protected PagingFeatureCollection getPagingFeatureCollection(
+            SimpleFeatureCollection result, Integer matched, ObjectNode next) {
+        return new PagingFeatureCollection(result, next, matched);
     }
 
     /** */

--- a/modules/unsupported/stac-store/src/main/java/org/geotools/stac/client/STACClient.java
+++ b/modules/unsupported/stac-store/src/main/java/org/geotools/stac/client/STACClient.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.lang3.StringUtils;
-import org.geotools.data.geojson.GeoJSONReader;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.http.HTTPClient;
 import org.geotools.http.HTTPResponse;
@@ -176,7 +175,10 @@ public class STACClient implements Closeable {
             checkGeoJSONResponse(response);
 
             // TODO: support paging following links
-            return new GeoJSONReader(response.getResponseStream()).getFeatures();
+            try (STACGeoJSONReader reader =
+                    new STACGeoJSONReader(response.getResponseStream(), http)) {
+                return reader.getFeatures();
+            }
         } catch (URISyntaxException e) {
             throw new IOException("Failed to build the search query URL", e);
         }

--- a/modules/unsupported/stac-store/src/main/java/org/geotools/stac/client/STACGeoJSONReader.java
+++ b/modules/unsupported/stac-store/src/main/java/org/geotools/stac/client/STACGeoJSONReader.java
@@ -1,0 +1,42 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.stac.client;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.io.InputStream;
+import org.geotools.data.geojson.GeoJSONReader;
+import org.geotools.data.geojson.PagingFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.http.HTTPClient;
+
+/** A subclass of GeoJSONReader that can perform paging requests using a given {@link HTTPClient} */
+class STACGeoJSONReader extends GeoJSONReader {
+
+    private final HTTPClient http;
+
+    public STACGeoJSONReader(InputStream is, HTTPClient http) throws IOException {
+        super(is);
+        this.http = http;
+    }
+
+    @Override
+    protected PagingFeatureCollection getPagingFeatureCollection(
+            SimpleFeatureCollection result, Integer matched, ObjectNode next) {
+        return new STACPagingFeatureCollection(result, next, matched, http);
+    }
+}

--- a/modules/unsupported/stac-store/src/main/java/org/geotools/stac/client/STACPagingFeatureCollection.java
+++ b/modules/unsupported/stac-store/src/main/java/org/geotools/stac/client/STACPagingFeatureCollection.java
@@ -1,0 +1,53 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.stac.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import org.geotools.data.geojson.PagingFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.http.HTTPClient;
+
+class STACPagingFeatureCollection extends PagingFeatureCollection {
+
+    private final HTTPClient http;
+
+    public STACPagingFeatureCollection(
+            SimpleFeatureCollection first, ObjectNode next, Integer matched, HTTPClient http) {
+        super(first, next, matched);
+        this.http = http;
+    }
+
+    @Override
+    protected SimpleFeatureCollection readNext(ObjectNode next) throws IOException {
+        if (next == null) return null;
+        JsonNode href = next.get("href");
+        if (href == null) return null;
+
+        // TODO: consider complex request merge logic for POST requests, described at
+        // https://github.com/radiantearth/stac-api-spec/tree/main/item-search#pagination
+
+        LOGGER.fine(() -> "Fetching next page of data at " + href.textValue());
+        try (InputStream is = http.get(new URL(href.textValue())).getResponseStream();
+                STACGeoJSONReader reader = new STACGeoJSONReader(is, http)) {
+            return reader.getFeatures();
+        }
+    }
+}

--- a/modules/unsupported/stac-store/src/main/java/org/geotools/stac/store/STACDataStore.java
+++ b/modules/unsupported/stac-store/src/main/java/org/geotools/stac/store/STACDataStore.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.geotools.data.DataStore;
 import org.geotools.data.store.ContentDataStore;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureSource;
@@ -30,13 +31,15 @@ import org.geotools.util.logging.Logging;
 import org.opengis.feature.type.Name;
 
 /**
- * A {@link org.geotools.data.DataStore} implementation connecting to a <a
+ * A {@link DataStore} implementation connecting to a <a
  * href="https://github.com/radiantearth/stac-api-spec">STAC API</a>, exposing collections as
  * feature types, and items as features.
  */
 public class STACDataStore extends ContentDataStore {
 
     static final int DEFAULT_FETCH_SIZE = 1000;
+
+    static final Integer DEFAULT_HARD_LIMIT = 100000;
 
     static final Logger LOGGER = Logging.getLogger(STACDataStore.class);
 
@@ -45,6 +48,7 @@ public class STACDataStore extends ContentDataStore {
     private STACClient.SearchMode searchMode = STACClient.SearchMode.GET;
 
     private int fetchSize = DEFAULT_FETCH_SIZE;
+    private Integer hardLimit = DEFAULT_HARD_LIMIT;
 
     public STACDataStore(STACClient client) {
         this.client = client;
@@ -75,7 +79,7 @@ public class STACDataStore extends ContentDataStore {
 
     @Override
     protected ContentFeatureSource createFeatureSource(ContentEntry entry) throws IOException {
-        return new STACFeatureSource(entry, client, searchMode, fetchSize);
+        return new STACFeatureSource(entry, client);
     }
 
     @Override
@@ -85,5 +89,19 @@ public class STACDataStore extends ContentDataStore {
         } catch (IOException e) {
             LOGGER.log(Level.FINE, "Failed to cleanly close the STAC client", e);
         }
+    }
+
+    /**
+     * Maximum number of STAC items a collection will ever provide (set to zero or negative not to
+     * have this limit).
+     *
+     * @param hardLimit
+     */
+    public void setHardLimit(int hardLimit) {
+        this.hardLimit = hardLimit;
+    }
+
+    public int getHardLimit() {
+        return hardLimit;
     }
 }

--- a/modules/unsupported/stac-store/src/main/java/org/geotools/stac/store/STACDataStoreFactory.java
+++ b/modules/unsupported/stac-store/src/main/java/org/geotools/stac/store/STACDataStoreFactory.java
@@ -69,7 +69,16 @@ public class STACDataStoreFactory implements DataStoreFactorySpi {
                     Integer.class,
                     "How many items to fetch in a single request (just a suggestion to the server)",
                     false,
-                    1000,
+                    STACDataStore.DEFAULT_FETCH_SIZE,
+                    Collections.singletonMap(Parameter.MIN, 1));
+
+    public static final Param HARD_LIMIT =
+            new Param(
+                    "hardLimit",
+                    Integer.class,
+                    "How many items to fetch from a collection, tops, even while paging. Set to zero or negative to disable.",
+                    false,
+                    STACDataStore.DEFAULT_HARD_LIMIT,
                     Collections.singletonMap(Parameter.MIN, 1));
 
     @Override
@@ -84,7 +93,7 @@ public class STACDataStoreFactory implements DataStoreFactorySpi {
 
     @Override
     public Param[] getParametersInfo() {
-        return new Param[] {NAMESPACE, DBTYPE, LANDING_PAGE, SEARCH_MODE, FETCH_SIZE};
+        return new Param[] {NAMESPACE, DBTYPE, LANDING_PAGE, SEARCH_MODE, FETCH_SIZE, HARD_LIMIT};
     }
 
     @Override
@@ -98,6 +107,7 @@ public class STACDataStoreFactory implements DataStoreFactorySpi {
         URI namespace = (URI) NAMESPACE.lookUp(params);
         SearchMode mode = (SearchMode) SEARCH_MODE.lookUp(params);
         Integer fetchSize = (Integer) FETCH_SIZE.lookUp(params);
+        Integer hardLimit = (Integer) HARD_LIMIT.lookUp(params);
 
         // TODO: make the HTTP client configurable just like a WMS store
         @SuppressWarnings("PMD.CloseResource") // will be closed by the store
@@ -106,6 +116,7 @@ public class STACDataStoreFactory implements DataStoreFactorySpi {
         if (namespace != null) store.setNamespaceURI(namespace.toString());
         if (mode != null) store.setSearchMode(mode);
         if (fetchSize != null) store.setFetchSize(fetchSize);
+        if (hardLimit != null) store.setHardLimit(hardLimit);
         return store;
     }
 

--- a/modules/unsupported/stac-store/src/test/resources/org/geotools/stac/maja10.json
+++ b/modules/unsupported/stac-store/src/test/resources/org/geotools/stac/maja10.json
@@ -1,0 +1,11938 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2B_20220714-105646-098_L2A_T32ULB_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              6.1237,
+              51.4159
+            ],
+            [
+              7.7021,
+              51.444
+            ],
+            [
+              7.7293,
+              50.4569
+            ],
+            [
+              6.1839,
+              50.4297
+            ],
+            [
+              6.1237,
+              51.4159
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        6.123708248138,
+        50.429714202881,
+        7.7293009758,
+        51.443996429443
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:21.147+00:00",
+        "updated": "2022-07-19T06:15:21.147+00:00",
+        "datetime": "2022-07-14T10:46:29.024+00:00",
+        "platform": "SENTINEL-2B",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 51,
+        "eo:cloud_cover": 4,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 11.315982150736,
+        "view:azimuth": 290.772574338312,
+        "view:sun_azimuth": 160.776213409109,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2B_20220714-105646-098_L2A_T32ULB_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2B_20220714-105646-098_L2A_T32ULB_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2B_20220714-105646-098_L2A_T32ULB_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2B_20220714-105650-344_L2A_T31UGS_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              5.8757,
+              51.4159
+            ],
+            [
+              7.4506,
+              51.3666
+            ],
+            [
+              7.3576,
+              50.3821
+            ],
+            [
+              5.8155,
+              50.4297
+            ],
+            [
+              5.8757,
+              51.4159
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        5.81551027298,
+        50.382122039795,
+        7.45058965683,
+        51.415897369385
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:20.805+00:00",
+        "updated": "2022-07-19T06:15:20.805+00:00",
+        "datetime": "2022-07-14T10:46:29.024+00:00",
+        "platform": "SENTINEL-2B",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32631,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 51,
+        "eo:cloud_cover": 19,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 10.835713001516,
+        "view:azimuth": 290.111331091754,
+        "view:sun_azimuth": 160.211029504011,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2B_20220714-105650-344_L2A_T31UGS_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2B_20220714-105650-344_L2A_T31UGS_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2B_20220714-105650-344_L2A_T31UGS_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100627-146_L2A_T33UVU_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              13.5009,
+              53.2402
+            ],
+            [
+              15.1463,
+              53.2495
+            ],
+            [
+              15.143,
+              52.2625
+            ],
+            [
+              13.5344,
+              52.2534
+            ],
+            [
+              13.5009,
+              53.2402
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        13.500940322876,
+        52.253448486328,
+        15.146276473999,
+        53.249538421631
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:21.818+00:00",
+        "updated": "2022-07-19T06:15:21.818+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 0,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 11.322147577967,
+        "view:azimuth": 106.813516415435,
+        "view:sun_azimuth": 153.029545613249,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100627-146_L2A_T33UVU_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100627-146_L2A_T33UVU_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100627-146_L2A_T33UVU_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100638-447_L2A_T33UVT_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              13.5315,
+              52.3413
+            ],
+            [
+              15.1433,
+              52.3504
+            ],
+            [
+              15.1402,
+              51.3632
+            ],
+            [
+              13.5633,
+              51.3544
+            ],
+            [
+              13.5315,
+              52.3413
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        13.5315284729,
+        51.354431152344,
+        15.143290519714,
+        52.350387573242
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:22.009+00:00",
+        "updated": "2022-07-19T06:15:22.009+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 68,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 10.519370955831,
+        "view:azimuth": 105.566205514471,
+        "view:sun_azimuth": 152.515218952431,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100638-447_L2A_T33UVT_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100638-447_L2A_T33UVT_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100638-447_L2A_T33UVT_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              13.6143,
+              49.6444
+            ],
+            [
+              15.1352,
+              49.6526
+            ],
+            [
+              15.1326,
+              48.665
+            ],
+            [
+              13.6415,
+              48.657
+            ],
+            [
+              13.6143,
+              49.6444
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        13.614272117615,
+        48.657020568848,
+        15.135213851929,
+        49.652645111084
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:21.555+00:00",
+        "updated": "2022-07-19T06:15:21.555+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 31,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 7.399389448404,
+        "view:azimuth": 105.264121354708,
+        "view:sun_azimuth": 150.776490314821,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              12.2309,
+              49.6196
+            ],
+            [
+              13.7505,
+              49.646
+            ],
+            [
+              13.7751,
+              48.6585
+            ],
+            [
+              12.2854,
+              48.633
+            ],
+            [
+              12.2309,
+              49.6196
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        12.230932235718,
+        48.633029937744,
+        13.775131225586,
+        49.645980834961
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:21.361+00:00",
+        "updated": "2022-07-19T06:15:21.361+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 14,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 11.146217753419,
+        "view:azimuth": 106.295760601276,
+        "view:sun_azimuth": 148.425803386379,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100735-986_L2A_T33UVP_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              13.6392,
+              48.745
+            ],
+            [
+              15.1328,
+              48.7529
+            ],
+            [
+              15.1302,
+              47.7651
+            ],
+            [
+              13.6651,
+              47.7574
+            ],
+            [
+              13.6392,
+              48.745
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        13.639176368713,
+        47.757404327393,
+        15.132782936096,
+        48.752937316895
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:22.270+00:00",
+        "updated": "2022-07-19T06:15:22.270+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 22,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 5.535262435448,
+        "view:azimuth": 104.4554156595,
+        "view:sun_azimuth": 150.123254001626,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100735-986_L2A_T33UVP_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100735-986_L2A_T33UVP_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100735-986_L2A_T33UVP_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100739-746_L2A_T33UUP_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              12.2806,
+              48.7209
+            ],
+            [
+              13.773,
+              48.7465
+            ],
+            [
+              13.7964,
+              47.7589
+            ],
+            [
+              12.3325,
+              47.7342
+            ],
+            [
+              12.2806,
+              48.7209
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        12.280641555786,
+        47.734153747559,
+        13.796401977539,
+        48.746479034424
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:22.539+00:00",
+        "updated": "2022-07-19T06:15:22.539+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 27,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 10.2372574317,
+        "view:azimuth": 104.399441079965,
+        "view:sun_azimuth": 147.770724266001,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100739-746_L2A_T33UUP_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100739-746_L2A_T33UUP_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100739-746_L2A_T33UUP_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103555-720_L2A_T32UPF_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              10.5648,
+              55.0369
+            ],
+            [
+              12.2806,
+              55.0028
+            ],
+            [
+              12.2025,
+              54.0175
+            ],
+            [
+              10.5275,
+              54.0505
+            ],
+            [
+              10.5648,
+              55.0369
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        10.527468681335,
+        54.017539978027,
+        12.280574798584,
+        55.036930084229
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:23.517+00:00",
+        "updated": "2022-07-19T06:09:23.517+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 66,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 3.662705619461,
+        "view:azimuth": 254.008564095573,
+        "view:sun_azimuth": 161.302344644703,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103555-720_L2A_T32UPF_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103555-720_L2A_T32UPF_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103555-720_L2A_T32UPF_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103559-734_L2A_T32UNF_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              8.9997,
+              55.047
+            ],
+            [
+              10.7177,
+              55.0349
+            ],
+            [
+              10.6768,
+              54.0485
+            ],
+            [
+              8.9997,
+              54.0602
+            ],
+            [
+              8.9997,
+              55.047
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        8.999687194824,
+        54.048515319824,
+        10.717734336853,
+        55.046985626221
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:25.202+00:00",
+        "updated": "2022-07-19T06:09:25.202+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 55,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 4.48583069248,
+        "view:azimuth": 108.117143098194,
+        "view:sun_azimuth": 158.825150193525,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103559-734_L2A_T32UNF_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103559-734_L2A_T32UNF_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103559-734_L2A_T32UNF_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    }
+  ],
+  "numberMatched": 20,
+  "numberReturned": 10,
+  "stac_version": "1.0.0",
+  "links": [
+    {
+      "comment": "Next link removed to avoid client going online"
+    },
+    {
+      "type": "application/geo+json",
+      "rel": "next",
+      "href": "https://geoservice.dlr.de/eoc/ogc/stac/search?collections=S2_L2A_MAJA&requestId=1234&page=2"
+    }
+  ]
+}

--- a/modules/unsupported/stac-store/src/test/resources/org/geotools/stac/maja20.json
+++ b/modules/unsupported/stac-store/src/test/resources/org/geotools/stac/maja20.json
@@ -1,0 +1,23858 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2B_20220714-105646-098_L2A_T32ULB_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              6.1237,
+              51.4159
+            ],
+            [
+              7.7021,
+              51.444
+            ],
+            [
+              7.7293,
+              50.4569
+            ],
+            [
+              6.1839,
+              50.4297
+            ],
+            [
+              6.1237,
+              51.4159
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        6.123708248138,
+        50.429714202881,
+        7.7293009758,
+        51.443996429443
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:21.147+00:00",
+        "updated": "2022-07-19T06:15:21.147+00:00",
+        "datetime": "2022-07-14T10:46:29.024+00:00",
+        "platform": "SENTINEL-2B",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 51,
+        "eo:cloud_cover": 4,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 11.315982150736,
+        "view:azimuth": 290.772574338312,
+        "view:sun_azimuth": 160.776213409109,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/MASKS/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LB/2022/07/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_V1-3.zip#SENTINEL2B_20220714-105646-098_L2A_T32ULB_C/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105646-098_L2A_T32ULB_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2B_20220714-105646-098_L2A_T32ULB_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2B_20220714-105646-098_L2A_T32ULB_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2B_20220714-105646-098_L2A_T32ULB_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2B_20220714-105650-344_L2A_T31UGS_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              5.8757,
+              51.4159
+            ],
+            [
+              7.4506,
+              51.3666
+            ],
+            [
+              7.3576,
+              50.3821
+            ],
+            [
+              5.8155,
+              50.4297
+            ],
+            [
+              5.8757,
+              51.4159
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        5.81551027298,
+        50.382122039795,
+        7.45058965683,
+        51.415897369385
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:20.805+00:00",
+        "updated": "2022-07-19T06:15:20.805+00:00",
+        "datetime": "2022-07-14T10:46:29.024+00:00",
+        "platform": "SENTINEL-2B",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32631,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 51,
+        "eo:cloud_cover": 19,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 10.835713001516,
+        "view:azimuth": 290.111331091754,
+        "view:sun_azimuth": 160.211029504011,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/MASKS/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GS/2022/07/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_V1-3.zip#SENTINEL2B_20220714-105650-344_L2A_T31UGS_C/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5700000.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2B_20220714-105650-344_L2A_T31UGS_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2B_20220714-105650-344_L2A_T31UGS_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2B_20220714-105650-344_L2A_T31UGS_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2B_20220714-105650-344_L2A_T31UGS_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100627-146_L2A_T33UVU_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              13.5009,
+              53.2402
+            ],
+            [
+              15.1463,
+              53.2495
+            ],
+            [
+              15.143,
+              52.2625
+            ],
+            [
+              13.5344,
+              52.2534
+            ],
+            [
+              13.5009,
+              53.2402
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        13.500940322876,
+        52.253448486328,
+        15.146276473999,
+        53.249538421631
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:21.818+00:00",
+        "updated": "2022-07-19T06:15:21.818+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 0,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 11.322147577967,
+        "view:azimuth": 106.813516415435,
+        "view:sun_azimuth": 153.029545613249,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/MASKS/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VU/2022/07/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_V1-3.zip#SENTINEL2A_20220714-100627-146_L2A_T33UVU_C/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100627-146_L2A_T33UVU_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100627-146_L2A_T33UVU_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100627-146_L2A_T33UVU_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100627-146_L2A_T33UVU_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100638-447_L2A_T33UVT_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              13.5315,
+              52.3413
+            ],
+            [
+              15.1433,
+              52.3504
+            ],
+            [
+              15.1402,
+              51.3632
+            ],
+            [
+              13.5633,
+              51.3544
+            ],
+            [
+              13.5315,
+              52.3413
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        13.5315284729,
+        51.354431152344,
+        15.143290519714,
+        52.350387573242
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:22.009+00:00",
+        "updated": "2022-07-19T06:15:22.009+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 68,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 10.519370955831,
+        "view:azimuth": 105.566205514471,
+        "view:sun_azimuth": 152.515218952431,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/MASKS/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VT/2022/07/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_V1-3.zip#SENTINEL2A_20220714-100638-447_L2A_T33UVT_C/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100638-447_L2A_T33UVT_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100638-447_L2A_T33UVT_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100638-447_L2A_T33UVT_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100638-447_L2A_T33UVT_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              13.6143,
+              49.6444
+            ],
+            [
+              15.1352,
+              49.6526
+            ],
+            [
+              15.1326,
+              48.665
+            ],
+            [
+              13.6415,
+              48.657
+            ],
+            [
+              13.6143,
+              49.6444
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        13.614272117615,
+        48.657020568848,
+        15.135213851929,
+        49.652645111084
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:21.555+00:00",
+        "updated": "2022-07-19T06:15:21.555+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 31,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 7.399389448404,
+        "view:azimuth": 105.264121354708,
+        "view:sun_azimuth": 150.776490314821,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/MASKS/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VQ/2022/07/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_V1-3.zip#SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100721-697_L2A_T33UVQ_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              12.2309,
+              49.6196
+            ],
+            [
+              13.7505,
+              49.646
+            ],
+            [
+              13.7751,
+              48.6585
+            ],
+            [
+              12.2854,
+              48.633
+            ],
+            [
+              12.2309,
+              49.6196
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        12.230932235718,
+        48.633029937744,
+        13.775131225586,
+        49.645980834961
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:21.361+00:00",
+        "updated": "2022-07-19T06:15:21.361+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 14,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 11.146217753419,
+        "view:azimuth": 106.295760601276,
+        "view:sun_azimuth": 148.425803386379,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/MASKS/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UQ/2022/07/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_V1-3.zip#SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5500020.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100727-780_L2A_T33UUQ_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100735-986_L2A_T33UVP_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              13.6392,
+              48.745
+            ],
+            [
+              15.1328,
+              48.7529
+            ],
+            [
+              15.1302,
+              47.7651
+            ],
+            [
+              13.6651,
+              47.7574
+            ],
+            [
+              13.6392,
+              48.745
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        13.639176368713,
+        47.757404327393,
+        15.132782936096,
+        48.752937316895
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:22.270+00:00",
+        "updated": "2022-07-19T06:15:22.270+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 22,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 5.535262435448,
+        "view:azimuth": 104.4554156595,
+        "view:sun_azimuth": 150.123254001626,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/MASKS/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/VP/2022/07/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_V1-3.zip#SENTINEL2A_20220714-100735-986_L2A_T33UVP_C/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100735-986_L2A_T33UVP_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100735-986_L2A_T33UVP_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100735-986_L2A_T33UVP_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100735-986_L2A_T33UVP_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220714-100739-746_L2A_T33UUP_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              12.2806,
+              48.7209
+            ],
+            [
+              13.773,
+              48.7465
+            ],
+            [
+              13.7964,
+              47.7589
+            ],
+            [
+              12.3325,
+              47.7342
+            ],
+            [
+              12.2806,
+              48.7209
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        12.280641555786,
+        47.734153747559,
+        13.796401977539,
+        48.746479034424
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:15:22.539+00:00",
+        "updated": "2022-07-19T06:15:22.539+00:00",
+        "datetime": "2022-07-14T10:00:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32633,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 122,
+        "eo:cloud_cover": 27,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 10.2372574317,
+        "view:azimuth": 104.399441079965,
+        "view:sun_azimuth": 147.770724266001,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/MASKS/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/33/U/UP/2022/07/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_V1-3.zip#SENTINEL2A_20220714-100739-746_L2A_T33UUP_C/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5400000.0
+          ],
+          "proj:epsg": 32633,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220714-100739-746_L2A_T33UUP_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100739-746_L2A_T33UUP_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220714-100739-746_L2A_T33UUP_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220714-100739-746_L2A_T33UUP_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103555-720_L2A_T32UPF_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              10.5648,
+              55.0369
+            ],
+            [
+              12.2806,
+              55.0028
+            ],
+            [
+              12.2025,
+              54.0175
+            ],
+            [
+              10.5275,
+              54.0505
+            ],
+            [
+              10.5648,
+              55.0369
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        10.527468681335,
+        54.017539978027,
+        12.280574798584,
+        55.036930084229
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:23.517+00:00",
+        "updated": "2022-07-19T06:09:23.517+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 66,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 3.662705619461,
+        "view:azimuth": 254.008564095573,
+        "view:sun_azimuth": 161.302344644703,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/MASKS/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PF/2022/07/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_V1-3.zip#SENTINEL2A_20220713-103555-720_L2A_T32UPF_C/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103555-720_L2A_T32UPF_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103555-720_L2A_T32UPF_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103555-720_L2A_T32UPF_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103555-720_L2A_T32UPF_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103559-734_L2A_T32UNF_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              8.9997,
+              55.047
+            ],
+            [
+              10.7177,
+              55.0349
+            ],
+            [
+              10.6768,
+              54.0485
+            ],
+            [
+              8.9997,
+              54.0602
+            ],
+            [
+              8.9997,
+              55.047
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        8.999687194824,
+        54.048515319824,
+        10.717734336853,
+        55.046985626221
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:25.202+00:00",
+        "updated": "2022-07-19T06:09:25.202+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 55,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 4.48583069248,
+        "view:azimuth": 108.117143098194,
+        "view:sun_azimuth": 158.825150193525,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/MASKS/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NF/2022/07/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_V1-3.zip#SENTINEL2A_20220713-103559-734_L2A_T32UNF_C/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103559-734_L2A_T32UNF_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103559-734_L2A_T32UNF_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103559-734_L2A_T32UNF_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103559-734_L2A_T32UNF_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103603-329_L2A_T32UMF_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              7.4346,
+              55.0369
+            ],
+            [
+              9.1528,
+              55.0469
+            ],
+            [
+              9.1491,
+              54.0601
+            ],
+            [
+              7.4719,
+              54.0505
+            ],
+            [
+              7.4346,
+              55.0369
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        7.434601783752,
+        54.050495147705,
+        9.152752876282,
+        55.046890258789
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:24.463+00:00",
+        "updated": "2022-07-19T06:09:24.463+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 57,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 9.705567909233,
+        "view:azimuth": 105.358956995488,
+        "view:sun_azimuth": 156.37220318027,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/MASKS/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MF/2022/07/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_V1-3.zip#SENTINEL2A_20220713-103603-329_L2A_T32UMF_C/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6100020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103603-329_L2A_T32UMF_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103603-329_L2A_T32UMF_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103603-329_L2A_T32UMF_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103603-329_L2A_T32UMF_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103610-048_L2A_T32UPE_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              10.5307,
+              54.1384
+            ],
+            [
+              12.2093,
+              54.1053
+            ],
+            [
+              12.1353,
+              53.1199
+            ],
+            [
+              10.4954,
+              53.1518
+            ],
+            [
+              10.5307,
+              54.1384
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        10.495379447937,
+        53.11988067627,
+        12.209259986877,
+        54.138374328613
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:25.982+00:00",
+        "updated": "2022-07-19T06:09:25.982+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 86,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 5.600546449128,
+        "view:azimuth": 285.636872281953,
+        "view:sun_azimuth": 160.875582933849,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/MASKS/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            600000.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/PE/2022/07/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_V1-3.zip#SENTINEL2A_20220713-103610-048_L2A_T32UPE_C/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            600000.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103610-048_L2A_T32UPE_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103610-048_L2A_T32UPE_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103610-048_L2A_T32UPE_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103610-048_L2A_T32UPE_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103614-198_L2A_T32UNE_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              8.9997,
+              54.1481
+            ],
+            [
+              10.6803,
+              54.1364
+            ],
+            [
+              10.6416,
+              53.1499
+            ],
+            [
+              8.9997,
+              53.1612
+            ],
+            [
+              8.9997,
+              54.1481
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        8.999693870544,
+        53.14986038208,
+        10.680335998535,
+        54.148105621338
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:22.724+00:00",
+        "updated": "2022-07-19T06:09:22.724+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 33,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 2.938189658681,
+        "view:azimuth": 140.158535877621,
+        "view:sun_azimuth": 158.402496066365,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/MASKS/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/NE/2022/07/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_V1-3.zip#SENTINEL2A_20220713-103614-198_L2A_T32UNE_C/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103614-198_L2A_T32UNE_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103614-198_L2A_T32UNE_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103614-198_L2A_T32UNE_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103614-198_L2A_T32UNE_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103618-140_L2A_T32UME_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              7.4687,
+              54.1384
+            ],
+            [
+              9.1494,
+              54.148
+            ],
+            [
+              9.146,
+              53.1611
+            ],
+            [
+              7.504,
+              53.1518
+            ],
+            [
+              7.4687,
+              54.1384
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        7.468686580658,
+        53.151779174805,
+        9.149425506592,
+        54.148010253906
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:21.703+00:00",
+        "updated": "2022-07-19T06:09:21.703+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 39,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 8.663645741266,
+        "view:azimuth": 105.790906404447,
+        "view:sun_azimuth": 155.955477853501,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/MASKS/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ME/2022/07/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_V1-3.zip#SENTINEL2A_20220713-103618-140_L2A_T32UME_C/SENTINEL2A_20220713-103618-140_L2A_T32UME_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            6000000.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103618-140_L2A_T32UME_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103618-140_L2A_T32UME_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103618-140_L2A_T32UME_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103618-140_L2A_T32UME_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103618-140_L2A_T32UME_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103618-140_L2A_T32UME_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103628-553_L2A_T32UND_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              8.9997,
+              53.2496
+            ],
+            [
+              10.6449,
+              53.2383
+            ],
+            [
+              10.6082,
+              52.2516
+            ],
+            [
+              8.9997,
+              52.2625
+            ],
+            [
+              8.9997,
+              53.2496
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        8.999700546265,
+        52.25159072876,
+        10.644947052002,
+        53.249626159668
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:23.277+00:00",
+        "updated": "2022-07-19T06:09:23.277+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 75,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 2.397387875753,
+        "view:azimuth": 184.930202555269,
+        "view:sun_azimuth": 157.957084247043,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/MASKS/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            499980.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/ND/2022/07/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_V1-3.zip#SENTINEL2A_20220713-103628-553_L2A_T32UND_C/SENTINEL2A_20220713-103628-553_L2A_T32UND_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            499980.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103628-553_L2A_T32UND_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103628-553_L2A_T32UND_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103628-553_L2A_T32UND_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103628-553_L2A_T32UND_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103628-553_L2A_T32UND_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103628-553_L2A_T32UND_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103632-616_L2A_T32UMD_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              7.5009,
+              53.2402
+            ],
+            [
+              9.1463,
+              53.2495
+            ],
+            [
+              9.143,
+              52.2625
+            ],
+            [
+              7.5344,
+              52.2534
+            ],
+            [
+              7.5009,
+              53.2402
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        7.500940322876,
+        52.253448486328,
+        9.146276473999,
+        53.249538421631
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:23.937+00:00",
+        "updated": "2022-07-19T06:09:23.937+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 27,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 7.490771597206,
+        "view:azimuth": 105.780296772074,
+        "view:sun_azimuth": 155.513196616379,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/MASKS/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MD/2022/07/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_V1-3.zip#SENTINEL2A_20220713-103632-616_L2A_T32UMD_C/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103632-616_L2A_T32UMD_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103632-616_L2A_T32UMD_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103632-616_L2A_T32UMD_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103632-616_L2A_T32UMD_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103639-094_L2A_T32ULD_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              6.0048,
+              53.212
+            ],
+            [
+              7.6483,
+              53.242
+            ],
+            [
+              7.6785,
+              52.2551
+            ],
+            [
+              6.0716,
+              52.2262
+            ],
+            [
+              6.0048,
+              53.212
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        6.004760742188,
+        52.226211547852,
+        7.678544044495,
+        53.241962432861
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:23.752+00:00",
+        "updated": "2022-07-19T06:09:23.752+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 13,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 11.180416474365,
+        "view:azimuth": 106.912561102099,
+        "view:sun_azimuth": 153.101195631774,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/MASKS/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LD/2022/07/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_V1-3.zip#SENTINEL2A_20220713-103639-094_L2A_T32ULD_C/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5900040.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103639-094_L2A_T32ULD_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103639-094_L2A_T32ULD_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103639-094_L2A_T32ULD_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103639-094_L2A_T32ULD_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103646-852_L2A_T32UMC_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              7.5315,
+              52.3413
+            ],
+            [
+              9.1433,
+              52.3504
+            ],
+            [
+              9.1402,
+              51.3632
+            ],
+            [
+              7.5633,
+              51.3544
+            ],
+            [
+              7.5315,
+              52.3413
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        7.531528949738,
+        51.354431152344,
+        9.143290519714,
+        52.350387573242
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:25.452+00:00",
+        "updated": "2022-07-19T06:09:25.452+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 78,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 5.581164031532,
+        "view:azimuth": 105.182579077173,
+        "view:sun_azimuth": 155.042889200543,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/MASKS/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            399960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/MC/2022/07/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_V1-3.zip#SENTINEL2A_20220713-103646-852_L2A_T32UMC_C/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            399960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103646-852_L2A_T32UMC_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103646-852_L2A_T32UMC_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103646-852_L2A_T32UMC_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103646-852_L2A_T32UMC_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103650-797_L2A_T32ULC_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              6.0658,
+              52.314
+            ],
+            [
+              7.6759,
+              52.3431
+            ],
+            [
+              7.7046,
+              51.3561
+            ],
+            [
+              6.1292,
+              51.3281
+            ],
+            [
+              6.0658,
+              52.314
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        6.065798282623,
+        51.328052520752,
+        7.704578399658,
+        52.343055725098
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:25.757+00:00",
+        "updated": "2022-07-19T06:09:25.757+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32632,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 65,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 10.241071780107,
+        "view:azimuth": 105.046228953212,
+        "view:sun_azimuth": 152.633300751837,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/MASKS/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            300000.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/32/U/LC/2022/07/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_V1-3.zip#SENTINEL2A_20220713-103650-797_L2A_T32ULC_C/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            300000.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32632,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103650-797_L2A_T32ULC_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103650-797_L2A_T32ULC_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103650-797_L2A_T32ULC_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103650-797_L2A_T32ULC_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+      ],
+      "id": "SENTINEL2A_20220713-103652-668_L2A_T31UGT_C",
+      "collection": "S2_L2A_MAJA",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              5.9336,
+              52.314
+            ],
+            [
+              7.54,
+              52.2631
+            ],
+            [
+              7.4421,
+              51.2789
+            ],
+            [
+              5.8702,
+              51.3281
+            ],
+            [
+              5.9336,
+              52.314
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        5.870215892792,
+        51.278926849365,
+        7.539979457855,
+        52.314037322998
+      ],
+      "keywords": [],
+      "properties": {
+        "created": "2022-07-19T06:09:20.632+00:00",
+        "updated": "2022-07-19T06:09:20.632+00:00",
+        "datetime": "2022-07-13T10:30:41.024+00:00",
+        "platform": "SENTINEL-2A",
+        "constellation": "SENTINEL-2",
+        "instruments": [
+          "MSI"
+        ],
+        "gsd": 10.0,
+        "license": "CC-BY-4.0",
+        "proj:epsg": 32631,
+        "sci:doi": "10.15489/ifczsszkcp63",
+        "sat:absolute_orbit": 108,
+        "eo:cloud_cover": 70,
+        "eo:snow_cover": 0,
+        "view:incidence_angle": 10.711901522983,
+        "view:azimuth": 106.026436424897,
+        "view:sun_azimuth": 152.28546248696,
+        "processing:facility": "DLR-EOC",
+        "processing:lineage": "CATENA",
+        "processing:level": "L2A",
+        "processing:software": {
+          "CATENA": "1.3"
+        },
+        "sar:frequency_band": "OPTICAL"
+      },
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/jpeg",
+          "roles": [
+            "thumbnail"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3_QKL_ALL.jpg"
+        },
+        "data": {
+          "title": "Product Download",
+          "type": "application/x-zip",
+          "roles": [
+            "product"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip"
+        },
+        "metadata": {
+          "title": "Original Metadata",
+          "type": "application/xml",
+          "roles": [
+            "metadata"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3_QKL_ALL.xml"
+        },
+        "info": {
+          "title": "Product Information",
+          "type": "application/pdf",
+          "roles": [
+            "info"
+          ],
+          "href": "https://theia.cnes.fr/atdistrib/documents/PSC-NT-411-0362-CNES_01_00_SENTINEL-2A_L2A_Products_Description.pdf"
+        },
+        "CLM_R1": {
+          "title": "Cloud Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_CLM_R1.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "CLM_R2": {
+          "title": "Cloud Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "cloud"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_CLM_R2.tif",
+          "eo:bands": [
+            {
+              "name": "CLM_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "EDG_R1": {
+          "title": "Edge Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_EDG_R1.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R1",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "gsd": 20
+        },
+        "EDG_R2": {
+          "title": "Edge Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_EDG_R2.tif",
+          "eo:bands": [
+            {
+              "name": "EDG_R2",
+              "description": "edge mask coded over 8 bits, 1 useful bit"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "IAB_R1": {
+          "title": "IAB (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_IAB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R1"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "IAB_R2": {
+          "title": "IAB (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_IAB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "IAB_R2"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "MG2_R1": {
+          "title": "Geophysical Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_MG2_R1.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R1",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "MG2_R2": {
+          "title": "Geophysical Mask (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_MG2_R2.tif",
+          "eo:bands": [
+            {
+              "name": "MG2_R2",
+              "description": "geophysical mask of level 2, made of 1 band coded over 8 useful bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SAT_R1": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SAT_R1.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R1",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SAT_R2": {
+          "title": "Saturation Mask (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "saturation"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/MASKS/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SAT_R2.tif",
+          "eo:bands": [
+            {
+              "name": "SAT_R2",
+              "description": "Saturation mask coded over 8 bits, 1 bit per spectral band (number of useful bits = numberof spectral bands)"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "ATB_R1": {
+          "title": "Atmospheric and biophysical parameters (R1 - 10m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_ATB_R1.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "ATB_R2": {
+          "title": "Atmospheric and biophysical parameters (R2 - 20m)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_ATB_R2.tif",
+          "eo:bands": [
+            {
+              "name": "WVC",
+              "description": "Water vapor content (WVC) coded over 8 bits"
+            },
+            {
+              "name": "AOT",
+              "description": "Aerosol optical thickness (AOT) coded over 8 bits"
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B2": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B3": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B4": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B5": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B6": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B7": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B8": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "FRE_B8A": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B11": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "FRE_B12": {
+          "title": "Surface Reflectance Slope Corrected (FRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_FRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "FRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance with the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B2": {
+          "title": "Surface Reflectance (SRE_B2)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B2.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B2",
+              "common_name": "blue",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 496.6,
+              "full_width_half_max": 98
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B3": {
+          "title": "Surface Reflectance (SRE_B3)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B3.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B3",
+              "common_name": "green",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 560,
+              "full_width_half_max": 45
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B4": {
+          "title": "Surface Reflectance (SRE_B4)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B4.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B4",
+              "common_name": "red",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 664.5,
+              "full_width_half_max": 38
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B5": {
+          "title": "Surface Reflectance (SRE_B5)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B5.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B5",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 703.9,
+              "full_width_half_max": 19
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B6": {
+          "title": "Surface Reflectance (SRE_B6)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B6.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B6",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 740.2,
+              "full_width_half_max": 18
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B7": {
+          "title": "Surface Reflectance (SRE_B7)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B7.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B7",
+              "common_name": "rededge",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 782.5,
+              "full_width_half_max": 28
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B8": {
+          "title": "Surface Reflectance (SRE_B8)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B8.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8",
+              "common_name": "nir",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 835.1,
+              "full_width_half_max": 148
+            }
+          ],
+          "proj:shape": [
+            10980,
+            10980
+          ],
+          "proj:transform": [
+            10.0,
+            0.0,
+            699960.0,
+            0.0,
+            -10.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 10
+        },
+        "SRE_B8A": {
+          "title": "Surface Reflectance (SRE_B8A)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B8A.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B8A",
+              "common_name": "nir08",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 864.8,
+              "full_width_half_max": 33
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B11": {
+          "title": "Surface Reflectance (SRE_B11)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B11.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B11",
+              "common_name": "swir16",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 1613.7,
+              "full_width_half_max": 143
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        },
+        "SRE_B12": {
+          "title": "Surface Reflectance (SRE_B12)",
+          "type": "image/tiff; application=geotiff",
+          "roles": [
+            "data",
+            "reflectance"
+          ],
+          "href": "https://download.geoservice.dlr.de/S2_L2A_MAJA/files/31/U/GT/2022/07/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_V1-3.zip#SENTINEL2A_20220713-103652-668_L2A_T31UGT_C/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C_SRE_B12.tif",
+          "eo:bands": [
+            {
+              "name": "SRE_B12",
+              "common_name": "swir22",
+              "description": "Image in ground reflectance without the correction of slope effects",
+              "center_wavelength": 2202.4,
+              "full_width_half_max": 242
+            }
+          ],
+          "proj:shape": [
+            5490,
+            5490
+          ],
+          "proj:transform": [
+            20.0,
+            0.0,
+            699960.0,
+            0.0,
+            -20.0,
+            5800020.0
+          ],
+          "proj:epsg": 32631,
+          "gsd": 20
+        }
+      },
+      "links": [
+        {
+          "title": "Root",
+          "rel": "root",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Parent",
+          "rel": "parent",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac?f=application/json",
+          "type": "application/json"
+        },
+        {
+          "title": "Self",
+          "rel": "self",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Item as HTML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items/SENTINEL2A_20220713-103652-668_L2A_T31UGT_C?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Items",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "Items as HTML",
+          "rel": "items",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/items?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collection",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collection as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "Collections",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=application%2Fjson",
+          "type": "application/json"
+        },
+        {
+          "title": "Collections as HTML",
+          "rel": "collection",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections?f=text%2Fhtml",
+          "type": "text/html"
+        },
+        {
+          "title": "OpenSearch GeoJSON",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103652-668_L2A_T31UGT_C&httpAccept=application%2Fgeo%2Bjson",
+          "type": "application/geo+json"
+        },
+        {
+          "title": "OpenSearch Atom XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/search?parentIdentifier=S2_L2A_MAJA&identifier=SENTINEL2A_20220713-103652-668_L2A_T31UGT_C&httpAccept=application%2Fatom%2Bxml",
+          "type": "application/atom+xml"
+        },
+        {
+          "title": "OpenSearch O&M XML",
+          "rel": "item",
+          "href": "https://geoservice.dlr.de/eoc/oseo/metadata?parentId=S2_L2A_MAJA&uid=SENTINEL2A_20220713-103652-668_L2A_T31UGT_C&httpAccept=application%2Fgml%2Bxml",
+          "type": "application/gml+xml"
+        },
+        {
+          "title": "Queryables",
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+          "href": "https://geoservice.dlr.de/eoc/ogc/stac/collections/S2_L2A_MAJA/queryables?f=json",
+          "type": "application/schema+json"
+        },
+        {
+          "rel": "license",
+          "href": "https://spdx.org/licenses/CC-BY-4.0",
+          "type": "text/html",
+          "title": "CC-BY-4.0"
+        }
+      ]
+    }
+  ],
+  "numberMatched": 20,
+  "numberReturned": 20,
+  "stac_version": "1.0.0",
+  "links": [
+    {
+      "comment": "Next link removed to avoid client going online"
+    },
+    {
+      "type": "application/geo+json",
+      "rel": "self",
+      "href": "http://geoservice.dlr.de/eoc/ogc/stac/search?collections=S2_L2A_MAJA&f=json"
+    }
+  ]
+}


### PR DESCRIPTION
See tickets:
* https://osgeo-org.atlassian.net/browse/GEOT-7190
* https://osgeo-org.atlassian.net/browse/GEOT-7191

I think the first one could be of general interest, also for an eventual GeoJSONDataStore improvement, if the GeoJSON were to be placed online, or as a pattern to reuse on OGC clients fetching lots of data.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->