### PR TITLE
[GEOT-7255] Fix index out of bounds in joining feature source

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSource.java
@@ -1465,7 +1465,7 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
         String[] attributes = extractor.getAttributeNames();
         // the id from the app-schema configuration
         String idMapping = attributes.length > 0 ? extractor.getAttributeNames()[0] : null;
-        boolean idsColumnEquals = idColumnName.equals(idMapping);
+        boolean idsColumnEquals = idColumnName != null && idColumnName.equals(idMapping);
         Filter filter = jQuery.getFilter();
         filter.accept(extractor, null);
 
@@ -1581,7 +1581,11 @@ public class JoiningJDBCFeatureSource extends JDBCFeatureSource {
     }
 
     private String getIdColumnName(SimpleFeatureType featureType) throws IOException {
-        PrimaryKeyColumn column = getDataStore().getPrimaryKey(featureType).getColumns().get(0);
+        List<PrimaryKeyColumn> columns = getDataStore().getPrimaryKey(featureType).getColumns();
+        if (columns.isEmpty()) {
+            return null;
+        }
+        PrimaryKeyColumn column = columns.get(0);
         String columnName = column.getName();
         return columnName;
     }

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSourceTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/appschema/jdbc/JoiningJDBCFeatureSourceTest.java
@@ -19,7 +19,9 @@ package org.geotools.appschema.jdbc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import java.io.IOException;
 import java.util.Collections;
 import org.geotools.data.joining.JoiningQuery;
 import org.geotools.data.postgis.PostGISDialect;
@@ -59,5 +61,27 @@ public class JoiningJDBCFeatureSourceTest {
         assertNotNull(type);
         assertEquals("FOREIGN_ID_0_0", type.getDescriptor(0).getName().getLocalPart());
         assertEquals("FOREIGN_ID_0_1", type.getDescriptor(1).getName().getLocalPart());
+    }
+
+    @Test
+    public void testSimpleFeatureTypeNoPk() throws IOException {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("test");
+
+        JoiningQuery query = new JoiningQuery();
+        JoiningQuery.QueryJoin join = new JoiningQuery.QueryJoin();
+        join.getIds().add("one");
+        join.getIds().add("two");
+        query.setQueryJoins(Collections.singletonList(join));
+
+        JDBCDataStore mockStore = Mockito.mock(JDBCDataStore.class);
+        ContentEntry mockEntry = Mockito.mock(ContentEntry.class);
+
+        Mockito.when(mockStore.getSQLDialect()).thenReturn(new PostGISDialect(mockStore));
+        Mockito.when(mockEntry.getDataStore()).thenReturn(mockStore);
+        JoiningJDBCFeatureSource source =
+                new JoiningJDBCFeatureSource(new JDBCFeatureSource(mockEntry, null));
+
+        assertNull(source.getPrimaryKey());
     }
 }


### PR DESCRIPTION
[![GEOT-7255](https://badgen.net/badge/JIRA/GEOT-7255/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7255) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This fixes an `IndexOutOfBoundsException` in the `JoiningJDBCFeatureSource` class in case a feature type/data store doesn't have a primary key.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).