### PR TITLE
[GEOT-7276] Remove deprecated from gt-wmts

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WMTSSpecification.java
@@ -29,7 +29,6 @@ import java.util.logging.Logger;
 import org.apache.commons.lang3.StringUtils;
 import org.geotools.data.ows.AbstractGetCapabilitiesRequest;
 import org.geotools.data.ows.GetCapabilitiesRequest;
-import org.geotools.data.ows.Response;
 import org.geotools.data.ows.Specification;
 import org.geotools.http.HTTPClient;
 import org.geotools.http.HTTPClientFinder;
@@ -77,43 +76,10 @@ public class WMTSSpecification extends Specification {
         return new GetCapsRequest(server);
     }
 
-    /** @deprecated Use createGetMultiTileRequest */
-    @Deprecated
-    public GetTileRequest createGetTileRequest(
-            URL server, Properties props, WMTSCapabilities caps) {
-        return this.createGetTileRequest(server, props, caps, HTTPClientFinder.createClient());
-    }
-
-    /** @deprecated Use createGetMultiTileRequest */
-    @Deprecated
-    public GetTileRequest createGetTileRequest(
-            URL server, Properties props, WMTSCapabilities caps, HTTPClient client) {
-        return new GetTileRequest(server, props, caps, client);
-    }
-
     /** Create a GetMultiTileRequest */
     GetMultiTileRequest createGetMultiTileRequest(
             URL server, Properties props, WMTSCapabilities caps, HTTPClient client) {
         return new GetMultiTileRequest(server, props, caps, client);
-    }
-
-    /** @deprecated Avoid usage of this - change to GetMultiTileRequest */
-    @Deprecated
-    public static class GetTileRequest extends GetMultiTileRequest {
-
-        public GetTileRequest(
-                URL onlineResource,
-                Properties properties,
-                WMTSCapabilities capabilities,
-                HTTPClient client) {
-            super(onlineResource, properties, capabilities, client);
-        }
-
-        /** Returns a GetTileResponse which in most cases represents an Image. */
-        @Override
-        public Response createResponse(HTTPResponse response) throws ServiceException, IOException {
-            return new GetTileResponse(response, getType());
-        }
     }
 
     /** GetMultiTileRequest - used for getting a Set of tiles */

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
@@ -17,7 +17,6 @@
 package org.geotools.ows.wmts;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 import java.util.Properties;
@@ -150,46 +149,6 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
     public WebMapTileServer(URL serverURL) throws IOException, ServiceException {
         super(serverURL);
         setupType();
-    }
-
-    /**
-     * Set up the WebMapTileServer with the given capabilities. Using the default http client.
-     *
-     * @param capabilities
-     * @throws ServiceException
-     * @throws IOException
-     * @deprecated Use constructor with serverUrl and capabilities
-     */
-    @Deprecated
-    public WebMapTileServer(WMTSCapabilities capabilities) throws ServiceException, IOException {
-        this(capabilities, HTTPClientFinder.createClient());
-    }
-
-    /**
-     * Set up the WebMapTileServer with the given capabilities, using a custom http client.
-     *
-     * @param capabilities
-     * @throws ServiceException
-     * @throws IOException
-     * @deprecated Use constructor with serverUrl, capabilities and httpClient.
-     */
-    @Deprecated
-    public WebMapTileServer(WMTSCapabilities capabilities, HTTPClient httpClient)
-            throws ServiceException, IOException {
-        super(extractServerURL(capabilities), httpClient, capabilities);
-        setupType();
-    }
-
-    private static URL extractServerURL(WMTSCapabilities capabilities) {
-        URL url = capabilities.getRequest().getGetCapabilities().getGet();
-        if (url == null) {
-            try {
-                url = new URL("http://missing.url/");
-            } catch (MalformedURLException e) {
-                //
-            }
-        }
-        return url;
     }
 
     /**

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTile.java
@@ -16,20 +16,12 @@
  */
 package org.geotools.ows.wmts.client;
 
-import java.awt.image.BufferedImage;
-import java.io.IOException;
 import java.net.URL;
-import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.geotools.http.HTTPResponse;
-import org.geotools.image.io.ImageIOExt;
 import org.geotools.tile.Tile;
 import org.geotools.tile.TileIdentifier;
 import org.geotools.tile.TileService;
 import org.geotools.tile.impl.ZoomLevel;
-import org.geotools.util.ObjectCache;
-import org.geotools.util.ObjectCaches;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -43,30 +35,6 @@ class WMTSTile extends Tile {
     protected static final Logger LOGGER = Logging.getLogger(WMTSTile.class);
 
     public static final String WMTS_TILE_CACHE_SIZE_PROPERTY_NAME = "wmts.tile.cache.size";
-
-    /**
-     * Cache for tiles.
-     *
-     * <p>Many WMTS tiles may be reloaded over and over, especially in a tiled getMap request.
-     *
-     * <p>You can set the cache size using the property WMTS_TILE_CACHE_SIZE_PROPERTY_NAME.
-     */
-    private static final ObjectCache<String, BufferedImage> tileImages;
-
-    static {
-        int cacheSize = 150;
-
-        String size = System.getProperty(WMTS_TILE_CACHE_SIZE_PROPERTY_NAME);
-        if (size != null) {
-            try {
-                cacheSize = Integer.parseUnsignedInt(size);
-            } catch (NumberFormatException ex) {
-                LOGGER.info(
-                        "Bad " + WMTS_TILE_CACHE_SIZE_PROPERTY_NAME + " property '" + size + "'");
-            }
-        }
-        tileImages = ObjectCaches.create("soft", cacheSize);
-    }
 
     private URL url = null;
 
@@ -99,42 +67,5 @@ class WMTSTile extends Tile {
             url = getService().createURL(this);
         }
         return url;
-    }
-
-    /** @deprecated Loading is handled by WMTSTileService.loadImageTileImage */
-    @Deprecated
-    @Override
-    public BufferedImage loadImageTileImage(Tile tile) throws IOException {
-        final URL url = getUrl();
-        LOGGER.log(Level.FINE, "Loading tile " + getId() + ": " + url);
-
-        String tileKey = url.toString();
-
-        if (!(tileImages.peek(tileKey) == null || tileImages.get(tileKey) == null)) {
-            if (LOGGER.isLoggable(Level.FINE))
-                LOGGER.log(Level.FINE, "Tile image already loaded for tile " + getId());
-            return tileImages.get(tileKey);
-        } else {
-            if (LOGGER.isLoggable(Level.FINE))
-                LOGGER.log(Level.FINE, "Tile image not yet loaded for tile " + getId());
-            BufferedImage bi = doLoadImageTileImage(tile);
-            tileImages.put(tileKey, bi);
-            return bi;
-        }
-    }
-
-    /** @deprecated Loading is handled by WMTSTileService */
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public BufferedImage doLoadImageTileImage(Tile tile) throws IOException {
-        final WMTSTileService service = getService();
-        Map<String, String> headers =
-                (Map<String, String>) service.getExtrainfo().get(WMTSTileService.EXTRA_HEADERS);
-        HTTPResponse http = service.getHttpClient().get(getUrl(), headers);
-        try {
-            return ImageIOExt.readBufferedImage(http.getResponseStream());
-        } finally {
-            http.dispose();
-        }
     }
 }

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSCoverageReader.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSCoverageReader.java
@@ -88,9 +88,6 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
     /** The cached layer bounds */
     ReferencedEnvelope bounds;
 
-    /** Keep the last tileRequest that was handled by this Reader */
-    private GetTileRequest lastTileRequest;
-
     private String requestedTime;
 
     public final boolean debug = System.getProperty("wmts.debug") != null;
@@ -507,18 +504,6 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
         return super.getMetadataValue(name);
     }
 
-    /** @return the mapRequest */
-    @Deprecated
-    public GetTileRequest getTileRequest() {
-        return this.lastTileRequest;
-    }
-
-    /** @param mapRequest the mapRequest to set */
-    @Deprecated
-    public void setTileRequest(GetTileRequest mapRequest) {
-        this.lastTileRequest = mapRequest;
-    }
-
     /** Get the Request time */
     public String getRequestedTime() {
         return this.requestedTime;
@@ -727,8 +712,6 @@ public class WMTSCoverageReader extends AbstractGridCoverage2DReader {
                 tileRequest.setRequestedBBox(envelope);
                 tileRequest.setRequestedTime(time);
                 tileRequest.setFormat(format);
-
-                WMTSCoverageReader.this.lastTileRequest = tileRequest;
 
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.log(Level.FINE, "Issuing request: " + tileRequest.getFinalURL());

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSMapLayer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/map/WMTSMapLayer.java
@@ -22,7 +22,6 @@ import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.map.GridReaderLayer;
 import org.geotools.ows.wms.Layer;
 import org.geotools.ows.wmts.WebMapTileServer;
-import org.geotools.ows.wmts.request.GetTileRequest;
 import org.geotools.parameter.DefaultParameterDescriptor;
 import org.geotools.parameter.Parameter;
 import org.geotools.styling.FeatureTypeStyle;
@@ -98,21 +97,9 @@ public class WMTSMapLayer extends GridReaderLayer {
         return super.getBounds();
     }
 
-    /** Returns the {@link WebMapTileServer} used by this layer */
-    @Deprecated
-    public WebMapTileServer getWebMapServer() {
-        return getReader().wmts;
-    }
-
     /** Returns the CRS used to make requests to the remote WMTS */
     public CoordinateReferenceSystem getCoordinateReferenceSystem() {
         return reader.getCoordinateReferenceSystem();
-    }
-
-    /** Returns last GetMap request performed by this layer */
-    @Deprecated
-    public GetTileRequest getLastGetMap() {
-        return getReader().getTileRequest();
     }
 
     /**


### PR DESCRIPTION
[![GEOT-7276](https://badgen.net/badge/JIRA/GEOT-7276/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7276) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removing deprecated function's and instance variables not in use.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->