### PR TITLE
[GEOT-7304] DateTimeParser parse fails with negative year and Norwegian locale

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/DateTimeParser.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/DateTimeParser.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeSet;
@@ -151,7 +152,7 @@ public class DateTimeParser {
         }
 
         public SimpleDateFormat getFormat() {
-            SimpleDateFormat sdf = new SimpleDateFormat(format);
+            SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ROOT);
             sdf.setTimeZone(UTC_TZ);
             return sdf;
         }
@@ -599,7 +600,7 @@ public class DateTimeParser {
         if (parsed == null && isFlagSet(FLAG_IS_LENIENT)) {
             for (String lenientFormat : f.getLenientFormats()) {
                 // rebuild formats at each parse since date formats are not thread safe
-                final SimpleDateFormat format = new SimpleDateFormat(lenientFormat);
+                final SimpleDateFormat format = new SimpleDateFormat(lenientFormat, Locale.ROOT);
                 format.setTimeZone(UTC_TZ);
                 // The lenientFormat is already somehow a lenient version of the
                 // official format. no need to have it lenient too.


### PR DESCRIPTION
[![GEOT-7304](https://badgen.net/badge/JIRA/GEOT-7304/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7304) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes a failing test in GeoServer. Copied parts of that test, and added parameterizing of Locale's.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->