### PR TITLE
[GEOT-7203] Split package introduces in gt-geojson-core

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorFactory.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorFactory.java
@@ -39,12 +39,12 @@ import org.opengis.feature.type.GeometryDescriptor;
  */
 public class SimpleFeaturePropertyAccessorFactory implements PropertyAccessorFactory {
 
-    /** Single instnace is fine - we are not stateful */
-    static PropertyAccessor ATTRIBUTE_ACCESS = new SimpleFeaturePropertyAccessor();
+    /** Single instance is fine - we are not stateful */
+    public static final PropertyAccessor ATTRIBUTE_ACCESS = new SimpleFeaturePropertyAccessor();
 
-    static PropertyAccessor DEFAULT_GEOMETRY_ACCESS =
+    public static final PropertyAccessor DEFAULT_GEOMETRY_ACCESS =
             new DefaultGeometrySimpleFeaturePropertyAccessor();
-    static PropertyAccessor FID_ACCESS = new FidSimpleFeaturePropertyAccessor();
+    public static final PropertyAccessor FID_ACCESS = new FidSimpleFeaturePropertyAccessor();
     static Pattern idPattern = Pattern.compile("@(\\w+:)?id");
 
     private static final String NAME_START_CHAR =

--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorFactory.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorFactory.java
@@ -14,7 +14,7 @@
  *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *    Lesser General Public License for more details.
  */
-package org.geotools.filter.expression;
+package org.geotools.filter.expression.geojson;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -24,6 +24,8 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.Map;
 import org.geotools.data.geojson.GeoJSONReader;
+import org.geotools.filter.expression.PropertyAccessor;
+import org.geotools.filter.expression.PropertyAccessorFactory;
 import org.geotools.util.factory.Hints;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;

--- a/modules/unsupported/geojson-core/src/main/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
+++ b/modules/unsupported/geojson-core/src/main/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
@@ -1,1 +1,1 @@
-org.geotools.filter.expression.JSONNodePropertyAccessorFactory
+org.geotools.filter.expression.geojson.JSONNodePropertyAccessorFactory

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorFactoryTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorFactoryTest.java
@@ -14,7 +14,7 @@
  *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *    Lesser General Public License for more details.
  */
-package org.geotools.filter.expression;
+package org.geotools.filter.expression.geojson;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorTest.java
@@ -14,7 +14,7 @@
  *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *    Lesser General Public License for more details.
  */
-package org.geotools.filter.expression;
+package org.geotools.filter.expression.geojson;
 
 import static org.junit.Assert.assertEquals;
 
@@ -25,6 +25,8 @@ import java.util.Date;
 import java.util.Scanner;
 import org.geotools.data.geojson.GeoJSONReader;
 import org.geotools.data.geojson.GeoJSONReaderTest;
+import org.geotools.filter.expression.PropertyAccessor;
+import org.geotools.filter.expression.SimpleFeaturePropertyAccessorFactory;
 import org.geotools.test.TestData;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
[![GEOT-7203](https://badgen.net/badge/JIRA/GEOT-7203/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7203) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Refactor package
org.geotools.filter.expression -> org.geotools.filter.expression.geojson


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->