### PR TITLE
[GEOT-7295] HANA plugin attempts to create polygons consisting of 2 points only

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/wkb/HanaWKBParser.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/wkb/HanaWKBParser.java
@@ -199,8 +199,23 @@ public class HanaWKBParser {
     }
 
     private LinearRing parseLinearRing() {
-        CoordinateSequence cs = readCoordinateSequence();
+        CoordinateSequence cs = patchRing(readCoordinateSequence());
         return factory.createLinearRing(cs);
+    }
+
+    private CoordinateSequence patchRing(CoordinateSequence cs) {
+        if ((cs.size() >= 4) || (cs.size() == 0)) {
+            return cs;
+        }
+        Coordinate[] coords = new Coordinate[4];
+        for (int i = 0; i < cs.size(); ++i) {
+            coords[i] = cs.getCoordinate(i);
+        }
+        for (int i = cs.size(); i < 4; ++i) {
+            coords[i] = cs.getCoordinate(0);
+        }
+        CoordinateSequenceFactory csf = factory.getCoordinateSequenceFactory();
+        return csf.create(coords);
     }
 
     private CoordinateSequence readCoordinateSequence() {

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/wkb/HanaRingPatchingTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/wkb/HanaRingPatchingTest.java
@@ -1,0 +1,86 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana.wkb;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaRingPatchingTest {
+
+    @Test
+    public void testRingPatching() throws ParseException, HanaWKBParserException {
+        WKTReader reader = new WKTReader();
+        Geometry expected = reader.read("POLYGON((1 2, 1 2, 1 2, 1 2))");
+
+        // POLYGON((1 2, 1 2)) in little-endian WKB
+        byte[] wkb = {
+            0x01,
+            0x03,
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0x02,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            (byte) 0xF0,
+            0x3F,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x40,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            (byte) 0xF0,
+            0x3F,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x40
+        };
+        HanaWKBParser parser = new HanaWKBParser(new GeometryFactory());
+        Geometry actual = parser.parse(wkb);
+        Assert.assertEquals(0, actual.compareTo(expected));
+    }
+}


### PR DESCRIPTION
[![GEOT-7295](https://badgen.net/badge/JIRA/GEOT-7295/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7295) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

HANA allows the creation of polygons consisting of two points only, e.g. POLYGON((1 2, 1 2)). Especially, this can be the result of a geometry simplification (calling ST_Simplify()). Those polygons are then rejected by other geometry frameworks.

This change patches polygon rings consisting of 2 or 3 points only, so that they consist of 4 points.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [X] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).