### PR TITLE
[GEOT-7286] Let SQLDialect decide whether to apply hints on virtual tables

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -3501,8 +3501,10 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
     }
 
     private void applySearchHints(SimpleFeatureType featureType, Query query, StringBuffer sql) {
-        // we can apply search hints only on real tables
-        if (virtualTables.containsKey(featureType.getTypeName())) {
+        // If there are virtual tables in the query, ask the dialect whether select hints should be
+        // omitted
+        if (virtualTables.containsKey(featureType.getTypeName())
+                && !dialect.applyHintsOnVirtualTables()) {
             return;
         }
 

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
@@ -1266,6 +1266,15 @@ public abstract class SQLDialect {
         // nothing to do
     }
 
+    /**
+     * Controls whether select hints should be added to queries on virtual tables.
+     *
+     * @return True if select hints hould be added to queries on virtual tables, false otherwise.
+     */
+    public boolean applyHintsOnVirtualTables() {
+        return false;
+    }
+
     /** @return Table types filtered from jdbc {@link DatabaseMetaData} */
     public String[] getDesiredTablesType() {
         return new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "SYNONYM"};

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
@@ -826,6 +826,11 @@ public class HanaDialect extends PreparedStatementSQLDialect {
     }
 
     @Override
+    public boolean applyHintsOnVirtualTables() {
+        return true;
+    }
+
+    @Override
     public String[] getDesiredTablesType() {
         return new String[] {"TABLE", "OLAP VIEW", "JOIN VIEW", "VIEW", "CALC VIEW", "SYNONYM"};
     }

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaVirtualTableHintOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaVirtualTableHintOnlineTest.java
@@ -1,0 +1,56 @@
+package org.geotools.data.hana;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Map;
+import org.geotools.data.FeatureStore;
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.geotools.jdbc.VirtualTable;
+import org.junit.Test;
+
+public class HanaVirtualTableHintOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new HanaDataStoreAPITestSetup(new HanaTestSetupPSPooling());
+    }
+
+    @Test
+    public void testHintIsAppliedToVirtualTables() throws IOException {
+        String schema = getFixture().getProperty("schema", "geotools");
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("select * from ");
+        HanaTestUtil.encodeIdentifiers(sb, schema, "river");
+        VirtualTable vt = new VirtualTable("riverFull", sb.toString());
+        dataStore.createVirtualTable(vt);
+
+        SimpleFeatureSource fsView = dataStore.getFeatureSource("riverFull");
+        assertFalse(fsView instanceof FeatureStore);
+
+        try {
+            fsView.getCount(Query.ALL);
+            fail("Expected exception");
+        } catch (IOException e) {
+            boolean foundMessage = false;
+            for (Throwable t = e; (t != null) && !foundMessage; t = t.getCause()) {
+                String msg = e.getMessage();
+                foundMessage =
+                        (msg != null)
+                                && msg.contains("statement execution blocked by THROW_ERROR hint");
+            }
+        }
+    }
+
+    @Override
+    protected Map<String, Object> createDataStoreFactoryParams() throws Exception {
+        Map<String, Object> params = super.createDataStoreFactoryParams();
+        params.put(HanaDataStoreFactory.SELECT_HINTS.key, "THROW_ERROR");
+        return params;
+    }
+}


### PR DESCRIPTION
[![GEOT-7286](https://badgen.net/badge/JIRA/GEOT-7286/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7286) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

So far, ``JDBCDataStore`` does not add select-hints to queries on virtual tables. This makes sense for some ``SQLDialect``s, but not for all.

This change adds a new method ``applyHintsOnVirtualTables()`` to the ``SQLDialect`` class that allows the concrete ``SQLDialect`` to control whether hints are added to queries on virtual tables. The default implementation of ``applyHintsOnVirtualTables()`` returns ``false`` to keep the current behavior.

For the HANA plugin, the behavior has been adapted to add select-hints to queries on virtual tables.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [X] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).