### PR TITLE
[GEOT-7300] Filter capabilities does not support PropertyIsNil filters

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/Capabilities.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/Capabilities.java
@@ -42,6 +42,7 @@ import org.opengis.filter.PropertyIsGreaterThanOrEqualTo;
 import org.opengis.filter.PropertyIsLessThan;
 import org.opengis.filter.PropertyIsLessThanOrEqualTo;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.PropertyIsNil;
 import org.opengis.filter.PropertyIsNotEqualTo;
 import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.capability.FilterCapabilities;
@@ -120,6 +121,7 @@ public class Capabilities {
         scalarNames.put(PropertyIsGreaterThanOrEqualTo.class, PropertyIsGreaterThanOrEqualTo.NAME);
         scalarNames.put(PropertyIsLessThan.class, PropertyIsLessThan.NAME);
         scalarNames.put(PropertyIsLessThanOrEqualTo.class, PropertyIsLessThanOrEqualTo.NAME);
+        scalarNames.put(PropertyIsNil.class, PropertyIsNil.NAME);
         scalarNames.put(PropertyIsNull.class, PropertyIsNull.NAME);
         scalarNames.put(PropertyIsLike.class, PropertyIsLike.NAME);
         scalarNames.put(PropertyIsBetween.class, PropertyIsBetween.NAME);

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/CapabilitiesFilterSplitter.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/CapabilitiesFilterSplitter.java
@@ -815,7 +815,11 @@ public class CapabilitiesFilterSplitter implements FilterVisitor, ExpressionVisi
         }
 
         int i = postStack.size();
-        ((PropertyIsNull) filter).getExpression().accept(this, null);
+        if (filter instanceof PropertyIsNull) {
+            ((PropertyIsNull) filter).getExpression().accept(this, null);
+        } else {
+            ((PropertyIsNil) filter).getExpression().accept(this, null);
+        }
 
         if (i < postStack.size()) {
             postStack.pop();

--- a/modules/library/main/src/test/java/org/geotools/filter/CapabilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/CapabilitiesTest.java
@@ -30,6 +30,7 @@ import org.opengis.filter.And;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsNil;
 import org.opengis.filter.spatial.Beyond;
 import org.opengis.filter.temporal.After;
 import org.opengis.filter.temporal.BegunBy;
@@ -130,5 +131,15 @@ public class CapabilitiesTest {
         Assert.assertTrue("supports", capabilities.supports(filter));
 
         Assert.assertTrue("fullySupports", capabilities.fullySupports(filter));
+    }
+
+    @Test
+    public void testCapablities_PropertyIsNil() {
+        Capabilities capabilities = new Capabilities();
+        capabilities.addType(PropertyIsNil.class);
+
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        Filter filter = ff.isNil(ff.property("x"), null);
+        Assert.assertTrue("supports", capabilities.supports(filter));
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/CapabilitiesFilterSplitterTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/CapabilitiesFilterSplitterTest.java
@@ -30,6 +30,7 @@ import org.opengis.filter.Id;
 import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.PropertyIsNil;
 import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.spatial.BBOX;
 
@@ -151,6 +152,12 @@ public class CapabilitiesFilterSplitterTest extends AbstractCapabilitiesFilterSp
     public void testVisitNullFilter() throws Exception {
         Filter filter = ff.isNull(ff.property(nameAtt));
         runTest(filter, newCapabilities(PropertyIsNull.class), nameAtt);
+    }
+
+    @Test
+    public void testVisitNilFilter() throws Exception {
+        Filter filter = ff.isNil(ff.property(nameAtt), null);
+        runTest(filter, newCapabilities(PropertyIsNil.class), nameAtt);
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7300](https://badgen.net/badge/JIRA/GEOT-7300/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7300) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds PropertyIsNil filters to the filter Capabilities and fixes a ClassCastException when PropertyIsNil filters are supported.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->