### PR TITLE
[GEOT-7284] Support for Saxon Transformer

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
@@ -36,6 +36,8 @@ import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.NamespaceSupport;
@@ -959,6 +961,14 @@ public abstract class TransformerBase {
 
         public final Translator getTranslator() {
             return translator;
+        }
+
+        @Override
+        public void setFeature(String name, boolean value)
+                throws SAXNotRecognizedException, SAXNotSupportedException {
+            // no-op. The base XMLFilterImpl will throw an exception, so we must override this as
+            // Transformer implementations such as Saxonica's Saxon expect to at least switch on
+            // http://xml.org/sax/features/namespaces
         }
 
         @Override


### PR DESCRIPTION
[![GEOT-7284](https://badgen.net/badge/JIRA/GEOT-7284/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7284) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This solves the following error which occurs in version 27.2 when using Saxonica's Saxon instead of Apache's Xalan on JDK 8.

```
Caused by: net.sf.saxon.trans.XPathException: The SAX2 parser org.geotools.xml.transform.TransformerBase$XMLReaderSupport does not support setting the 'namespaces' feature to true
	at net.sf.saxon.event.Sender.configureParser(Sender.java:557)
	at net.sf.saxon.event.Sender.sendSAXSource(Sender.java:305)
	at net.sf.saxon.event.Sender.send(Sender.java:141)
	at net.sf.saxon.jaxp.IdentityTransformer.transform(IdentityTransformer.java:368)
	at org.geotools.xml.transform.TransformerBase$Task.run(TransformerBase.java:285)
	at org.geotools.xml.transform.TransformerBase.transform(TransformerBase.java:119)
	at org.geotools.xml.transform.TransformerBase.transform(TransformerBase.java:109)
	at org.geotools.xml.transform.TransformerBase.transform(TransformerBase.java:146)
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) - https://osgeo-org.atlassian.net/browse/GEOT-7284 (previously https://osgeo-org.atlassian.net/browse/GEO-305)
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).