### PR TITLE
[GEOT-7258] geojson-core is too lenient parsing as dates strings that are actually not (27.x backport)

### DIFF
--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/DateParser.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/DateParser.java
@@ -18,7 +18,7 @@ package org.geotools.data.geojson;
 
 import static org.geotools.data.geojson.GeoJSONWriter.DEFAULT_TIME_ZONE;
 
-import java.text.ParseException;
+import java.text.ParsePosition;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -92,8 +92,15 @@ class DateParser {
     public Date parse(String text) {
         for (FastDateFormat format : formats) {
             try {
-                return format.parse(text);
-            } catch (ParseException | NumberFormatException e) {
+                // FastDateFormat is lenient, but using a ParsePosition provides an indication
+                // of whether the parsing hit an error, or parsed the beginning of the string,
+                // looking like a date, without consuming it fully
+                ParsePosition pp = new ParsePosition(0);
+                Date result = format.parse(text, pp);
+                if (result == null || pp.getErrorIndex() > -1 || pp.getIndex() < text.length())
+                    continue;
+                return result;
+            } catch (NumberFormatException e) {
                 if (LOGGER.isLoggable(Level.FINEST))
                     LOGGER.log(
                             Level.FINEST,

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.data.geojson;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -27,11 +30,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.data.DataUtilities;
+import org.geotools.data.collection.ListFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.geometry.jts.WKTReader2;
@@ -417,5 +422,22 @@ public class GeoJSONReaderTest {
         assertEquals(10, (double) array.get(0), 0d);
         assertEquals("abc", array.get(1));
         assertNull(array.get(2));
+    }
+
+    @Test
+    public void testGuessDates() throws Exception {
+        URL url = TestData.url(GeoJSONReaderTest.class, "dates.json");
+        try (GeoJSONReader reader = new GeoJSONReader(url)) {
+            SimpleFeatureCollection features = reader.getFeatures();
+            assertThat(features, instanceOf(ListFeatureCollection.class));
+            assertEquals(1, features.size());
+            SimpleFeature feature = DataUtilities.first(features);
+            assertThat(feature.getAttribute("date"), instanceOf(Date.class));
+            assertThat(feature.getAttribute("dateTime"), instanceOf(Date.class));
+            assertThat(feature.getAttribute("dateTimeFull"), instanceOf(Date.class));
+            Object notDateValue = feature.getAttribute("notDate");
+            assertThat(notDateValue, instanceOf(String.class));
+            assertThat(notDateValue, equalTo("2009-08-29T223949_RE4_1B-NAC_1678843_48007"));
+        }
     }
 }

--- a/modules/unsupported/geojson-core/src/test/resources/org/geotools/data/geojson/test-data/dates.json
+++ b/modules/unsupported/geojson-core/src/test/resources/org/geotools/data/geojson/test-data/dates.json
@@ -1,0 +1,22 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "id": "identifier",
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.117,
+          46.067
+        ]
+      },
+      "properties": {
+        "date": "2022-03-27",
+        "dateTime": "2022-03-27T11:01:55Z",
+        "dateTimeFull": "2022-03-27T11:01:55.956478Z",
+        "notDate": "2009-08-29T223949_RE4_1B-NAC_1678843_48007"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
[![GEOT-7258](https://badgen.net/badge/JIRA/GEOT-7258/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7258) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport from main

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->