### PR TITLE
[GEOT-7225] Assertion in ShpFilesTestStream depends on environment

### DIFF
--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShpFilesStreamTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShpFilesStreamTest.java
@@ -44,7 +44,7 @@ import org.geotools.data.shapefile.files.StorageFile;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ShpFilesTestStream implements org.geotools.data.shapefile.files.FileWriter {
+public class ShpFilesStreamTest implements org.geotools.data.shapefile.files.FileWriter {
 
     private String typeName;
     private Map<ShpFileType, File> map;
@@ -182,12 +182,9 @@ public class ShpFilesTestStream implements org.geotools.data.shapefile.files.Fil
     }
 
     @Test
-    @SuppressWarnings("PMD.UnusedVariable") // really want to just open and close
     public void testGetReadChannelURL() throws IOException {
         URL url = TestData.url("shapes/statepop.shp");
         ShpFiles files = new ShpFiles(url);
-
-        assertFalse(files.isLocal());
 
         try (ReadableByteChannel read = files.getReadChannel(SHP, this)) {
             assertEquals(1, files.numberOfLocks());


### PR DESCRIPTION
[![GEOT-7225](https://badgen.net/badge/JIRA/GEOT-7225/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7225) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The fails on JDK 11, because of the assertion that isLocal will return false. For JDK 8 and earlier that was true, because the url would be jar:file... That has changed and the url will now be file:/.......jar!shapes/statepop.shp.

I don't see the need for that check, so I'm removing it.

I'm also renaming the file, so that the suffix of the class will be Test.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->