### PR TITLE
[GEOT-7208] Missing YSLD support for channel name expressions

### DIFF
--- a/modules/extension/ysld/src/main/java/org/geotools/ysld/encode/RasterSymbolizerEncoder.java
+++ b/modules/extension/ysld/src/main/java/org/geotools/ysld/encode/RasterSymbolizerEncoder.java
@@ -174,7 +174,7 @@ public class RasterSymbolizerEncoder extends SymbolizerEncoder<RasterSymbolizer>
         @Override
         protected void encode(SelectedChannelType channel) {
             push(band.key);
-            put("name", channel.getChannelName().evaluate(null, String.class));
+            put("name", channel.getChannelName());
             if (!emptyContrastEnhancement(channel.getContrastEnhancement())) {
                 inline(new ContrastEnhancementEncoder(channel.getContrastEnhancement()));
             }

--- a/modules/extension/ysld/src/main/java/org/geotools/ysld/parse/RasterParser.java
+++ b/modules/extension/ysld/src/main/java/org/geotools/ysld/parse/RasterParser.java
@@ -104,7 +104,7 @@ public class RasterParser extends SymbolizerParser<RasterSymbolizer> {
             if (map.get(band.key) instanceof Map) {
                 context.push(band.key, new SelectedChannelHandler(sel));
             } else {
-                sel.setChannelName(map.str(band.key));
+                sel.setChannelName(Util.expression(map.str(band.key), factory));
             }
         }
 
@@ -143,7 +143,7 @@ public class RasterParser extends SymbolizerParser<RasterSymbolizer> {
         @Override
         public void handle(YamlObject<?> obj, YamlParseContext context) {
             String name = obj.map().str("name");
-            sel.setChannelName(name);
+            sel.setChannelName(Util.expression(name, factory));
             context.push(
                     "contrast-enhancement",
                     new ContrastEnhancementHandler() {

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeCookbookTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeCookbookTest.java
@@ -2215,6 +2215,24 @@ public class YsldEncodeCookbookTest {
                                 lexEqualTo(""))));
     }
 
+    @Test
+    public void testRasterWithBandSelectionExpression() throws Exception {
+        YamlMap obj = encode("raster", "band-selection-expression.sld");
+        String name =
+                obj.seq("feature-styles")
+                        .map(0)
+                        .seq("rules")
+                        .map(0)
+                        .seq("symbolizers")
+                        .map(0)
+                        .map("raster")
+                        .map("channels")
+                        .map("gray")
+                        .str("name")
+                        .trim();
+        assertEquals("${env('B1','1')}", name);
+    }
+
     YamlMap encode(String dirname, String filename) throws Exception {
         SLDParser sldParser = new SLDParser(CommonFactoryFinder.getStyleFactory());
         sldParser.setInput(YsldTests.sld(dirname, filename));

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeTest.java
@@ -1418,6 +1418,36 @@ public class YsldEncodeTest {
                 yHasEntry("contrast-enhancement", yHasEntry("mode", equalTo("histogram"))));
     }
 
+    @Test
+    public void testBandSelectionExpression() throws Exception {
+        StyleFactory styleFactory = CommonFactoryFinder.getStyleFactory();
+        FilterFactory2 filterFactory = CommonFactoryFinder.getFilterFactory2();
+        Expression nameExpression =
+                filterFactory.function(
+                        "env", filterFactory.literal("B1"), filterFactory.literal("1"));
+        RasterSymbolizer r = styleFactory.createRasterSymbolizer();
+        ChannelSelection sel =
+                styleFactory.channelSelection(
+                        styleFactory.createSelectedChannelType(nameExpression, (Expression) null));
+        r.setChannelSelection(sel);
+
+        StringWriter out = new StringWriter();
+        Ysld.encode(sld(r), out);
+
+        YamlMap obj = new YamlMap(YamlUtil.getSafeYaml().load(out.toString()));
+        YamlMap channelMap =
+                obj.seq("feature-styles")
+                        .map(0)
+                        .seq("rules")
+                        .map(0)
+                        .seq("symbolizers")
+                        .map(0)
+                        .map("raster")
+                        .map("channels")
+                        .map("gray");
+        assertThat(channelMap, yHasEntry("name", equalTo("${env('B1','1')}")));
+    }
+
     StyledLayerDescriptor sld(Symbolizer sym) {
         return sld(fts(sym));
     }

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseCookbookTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseCookbookTest.java
@@ -29,6 +29,7 @@ import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
 import org.geotools.filter.Filters;
+import org.geotools.filter.function.EnvFunction;
 import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.styling.ColorMapEntry;
 import org.geotools.styling.ContrastEnhancement;
@@ -51,6 +52,7 @@ import org.geotools.styling.TextSymbolizer;
 import org.geotools.ysld.TestUtils;
 import org.geotools.ysld.YsldTests;
 import org.junit.Test;
+import org.opengis.filter.expression.Expression;
 import org.opengis.style.ContrastMethod;
 
 public class YsldParseCookbookTest {
@@ -1946,6 +1948,20 @@ public class YsldParseCookbookTest {
         e = raster.getColorMap().getColorMapEntry(1);
         assertEquals("#663333", Filters.asString(e.getColor()));
         assertEquals(256, Filters.asInt(e.getQuantity()));
+    }
+
+    @Test
+    public void testRasterWithBandSelectionExpression() throws Exception {
+        Style style = parse("raster", "band-selection-expression.sld");
+        RasterSymbolizer raster = SLD.rasterSymbolizer(style);
+        Expression name = raster.getChannelSelection().getGrayChannel().getChannelName();
+        assertEquals("1", name.evaluate(null, String.class).trim());
+        try {
+            EnvFunction.setLocalValue("B1", "2");
+            assertEquals("2", name.evaluate(null, String.class).trim());
+        } finally {
+            EnvFunction.clearLocalValues();
+        }
     }
 
     Style parse(String dir, String file) throws IOException {

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
@@ -59,6 +59,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import org.easymock.EasyMock;
+import org.geotools.filter.function.EnvFunction;
 import org.geotools.filter.function.RecodeFunction;
 import org.geotools.filter.function.string.ConcatenateFunction;
 import org.geotools.process.function.ProcessFunction;
@@ -1808,6 +1809,28 @@ public class YsldParseTest {
         assertThat(rgbChannels[2].getContrastEnhancement(), nullContrast());
         assertThat(rgbChannels[2].getChannelName().evaluate(null, String.class), equalTo("3"));
         assertThat(rgbChannels[2].getContrastEnhancement(), nullContrast());
+    }
+
+    @Test
+    public void testBandSelectionExpression() throws Exception {
+        String yaml =
+                "feature-styles:\n"
+                        + "- rules:\n"
+                        + "  - symbolizers:\n"
+                        + "    - raster:\n"
+                        + "        channels:\n"
+                        + "          gray:\n"
+                        + "            name: ${env('B1','1')}";
+        StyledLayerDescriptor sld = Ysld.parse(yaml);
+        RasterSymbolizer raster = SLD.rasterSymbolizer(SLD.defaultStyle(sld));
+        Expression name = raster.getChannelSelection().getGrayChannel().getChannelName();
+        assertEquals("1", name.evaluate(null, String.class));
+        try {
+            EnvFunction.setLocalValue("B1", "2");
+            assertEquals("2", name.evaluate(null, String.class));
+        } finally {
+            EnvFunction.clearLocalValues();
+        }
     }
 
     @Test

--- a/modules/extension/ysld/src/test/resources/org/geotools/ysld/sld/raster/band-selection-expression.sld
+++ b/modules/extension/ysld/src/test/resources/org/geotools/ysld/sld/raster/band-selection-expression.sld
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" 
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+    xmlns="http://www.opengis.net/sld" 
+    xmlns:ogc="http://www.opengis.net/ogc" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Band Selection Expression</Name>
+    <UserStyle>
+      <Title>Simple Raster With Band Selection Expression</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <RasterSymbolizer>
+            <ChannelSelection>
+              <GrayChannel>
+                <SourceChannelName>
+                  <ogc:Function name="env">
+                    <ogc:Literal>B1</ogc:Literal>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:Function>
+                </SourceChannelName>
+              </GrayChannel>
+            </ChannelSelection>
+          </RasterSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
[![GEOT-7208](https://badgen.net/badge/JIRA/GEOT-7208/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7208) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR allows YSLD styles to use raster channel name expressions, which was added for SLD styles a while ago.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->