### PR TITLE
[GEOT-7242] Simplification fails for geographic shapes in HANA

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
@@ -433,12 +433,25 @@ public class HanaDialect extends PreparedStatementSQLDialect {
     public void encodeGeometryColumnSimplified(
             GeometryDescriptor gatt, String prefix, int srid, StringBuffer sql, Double distance) {
         encodeColumnName(prefix, gatt.getLocalName(), sql);
-        if ((distance != null) && (distance > 0.0)) {
+        if ((distance != null)
+                && (distance >= 0.0)
+                && isPlanarCRS(gatt.getCoordinateReferenceSystem())) {
             sql.append(".ST_Simplify(");
             sql.append(distance.toString());
             sql.append(")");
         }
         sql.append(".ST_AsBinary()");
+    }
+
+    private boolean isPlanarCRS(CoordinateReferenceSystem crs) {
+        if (crs == null) {
+            return false;
+        }
+        CoordinateReferenceSystem hcrs = CRS.getHorizontalCRS(crs);
+        if (hcrs == null) {
+            return false;
+        }
+        return !(hcrs instanceof GeographicCRS);
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSimplificationOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSimplificationOnlineTest.java
@@ -1,0 +1,80 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
+
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.geotools.util.factory.Hints;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaSimplificationOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new HanaSimplificationTestSetup(new HanaTestSetupPSPooling());
+    }
+
+    @Test
+    public void testRoundEarthSimplification() throws Exception {
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("roundEarth"));
+
+        assumeTrue(fs.getSupportedHints().contains(Hints.GEOMETRY_SIMPLIFICATION));
+
+        Query query = new Query();
+        Hints hints = new Hints(Hints.GEOMETRY_SIMPLIFICATION, 0.5);
+        query.setHints(hints);
+
+        SimpleFeatureCollection coll = fs.getFeatures(query);
+        Geometry geom = null;
+        try (SimpleFeatureIterator iter = coll.features()) {
+            if (iter.hasNext()) {
+                geom = (Geometry) iter.next().getDefaultGeometry();
+            }
+        }
+        assertNotNull(geom);
+    }
+
+    @Test
+    public void testPlanarSimplification() throws Exception {
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("planar"));
+
+        assumeTrue(fs.getSupportedHints().contains(Hints.GEOMETRY_SIMPLIFICATION));
+
+        Query query = new Query();
+        Hints hints = new Hints(Hints.GEOMETRY_SIMPLIFICATION, 0.5);
+        query.setHints(hints);
+
+        SimpleFeatureCollection coll = fs.getFeatures(query);
+        Geometry geom = null;
+        try (SimpleFeatureIterator iter = coll.features()) {
+            if (iter.hasNext()) {
+                geom = (Geometry) iter.next().getDefaultGeometry();
+            }
+        }
+        assertEquals(2, geom.getNumPoints());
+    }
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSimplificationTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSimplificationTestSetup.java
@@ -1,0 +1,105 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.geotools.jdbc.JDBCDelegatingTestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaSimplificationTestSetup extends JDBCDelegatingTestSetup {
+
+    private static final String TABLE_ROUND_EARTH = "roundEarth";
+
+    private static final String TABLE_PLANAR = "planar";
+
+    public HanaSimplificationTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void setUpData() throws Exception {
+        try {
+            dropRoundEarthTable();
+        } catch (SQLException e) {
+        }
+
+        try {
+            dropPlanarTable();
+        } catch (SQLException e) {
+        }
+
+        createRoundEarthTable();
+        createPlanarTable();
+    }
+
+    private void createRoundEarthTable() throws SQLException, IOException {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn, fixture);
+            htu.createTestSchema();
+
+            String[][] cols = {
+                {"fid", "INT PRIMARY KEY"},
+                {"id", "INT"},
+                {"geom", "ST_Geometry(4326)"}
+            };
+            htu.createRegisteredTestTable(TABLE_ROUND_EARTH, cols);
+
+            htu.insertIntoTestTable(
+                    TABLE_ROUND_EARTH,
+                    htu.nextTestSequenceValueForColumn(TABLE_ROUND_EARTH, "fid"),
+                    0,
+                    htu.geometry("LINESTRING(0 0, 1 0, 2 0, 3 0)", 4326));
+        }
+    }
+
+    private void createPlanarTable() throws SQLException, IOException {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn, fixture);
+            htu.createTestSchema();
+
+            String[][] cols = {
+                {"fid", "INT PRIMARY KEY"},
+                {"id", "INT"},
+                {"geom", "ST_Geometry(3857)"}
+            };
+            htu.createRegisteredTestTable(TABLE_PLANAR, cols);
+
+            htu.insertIntoTestTable(
+                    TABLE_PLANAR,
+                    htu.nextTestSequenceValueForColumn(TABLE_PLANAR, "fid"),
+                    0,
+                    htu.geometry("LINESTRING(0 0, 1 0, 2 0, 3 0)", 3857));
+        }
+    }
+
+    private void dropRoundEarthTable() throws SQLException, IOException {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn, fixture);
+            htu.dropTestTableCascade(TABLE_ROUND_EARTH);
+        }
+    }
+
+    private void dropPlanarTable() throws SQLException, IOException {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn, fixture);
+            htu.dropTestTableCascade(TABLE_PLANAR);
+        }
+    }
+}


### PR DESCRIPTION
Simplification for geographic ("round-earth") shapes is not supported by HANA. Only projected ("planar") shapes can be simplified.

The encodeGeometryColumnSimplified() method must verify that the shape is planar before applying the ST_Simplify() function on it.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).
