### PR TITLE
[GEOT-7246] Correctly handle null geometries in GeoJSON

### DIFF
--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
@@ -207,6 +207,21 @@ public class GeoJSONWriteTest {
     }
 
     @Test
+    public void testWriteMissingGeometery() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        String featureDef = "1=POINT EMPTY";
+        SimpleFeatureType schema = DataUtilities.createType("test", "p:String");
+        SimpleFeature feature = DataUtilities.createFeature(schema, featureDef);
+        try (GeoJSONWriter writer = new GeoJSONWriter(out)) {
+            writer.write(feature);
+        }
+        String json = new String(out.toByteArray(), StandardCharsets.UTF_8);
+        assertEquals(
+                "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"p\":\"POINT EMPTY\"},\"geometry\":null,\"id\":\"1\"}]}",
+                json);
+    }
+
+    @Test
     public void testPrettyPrint() throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (GeoJSONWriter writer = new GeoJSONWriter(out)) {


### PR DESCRIPTION
[![GEOT-7246](https://badgen.net/badge/JIRA/GEOT-7246/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7246) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  A GeoJSON feature with no geometry should not throw a NPE. 
From the GeoJSON spec 

> A Feature object has a member with the name "geometry".  The value
      of the geometry member SHALL be either a Geometry object as
      defined above or, in the case that the Feature is unlocated, a
      JSON null value.
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->