### PR TITLE
[GEOT-7222] Image Mosaic excessive memory usage when mosaicking many little images (26.x backport)

### DIFF
--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicReaderTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageMosaicReaderTest.java
@@ -385,7 +385,6 @@ public class ImageMosaicReaderTest {
 
     /** Tests the {@link ImageMosaicReader} with default parameters for the various input params. */
     @Test
-    //	@Ignore
     public void overviews() throws Exception {
         final AbstractGridFormat format = TestUtils.getFormat(overviewURL);
         ParameterValueGroup readParams = format.getReadParameters();
@@ -427,8 +426,20 @@ public class ImageMosaicReaderTest {
         tileSize.setValue("128,128");
 
         // Test the output coverage
-        TestUtils.checkCoverage(
-                reader, new GeneralParameterValue[] {gg, useJai, tileSize}, "overviews test");
+        GridCoverage2D coverage =
+                TestUtils.checkCoverage(
+                        reader,
+                        new GeneralParameterValue[] {gg, useJai, tileSize},
+                        "overviews test");
+        RenderedImage image = coverage.getRenderedImage();
+        assertEquals(128, image.getTileWidth());
+        assertEquals(128, image.getTileHeight());
+        // source images are smaller than the tile size, make sure they have not been inflated
+        for (RenderedImage source : image.getSources()) {
+            assertEquals(70, source.getTileWidth());
+            assertEquals(94, source.getTileHeight());
+        }
+        coverage.dispose(true);
         reader.dispose();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
     <src.output>${basedir}/target</src.output>
     <imageio.ext.version>1.3.13</imageio.ext.version>
     <jts.version>1.18.2</jts.version>
-    <jaiext.version>1.1.23</jaiext.version>
+    <jaiext.version>1.1.24</jaiext.version>
     <netcdf.version>4.6.15</netcdf.version>
     <commons-beanutils.version>1.9.2</commons-beanutils.version>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>


### PR DESCRIPTION
[![GEOT-7222](https://badgen.net/badge/JIRA/GEOT-7222/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7222) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->