### PR TITLE
[GEOT-7210] YSLD does not encode layer name

### DIFF
--- a/docs/user/extension/ysld.rst
+++ b/docs/user/extension/ysld.rst
@@ -218,12 +218,28 @@ Style definition:
 .. code-block:: yaml
 
     # style definition 
-    layer-name: <text>
     name: <text>
     title: <text>
     abstract: <text>
     feature-styles:
     - <feature style>
+
+Optional top-level sld and layer definition:
+
+.. code-block:: yaml
+   
+   # sld definition
+   sld-name: <text>
+   sld-title: <text>
+   sld-abstract: <text>
+   
+   # named layer definition
+   layer-name: <text>
+
+   # user layer definition
+   user-name: <text>
+   user-remote: <text>
+   user-service: <text>
 
 Feature style definition:
 

--- a/modules/extension/ysld/src/main/java/org/geotools/ysld/encode/RootEncoder.java
+++ b/modules/extension/ysld/src/main/java/org/geotools/ysld/encode/RootEncoder.java
@@ -18,14 +18,23 @@
 package org.geotools.ysld.encode;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
+import org.geotools.styling.NamedLayer;
+import org.geotools.styling.RemoteOWS;
 import org.geotools.styling.SLD;
 import org.geotools.styling.Style;
+import org.geotools.styling.StyledLayer;
 import org.geotools.styling.StyledLayerDescriptor;
+import org.geotools.styling.UserLayer;
 
 /**
  * Encodes a {@link StyledLayerDescriptor} as YSLD. Handles top-level elements such a name and
  * title, and delegates to {@link FeatureStyleEncoder} for the content.
+ *
+ * <p>YSLD focuses on SymbologyEncoding specification; encoding the default (or first) style found,
+ * and treating surrounding StyleLayerDescriptor / NamedLayer as a wrapper.
  */
 public class RootEncoder extends YsldEncodeHandler<StyledLayerDescriptor> {
 
@@ -33,22 +42,103 @@ public class RootEncoder extends YsldEncodeHandler<StyledLayerDescriptor> {
         super(Collections.singleton(sld).iterator());
     }
 
+    /**
+     * Encode sld as part of root-level information prefixed with {@code sld}.
+     *
+     * <p>This method looks and encodes the {@link SLD#defaultStyle(StyledLayerDescriptor)} along
+     * with it's parent layer.
+     *
+     * @param sld
+     */
     @Override
     protected void encode(StyledLayerDescriptor sld) {
+        StyledLayer[] layers = sld.getStyledLayers();
+
+        put("sld-name", sld.getName());
+        put("sld-title", sld.getTitle());
+        put("sld-abstract", sld.getAbstract());
+
         Style style = SLD.defaultStyle(sld);
-        if (style != null) {
-            put("name", style.getName());
-            put(
-                    "title",
-                    Optional.ofNullable(style.getDescription().getTitle())
-                            .map(Object::toString)
-                            .orElse(null));
-            put(
-                    "abstract",
-                    Optional.ofNullable(style.getDescription().getAbstract())
-                            .map(Object::toString)
-                            .orElse(null));
-            put("feature-styles", new FeatureStyleEncoder(style));
+
+        StyledLayer layer = findParentLayer(sld, style);
+        encode(layer);
+        encode(style);
+    }
+
+    /**
+     * Encode user layer information as part of root-level information prefixed with {@code user}.
+     *
+     * @param layer User layer, or {@code null} if not available.
+     */
+    protected void encode(UserLayer layer) {
+        if (layer == null) return;
+        put("user-name", layer.getName());
+        if (layer.getRemoteOWS() != null) {
+            RemoteOWS remote = layer.getRemoteOWS();
+            put("user-service", remote.getService());
+            put("user-remote", remote.getOnlineResource());
         }
+    }
+
+    /**
+     * Encode named layer information as part of root-level with prefix {@code layer}.
+     *
+     * @param layer Named layer, or null if not available.
+     */
+    protected void encode(NamedLayer layer) {
+        if (layer == null) return;
+        put("layer-name", layer.getName());
+    }
+    /**
+     * Look up layer (example UserLayer) containing the provided style.
+     *
+     * @param sld
+     * @param style
+     * @return layer containing the provided style, or {@code null} if not found
+     */
+    private StyledLayer findParentLayer(StyledLayerDescriptor sld, Style style) {
+        if (style == null) return null;
+
+        return sld.layers().stream()
+                .filter(
+                        new Predicate<StyledLayer>() {
+                            @Override
+                            public boolean test(StyledLayer styledLayer) {
+                                List<Style> styles;
+                                if (styledLayer instanceof NamedLayer)
+                                    styles = ((NamedLayer) styledLayer).styles();
+                                else if (styledLayer instanceof UserLayer) {
+                                    styles = ((UserLayer) styledLayer).userStyles();
+                                } else {
+                                    styles = Collections.emptyList();
+                                }
+                                return styles.contains(style);
+                            }
+                        })
+                .findFirst()
+                .orElse(null);
+    }
+
+    protected void encode(StyledLayer layer) {
+        if (layer instanceof UserLayer) {
+            encode((UserLayer) layer);
+        } else if (layer instanceof NamedLayer) {
+            encode((NamedLayer) layer);
+        }
+    }
+
+    protected void encode(Style style) {
+        put("name", style.getName());
+        put(
+                "title",
+                Optional.ofNullable(style.getDescription().getTitle())
+                        .map(Object::toString)
+                        .orElse(null));
+        put(
+                "abstract",
+                Optional.ofNullable(style.getDescription().getAbstract())
+                        .map(Object::toString)
+                        .orElse(null));
+        put("feature-styles", new FeatureStyleEncoder(style));
     }
 }

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/parse/YsldParseTest.java
@@ -79,6 +79,7 @@ import org.geotools.styling.StyledLayerDescriptor;
 import org.geotools.styling.TextSymbolizer;
 import org.geotools.styling.TextSymbolizer2;
 import org.geotools.styling.UomOgcMapping;
+import org.geotools.styling.UserLayer;
 import org.geotools.util.logging.Logging;
 import org.geotools.ysld.Ysld;
 import org.geotools.ysld.YsldTests;
@@ -112,11 +113,30 @@ public class YsldParseTest {
     Logger LOG = Logging.getLogger("org.geotools.ysld.Ysld");
 
     @Test
-    public void testName() throws Exception {
+    public void testRoot() throws Exception {
         StyledLayerDescriptor sld = Ysld.parse("layer-name: MyLayer\nname: MyStyle");
-        NamedLayer layer = (NamedLayer) sld.layers().get(0);
-        assertEquals("MyLayer", layer.getName());
-        assertEquals("MyStyle", layer.styles().get(0).getName());
+        NamedLayer namedLayer = (NamedLayer) sld.layers().get(0);
+        assertEquals("MyLayer", namedLayer.getName());
+        assertEquals("MyStyle", namedLayer.styles().get(0).getName());
+
+        sld =
+                Ysld.parse(
+                        "sld-name: SLDName\nsld-title: SLD Title\nsld-abstract: Remote user layer\n"
+                                + "user-name: RemoteLayer\nuser-remote: http://localhost:8080/geoserver/wms\nuser-service: wms\n"
+                                + "name: RemoteStyle");
+
+        assertEquals("SLDName", sld.getName());
+        assertEquals("SLD Title", sld.getTitle());
+        assertEquals("Remote user layer", sld.getAbstract());
+
+        UserLayer userlayer = (UserLayer) sld.layers().get(0);
+        assertEquals("RemoteLayer", userlayer.getName());
+        assertEquals("wms", userlayer.getRemoteOWS().getService());
+        assertEquals(
+                "http://localhost:8080/geoserver/wms",
+                userlayer.getRemoteOWS().getOnlineResource());
+
+        assertEquals("RemoteStyle", userlayer.userStyles().get(0).getName());
     }
 
     @Test

--- a/modules/library/main/src/main/java/org/geotools/styling/SLD.java
+++ b/modules/library/main/src/main/java/org/geotools/styling/SLD.java
@@ -1584,8 +1584,8 @@ public class SLD {
      * Retrieve the default style from the given StyledLayerDescriptor.
      *
      * @param sld the StyledLayerDescriptor object
-     * @return the default style; or the first style if no default is defined; or null if there are
-     *     not styles
+     * @return the default style; or the first style if no default is defined; or {@code null} if
+     *     there are no styles
      */
     public static Style defaultStyle(StyledLayerDescriptor sld) {
         Style[] style = styles(sld);


### PR DESCRIPTION
[![GEOT-7210](https://badgen.net/badge/JIRA/GEOT-7210/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7210) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Previously the encoder relied on utility method to extract the first style and did not have any referenced to named layer to user layer. I am preserving the limitation of only encoding one style (as YSLD is more accurately a representation of Symbology Encoding and has not previously had the concept of SLD NamedLayer.

This pull request completes the work started by https://github.com/geotools/geotools/pull/4000 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->