### PR TITLE
[GEOT-7229] WMTSCapabilities throws NPE for misconfigured capabilities

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
@@ -19,11 +19,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.opengis.ows11.AllowedValuesType;
@@ -54,13 +51,13 @@ import org.geotools.data.ows.OperationType;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.ows.ServiceException;
 import org.geotools.ows.wms.CRSEnvelope;
-import org.geotools.ows.wms.Layer;
 import org.geotools.ows.wms.StyleImpl;
 import org.geotools.ows.wms.xml.Dimension;
 import org.geotools.ows.wms.xml.Extent;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.util.SimpleInternationalString;
+import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opengis.referencing.FactoryException;
@@ -78,8 +75,7 @@ import org.opengis.referencing.operation.TransformException;
  */
 public class WMTSCapabilities extends Capabilities {
 
-    public static final Logger LOGGER =
-            org.geotools.util.logging.Logging.getLogger(WMTSCapabilities.class);
+    public static final Logger LOGGER = Logging.getLogger(WMTSCapabilities.class);
 
     private WMTSRequest request;
 
@@ -87,15 +83,12 @@ public class WMTSCapabilities extends Capabilities {
 
     CapabilitiesType caps;
 
-    private Map<String, WMTSLayer> layerMap = new HashMap<>();
-
-    private List<WMTSLayer> layers = new ArrayList<>(); // cache
+    private final Map<String, WMTSLayer> layerMap = new HashMap<>();
+    private final List<WMTSLayer> layers = new ArrayList<>();
+    private final Map<String, TileMatrixSet> matrixSetMap = new HashMap<>();
+    private final List<TileMatrixSet> matrixes = new ArrayList<>();
 
     private String[] exceptions = new String[0];
-
-    private List<TileMatrixSet> matrixes = new ArrayList<>();
-
-    private Map<String, TileMatrixSet> matrixSetMap = new HashMap<>();
 
     private WMTSServiceType type;
 
@@ -113,7 +106,6 @@ public class WMTSCapabilities extends Capabilities {
                 WMTSLayer layer = parseLayer(layerType);
                 layers.add(layer);
                 layerMap.put(layer.getName(), layer);
-
             } else {
                 if (LOGGER.isLoggable(Level.INFO)) {
                     LOGGER.info("Unknown object " + l);
@@ -128,22 +120,9 @@ public class WMTSCapabilities extends Capabilities {
             matrixSetMap.put(matrixSet.getIdentifier(), matrixSet);
         }
 
-        // set layer SRS - this comes from the tile matrix link
-        Set<String> srs = new TreeSet<>();
-        Set<CoordinateReferenceSystem> crs = new HashSet<>();
-        Map<String, CoordinateReferenceSystem> names = new HashMap<>();
-        for (TileMatrixSet tms : matrixes) {
-            CoordinateReferenceSystem refSystem = tms.getCoordinateReferenceSystem();
-            crs.add(refSystem);
-            names.put(tms.getIdentifier(), refSystem);
-
-            srs.add(tms.getCrs());
-        }
-
         // Fill in some layers info from the linked MatrixSets
-        for (Layer l : layers) {
-            WMTSLayer wmtsLayer = (WMTSLayer) l;
-            fillTileMatrixSet(wmtsLayer, names);
+        for (WMTSLayer wmtsLayer : layers) {
+            fillTileMatrixSet(wmtsLayer);
         }
 
         request = new WMTSRequest();
@@ -234,19 +213,30 @@ public class WMTSCapabilities extends Capabilities {
         }
     }
 
-    private void fillTileMatrixSet(
-            WMTSLayer wmtsLayer, Map<String, CoordinateReferenceSystem> crsLookup) {
-        Map<String, TileMatrixSetLink> tileMatrixLinks = wmtsLayer.getTileMatrixLinks();
-        if (wmtsLayer.getLatLonBoundingBox() == null) setLatLonBBox(wmtsLayer);
-
+    private void fillTileMatrixSet(WMTSLayer wmtsLayer) {
+        // set WGS84 LatLonBBox if not present
+        if (wmtsLayer.getLatLonBoundingBox() == null) {
+            setLatLonBBox(wmtsLayer);
+        }
         ReferencedEnvelope wgs84Env = new ReferencedEnvelope(wmtsLayer.getLatLonBoundingBox());
 
+        Map<String, TileMatrixSetLink> tileMatrixLinks = wmtsLayer.getTileMatrixLinks();
         // add a bbox for every CRS
         for (TileMatrixSetLink tmsLink : tileMatrixLinks.values()) {
-            CoordinateReferenceSystem tmsCRS = crsLookup.get(tmsLink.getIdentifier());
+            String tmsIdentifier = tmsLink.getIdentifier();
+            TileMatrixSet tms = matrixSetMap.get(tmsIdentifier);
+            if (tms == null) {
+                LOGGER.info(
+                        String.format(
+                                "WMTS capabilities for layer %s specified a TileMatrixSet link %s that doesn't exist.",
+                                wmtsLayer.getName(), tmsIdentifier));
+                tileMatrixLinks.remove(tmsIdentifier);
+                continue;
+            }
+            CoordinateReferenceSystem tmsCRS = tms.getCoordinateReferenceSystem();
             wmtsLayer.addSRS(tmsCRS);
             String srs = CRS.toSRS(tmsCRS);
-            TileMatrixSet tms = matrixSetMap.get(tmsLink.getIdentifier());
+
             if (tms.getBbox() != null) {
                 wmtsLayer.getBoundingBoxes().put(srs, tms.getBbox());
             } else {
@@ -507,14 +497,19 @@ public class WMTSCapabilities extends Capabilities {
         this.exceptions = exceptions;
     }
 
-    /** @return the matrixes */
+    /** @return An unmodifiable list of MatrixSets */
     public List<TileMatrixSet> getMatrixSets() {
-        return matrixes;
+        return Collections.unmodifiableList(matrixes);
     }
 
-    /** @param matrixes the matrixes to set */
+    /** Clears all matrixSet's and populates with the list */
     public void setMatrixSets(List<TileMatrixSet> matrixes) {
-        this.matrixes = matrixes;
+        matrixSetMap.clear();
+        this.matrixes.clear();
+        for (TileMatrixSet tms : matrixes) {
+            matrixSetMap.put(tms.getIdentifier(), tms);
+            this.matrixes.add(tms);
+        }
     }
 
     public TileMatrixSet getMatrixSet(String identifier) {

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
@@ -20,6 +20,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.Properties;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.data.ows.OperationType;
 import org.geotools.ows.wms.CRSEnvelope;
@@ -103,13 +104,26 @@ public class WMTSCapabilitiesTest {
             CRSEnvelope bbox = layers.get(1).getBoundingBoxes().get("EPSG:4326");
             Assert.assertNotNull(bbox);
         } catch (Exception e) {
-            java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
+            Logger.getGlobal().log(Level.INFO, "", e);
             if ((e.getMessage() != null) && e.getMessage().indexOf("timed out") > 0) {
                 LOGGER.warning("Unable to test - timed out: " + e);
             } else {
                 throw (e);
             }
         }
+    }
+
+    /**
+     * A Layer might have a MatrixSetLink with an identifier that isn't within the MatrixSet's. Such
+     * a link should be removed.
+     */
+    @Test
+    public void testMissingMatrixSetLink() throws Exception {
+        WMTSCapabilities capabilities = createCapabilities("nasa.getcapa.xml");
+        WMTSLayer layer = capabilities.getLayer("Blue_Marble_Extended");
+        TileMatrixSetLink link = layer.getTileMatrixLinks().get("1.5km");
+        Assert.assertTrue(
+                "1.5km isn't defined as a MatrixSet and should be omitted.", link == null);
     }
 
     @Test
@@ -165,7 +179,7 @@ public class WMTSCapabilitiesTest {
                     0d);
 
         } catch (Exception e) {
-            java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
+            Logger.getGlobal().log(Level.INFO, "", e);
             if ((e.getMessage() != null) && e.getMessage().indexOf("timed out") > 0) {
                 LOGGER.warning("Unable to test - timed out: " + e);
             } else {
@@ -195,7 +209,7 @@ public class WMTSCapabilitiesTest {
             OperationType getTile = request.getGetTile();
             Assert.assertNotNull(getTile);
 
-            Assert.assertEquals(519, capabilities.getLayerList().size());
+            Assert.assertEquals(520, capabilities.getLayerList().size());
 
             List<WMTSLayer> layers = capabilities.getLayerList();
             WMTSLayer l0 = layers.get(0);
@@ -217,7 +231,7 @@ public class WMTSCapabilitiesTest {
             Assert.assertNotNull(bbox);
 
         } catch (Exception e) {
-            java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
+            Logger.getGlobal().log(Level.INFO, "", e);
             if ((e.getMessage() != null) && e.getMessage().indexOf("timed out") > 0) {
                 LOGGER.warning("Unable to test - timed out: " + e);
             } else {

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
@@ -122,8 +122,8 @@ public class WMTSCapabilitiesTest {
         WMTSCapabilities capabilities = createCapabilities("nasa.getcapa.xml");
         WMTSLayer layer = capabilities.getLayer("Blue_Marble_Extended");
         TileMatrixSetLink link = layer.getTileMatrixLinks().get("1.5km");
-        Assert.assertTrue(
-                "1.5km isn't defined as a MatrixSet and should be omitted.", link == null);
+        Assert.assertNull(
+                "1.5km isn't defined as a MatrixSet and should be omitted.", link);
     }
 
     @Test

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
@@ -122,8 +122,7 @@ public class WMTSCapabilitiesTest {
         WMTSCapabilities capabilities = createCapabilities("nasa.getcapa.xml");
         WMTSLayer layer = capabilities.getLayer("Blue_Marble_Extended");
         TileMatrixSetLink link = layer.getTileMatrixLinks().get("1.5km");
-        Assert.assertNull(
-                "1.5km isn't defined as a MatrixSet and should be omitted.", link);
+        Assert.assertNull("1.5km isn't defined as a MatrixSet and should be omitted.", link);
     }
 
     @Test

--- a/modules/extension/wmts/src/test/resources/test-data/nasa.getcapa.xml
+++ b/modules/extension/wmts/src/test/resources/test-data/nasa.getcapa.xml
@@ -111,6 +111,27 @@
          <ResourceURL format="image/png" resourceType="tile" template="https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/AMSR2_Snow_Water_Equivalent/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
       </Layer>
       <Layer>
+         <ows:Title xml:lang="en">Blue Marble (Extended Extent)</ows:Title>
+         <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+            <ows:LowerCorner>-135 19.735368</ows:LowerCorner>
+            <ows:UpperCorner>45 19.735368</ows:UpperCorner>
+         </ows:WGS84BoundingBox>
+         <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::3031">
+            <ows:LowerCorner>-12400000 -12400000</ows:LowerCorner>
+            <ows:UpperCorner>12400000 12400000</ows:UpperCorner>
+         </ows:BoundingBox>
+         <ows:Identifier>Blue_Marble_Extended</ows:Identifier>
+         <Style isDefault="true">
+            <ows:Title xml:lang="en">default</ows:Title>
+            <ows:Identifier>default</ows:Identifier>
+         </Style>
+         <Format>image/jpeg</Format>
+         <TileMatrixSetLink>
+            <TileMatrixSet>1.5km</TileMatrixSet>
+         </TileMatrixSetLink>
+         <ResourceURL format="image/jpeg" resourceType="tile" template="https://gibs.earthdata.nasa.gov/wmts/epsg3031/best/Blue_Marble_Extended/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpeg"/>
+      </Layer>
+      <Layer>
          <ows:Title xml:lang="en">Soil Moisture (Normalized Polarization Difference, Day, AMSR2, GCOM-W1)</ows:Title>
          <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
             <ows:LowerCorner>-180 -90</ows:LowerCorner>


### PR DESCRIPTION
[![GEOT-7229](https://badgen.net/badge/JIRA/GEOT-7229/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7229) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The constructor of WMTSCapabilities will throw an exception if a Layer has a MatrixTileSetLink that points to a MatrixTileSet that isn’t specified among the MatrixTileSet’s of the same document.

I've copied the Layer-element into nasa.getcapa.xml. Therefore I had to change one of the expectations in a different test. 

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->