### PR TITLE
[GEOT-7186] SRID of geometries in columns w/o SRID constraint not detected properly

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
@@ -234,6 +234,7 @@ public class HanaDialect extends PreparedStatementSQLDialect {
             rs = ps.executeQuery();
             if (!rs.next()) return null;
             int srid = rs.getInt(1);
+            if (rs.wasNull()) return null;
             if (rs.next()) return null;
             return srid;
         } finally {

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaColumnWoSridConstraintOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaColumnWoSridConstraintOnlineTest.java
@@ -1,0 +1,72 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import java.sql.Connection;
+import org.geotools.data.store.ContentFeatureCollection;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.junit.Test;
+import org.opengis.filter.FilterFactory;
+import org.opengis.filter.spatial.BBOX;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaColumnWoSridConstraintOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new HanaColumnWoSridConstraintTestSetup();
+    }
+
+    private boolean supportsColumnsWoSridConstraint(HanaVersion version) {
+        return ((version.getVersion() > 2)
+                || ((version.getVersion() == 2) && (version.getRevision() >= 60)));
+    }
+
+    @Test
+    public void testFindSridOnColumn() throws Exception {
+        try (Connection conn = dataStore.getDataSource().getConnection()) {
+            HanaVersion version = new HanaVersion(conn.getMetaData().getDatabaseProductVersion());
+            assumeTrue(supportsColumnsWoSridConstraint(version));
+
+            HanaDialect dialect = (HanaDialect) this.dialect;
+            dialect.initializeConnection(conn);
+            Integer srid =
+                    dialect.getGeometrySRID(
+                            dataStore.getDatabaseSchema(), tname("tabwosc"), aname("geom"), conn);
+            assertEquals(Integer.valueOf(3857), srid);
+        }
+    }
+
+    @Test
+    public void testFilterOnColumn() throws Exception {
+        try (Connection conn = dataStore.getDataSource().getConnection()) {
+            HanaVersion version = new HanaVersion(conn.getMetaData().getDatabaseProductVersion());
+            assumeTrue(supportsColumnsWoSridConstraint(version));
+        }
+
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        BBOX bbox = ff.bbox(aname("geom"), 0, 0, 10, 10, "EPSG:3857");
+        ContentFeatureCollection features =
+                dataStore.getFeatureSource(tname("tabwosc")).getFeatures(bbox);
+        assertEquals(1, features.size());
+    }
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaColumnWoSridConstraintTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaColumnWoSridConstraintTestSetup.java
@@ -1,0 +1,49 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import java.sql.Connection;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaColumnWoSridConstraintTestSetup extends HanaTestSetupPSPooling {
+
+    private static final String TABLE = "tabwosc";
+
+    @Override
+    protected void setUpData() throws Exception {
+        try (Connection conn = getConnection()) {
+            HanaVersion version = new HanaVersion(conn.getMetaData().getDatabaseProductVersion());
+            if ((version.getVersion() < 2)
+                    || ((version.getVersion() == 2) && (version.getRevision() < 60))) {
+                // Columns without SRID constraint are supported only in HANA 2 revision 60 and
+                // later
+                return;
+            }
+
+            HanaTestUtil htu = new HanaTestUtil(conn, fixture);
+            htu.createTestSchema();
+
+            htu.dropTestTableCascade(TABLE);
+
+            String[][] cols = {{"id", "INT"}, {"geom", "ST_Geometry(NULL)"}};
+            htu.createTestTable(TABLE, cols);
+
+            htu.insertIntoTestTable(TABLE, 1, htu.geometry("POINT(3 4)", 3857));
+            htu.insertIntoTestTable(TABLE, 2, htu.geometry("POINT(-3 -4)", 3857));
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-7186](https://badgen.net/badge/JIRA/GEOT-7186/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7186) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

If a column does not have an SRID constraint, ``HanaDialect#getGeometrySRID()`` did not return the correct SRID, but 0 instead.

As the ST_GeometryColumns view does not specify the SRID, we select a geometry from the column now to detect the SRID.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->