### PR TITLE
[GEOT-7261] WFSContentComplexFeatureSource.getBounds will end up in StackOverflowException

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSource.java
@@ -205,12 +205,21 @@ public class WFSContentComplexFeatureSource implements FeatureSource<FeatureType
 
     @Override
     public ReferencedEnvelope getBounds() throws IOException {
-        return dataAccess.getFeatureSource(typeName).getBounds();
+        return getBounds(Query.ALL);
     }
 
     @Override
     public ReferencedEnvelope getBounds(Query query) throws IOException {
-        return dataAccess.getFeatureSource(typeName).getBounds(query);
+        if (!Filter.INCLUDE.equals(query.getFilter())) {
+            return null;
+        }
+        QName name = dataAccess.getRemoteTypeName(typeName);
+        final CoordinateReferenceSystem targetCrs =
+                query.getCoordinateSystemReproject() != null
+                        ? query.getCoordinateSystemReproject()
+                        : client.getDefaultCRS(name);
+
+        return client.getBounds(name, targetCrs);
     }
 
     @Override

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
@@ -19,16 +19,21 @@ import org.geotools.data.Query;
 import org.geotools.data.wfs.TestHttpClient;
 import org.geotools.data.wfs.TestWFSClient;
 import org.geotools.data.wfs.internal.WFSClient;
+import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.NameImpl;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.http.MockHttpResponse;
+import org.geotools.referencing.CRS;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.Name;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * WFS returning complex feature source
@@ -47,6 +52,8 @@ public class WFSContentComplexFeatureSourceTest {
             new NameImpl(
                     "http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115",
                     STED);
+
+    private static final String DEFAULT_SRS = "urn:ogc:def:crs:EPSG::4258";
 
     @Test
     public void testGetFeaturesWithoutArgument() throws Exception {
@@ -77,6 +84,46 @@ public class WFSContentComplexFeatureSourceTest {
         try (FeatureIterator<Feature> features = collection.features()) {
             Assert.assertNotNull(features);
         }
+    }
+
+    @Test
+    public void testGetBounds() throws Exception {
+        final WFSClient client = createWFSClient();
+        final WFSContentDataAccess dataAccess = createDataAccess(client);
+
+        ReferencedEnvelope envelope = dataAccess.getFeatureSource(STED_NAME).getBounds();
+        Assert.assertNotNull(envelope);
+        ReferencedEnvelope actual =
+                new ReferencedEnvelope(
+                        58.111523, 70.671561, 6.034809, 30.528068, CRS.decode(DEFAULT_SRS));
+        assertEnvelope(actual, envelope);
+
+        CoordinateReferenceSystem utm33 = CRS.decode("EPSG:32633");
+        Query reprojectQuery = new Query();
+        reprojectQuery.setCoordinateSystemReproject(utm33);
+
+        ReferencedEnvelope envelopeReprojected =
+                dataAccess.getFeatureSource(STED_NAME).getBounds(reprojectQuery);
+        ReferencedEnvelope actualReprojected = actual.transform(utm33, true);
+        assertEnvelope(actualReprojected, envelopeReprojected);
+
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+        Query filteredQuery =
+                new Query(STED, ff.bbox("posisjon", 60.0, 20.0, 61.0, 21.0, DEFAULT_SRS));
+        ReferencedEnvelope envelopeFilter =
+                dataAccess.getFeatureSource(STED_NAME).getBounds(filteredQuery);
+        Assert.assertNull("We're assuming a null when using a filter.", envelopeFilter);
+    }
+
+    private void assertEnvelope(ReferencedEnvelope actual, ReferencedEnvelope test) {
+        Assert.assertTrue(
+                CRS.equalsIgnoreMetadata(
+                        actual.getCoordinateReferenceSystem(),
+                        test.getCoordinateReferenceSystem()));
+        Assert.assertEquals(actual.getMinX(), test.getMinX(), 0.1);
+        Assert.assertEquals(actual.getMaxX(), test.getMaxX(), 0.1);
+        Assert.assertEquals(actual.getMinY(), test.getMinY(), 0.1);
+        Assert.assertEquals(actual.getMaxY(), test.getMaxY(), 0.1);
     }
 
     private TestWFSClient createWFSClient() throws Exception {


### PR DESCRIPTION
[![GEOT-7261](https://badgen.net/badge/JIRA/GEOT-7261/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7261) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Using same approach as WFSFeatureSource:
Return the bounds specified in the capabilities. If a crs is given in the query, we will retroject. For any other filter than All we will return null.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->