### PR TITLE
[GEOT-7285] JDBCDataStore.getConnection(Transaction t) throws NullPoi…

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -2202,10 +2202,11 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
      *       use the {@link Transaction} facilities to do so instead
      * </ul>
      *
-     * @param t The GeoTools transaction. Can be {@code null}, in that case a new connection will be
-     *     returned (as if {@link Transaction#AUTO_COMMIT} was provided)
+     * @param t The GeoTools transaction, can not be null
      */
     public Connection getConnection(Transaction t) throws IOException {
+        Objects.requireNonNull(t);
+
         // short circuit this state, all auto commit transactions are using the same
         if (t == Transaction.AUTO_COMMIT) {
             Connection cx = createConnection();

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreTest.java
@@ -245,7 +245,10 @@ public class JDBCDataStoreTest {
             Assert.assertEquals(Boolean.FALSE, conn2.getAutoCommit());
         }
 
-        Transaction transaction = null;
-        Assert.assertThrows(Exception.class, () -> store.getConnection(transaction));
+        Assert.assertThrows(
+                Exception.class,
+                () -> {
+                    try (Connection connection = store.getConnection((Transaction) null)) {}
+                });
     }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCDataStoreTest.java
@@ -246,10 +246,6 @@ public class JDBCDataStoreTest {
         }
 
         Transaction transaction = null;
-        try (Connection conn = store.getConnection(transaction)) {
-            Assert.fail("Transaction should be set.");
-        } catch (Exception e) {
-            // should fail
-        }
+        Assert.assertThrows(Exception.class, () -> store.getConnection(transaction));
     }
 }


### PR DESCRIPTION
[![GEOT-7285](https://badgen.net/badge/JIRA/GEOT-7285/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7285) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Changed the Javadoc to point out that a transaction must be provided.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->