### PR TITLE
[GEOT-7298] H2GIS doesn't return the proper srid for an existing table

### DIFF
--- a/modules/unsupported/jdbc-h2gis/src/main/java/org/h2gis/geotools/H2GISDialect.java
+++ b/modules/unsupported/jdbc-h2gis/src/main/java/org/h2gis/geotools/H2GISDialect.java
@@ -250,7 +250,7 @@ public class H2GISDialect extends BasicSQLDialect {
                 if (geomMetata != null) {
                     gType = geomMetata.getGeometryType();
                 }
-            } else if (getH2GISVersion(cx).compareTo(V_2_0_0) <= 0) {
+            } else if (getH2GISVersion(cx).getMajor().equals(2)) {
                 GeometryMetaData geomMetata =
                         GeometryMetaData.getMetaDataFromTablePattern(typeName);
                 if (geomMetata != null) {
@@ -636,7 +636,7 @@ public class H2GISDialect extends BasicSQLDialect {
                                         + ");";
                         LOGGER.fine(sql);
                         st.execute(sql);
-                    } else if (getH2GISVersion(cx).compareTo(V_2_0_0) <= 0) {
+                    } else if (getH2GISVersion(cx).getMajor().equals(2)) {
                         // setup the geometry type
                         if (dimensions == 3) {
                             geomType = geomType + "Z";
@@ -869,11 +869,7 @@ public class H2GISDialect extends BasicSQLDialect {
         int srid = 0;
         try (ResultSet geomResultSet =
                 GeometryTableUtilities.getGeometryColumnsView(
-                        connection,
-                        "",
-                        schema,
-                        table,
-                        TableLocation.quoteIdentifier(geometryColumnName))) {
+                        connection, "", schema, table, geometryColumnName)) {
             if (geomResultSet.next()) {
                 srid = geomResultSet.getInt("srid");
             }


### PR DESCRIPTION
[![GEOT-7298](https://badgen.net/badge/JIRA/GEOT-7298/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7298) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fix srid and geometry type detection due to the last H2GIS 2.2.0 version.
  

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->