### PR TITLE
[GEOT-7239] WFSContentDataAccess will fail when using HTTP POST

### DIFF
--- a/modules/library/http/src/test/java/org/geotools/http/MockHttpClient.java
+++ b/modules/library/http/src/test/java/org/geotools/http/MockHttpClient.java
@@ -204,8 +204,9 @@ public class MockHttpClient extends AbstractHttpClient {
                                 ? ""
                                 : ", content type "
                                         + contentType
-                                        + ", content "
-                                        + new String(postContent, StandardCharsets.UTF_8));
+                                        + ", content ["
+                                        + new String(postContent, StandardCharsets.UTF_8))
+                        + "]";
             }
         }
     }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSource.java
@@ -100,10 +100,9 @@ public class WFSContentComplexFeatureSource implements FeatureSource<FeatureType
         request.setSortBy(query.getSortBy());
 
         String srsName = null;
-
         request.setSrsName(srsName);
 
-        return new WFSContentComplexFeatureCollection(request, schema, name);
+        return new WFSContentComplexFeatureCollection(request, schema, name, client);
     }
 
     @Override

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSContentDataAccess.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSContentDataAccess.java
@@ -32,7 +32,6 @@ import org.geotools.data.ServiceInfo;
 import org.geotools.data.complex.feature.type.ComplexFeatureTypeFactoryImpl;
 import org.geotools.data.complex.feature.type.FeatureTypeRegistry;
 import org.geotools.data.complex.util.EmfComplexFeatureReader;
-import org.geotools.data.wfs.internal.DescribeFeatureTypeRequest;
 import org.geotools.data.wfs.internal.WFSClient;
 import org.geotools.feature.NameImpl;
 import org.geotools.gml3.complex.GmlFeatureTypeRegistryConfiguration;
@@ -149,6 +148,10 @@ public class WFSContentDataAccess implements DataAccess<FeatureType, Feature> {
         return qName;
     }
 
+    /**
+     * Create the FeatureType based on a call to DescribeFeatureType. Using gt-complex to parse the
+     * xsd-document, and use the schema cache.
+     */
     @Override
     public FeatureType getSchema(Name name) throws IOException {
         // If there are no values in this.names it probably means that getNames
@@ -157,13 +160,11 @@ public class WFSContentDataAccess implements DataAccess<FeatureType, Feature> {
             this.getNames();
         }
 
-        // Generate the URL for the feature request:
+        // Generate the URL for the feature request
+        // (should be for a GET request):
         // -----------------------------------------
-        DescribeFeatureTypeRequest describeFeatureTypeRequest =
-                client.createDescribeFeatureTypeRequest();
         QName qname = this.names.get(name);
-        describeFeatureTypeRequest.setTypeName(qname);
-        URL describeRequestURL = describeFeatureTypeRequest.getFinalURL();
+        URL describeRequestURL = client.getDescribeFeatureTypeGetURL(qname);
 
         // Create type registry and add the schema to it:
         // ----------------------------------------------

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/ComplexGetFeatureResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/ComplexGetFeatureResponse.java
@@ -1,0 +1,50 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.wfs.internal;
+
+import java.io.IOException;
+import org.geotools.data.wfs.internal.parsers.XmlComplexFeatureParser;
+import org.geotools.feature.FeatureIterator;
+import org.geotools.http.HTTPResponse;
+import org.geotools.ows.ServiceException;
+import org.opengis.feature.Feature;
+
+/**
+ * GetFeature response for feature's that isn't treated as SimpleFeatureType.
+ *
+ * <p>Created when calling {@link WFSClient#issueComplexRequest(GetFeatureRequest)}.
+ *
+ * @author Roar Brænden
+ */
+public class ComplexGetFeatureResponse extends WFSResponse {
+
+    private final XmlComplexFeatureParser parser;
+
+    public ComplexGetFeatureResponse(
+            WFSRequest originatingRequest,
+            HTTPResponse httpResponse,
+            XmlComplexFeatureParser parser)
+            throws ServiceException, IOException {
+        super(originatingRequest, httpResponse);
+        this.parser = parser;
+    }
+
+    /** Should only be called once. Call close() after use. */
+    public FeatureIterator<Feature> features() {
+        return new ComplexFeatureIteratorImpl(parser);
+    }
+}

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureResponseParserFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureResponseParserFactory.java
@@ -52,7 +52,7 @@ public abstract class AbstractGetFeatureResponseParserFactory extends AbstractWF
      * GetFeatureType GetFeature} request and the request output format matches {@code "text/xml;
      * subtype=gml/3.1.1"}.
      *
-     * <p>It also check's that requested type is a SimpleFeatureType
+     * <p>It also checks that the requested type is a SimpleFeatureType
      *
      * @see WFSResponseFactory#canProcess(WFSOperationType, String)
      */

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureResponseParserFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureResponseParserFactory.java
@@ -30,8 +30,12 @@ import org.geotools.data.wfs.internal.WFSResponseFactory;
 import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.type.FeatureType;
 
-/** An abstract WFS response parser factory for GetFeature requests in GML output formats. */
+/**
+ * An abstract WFS response parser factory for GetFeature requests in GML output formats. Treats
+ * feature type's that implement SimpleFeatureType
+ */
 public abstract class AbstractGetFeatureResponseParserFactory extends AbstractWFSResponseFactory {
 
     /** @see WFSResponseFactory#isAvailable() */
@@ -47,6 +51,8 @@ public abstract class AbstractGetFeatureResponseParserFactory extends AbstractWF
      * <p>For instance, this factory can create a parser as long as the request is a {@link
      * GetFeatureType GetFeature} request and the request output format matches {@code "text/xml;
      * subtype=gml/3.1.1"}.
+     *
+     * <p>It also check's that requested type is a SimpleFeatureType
      *
      * @see WFSResponseFactory#canProcess(WFSOperationType, String)
      */
@@ -92,6 +98,14 @@ public abstract class AbstractGetFeatureResponseParserFactory extends AbstractWF
     @Override
     public boolean canProcess(WFSOperationType operation) {
         return WFSOperationType.GET_FEATURE.equals(operation);
+    }
+
+    protected FeatureType getRequestedType(GetFeatureRequest request) {
+        FeatureType queryType = request.getQueryType();
+        if (queryType == null) {
+            queryType = request.getFullType();
+        }
+        return queryType;
     }
 
     protected abstract GetParser<SimpleFeature> parser(GetFeatureRequest request, InputStream in)

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/ComplexGetFeatureResponseParserFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/ComplexGetFeatureResponseParserFactory.java
@@ -1,0 +1,96 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.wfs.internal.parsers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.geotools.data.wfs.internal.ComplexGetFeatureResponse;
+import org.geotools.data.wfs.internal.GetFeatureRequest;
+import org.geotools.data.wfs.internal.GetParser;
+import org.geotools.data.wfs.internal.WFSRequest;
+import org.geotools.data.wfs.internal.WFSResponse;
+import org.geotools.http.HTTPResponse;
+import org.geotools.ows.ServiceException;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.FeatureType;
+
+/**
+ * Creating GetFeatureResponse parsers that can treat featureType that don't extend
+ * SimpleFeatureType.
+ *
+ * <p>Treats the same OutputFormats and Versions as GetFeatureResponseParserFactory.
+ *
+ * @author Roar Brænden
+ */
+public class ComplexGetFeatureResponseParserFactory
+        extends AbstractGetFeatureResponseParserFactory {
+
+    /**
+     * Supporting GetFeature requests that also have request.getFullType() not being a
+     * SimpleFeatureType.
+     */
+    @Override
+    public boolean canProcess(WFSRequest request, String contentType) {
+        if (!super.canProcess(request, contentType)) {
+            return false;
+        }
+        if (getRequestedType((GetFeatureRequest) request) instanceof SimpleFeatureType) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> getSupportedOutputFormats() {
+        return GetFeatureResponseParserFactory.SUPPORTED_FORMATS;
+    }
+
+    @Override
+    protected List<String> getSupportedVersions() {
+        return GetFeatureResponseParserFactory.SUPPORTED_VERSIONS;
+    }
+
+    /**
+     * Wrapping a XmlComplexFeatureParser over the input stream.
+     *
+     * <p>Using "in" instead of response.getResponseStream()
+     */
+    @Override
+    protected WFSResponse createResponseImpl(
+            WFSRequest request, HTTPResponse response, InputStream in) throws IOException {
+        FeatureType schema =
+                ((GetFeatureRequest) request).getQueryType() == null
+                        ? ((GetFeatureRequest) request).getFullType()
+                        : ((GetFeatureRequest) request).getQueryType();
+        XmlComplexFeatureParser parser =
+                new XmlComplexFeatureParser(
+                        in, schema, request.getTypeName(), null, request.getStrategy());
+        try {
+            return new ComplexGetFeatureResponse(request, response, parser);
+        } catch (ServiceException e) {
+            throw new IOException("Server responded with error: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected GetParser<SimpleFeature> parser(GetFeatureRequest request, InputStream in)
+            throws IOException {
+        throw new UnsupportedOperationException("We don't support parsing SimpleFeature's.");
+    }
+}

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/GetFeatureResponseParserFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/GetFeatureResponseParserFactory.java
@@ -24,9 +24,11 @@ import java.util.List;
 import org.geotools.data.wfs.internal.GetFeatureRequest;
 import org.geotools.data.wfs.internal.GetParser;
 import org.geotools.data.wfs.internal.Versions;
+import org.geotools.data.wfs.internal.WFSRequest;
 import org.geotools.wfs.v1_0.WFSConfiguration_1_0;
 import org.geotools.xsd.Configuration;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.FeatureType;
 
 /**
@@ -39,7 +41,7 @@ import org.opengis.feature.type.FeatureType;
  */
 public class GetFeatureResponseParserFactory extends AbstractGetFeatureResponseParserFactory {
 
-    private static final List<String> SUPPORTED_FORMATS =
+    static final List<String> SUPPORTED_FORMATS =
             Collections.unmodifiableList(
                     Arrays.asList( //
                             "text/xml; subtype=gml/3.1.1", //
@@ -69,7 +71,7 @@ public class GetFeatureResponseParserFactory extends AbstractGetFeatureResponseP
                             "gml32" //
                             ));
 
-    private static final List<String> SUPPORTED_VERSIONS =
+    static final List<String> SUPPORTED_VERSIONS =
             Collections.unmodifiableList(
                     Arrays.asList(
                             Versions.v2_0_0.toString()
@@ -80,13 +82,21 @@ public class GetFeatureResponseParserFactory extends AbstractGetFeatureResponseP
                             ));
 
     @Override
+    public boolean canProcess(final WFSRequest request, final String contentType) {
+        if (!super.canProcess(request, contentType)) {
+            return false;
+        }
+        if (!(getRequestedType((GetFeatureRequest) request) instanceof SimpleFeatureType)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     protected GetParser<SimpleFeature> parser(GetFeatureRequest request, InputStream in)
             throws IOException {
 
-        FeatureType queryType = request.getQueryType();
-        if (queryType == null) {
-            queryType = request.getFullType();
-        }
+        FeatureType queryType = getRequestedType(request);
 
         Configuration config = null;
         if (request.getStrategy().getVersion().equals(Versions.v2_0_0.toString())) {

--- a/modules/unsupported/wfs-ng/src/main/resources/META-INF/services/org.geotools.data.wfs.internal.WFSResponseFactory
+++ b/modules/unsupported/wfs-ng/src/main/resources/META-INF/services/org.geotools.data.wfs.internal.WFSResponseFactory
@@ -4,3 +4,4 @@ org.geotools.data.wfs.internal.parsers.GmlGetFeatureResponseParserFactory
 org.geotools.data.wfs.internal.parsers.ListStoredQueriesResponseFactory
 org.geotools.data.wfs.internal.parsers.TransactionResponseFactory
 org.geotools.data.wfs.internal.parsers.GetFeatureResponseParserFactory
+org.geotools.data.wfs.internal.parsers.ComplexGetFeatureResponseParserFactory

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
@@ -61,7 +61,7 @@ public class WFSContentComplexFeatureSourceTest {
 
     @Test
     public void testGetFeaturesWithoutArgument() throws Exception {
-        final WFSClient client = createWFSClient();
+        final WFSClient client = createWFSClient(true);
         final WFSContentDataAccess dataAccess = createDataAccess(client);
 
         WFSContentComplexFeatureSource featureSource =
@@ -73,7 +73,7 @@ public class WFSContentComplexFeatureSourceTest {
 
     @Test
     public void testGetFeaturesWithFilter() throws Exception {
-        final WFSClient client = createWFSClient();
+        final WFSClient client = createWFSClient(false);
         final WFSContentDataAccess dataAccess = createDataAccess(client);
 
         WFSContentComplexFeatureSource featureSource =
@@ -91,7 +91,7 @@ public class WFSContentComplexFeatureSourceTest {
 
     @Test
     public void testGetFeaturesWithNameQuery() throws Exception {
-        final WFSClient client = createWFSClient();
+        final WFSClient client = createWFSClient(true);
         final WFSContentDataAccess dataAccess = createDataAccess(client);
 
         WFSContentComplexFeatureSource featureSource =
@@ -110,7 +110,7 @@ public class WFSContentComplexFeatureSourceTest {
 
     @Test
     public void testGetBounds() throws Exception {
-        final WFSClient client = createWFSClient();
+        final WFSClient client = createWFSClient(true);
         final WFSContentDataAccess dataAccess = createDataAccess(client);
 
         ReferencedEnvelope envelope = dataAccess.getFeatureSource(STED_NAME).getBounds();
@@ -148,7 +148,7 @@ public class WFSContentComplexFeatureSourceTest {
         Assert.assertEquals(actual.getMaxY(), test.getMaxY(), 0.1);
     }
 
-    private TestWFSClient createWFSClient() throws Exception {
+    private TestWFSClient createWFSClient(boolean usingGet) throws Exception {
         final URL capabilities = new URL("https://wfs.geonorge.no/skwms1/wfs.stedsnavn");
 
         TestHttpClient mockHttp = new TestHttpClient();
@@ -166,16 +166,30 @@ public class WFSContentComplexFeatureSourceTest {
                         TestData.file(TestHttpClient.class, "KartverketNo/GetFeature_sted.xml"),
                         "text/xml"));
 
-        mockHttp.expectGet(
-                new URL(
-                        "https://wfs.geonorge.no/skwms1/wfs.stedsnavn?FILTER=%3Cfes%3AFilter+xmlns%3Axs%3D%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%22+xmlns%3Afes%3D%22http%3A%2F%2Fwww.opengis.net%2Ffes%2F2.0%22+xmlns%3Agml%3D%22http%3A%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3Cfes%3ABBOX%3E%3Cfes%3AValueReference%3Eposisjon%3C%2Ffes%3AValueReference%3E%3Cgml%3AEnvelope+srsDimension%3D%222%22+srsName%3D%22urn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4258%22%3E%3Cgml%3AlowerCorner%3E7.39+7.41%3C%2Fgml%3AlowerCorner%3E%3Cgml%3AupperCorner%3E58.71+58.73%3C%2Fgml%3AupperCorner%3E%3C%2Fgml%3AEnvelope%3E%3C%2Ffes%3ABBOX%3E%3C%2Ffes%3AFilter%3E&REQUEST=GetFeature&RESULTTYPE=RESULTS&OUTPUTFORMAT=application%2Fgml%2Bxml%3B+version%3D3.2&VERSION=2.0.0&TYPENAMES=app%3ASted&SERVICE=WFS"),
+        mockHttp.expectPost(
+                new URL("https://wfs.geonorge.no/skwms1/wfs.stedsnavn"),
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><wfs:GetFeature xmlns:app=\"http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:fes=\"http://www.opengis.net/fes/2.0\" xmlns:wfs=\"http://www.opengis.net/wfs/2.0\" xmlns:gml=\"http://www.opengis.net/gml/3.2\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"  outputFormat=\"application/gml+xml; version=3.2\" resolve=\"none\" resolveDepth=\"*\" resolveTimeout=\"300\" resultType=\"results\" service=\"WFS\" version=\"2.0.0\">\n"
+                        + " <wfs:Query srsName=\"urn:ogc:def:crs:EPSG::4258\" typeNames=\"app:Sted\">\n"
+                        + "  <fes:Filter>\n"
+                        + "   <fes:BBOX>\n"
+                        + "    <fes:ValueReference>posisjon</fes:ValueReference>\n"
+                        + "    <gml:Envelope srsDimension=\"2\" srsName=\"urn:ogc:def:crs:EPSG::4258\">\n"
+                        + "     <gml:lowerCorner>7.39 7.41</gml:lowerCorner>\n"
+                        + "     <gml:upperCorner>58.71 58.73</gml:upperCorner>\n"
+                        + "    </gml:Envelope>\n"
+                        + "   </fes:BBOX>\n"
+                        + "  </fes:Filter>\n"
+                        + " </wfs:Query>\n"
+                        + "</wfs:GetFeature>\n",
+                "text/xml",
                 new MockHttpResponse(
                         TestData.file(TestHttpClient.class, "KartverketNo/GetFeature_sted.xml"),
                         "text/xml"));
 
         TestWFSClient client = new TestWFSClient(capabilities, mockHttp);
-        client.setProtocol(false); // Http GET method
-
+        if (usingGet) {
+            client.setProtocol(false); // Http GET method
+        }
         return client;
     }
 


### PR DESCRIPTION
[![GEOT-7239](https://badgen.net/badge/JIRA/GEOT-7239/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7239) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR fixes two bug's that prevented WFSContentDataAccess to work when using POST as HTTP transport.

- Within WFSContentDataAccess.getSchema() we were using client.createDescribeFeatureTypeRequest to get a url that was used in SchemaParser. When using POST that url would be incomplete.
- WFSContentComplexFeatureCollection we were using the GetFeatureRequest.getFinalUrl to get an URL for GetFeature request. When using POST that url would be incomplete. This fix involved a series of new classes involving AbstractGetFeatureResponseParserFactory.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->