### PR TITLE
[GEOT-7230] Implement a HINT parameter as part of the HANA plug-in

### DIFF
--- a/docs/user/library/jdbc/hana.rst
+++ b/docs/user/library/jdbc/hana.rst
@@ -3,9 +3,13 @@ HANA Plugin
 
 Supports direct access to a HANA database.
 
-A free version of HANA (HANA Express Edition) can be downloaded at the link below.
+A free version of HANA (HANA Express Edition) can be downloaded at the link
+below.
 
-You need HANA's JDBC driver ``ngdbc.jar`` to connect to HANA. Its license does not allow redistribution, so you have to download it separately. It can be downloaded from SAP's Development Tools site and is also part of HANA Express Edition.
+You need HANA's JDBC driver ``ngdbc.jar`` to connect to HANA. Its license does
+not allow redistribution, so you have to download it separately. It can be
+downloaded from SAP's Development Tools site and is also part of HANA Express
+Edition.
 
 **References**
 
@@ -14,7 +18,8 @@ You need HANA's JDBC driver ``ngdbc.jar`` to connect to HANA. Its license does n
 
 **Maven**
    
-Note that the ``groupId`` is ``org.geotools.jdbc`` for this and other JDBC plugin modules.
+Note that the ``groupId`` is ``org.geotools.jdbc`` for this and other JDBC
+plugin modules.
 
 ::
 
@@ -27,19 +32,25 @@ Note that the ``groupId`` is ``org.geotools.jdbc`` for this and other JDBC plugi
 Connection Parameters
 ^^^^^^^^^^^^^^^^^^^^^
 
-============== ============================================
-Parameter      Description
-============== ============================================
+================ ===============================================================
+Parameter        Description
+================ ===============================================================
 ``dbtype``       Must be the string ``hana``
 ``host``         Machine name or IP address to connect to
-``port``         Port to connect to. If set and different from 0, parameters "instance" and "database" are ignored. If not set or 0, the "instance" parameter must be set.
+``port``         Port to connect to. If set and different from 0, parameters
+                 ``instance`` and ``database`` are ignored. If not set or 0, the
+                 ``instance`` parameter must be set.
 ``instance``     Instance of the database
-``database``     Database to connect to. Leave empty in case of single-container databases. Set to ``SYSTEMDB`` to connect to the system database of a multi-container database.
+``database``     Database to connect to. Leave empty in case of single-container
+                 databases. Set to ``SYSTEMDB`` to connect to the system
+                 database of a multi-container database.
 ``schema``       The database schema to access
 ``user``         User name
 ``passwd``       Password
 ``use ssl``      Use SSL to connect
-============== ============================================
+``SELECT Hints`` Comma-separated list of hints that will be applied to SELECT
+                 queries, e.g. ``ESTIMATION_SAPLES(0), NO_HASH_JOIN``.
+================ ===============================================================
 
 Creating
 ^^^^^^^^
@@ -54,24 +65,25 @@ Here is an example of connecting::
   params.put("schema", "geotools");   //the table schema
   params.put("user", "SYSTEM");       //the user to connect with
   params.put("passwd", "pw");         //the password of the user
-  
+
   DataStore datastore = DataStoreFinder.getDataStore(params);
 
 Advanced GeoTools Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-+----------------------+-------------------------------------------+
-| Parameter            | Description                               |
-+======================+===========================================+
-| ``encode functions`` | Flag controlling if a set of filter       |
-|                      | functions are translated directly in SQL. |
-|                      | Default is false.                         |
-+----------------------+-------------------------------------------+
+==================== ===========================================================
+Parameter            Description
+==================== ===========================================================
+``encode functions`` Flag controlling if a set of filter functions are
+                     translated directly in SQL. Default is false.
+==================== ===========================================================
 
 Importing spatial reference systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-HANA includes only a few spatial reference systems by default. Therefore, the plugin contains an application for installing all EPSG spatial reference systems.
+HANA includes only a few spatial reference systems by default. Therefore, the
+plugin contains an application for installing all EPSG spatial reference
+systems.
 
 On Windows::
 

--- a/docs/user/library/jdbc/hana.rst
+++ b/docs/user/library/jdbc/hana.rst
@@ -49,7 +49,7 @@ Parameter        Description
 ``passwd``       Password
 ``use ssl``      Use SSL to connect
 ``SELECT Hints`` Comma-separated list of hints that will be applied to SELECT
-                 queries, e.g. ``ESTIMATION_SAPLES(0), NO_HASH_JOIN``.
+                 queries, e.g. ``ESTIMATION_SAMPLES(0), NO_HASH_JOIN``.
 ================ ===============================================================
 
 Creating

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDataStoreFactory.java
@@ -86,7 +86,7 @@ public class HanaDataStoreFactory extends JDBCDataStoreFactory {
             new Param(
                     "SELECT Hints",
                     String.class,
-                    "Comma-separated list of hints that will be applied to SELECT queries, e.g. ESTIMATION_SAPLES(0), NO_HASH_JOIN",
+                    "Comma-separated list of hints that will be applied to SELECT queries, e.g. ESTIMATION_SAMPLES(0), NO_HASH_JOIN",
                     false,
                     null,
                     Collections.singletonMap(Parameter.IS_LARGE_TEXT, Boolean.TRUE));

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
@@ -148,12 +148,18 @@ public class HanaDialect extends PreparedStatementSQLDialect {
 
     private boolean functionEncodingEnabled;
 
+    private String selectHints;
+
     private HanaVersion hanaVersion;
 
     private SchemaCache currentSchemaCache = new SchemaCache();
 
     public void setFunctionEncodingEnabled(boolean enabled) {
         functionEncodingEnabled = enabled;
+    }
+
+    public void setSelectHints(String selectHints) {
+        this.selectHints = selectHints;
     }
 
     @Override
@@ -811,7 +817,12 @@ public class HanaDialect extends PreparedStatementSQLDialect {
 
     @Override
     public void handleSelectHints(StringBuffer sql, SimpleFeatureType featureType, Query query) {
-        // TODO Maybe apply estimation samples hint
+        if ((selectHints == null) || selectHints.trim().isEmpty()) {
+            return;
+        }
+        sql.append(" WITH HINT( ");
+        sql.append(selectHints);
+        sql.append(" )");
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaJNDIDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaJNDIDataStoreFactory.java
@@ -18,6 +18,7 @@ package org.geotools.data.hana;
 
 import static org.geotools.data.hana.HanaDataStoreFactory.ENCODE_FUNCTIONS;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.geotools.jdbc.JDBCJNDIDataStoreFactory;
 
@@ -35,7 +36,17 @@ public class HanaJNDIDataStoreFactory extends JDBCJNDIDataStoreFactory {
     @Override
     @SuppressWarnings("unchecked")
     protected void setupParameters(Map parameters) {
-        super.setupParameters(parameters);
-        parameters.put(ENCODE_FUNCTIONS.key, ENCODE_FUNCTIONS);
+        LinkedHashMap<String, Object> parentParams = new LinkedHashMap<>();
+        super.setupParameters(parentParams);
+
+        // Insert additional parameters at the proper place
+        for (Map.Entry<String, Object> param : parentParams.entrySet()) {
+            parameters.put(param.getKey(), param.getValue());
+            if (EXPOSE_PK.key.equals(param.getKey())) {
+                parameters.put(ENCODE_FUNCTIONS.key, ENCODE_FUNCTIONS);
+                parameters.put(
+                        HanaDataStoreFactory.SELECT_HINTS.key, HanaDataStoreFactory.SELECT_HINTS);
+            }
+        }
     }
 }

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSelectHintOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaSelectHintOnlineTest.java
@@ -1,0 +1,32 @@
+package org.geotools.data.hana;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.geotools.jdbc.SQLDialect;
+import org.junit.Test;
+
+public class HanaSelectHintOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new HanaTestSetupPSPooling();
+    }
+
+    @Override
+    protected Map<String, Object> createDataStoreFactoryParams() throws Exception {
+        Map<String, Object> params = super.createDataStoreFactoryParams();
+        params.put("SELECT Hints", "MYHINT1, MYHINT2");
+        return params;
+    }
+
+    @Test
+    public void testSelectHint() throws Exception {
+        SQLDialect dialect = dataStore.getSQLDialect();
+        StringBuffer sql = new StringBuffer();
+        dialect.handleSelectHints(sql, null, null);
+        assertEquals(" WITH HINT( MYHINT1, MYHINT2 )", sql.toString());
+    }
+}


### PR DESCRIPTION
This pull request adds a new "SELECT Hint" parameter to the HANA JDBC plugin.

`SELECT Hint`s are appended to SELECT queries, embedded in the string

```
        WITH HINT( <SELECT Hints> )
```

Setting `SELECT Hint`s enables a user to configure HANA specific query hints that will be considered during query plan generation.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [X] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
