### PR TITLE
[GEOT-7235] Deprecate org.geotools.util.Java6

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/metadata/math/XMath.java
+++ b/modules/library/metadata/src/main/java/org/geotools/metadata/math/XMath.java
@@ -19,6 +19,7 @@ package org.geotools.metadata.math;
 import static org.geotools.util.XMath.next;
 import static org.geotools.util.XMath.previous;
 
+import java.util.Arrays;
 import org.geotools.util.XArray;
 
 /**
@@ -386,7 +387,7 @@ public final class XMath {
             for (int j = i; j < count; j++) {
                 d2 = d1 * divisors[j];
                 if (number % d2 == 0) {
-                    int p = org.geotools.util.Java6.binarySearch(divisors, j, count, d2);
+                    int p = Arrays.binarySearch(divisors, j, count, d2);
                     if (p < 0) {
                         p = ~p; // ~ operator, not minus
                         if (count == divisors.length) {

--- a/modules/library/metadata/src/main/java/org/geotools/util/Arguments.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/Arguments.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.util;
 
+import java.io.Console;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -351,9 +352,9 @@ public class Arguments {
      */
     public static Reader getReader(final InputStream in) {
         if (in == System.in) {
-            final Reader candidate = Java6.consoleReader();
+            final Console candidate = System.console();
             if (candidate != null) {
-                return candidate;
+                return candidate.reader();
             }
         }
         return new InputStreamReader(in);
@@ -367,9 +368,9 @@ public class Arguments {
      */
     public static Writer getWriter(final OutputStream out) {
         if (out == System.out || out == System.err) {
-            final PrintWriter candidate = Java6.consoleWriter();
+            final Console candidate = System.console();
             if (candidate != null) {
-                return candidate;
+                return candidate.writer();
             }
         }
         return new OutputStreamWriter(out);
@@ -383,9 +384,9 @@ public class Arguments {
      */
     public static PrintWriter getPrintWriter(final PrintStream out) {
         if (out == System.out || out == System.err) {
-            final PrintWriter candidate = Java6.consoleWriter();
+            final Console candidate = System.console();
             if (candidate != null) {
-                return candidate;
+                return candidate.writer();
             }
         }
         return new PrintWriter(out, true);

--- a/modules/library/metadata/src/main/java/org/geotools/util/Java6.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/Java6.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
  * @version $Id$
  * @author Martin Desruisseaux
  */
+@Deprecated
 public final class Java6 {
     private Java6() {}
 

--- a/modules/library/metadata/src/main/java/org/geotools/util/package.html
+++ b/modules/library/metadata/src/main/java/org/geotools/util/package.html
@@ -2,7 +2,7 @@
 
 <HTML>
   <HEAD>
-    <TITLE>package org.geotools.resources</TITLE>
+    <TITLE>package org.geotools.util</TITLE>
   </HEAD>
   <BODY>
     A set of helper classes for Geotools implementation;


### PR DESCRIPTION
[![GEOT-7235](https://badgen.net/badge/JIRA/GEOT-7235/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7235) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Just added a Deprecated. Even though the Javadocs states that changes to the API might happen.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->