### PR TITLE
[GEOT-6324] WFS-NG online tests don't extend OnlineTestSupport

### DIFF
--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v2_0/Capabilities200ServiceInfoOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/v2_0/Capabilities200ServiceInfoOnlineTest.java
@@ -20,6 +20,7 @@ import net.opengis.wfs20.WFSCapabilitiesType;
 import org.geotools.wfs.v2_0.WFSConfiguration;
 import org.geotools.xsd.Parser;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -27,6 +28,7 @@ import org.junit.Test;
  *
  * @author Matthias Schulze (LDBV at ldbv dot bayern dot de)
  */
+@Ignore
 public class Capabilities200ServiceInfoOnlineTest {
     public static final String SERVER_URL =
             "http://laermkartierung1.eisenbahn-bundesamt.de/deegree/services/wfs?service=WFS&request=GetCapabilities"; // $NON-NLS-1$

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/Capabilities200ServiceInfoOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/Capabilities200ServiceInfoOnlineTest.java
@@ -11,12 +11,13 @@
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
  */
-package org.geotools.data.wfs.internal.v2_0;
+package org.geotools.data.wfs.online.v2_0;
 
 import static org.junit.Assert.assertNotNull;
 
 import java.net.URL;
 import net.opengis.wfs20.WFSCapabilitiesType;
+import org.geotools.data.wfs.internal.v2_0.Capabilities200ServiceInfo;
 import org.geotools.wfs.v2_0.WFSConfiguration;
 import org.geotools.xsd.Parser;
 import org.junit.Before;
@@ -28,10 +29,10 @@ import org.junit.Test;
  *
  * @author Matthias Schulze (LDBV at ldbv dot bayern dot de)
  */
-@Ignore
+@Ignore("Server has an certificate failure.")
 public class Capabilities200ServiceInfoOnlineTest {
     public static final String SERVER_URL =
-            "http://laermkartierung1.eisenbahn-bundesamt.de/deegree/services/wfs?service=WFS&request=GetCapabilities"; // $NON-NLS-1$
+            "https://laermkartierung1.eisenbahn-bundesamt.de/deegree/services/wfs?service=WFS&request=GetCapabilities"; // $NON-NLS-1$
 
     private Capabilities200ServiceInfo featureType;
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/Capabilities200ServiceInfoOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/Capabilities200ServiceInfoOnlineTest.java
@@ -21,7 +21,6 @@ import org.geotools.data.wfs.internal.v2_0.Capabilities200ServiceInfo;
 import org.geotools.wfs.v2_0.WFSConfiguration;
 import org.geotools.xsd.Parser;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -29,10 +28,9 @@ import org.junit.Test;
  *
  * @author Matthias Schulze (LDBV at ldbv dot bayern dot de)
  */
-@Ignore("Server has an certificate failure.")
 public class Capabilities200ServiceInfoOnlineTest {
     public static final String SERVER_URL =
-            "https://laermkartierung1.eisenbahn-bundesamt.de/deegree/services/wfs?service=WFS&request=GetCapabilities"; // $NON-NLS-1$
+            "https://laermkartierung.eisenbahn-bundesamt.de/deegree/services/wfs?service=WFS&request=GetCapabilities"; // $NON-NLS-1$
 
     private Capabilities200ServiceInfo featureType;
 


### PR DESCRIPTION
[![GEOT-6324](https://badgen.net/badge/JIRA/GEOT-6324/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6324) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Made AbstractWfsDataStoreOnlineTest subclass of OnlineTestSupport.

Added a fixture "wfs" to run those test cases that extended AbstractWfsDataStoreOnlineTest, and added an individual check for availability using HTTPClient instead on url.openStream().

Ignoring the test Capabilities200ServiceInfoOnlineTest because it didn't extend AbstractWfsDataStoreOnelineTest nor OnlineTestSupport, and because the url was wrong.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->