### PR TITLE
GEOT-7231: Z values shapefiles don't handle NaN M values correctly

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/coordinatesequence/CoordinateSequences.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/coordinatesequence/CoordinateSequences.java
@@ -173,7 +173,7 @@ public class CoordinateSequences extends org.locationtech.jts.geom.CoordinateSeq
         if (seq == null) return 3;
 
         int dim = seq.getDimension();
-        if (dim != 3) return dim;
+        if (dim < 3) return dim;
 
         // hack to handle issue that CoordinateArraySequence always reports
         // dimension = 3
@@ -182,6 +182,13 @@ public class CoordinateSequences extends org.locationtech.jts.geom.CoordinateSeq
             if (seq.size() > 0) {
                 if (Double.isNaN(seq.getOrdinate(0, CoordinateSequence.Y))) return 1;
                 if (Double.isNaN(seq.getOrdinate(0, CoordinateSequence.Z))) return 2;
+                if (dim == 4) {
+                    if (Double.isNaN(seq.getM(0))) {
+                        return 3;
+                    } else {
+                        return 4;
+                    }
+                }
             }
         }
         return 3;
@@ -205,7 +212,8 @@ public class CoordinateSequences extends org.locationtech.jts.geom.CoordinateSeq
             return true;
         }
 
-        // ok, 2d equal, it means they have the same list of geometries and coordinate sequences, in
+        // ok, 2d equal, it means they have the same list of geometries and
+        // coordinate sequences, in
         // the same order
         List<CoordinateSequence> sequences1 = CoordinateSequenceCollector.find(g1);
         List<CoordinateSequence> sequences2 = CoordinateSequenceCollector.find(g2);

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/MultiLineHandler.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/MultiLineHandler.java
@@ -197,7 +197,9 @@ public class MultiLineHandler implements ShapeHandler {
         if (shapeType == ShapeType.ARCZ && !flatGeometry) {
             // z min, max
             // buffer.position(buffer.position() + 2 * 8);
-            ((Buffer) doubleBuffer).position(doubleBuffer.position() + 2);
+            // ((Buffer) doubleBuffer).position(doubleBuffer.position() + 2);
+            double[] minmax = new double[2];
+            doubleBuffer.get(minmax);
             for (int part = 0; part < numParts; part++) {
                 start = partOffsets[part];
 
@@ -227,7 +229,9 @@ public class MultiLineHandler implements ShapeHandler {
         if ((isArcZWithM || shapeType == ShapeType.ARCM) && !flatGeometry) {
             // M min, max
             // buffer.position(buffer.position() + 2 * 8);
-            ((Buffer) doubleBuffer).position(doubleBuffer.position() + 2);
+            // ((Buffer) doubleBuffer).position(doubleBuffer.position() + 2);
+            double[] minmax = new double[2];
+            doubleBuffer.get(minmax);
 
             for (int part = 0; part < numParts; part++) {
                 start = partOffsets[part];
@@ -249,6 +253,11 @@ public class MultiLineHandler implements ShapeHandler {
                 double[] m = new double[length];
                 doubleBuffer.get(m);
                 for (int i = 0; i < length; i++) {
+                    // Page 2 of the spec says that values less than -10E38 are
+                    // NaNs
+                    if (m[i] < -10e38) {
+                        m[i] = Double.NaN;
+                    }
                     lines[part].setOrdinate(i, CoordinateSequence.M, m[i]);
                 }
             }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/MultiPointHandler.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/MultiPointHandler.java
@@ -151,6 +151,11 @@ public class MultiPointHandler implements ShapeHandler {
 
             dbuffer.get(ordinates, 0, numpoints);
             for (int t = 0; t < numpoints; t++) {
+                // Page 2 of the spec says that values less than 10E-38 are
+                // NaNs
+                if (ordinates[t] < -10e38) {
+                    ordinates[t] = Double.NaN;
+                }
                 cs.setOrdinate(t, CoordinateSequence.M, ordinates[t]); // m
             }
         }

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/PointHandler.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/PointHandler.java
@@ -95,7 +95,13 @@ public class PointHandler implements ShapeHandler {
         c.setY(buffer.getDouble());
 
         if (shapeType == ShapeType.POINTM && !flatGeometry) {
-            c.setM(buffer.getDouble());
+            double m = buffer.getDouble();
+            // Page 2 of the spec says that values less than 10E-38 are
+            // NaNs
+            if (m < -10e38) {
+                m = Double.NaN;
+            }
+            c.setM(m);
         }
 
         if (shapeType == ShapeType.POINTZ && !flatGeometry) {

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/PolygonHandler.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/PolygonHandler.java
@@ -207,10 +207,11 @@ public class PolygonHandler implements ShapeHandler {
                             coords.getOrdinate(offset, CoordinateSequence.Z));
                 }
                 if (coords.hasM() && !flatFeature) {
-                    csRing.setOrdinate(
-                            i,
-                            CoordinateSequence.M,
-                            coords.getOrdinate(offset, CoordinateSequence.M));
+                    double m = coords.getOrdinate(offset, CoordinateSequence.M);
+                    if (m < -10e38) {
+                        m = Double.NaN;
+                    }
+                    csRing.setOrdinate(i, CoordinateSequence.M, m);
                 }
                 offset++;
             }

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/shp/ZMHandlersTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/shp/ZMHandlersTest.java
@@ -18,6 +18,7 @@ package org.geotools.data.shapefile.shp;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -86,6 +87,28 @@ public class ZMHandlersTest {
                 SimpleFeature f = reader.next();
                 assertNotNull(f.getDefaultGeometry());
             }
+        }
+        store.dispose();
+    }
+
+    @Test
+    public void testReadTazRoads() throws IOException {
+        // tests that tasmainia roads (a LineStringZ) file reads correctly
+        URL url = TestData.url(ShapefileDataStore.class, "taz_shapes/tasmania_roads.shp");
+        ShapefileDataStore store = new ShapefileDataStore(url);
+        Query q = new Query(store.getTypeNames()[0]);
+
+        try (FeatureReader<SimpleFeatureType, SimpleFeature> reader =
+                store.getFeatureReader(q, Transaction.AUTO_COMMIT)) {
+            reader.hasNext();
+            SimpleFeature f = reader.next();
+            Geometry geom = (Geometry) f.getDefaultGeometry();
+            assertNotNull(geom);
+            Coordinate coord = geom.getCoordinates()[0];
+            assertEquals("wrong x", coord.getX(), 146.468582, 0.00001);
+            assertEquals("wrong y", coord.getY(), -41.241478, 0.00001);
+            assertEquals("wrong z", coord.getZ(), -41.241478, 0.00001);
+            assertTrue("Bad M value " + coord.getM(), Double.isNaN(coord.getM()));
         }
         store.dispose();
     }
@@ -175,6 +198,7 @@ public class ZMHandlersTest {
         assertEquals("wrong x", 340d, coordinate.getX(), 0.001);
         assertEquals("wrong y", 377d, coordinate.getY(), 0.001);
         assertEquals("wrong z", 3d, coordinate.getZ(), 0.00001);
+
         store.dispose();
     }
 
@@ -230,15 +254,6 @@ public class ZMHandlersTest {
             assertEquals("wrong z", expected[k + 2], coordinate.getZ(), 0.00001);
         }
 
-        //        Query query = new Query();
-        //        query.getHints().put(Hints.FEATURE_2D, Boolean.TRUE);
-        //        try (SimpleFeatureIterator itr =
-        // store.getFeatureSource().getFeatures(query).features()) {
-        //            while (itr.hasNext()) {
-        //                SimpleFeature f = itr.next();
-        //                System.out.println(f.getDefaultGeometryProperty());
-        //            }
-        //        }
         store.dispose();
     }
 
@@ -466,7 +481,8 @@ public class ZMHandlersTest {
 
     @Test
     public void testReadZPointsFalse2D() throws IOException {
-        // tests that Point with Z and without optional M and with Feature2D false are correctly
+        // tests that Point with Z and without optional M and with Feature2D false
+        // are correctly
         // parsed
         URL url = TestData.url(ShapefileDataStore.class, "mzvalues/pointZ.shp");
         ShapefileDataStore store = new ShapefileDataStore(url);


### PR DESCRIPTION
[![GEOT-7231](https://badgen.net/badge/JIRA/GEOT-7231/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7231) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  Page 2 of the [Shapefile spec](https://support.esri.com/en/white-paper/279) says:

>  Floating point numbers must be numeric values. Positive infinity, negative infinity, and Not-a-Number (NaN) values are not allowed in shapefiles. Nevertheless, shapefiles support the concept of "no data" values, but they are currently used only for measures.  Any floating point number smaller than –10^38 is considered by a shapefile reader to represent a "no data" value.

Combined with the note on page 14:

> Shapes of this type have an additional coordinateM. Note that "no data" value can be specified as a value for M (see Numeric Types on page 2).

Means that we need to check `M` values before adding them to the `CoordinateSequence` and take account of `NaN` in the `M` coordinate when checking for dimensions.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->