### PR TITLE
[GEOT-7281] Add TransformFeatureLocking wrapper

### DIFF
--- a/docs/user/extension/transform/transform.rst
+++ b/docs/user/extension/transform/transform.rst
@@ -1,7 +1,7 @@
 Transform plugin
 ----------------
 
-The *gt-transform* module allows to wrap ``SimpleFeatureSource`` or ``SimpleFeatureStore`` objects and transform their features and feature types. The transformation abilities include:
+The *gt-transform* module allows to wrap ``SimpleFeatureSource``, ``SimpleFeatureStore`` or ``SimpleFeatureLocking`` objects and transform their features and feature types. The transformation abilities include:
 
   * renaming existing attributes
   * convert an attribute type to a different type (via Converters API)

--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFactory.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFactory.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geotools.data.simple.SimpleFeatureLocking;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.feature.NameImpl;
@@ -62,6 +63,19 @@ public class TransformFactory {
     public static SimpleFeatureSource transform(
             SimpleFeatureSource source, Name name, List<Definition> definitions)
             throws IOException {
+        if (source instanceof SimpleFeatureLocking) {
+            try {
+                return new TransformFeatureLocking(
+                        (SimpleFeatureLocking) source, name, definitions);
+            } catch (IllegalArgumentException e) {
+                LOGGER.log(
+                        Level.FINEST,
+                        "Could not transform the provided locking, will turn it into a read "
+                                + "only SimpleFeatureSource instead (this is not a problem unless you "
+                                + "actually needed to write on the store)",
+                        e);
+            }
+        }
         if (source instanceof SimpleFeatureStore) {
             try {
                 return new TransformFeatureStore((SimpleFeatureStore) source, name, definitions);

--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureLocking.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureLocking.java
@@ -1,0 +1,75 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.transform;
+
+import java.io.IOException;
+import java.util.List;
+import org.geotools.data.FeatureLock;
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureLocking;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.Filter;
+
+public class TransformFeatureLocking extends TransformFeatureStore implements SimpleFeatureLocking {
+    private final SimpleFeatureLocking locking;
+
+    public TransformFeatureLocking(
+            SimpleFeatureLocking locking, Name name, List<Definition> definitions)
+            throws IOException {
+        super(locking, name, definitions);
+        this.locking = locking;
+    }
+
+    @Override
+    public void setFeatureLock(FeatureLock lock) {
+        locking.setFeatureLock(lock);
+    }
+
+    @Override
+    public int lockFeatures(Query query) throws IOException {
+        Query txQuery = transformer.transformQuery(query);
+        return locking.lockFeatures(txQuery);
+    }
+
+    @Override
+    public int lockFeatures(Filter filter) throws IOException {
+        Filter txFilter = transformer.transformFilter(filter);
+        return locking.lockFeatures(txFilter);
+    }
+
+    @Override
+    public int lockFeatures() throws IOException {
+        return locking.lockFeatures();
+    }
+
+    @Override
+    public void unLockFeatures() throws IOException {
+        locking.unLockFeatures();
+    }
+
+    @Override
+    public void unLockFeatures(Filter filter) throws IOException {
+        Filter txFilter = transformer.transformFilter(filter);
+        locking.unLockFeatures(txFilter);
+    }
+
+    @Override
+    public void unLockFeatures(Query query) throws IOException {
+        Query txQuery = transformer.transformQuery(query);
+        locking.unLockFeatures(txQuery);
+    }
+}

--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureLocking.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureLocking.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/extension/transform/src/test/java/org/geotools/data/transform/AbstractTransformTest.java
+++ b/modules/extension/transform/src/test/java/org/geotools/data/transform/AbstractTransformTest.java
@@ -9,6 +9,7 @@ import org.geotools.data.collection.ListFeatureCollection;
 import org.geotools.data.property.PropertyDataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
@@ -20,6 +21,8 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 public abstract class AbstractTransformTest {
 
     static SimpleFeatureSource STATES;
+
+    static SimpleFeatureSource STATES2;
 
     static ReferencedEnvelope DELAWARE_BOUNDS;
 
@@ -41,26 +44,36 @@ public abstract class AbstractTransformTest {
         PropertyDataStore pds =
                 new PropertyDataStore(new File("./src/test/resources/org/geotools/data/transform"));
         STATES = pds.getFeatureSource("states");
+        STATES2 = pds.getFeatureSource("states");
     }
 
     SimpleFeatureSource transformWithSelection() throws IOException {
+        return transformWithSelection(STATES);
+    }
+
+    SimpleFeatureSource transformWithSelection(SimpleFeatureSource states) throws IOException {
         List<Definition> definitions = new ArrayList<>();
         definitions.add(new Definition("the_geom"));
         definitions.add(new Definition("state_name"));
         definitions.add(new Definition("persons"));
 
         SimpleFeatureSource transformed =
-                TransformFactory.transform(STATES, "states_mini", definitions);
+                TransformFactory.transform(states, "states_mini", definitions);
         return transformed;
     }
 
     SimpleFeatureSource transformWithRename() throws Exception {
+        return transformWithRename(STATES);
+    }
+
+    SimpleFeatureSource transformWithRename(SimpleFeatureSource states)
+            throws CQLException, IOException {
         List<Definition> definitions = new ArrayList<>();
         definitions.add(new Definition("geom", ECQL.toExpression("the_geom")));
         definitions.add(new Definition("name", ECQL.toExpression("state_name")));
         definitions.add(new Definition("people", ECQL.toExpression("persons")));
 
-        SimpleFeatureSource transformed = TransformFactory.transform(STATES, "usa", definitions);
+        SimpleFeatureSource transformed = TransformFactory.transform(states, "usa", definitions);
         return transformed;
     }
 

--- a/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformFeatureLockingTest.java
+++ b/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformFeatureLockingTest.java
@@ -1,0 +1,85 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.transform;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.FeatureLock;
+import org.geotools.data.simple.SimpleFeatureLocking;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.filter.text.cql2.CQL;
+import org.geotools.filter.text.cql2.CQLException;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+
+public class TransformFeatureLockingTest extends AbstractTransformTest {
+
+    @Test
+    public void testFeatureLocking() throws Exception {
+        // these are easy, selection and renaming, they can be inverted
+        assertTrue(transformWithSelection() instanceof SimpleFeatureLocking);
+        assertTrue(transformWithRename() instanceof SimpleFeatureLocking);
+        // this one does not have any definition that can be inverted
+        assertTrue(transformWithExpressions() instanceof SimpleFeatureSource);
+    }
+
+    @Test
+    public void testLockOnSelection() throws Exception {
+        performLockingTest(
+                (SimpleFeatureLocking) transformWithSelection(STATES),
+                (SimpleFeatureLocking) transformWithSelection(STATES2),
+                CQL.toFilter("state_name = 'Delaware'"));
+    }
+
+    @Test
+    public void testLockOnRename() throws Exception {
+        performLockingTest(
+                (SimpleFeatureLocking) transformWithRename(STATES),
+                (SimpleFeatureLocking) transformWithRename(STATES2),
+                CQL.toFilter("name = 'Delaware'"));
+    }
+
+    private void performLockingTest(
+            SimpleFeatureLocking fl1, SimpleFeatureLocking fl2, Filter filter)
+            throws CQLException, IOException {
+        final FeatureLock lock1 = new FeatureLock("lock", 10 * 60 * 1000);
+        final FeatureLock lock2 = new FeatureLock("lock", 10 * 60 * 1000);
+
+        try (DefaultTransaction t1 = new DefaultTransaction();
+                DefaultTransaction t2 = new DefaultTransaction()) {
+            t1.addAuthorization(lock1.getAuthorization());
+            fl1.setTransaction(t1);
+            fl1.setFeatureLock(lock1);
+
+            t2.addAuthorization(lock2.getAuthorization());
+            fl2.setTransaction(t2);
+            fl2.setFeatureLock(lock2);
+
+            // first attempt will lock just the one Delaware, works with one but not the other
+            assertEquals(1, fl1.lockFeatures(filter));
+            assertEquals(0, fl2.lockFeatures(filter));
+
+            // now unlock and try again, this time transformed2 should be able to lock
+            fl1.unLockFeatures(filter);
+            assertEquals(1, fl2.lockFeatures(filter));
+            fl2.unLockFeatures(filter);
+        }
+    }
+}

--- a/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformFeatureLockingTest.java
+++ b/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformFeatureLockingTest.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/library/main/src/main/java/org/geotools/data/FeatureLocking.java
+++ b/modules/library/main/src/main/java/org/geotools/data/FeatureLocking.java
@@ -93,9 +93,9 @@ public interface FeatureLocking<T extends FeatureType, F extends Feature>
     /**
      * FeatureLock features described by Filter.
      *
-     * <p>To implement WFS parcial Locking retrieve your features with a query operation first
+     * <p>To implement WFS partial Locking retrieve your features with a query operation first
      * before trying to lock them individually. If you are not into WFS please don't ask what
-     * parcial locking is.
+     * partial locking is.
      *
      * @param filter Filter describing the features to lock
      * @return Number of features locked


### PR DESCRIPTION
[![GEOT-7281](https://badgen.net/badge/JIRA/GEOT-7281/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7281) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adds support for locking on transformed feature types

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->