### PR TITLE
[GEOT-7294] Geometry simplification cannot be disabled in HANA plugin

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDataStoreFactory.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.geotools.data.DataAccessFactory.Param;
 import org.geotools.data.Parameter;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
@@ -81,6 +80,16 @@ public class HanaDataStoreFactory extends JDBCDataStoreFactory {
                     false,
                     Boolean.FALSE,
                     Collections.singletonMap(Param.LEVEL, "advanced"));
+
+    /** Prevents simplification by the database */
+    public static final Param DISABLE_SIMPLIFY =
+            new Param(
+                    "disable simplification",
+                    Boolean.class,
+                    "Certain operations like map rendering can request geometry simplification from the database. "
+                            + "Setting this option to true will prevent geometry simplifcation by the database.",
+                    false,
+                    Boolean.FALSE);
 
     public static final Param SELECT_HINTS =
             new Param(
@@ -145,6 +154,7 @@ public class HanaDataStoreFactory extends JDBCDataStoreFactory {
             }
             if (EXPOSE_PK.key.equals(param.getKey())) {
                 parameters.put(ENCODE_FUNCTIONS.key, ENCODE_FUNCTIONS);
+                parameters.put(DISABLE_SIMPLIFY.key, DISABLE_SIMPLIFY);
                 parameters.put(SELECT_HINTS.key, SELECT_HINTS);
             }
         }
@@ -182,6 +192,8 @@ public class HanaDataStoreFactory extends JDBCDataStoreFactory {
         HanaDialect dialect = (HanaDialect) dataStore.getSQLDialect();
         Boolean encodeFunctions = (Boolean) ENCODE_FUNCTIONS.lookUp(params);
         dialect.setFunctionEncodingEnabled((encodeFunctions != null) && encodeFunctions);
+        Boolean disableSimplify = (Boolean) DISABLE_SIMPLIFY.lookUp(params);
+        dialect.setSimplifyDisabled((disableSimplify != null) && disableSimplify);
         String selectHints = (String) SELECT_HINTS.lookUp(params);
         dialect.setSelectHints(selectHints);
         return dataStore;

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
@@ -148,6 +148,8 @@ public class HanaDialect extends PreparedStatementSQLDialect {
 
     private boolean functionEncodingEnabled;
 
+    private boolean simplifyDisabled;
+
     private String selectHints;
 
     private HanaVersion hanaVersion;
@@ -156,6 +158,10 @@ public class HanaDialect extends PreparedStatementSQLDialect {
 
     public void setFunctionEncodingEnabled(boolean enabled) {
         functionEncodingEnabled = enabled;
+    }
+
+    public void setSimplifyDisabled(boolean disabled) {
+        simplifyDisabled = disabled;
     }
 
     public void setSelectHints(String selectHints) {
@@ -441,6 +447,7 @@ public class HanaDialect extends PreparedStatementSQLDialect {
         encodeColumnName(prefix, gatt.getLocalName(), sql);
         if ((distance != null)
                 && (distance >= 0.0)
+                && !simplifyDisabled
                 && isPlanarCRS(gatt.getCoordinateReferenceSystem())) {
             sql.append(".ST_Simplify(");
             sql.append(distance.toString());
@@ -799,9 +806,11 @@ public class HanaDialect extends PreparedStatementSQLDialect {
 
     @Override
     protected void addSupportedHints(Set<org.geotools.util.factory.Hints.Key> hints) {
-        if ((hanaVersion.getVersion() > 2)
-                || ((hanaVersion.getVersion() == 2) && (hanaVersion.getRevision() >= 40))) {
-            hints.add(Hints.GEOMETRY_SIMPLIFICATION);
+        if (!simplifyDisabled) {
+            if ((hanaVersion.getVersion() > 2)
+                    || ((hanaVersion.getVersion() == 2) && (hanaVersion.getRevision() >= 40))) {
+                hints.add(Hints.GEOMETRY_SIMPLIFICATION);
+            }
         }
     }
 

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaJNDIDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaJNDIDataStoreFactory.java
@@ -45,6 +45,9 @@ public class HanaJNDIDataStoreFactory extends JDBCJNDIDataStoreFactory {
             if (EXPOSE_PK.key.equals(param.getKey())) {
                 parameters.put(ENCODE_FUNCTIONS.key, ENCODE_FUNCTIONS);
                 parameters.put(
+                        HanaDataStoreFactory.DISABLE_SIMPLIFY.key,
+                        HanaDataStoreFactory.DISABLE_SIMPLIFY);
+                parameters.put(
                         HanaDataStoreFactory.SELECT_HINTS.key, HanaDataStoreFactory.SELECT_HINTS);
             }
         }

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaDisableSimplificationOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaDisableSimplificationOnlineTest.java
@@ -1,0 +1,59 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.geotools.util.factory.Hints;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaDisableSimplificationOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new HanaDisableSimplificationTestSetup(new HanaTestSetupPSPooling());
+    }
+
+    @Test
+    public void testDisabledSimplification() throws Exception {
+        SimpleFeatureSource fs = dataStore.getFeatureSource(tname("testtab"));
+
+        assumeFalse(fs.getSupportedHints().contains(Hints.GEOMETRY_SIMPLIFICATION));
+
+        Query query = new Query();
+        Hints hints = new Hints(Hints.GEOMETRY_SIMPLIFICATION, 0.5);
+        query.setHints(hints);
+
+        SimpleFeatureCollection coll = fs.getFeatures(query);
+        Geometry geom = null;
+        try (SimpleFeatureIterator iter = coll.features()) {
+            if (iter.hasNext()) {
+                geom = (Geometry) iter.next().getDefaultGeometry();
+            }
+        }
+        assertEquals(4, geom.getNumPoints());
+    }
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaDisableSimplificationTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaDisableSimplificationTestSetup.java
@@ -1,0 +1,77 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.geotools.jdbc.JDBCDelegatingTestSetup;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaDisableSimplificationTestSetup extends JDBCDelegatingTestSetup {
+
+    private static final String TABLE_NAME = "testtab";
+
+    public HanaDisableSimplificationTestSetup(JDBCTestSetup delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void setUpData() throws Exception {
+        try {
+            dropTestTable();
+        } catch (SQLException e) {
+        }
+
+        createTestTable();
+    }
+
+    private void createTestTable() throws SQLException, IOException {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn, fixture);
+            htu.createTestSchema();
+
+            String[][] cols = {
+                {"fid", "INT PRIMARY KEY"},
+                {"id", "INT"},
+                {"geom", "ST_Geometry(3857)"}
+            };
+            htu.createRegisteredTestTable(TABLE_NAME, cols);
+
+            htu.insertIntoTestTable(
+                    TABLE_NAME,
+                    htu.nextTestSequenceValueForColumn(TABLE_NAME, "fid"),
+                    0,
+                    htu.geometry("LINESTRING(0 0, 1 0, 2 0, 3 0)", 3857));
+        }
+    }
+
+    private void dropTestTable() throws SQLException, IOException {
+        try (Connection conn = getConnection()) {
+            HanaTestUtil htu = new HanaTestUtil(conn, fixture);
+            htu.dropTestTableCascade(TABLE_NAME);
+        }
+    }
+
+    @Override
+    public void setFixture(Properties fixture) {
+        fixture.setProperty("disable simplification", "true");
+        super.setFixture(fixture);
+    }
+}


### PR DESCRIPTION
[![GEOT-7294](https://badgen.net/badge/JIRA/GEOT-7294/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7294) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This change adds an option to the HANA plugin that allows disabling geometry simplification by the database.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [X] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).