### PR TITLE
[GEOT-7220] Support datetime2 and datetimeoffset in JDBC SQL Server (28.x backport)

### DIFF
--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDialect.java
@@ -24,7 +24,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
+import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -165,6 +167,9 @@ public class SQLServerDialect extends BasicSQLDialect {
         mappings.put("uniqueidentifier", UUID.class);
         mappings.put("time", Time.class);
         mappings.put("date", Date.class);
+        mappings.put("datetime", Timestamp.class);
+        mappings.put("datetime2", Timestamp.class);
+        mappings.put("datetimeoffset", OffsetDateTime.class);
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDateOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDateOnlineTest.java
@@ -16,13 +16,80 @@
  */
 package org.geotools.data.sqlserver;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.List;
+import microsoft.sql.DateTimeOffset;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureStore;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.store.ContentFeatureCollection;
 import org.geotools.jdbc.JDBCDateOnlineTest;
 import org.geotools.jdbc.JDBCDateTestSetup;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.identity.FeatureId;
 
 public class SQLServerDateOnlineTest extends JDBCDateOnlineTest {
 
     @Override
     protected JDBCDateTestSetup createTestSetup() {
         return new SQLServerDateTestSetup();
+    }
+
+    @Test
+    public void testInsert() throws Exception {
+        dataStore.setExposePrimaryKeyColumns(true);
+        SimpleFeatureType ft = dataStore.getSchema(tname("dates"));
+        SimpleFeature datesFeat =
+                DataUtilities.createFeature(
+                        ft,
+                        "id=4|2009-09-29|2009-09-29T17:54:23|2009-09-29T17:54:23|2009-09-29T17:54:23+02:00|17:54:23");
+        FeatureStore<SimpleFeatureType, SimpleFeature> fs =
+                (FeatureStore<SimpleFeatureType, SimpleFeature>)
+                        (dataStore.getFeatureSource("dates"));
+        List<FeatureId> featIds = fs.addFeatures(DataUtilities.collection(datesFeat));
+        assertEquals(1, featIds.size());
+    }
+
+    @Test
+    public void testQuery() throws IOException {
+        ContentFeatureCollection fc = dataStore.getFeatureSource("dates").getFeatures();
+        try (SimpleFeatureIterator it = fc.features()) {
+            SimpleFeature f1 = it.next();
+            Object a1 = f1.getAttribute(0);
+            assertEquals(Date.class, a1.getClass());
+            assertEquals("2009-06-28", ((Date) a1).toString());
+            Object a2 = f1.getAttribute(1);
+            assertEquals(Timestamp.class, a2.getClass());
+            assertEquals("2009-06-28 15:12:41.0", ((Timestamp) a2).toString());
+            Object a3 = f1.getAttribute(2);
+            assertEquals(Timestamp.class, a3.getClass());
+            assertEquals("2009-06-28 15:12:41.0", ((Timestamp) a3).toString());
+            Object a4 = f1.getAttribute(3);
+            assertEquals(DateTimeOffset.class, a4.getClass());
+            assertEquals("2009-06-28 15:12:41 +00:00", ((DateTimeOffset) a4).toString());
+            Object a5 = f1.getAttribute(4);
+            assertEquals(Time.class, a5.getClass());
+            assertEquals("15:12:41", ((Time) a5).toString());
+            SimpleFeature f2 = it.next();
+            a4 = f2.getAttribute(3);
+            assertEquals(DateTimeOffset.class, a4.getClass());
+            assertEquals("2009-01-15 13:10:12 +00:00", ((DateTimeOffset) a4).toString());
+            SimpleFeature f3 = it.next();
+            a4 = f3.getAttribute(3);
+            assertEquals(DateTimeOffset.class, a4.getClass());
+            assertEquals("2009-09-29 17:54:23 +02:00", ((DateTimeOffset) a4).toString());
+            SimpleFeature f4 = it.next();
+            a4 = f4.getAttribute(3);
+            assertEquals(null, a4);
+            assertEquals(false, it.hasNext());
+        }
+        assertEquals(4, fc.size());
     }
 }

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDateTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDateTestSetup.java
@@ -26,26 +26,40 @@ public class SQLServerDateTestSetup extends JDBCDateTestSetup {
 
     @Override
     protected void createDateTable() throws Exception {
-        run("CREATE TABLE dates (d DATE, dt DATETIME, t TIME)");
+        run(
+                "CREATE TABLE dates (id int IDENTITY(1,1) PRIMARY KEY, d DATE, dt DATETIME, dt2 DATETIME2, dto DATETIMEOFFSET, t TIME)");
 
         // make the test runnable on sql server installs in countries using a different date format
         run(
-                "INSERT INTO dates VALUES ("
+                "INSERT INTO dates (d, dt, dt2, dto, t) VALUES ("
                         + "CAST('2009-06-28' as DATE), "
                         + "CAST('2009-06-28T15:12:41' as DATETIME),"
+                        + "CAST('2009-06-28T15:12:41' as DATETIME2),"
+                        + "CAST('2009-06-28T15:12:41' as DATETIMEOFFSET),"
                         + "CAST('15:12:41' as TIME)  )");
 
         run(
-                "INSERT INTO dates VALUES ("
+                "INSERT INTO dates (d, dt, dt2, dto, t) VALUES ("
                         + "CAST('2009-01-15' as DATE), "
                         + "CAST('2009-01-15T13:10:12' as DATETIME),"
+                        + "CAST('2009-01-15T13:10:12' as DATETIME2),"
+                        + "CAST('2009-01-15T13:10:12Z' as DATETIMEOFFSET),"
                         + "CAST('13:10:12' as TIME)  )");
 
         run(
-                "INSERT INTO dates VALUES ("
+                "INSERT INTO dates (d, dt, dt2, dto, t) VALUES ("
                         + "CAST('2009-09-29' as DATE), "
                         + "CAST('2009-09-29T17:54:23' as DATETIME),"
+                        + "CAST('2009-09-29T17:54:23' as DATETIME2),"
+                        + "CAST('2009-09-29T17:54:23+02:00' as DATETIMEOFFSET),"
                         + "CAST('17:54:23' as TIME)  )");
+        run(
+                "INSERT INTO dates (d, dt, dt2, dto, t) VALUES ("
+                        + "NULL, "
+                        + "NULL,"
+                        + "NULL,"
+                        + "NULL,"
+                        + "NULL  )");
     }
 
     @Override


### PR DESCRIPTION
[![GEOT-7220](https://badgen.net/badge/JIRA/GEOT-7220/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7220) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

