### PR TITLE
[GEOT-7210] YSLD styles do not set the layer name

### DIFF
--- a/docs/user/extension/ysld.rst
+++ b/docs/user/extension/ysld.rst
@@ -218,6 +218,7 @@ Style definition:
 .. code-block:: yaml
 
     # style definition 
+    layer-name: <text>
     name: <text>
     title: <text>
     abstract: <text>

--- a/modules/extension/ysld/src/main/java/org/geotools/ysld/parse/RootParser.java
+++ b/modules/extension/ysld/src/main/java/org/geotools/ysld/parse/RootParser.java
@@ -64,7 +64,7 @@ public class RootParser extends YsldParseHandler {
             context.setDocHint(ZoomContext.HINT_ID, getZoomContext(root.map("grid")));
         }
 
-        layer.setName(root.str("name"));
+        layer.setName(root.str("layer-name"));
         style.setName(root.str("name"));
         if (root.has("title")) {
             style.getDescription().setTitle(root.str("title"));

--- a/modules/extension/ysld/src/main/java/org/geotools/ysld/parse/RootParser.java
+++ b/modules/extension/ysld/src/main/java/org/geotools/ysld/parse/RootParser.java
@@ -64,6 +64,7 @@ public class RootParser extends YsldParseHandler {
             context.setDocHint(ZoomContext.HINT_ID, getZoomContext(root.map("grid")));
         }
 
+        layer.setName(root.str("name"));
         style.setName(root.str("name"));
         if (root.has("title")) {
             style.getDescription().setTitle(root.str("title"));
@@ -71,7 +72,6 @@ public class RootParser extends YsldParseHandler {
         if (root.has("abstract")) {
             style.getDescription().setAbstract(root.str("abstract"));
         }
-        style.setName(root.str("name"));
 
         if (root.has("feature-styles")) {
             context.push("feature-styles", new FeatureStyleParser(style, factory));

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
@@ -67,6 +67,7 @@ import org.geotools.styling.ExternalGraphic;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.LabelPlacement;
 import org.geotools.styling.LineSymbolizer;
+import org.geotools.styling.NamedLayer;
 import org.geotools.styling.PointSymbolizer;
 import org.geotools.styling.PolygonSymbolizer;
 import org.geotools.styling.ResourceLocator;
@@ -108,6 +109,14 @@ import org.yaml.snakeyaml.constructor.ConstructorException;
 @SuppressWarnings("unchecked") // unchecked generics array creation due to Hamcrest
 public class YsldParseTest {
     Logger LOG = Logging.getLogger("org.geotools.ysld.Ysld");
+
+    @Test
+    public void testName() throws Exception {
+        StyledLayerDescriptor sld = Ysld.parse("name: Simple");
+        NamedLayer layer = (NamedLayer) sld.layers().get(0);
+        assertEquals("Simple", layer.getName());
+        assertEquals("Simple", layer.styles().get(0).getName());
+    }
 
     @Test
     public void testAnchor() throws Exception {

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
@@ -112,10 +112,10 @@ public class YsldParseTest {
 
     @Test
     public void testName() throws Exception {
-        StyledLayerDescriptor sld = Ysld.parse("name: Simple");
+        StyledLayerDescriptor sld = Ysld.parse("layer-name: MyLayer\nname: MyStyle");
         NamedLayer layer = (NamedLayer) sld.layers().get(0);
-        assertEquals("Simple", layer.getName());
-        assertEquals("Simple", layer.styles().get(0).getName());
+        assertEquals("MyLayer", layer.getName());
+        assertEquals("MyStyle", layer.styles().get(0).getName());
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7210](https://badgen.net/badge/JIRA/GEOT-7210/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7210) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR updates the YSLD parser to set the name of the NamedLayer so that YSLD styles can be used with GeoServer's WMS dynamic styling.  The style name was unnecessarily being set twice.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->