### PR TITLE
[GEOT-7258] geojson-core is too lenient parsing as dates strings that are actually not

### DIFF
--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.data.geojson;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -30,6 +32,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +48,6 @@ import org.geotools.referencing.CRS.AxisOrder;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.test.TestData;
 import org.geotools.util.logging.Logging;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -621,7 +623,7 @@ public class GeoJSONReaderTest {
         URL url = TestData.url(GeoJSONReaderTest.class, "poi1.json");
         try (GeoJSONReader reader = new GeoJSONReader(url)) {
             SimpleFeatureCollection features = reader.getFeatures();
-            assertThat(features, CoreMatchers.instanceOf(PagingFeatureCollection.class));
+            assertThat(features, instanceOf(PagingFeatureCollection.class));
             assertNotNull(((PagingFeatureCollection) features).matched);
             assertEquals(6, ((PagingFeatureCollection) features).matched.intValue());
             assertEquals(6, features.size());
@@ -642,7 +644,7 @@ public class GeoJSONReaderTest {
         URL url = TestData.url(GeoJSONReaderTest.class, "stac1.json");
         try (GeoJSONReader reader = new GeoJSONReader(url)) {
             SimpleFeatureCollection features = reader.getFeatures();
-            assertThat(features, CoreMatchers.instanceOf(PagingFeatureCollection.class));
+            assertThat(features, instanceOf(PagingFeatureCollection.class));
             assertNotNull(((PagingFeatureCollection) features).matched);
             assertEquals(2, ((PagingFeatureCollection) features).matched.intValue());
             assertEquals(2, features.size());
@@ -663,7 +665,7 @@ public class GeoJSONReaderTest {
         URL url = TestData.url(GeoJSONReaderTest.class, "propertyless.json");
         try (GeoJSONReader reader = new GeoJSONReader(url)) {
             SimpleFeatureCollection features = reader.getFeatures();
-            assertThat(features, CoreMatchers.instanceOf(ListFeatureCollection.class));
+            assertThat(features, instanceOf(ListFeatureCollection.class));
             assertEquals(1, features.size());
             assertEquals(1, features.getSchema().getAttributeCount());
             assertEquals(
@@ -679,7 +681,7 @@ public class GeoJSONReaderTest {
         URL url = TestData.url(GeoJSONReaderTest.class, "geometryless.json");
         try (GeoJSONReader reader = new GeoJSONReader(url)) {
             SimpleFeatureCollection features = reader.getFeatures();
-            assertThat(features, CoreMatchers.instanceOf(ListFeatureCollection.class));
+            assertThat(features, instanceOf(ListFeatureCollection.class));
             assertEquals(1, features.size());
             assertNull(features.getSchema().getGeometryDescriptor());
             SimpleFeature feature = DataUtilities.first(features);
@@ -697,6 +699,23 @@ public class GeoJSONReaderTest {
             assertTrue(features.isEmpty());
             assertNotNull(features.getSchema());
             assertEquals(0, features.getSchema().getAttributeCount());
+        }
+    }
+
+    @Test
+    public void testGuessDates() throws Exception {
+        URL url = TestData.url(GeoJSONReaderTest.class, "dates.json");
+        try (GeoJSONReader reader = new GeoJSONReader(url)) {
+            SimpleFeatureCollection features = reader.getFeatures();
+            assertThat(features, instanceOf(ListFeatureCollection.class));
+            assertEquals(1, features.size());
+            SimpleFeature feature = DataUtilities.first(features);
+            assertThat(feature.getAttribute("date"), instanceOf(Date.class));
+            assertThat(feature.getAttribute("dateTime"), instanceOf(Date.class));
+            assertThat(feature.getAttribute("dateTimeFull"), instanceOf(Date.class));
+            Object notDateValue = feature.getAttribute("notDate");
+            assertThat(notDateValue, instanceOf(String.class));
+            assertThat(notDateValue, equalTo("2009-08-29T223949_RE4_1B-NAC_1678843_48007"));
         }
     }
 }

--- a/modules/unsupported/geojson-core/src/test/resources/org/geotools/data/geojson/test-data/dates.json
+++ b/modules/unsupported/geojson-core/src/test/resources/org/geotools/data/geojson/test-data/dates.json
@@ -1,0 +1,15 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "id": "identifier",
+      "type": "Feature",
+      "properties": {
+        "date": "2022-03-27",
+        "dateTime": "2022-03-27T11:01:55Z",
+        "dateTimeFull": "2022-03-27T11:01:55.956478Z",
+        "notDate": "2009-08-29T223949_RE4_1B-NAC_1678843_48007"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
See ticket for details. @ianturton could you review?

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
