### PR TITLE
[GEOT-7283] update Batik to 1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <series>latest</series>
     <!-- dependency management -->
-    <batik.version>1.14</batik.version>
+    <batik.version>1.16</batik.version>
     <commons-beanutils.version>1.9.2</commons-beanutils.version>
     <db2.jdbc.version>11.5.6.0</db2.jdbc.version>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>


### PR DESCRIPTION
[![GEOT-7283](https://badgen.net/badge/JIRA/GEOT-7283/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7283) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Updates Batik dependencies to 1.16. We currently have 1.14. The changes are basically bug fixes, as noted at https://xmlgraphics.apache.org/batik/

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [X] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [N/A] New unit tests have been added covering the changes.
- [N/A] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->