### PR TITLE
[GEOT-7240] Remove deprecated constructor from WFSFeatureReader

### DIFF
--- a/docs/user/welcome/upgrade.rst
+++ b/docs/user/welcome/upgrade.rst
@@ -29,6 +29,15 @@ The first step to upgrade: change the ``geotools.version`` of your dependencies 
         ....
     </dependencies>
 
+GeoTools 29.x
+-------------
+
+Deprecated functions removed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In gt-wfs-ng we've removed:
+``org.geotools.data.wfs.WFSFeatureReader.WFSFeatureReader(GetParser<SimpleFeature>)``
+
 GeoTools 27.x
 -------------
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureReader.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureReader.java
@@ -40,12 +40,6 @@ class WFSFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeature
 
     private GetFeatureResponse response;
 
-    /** @Deprecated (pass on response so it can be disposed.) */
-    @Deprecated
-    public WFSFeatureReader(final GetParser<SimpleFeature> parser) throws IOException {
-        this(parser, null);
-    }
-
     public WFSFeatureReader(
             final GetParser<SimpleFeature> parser, final GetFeatureResponse response)
             throws IOException {


### PR DESCRIPTION
[![GEOT-7240](https://badgen.net/badge/JIRA/GEOT-7240/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7240) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removing a deprecated function.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->