### PR TITLE
Revert "Bump aws-java-sdk-s3 from 1.11.36 to 1.12.261 in /modules/unsupported/s3-geotiff"

### DIFF
--- a/modules/unsupported/s3-geotiff/pom.xml
+++ b/modules/unsupported/s3-geotiff/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.12.261</version>
+      <version>1.11.36</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>


### PR DESCRIPTION
Reverts geotools/geotools#3966

because the original PR did not comply with the QA: https://github.com/geotools/geotools/actions/runs/2679353957/jobs/4176462298

/cc @ianturton @aaime