### PR TITLE
[GEOT-7244] Constructor GridGeometry2D(Rectangle, Rectangle2D) looses CRS

### DIFF
--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridGeometryTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridGeometryTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.geometry.Envelope2D;
 import org.geotools.geometry.GeneralEnvelope;
@@ -34,6 +35,7 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.junit.Assert;
 import org.junit.Test;
 import org.locationtech.jts.geom.Envelope;
 import org.opengis.coverage.grid.GridEnvelope;
@@ -309,6 +311,25 @@ public final class GridGeometryTest extends GridCoverageTestBase {
 
         GridGeometry2D canonical = gg.toCanonical();
         assertEquivalentCanonical(gg, canonical);
+    }
+
+    @Test
+    public void testRectangleConstructor() throws Exception {
+        GridGeometry2D gg1 =
+                new GridGeometry2D(
+                        new Rectangle(100, 100),
+                        new Envelope2D(DefaultGeographicCRS.WGS84, -180, 180, -90, 90));
+        Assert.assertTrue(gg1.isDefined(GridGeometry2D.CRS_BITMASK));
+        try {
+            Assert.assertNotNull(gg1.getCoordinateReferenceSystem());
+        } catch (InvalidGridGeometryException e) {
+            Assert.fail("crs should be set.");
+        }
+
+        GridGeometry2D gg2 =
+                new GridGeometry2D(
+                        new Rectangle(100, 100), new Rectangle2D.Double(-180, 180, -90, 90));
+        Assert.assertFalse(gg2.isDefined(GridGeometry2D.CRS_BITMASK));
     }
 
     private void assertEquivalentCanonical(GridGeometry2D original, GridGeometry2D canonical) {


### PR DESCRIPTION
[![GEOT-7244](https://badgen.net/badge/JIRA/GEOT-7244/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7244) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The constructor was added prior to this PR.
This PR will fix a problem were the crs of the incoming userRange was omitted.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->