### PR TITLE
ERROR: function postgis_lib_version() does not exist

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -1491,7 +1491,7 @@ public class PostGISDialect extends BasicSQLDialect {
             ResultSet rs = null;
             try {
                 st = conn.createStatement();
-                rs = st.executeQuery("select PostGIS_Lib_Version()");
+                rs = st.executeQuery("select PostGIS_Lib_Version()");// If the PostGIS extension is in other schema (not public schema), an exception is thrown. 
                 if (rs.next()) {
                     version = new Version(rs.getString(1));
                 }


### PR DESCRIPTION
If the PostGIS extension is in other schema (not public schema), an exception is thrown. So I think we need to add a schema parameter in the here. Do you agree with me? Thanks. 
The following is the exception information:
"Caused by: org.postgresql.util.PSQLException: ERROR: function postgis_lib_version() does not exist".