### PR TITLE
[GEOT-7207] Use parameters instead of hard-coded values for BBOX filters

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
@@ -22,8 +22,7 @@ import java.util.Map;
 import javax.measure.Unit;
 import javax.measure.UnitConverter;
 import javax.measure.quantity.Length;
-import org.geotools.data.hana.wkb.HanaWKBWriter;
-import org.geotools.data.hana.wkb.HanaWKBWriterException;
+import org.geotools.filter.ConstantExpression;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.function.FilterFunction_strConcat;
 import org.geotools.filter.function.FilterFunction_strEndsWith;
@@ -50,6 +49,7 @@ import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Function;
 import org.opengis.filter.expression.Literal;
@@ -205,8 +205,7 @@ public class HanaFilterToSQL extends PreparedFilterToSQL {
 
     @Override
     protected void visitLiteralGeometry(Literal expression) throws IOException {
-        Geometry geom = (Geometry) evaluateLiteral(expression, Geometry.class);
-        visitGeometry(geom);
+        ConstantExpression.constant(expression).accept(this, null);
     }
 
     private Object visitDistanceSpatialOperator(
@@ -282,11 +281,11 @@ public class HanaFilterToSQL extends PreparedFilterToSQL {
                 out.write(" AND ");
                 property.accept(this, extraData);
                 out.write(".ST_ZMin() <= ");
-                out.write(Double.toString(maxz));
+                ConstantExpression.constant(maxz).accept(this, Double.class);
                 out.write(" AND ");
                 property.accept(this, extraData);
                 out.write(".ST_ZMax() >= ");
-                out.write(Double.toString(minz));
+                ConstantExpression.constant(minz).accept(this, Double.class);
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -308,12 +307,12 @@ public class HanaFilterToSQL extends PreparedFilterToSQL {
         out.write('.');
         out.write(function);
         out.write("(");
-        Coordinate ll = new Coordinate(bbox.getMinX(), bbox.getMinY());
-        Coordinate ur = new Coordinate(bbox.getMaxX(), bbox.getMaxY());
         GeometryFactory factory = new GeometryFactory();
-        visitGeometry(factory.createPoint(ll));
+        Point ll = factory.createPoint(new Coordinate(bbox.getMinX(), bbox.getMinY()));
+        ConstantExpression.constant(ll).accept(this, Geometry.class);
         out.write(", ");
-        visitGeometry(factory.createPoint(ur));
+        Point ur = factory.createPoint(new Coordinate(bbox.getMaxX(), bbox.getMaxY()));
+        ConstantExpression.constant(ur).accept(this, Geometry.class);
         out.write(") = 1");
     }
 
@@ -399,45 +398,6 @@ public class HanaFilterToSQL extends PreparedFilterToSQL {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private void visitGeometry(Geometry geom) throws IOException {
-        if (geom == null) {
-            out.write("NULL");
-            return;
-        }
-
-        int dimension = HanaDimensionFinder.findDimension(geom);
-        byte[] wkb;
-        try {
-            wkb = HanaWKBWriter.write(geom, dimension);
-        } catch (HanaWKBWriterException e) {
-            throw new IOException(e);
-        }
-
-        out.write("ST_GeomFromWKB('");
-        out.write(encodeAsHex(wkb));
-        if ((currentSRID == null) && (currentGeometry != null)) {
-            out.write("', ");
-            out.write(HanaUtil.encodeIdentifier(currentGeometry.getLocalName()));
-            out.write(".ST_SRID())");
-        } else {
-            out.write("', " + currentSRID + ")");
-        }
-    }
-
-    private static final char[] HEXDIGITS = {
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
-    };
-
-    private char[] encodeAsHex(byte[] data) {
-        int l = data.length;
-        char[] ret = new char[2 * l];
-        for (int i = 0, j = 0; i < l; i++) {
-            ret[j++] = HEXDIGITS[(0xF0 & data[i]) >>> 4];
-            ret[j++] = HEXDIGITS[0x0F & data[i]];
-        }
-        return ret;
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaBBOXFilterOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaBBOXFilterOnlineTest.java
@@ -1,0 +1,66 @@
+package org.geotools.data.hana;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.geotools.geometry.jts.ReferencedEnvelope3D;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.spatial.BBOX;
+import org.opengis.filter.spatial.BBOX3D;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+public class HanaBBOXFilterOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new HanaTestSetupPSPooling();
+    }
+
+    @Test
+    public void testPrepare2DBBOXFilter() throws Exception {
+        HanaDialect dialect = new HanaDialect(dataStore);
+        HanaVersion version = new HanaVersion("2.00.60.0.0");
+        HanaFilterToSQL filterToSQL = new HanaFilterToSQL(dialect, true, version);
+
+        FilterFactory ff = dataStore.getFilterFactory();
+        BBOX filter = ff.bbox(aname("GEOM"), 1, 2, 3, 4, "EPSG:4326");
+        String s = filterToSQL.encodeToString(filter);
+        assertEquals(
+                "WHERE GEOM.ST_IntersectsRectPlanar(ST_GeomFromWKB(?, -1), ST_GeomFromWKB(?, -1)) = 1",
+                s);
+
+        GeometryFactory f = new GeometryFactory();
+        List<Object> literals = filterToSQL.getLiteralValues();
+        assertEquals(2, literals.size());
+        assertEquals(f.createPoint(new Coordinate(1, 2)), literals.get(0));
+        assertEquals(f.createPoint(new Coordinate(3, 4)), literals.get(1));
+    }
+
+    @Test
+    public void testPrepare3DBBOXFilter() throws Exception {
+        HanaDialect dialect = new HanaDialect(dataStore);
+        HanaVersion version = new HanaVersion("2.00.60.0.0");
+        HanaFilterToSQL filterToSQL = new HanaFilterToSQL(dialect, true, version);
+
+        FilterFactory ff = dataStore.getFilterFactory();
+        CoordinateReferenceSystem crs = decodeEPSG(4326);
+        BBOX3D filter = ff.bbox("GEOM", new ReferencedEnvelope3D(1, 2, 3, 4, 5, 6, crs));
+        String s = filterToSQL.encodeToString(filter);
+        assertEquals(
+                "WHERE GEOM.ST_IntersectsRectPlanar(ST_GeomFromWKB(?, -1), ST_GeomFromWKB(?, -1)) = 1 AND GEOM.ST_ZMin() <= ? AND GEOM.ST_ZMax() >= ?",
+                s);
+
+        GeometryFactory f = new GeometryFactory();
+        List<Object> literals = filterToSQL.getLiteralValues();
+        assertEquals(4, literals.size());
+        assertEquals(f.createPoint(new Coordinate(1, 3)), literals.get(0));
+        assertEquals(f.createPoint(new Coordinate(2, 4)), literals.get(1));
+        assertEquals(6.0, literals.get(2));
+        assertEquals(5.0, literals.get(3));
+    }
+}


### PR DESCRIPTION
[![GEOT-7207](https://badgen.net/badge/JIRA/GEOT-7207/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7207) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When adding a BBOX filter to a query, the HANA plugin will hard-code the
coordinates of the bounding box instead of using parameters (?) in the
generated query.

When executing the same query repeatedly with only a different bounding
box, the database cannot reuse a plan from the SQL plan cache due to the
changed hard-coded bounding box values, but has to generate a new plan.
This can be costly, especially if the query is complex.

Hence, when adding a BBOX filter, the filter should use parameters
instead of hard-coded values.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [X] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).