### PR TITLE
[GEOT-6262] Zooming in a lot (around 1:10 scale) can make TWKB transfer fail

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
@@ -155,11 +155,11 @@ public class GeometryColumnEncoder {
      */
     private int getTWKBDigits(Double distance) {
         int result = -(int) Math.floor(Math.log10(distance));
-        // Prevent PostGIS ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or less than -7
+        // Prevent PostGIS ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or
+        // less than -7
         if (result > 7) {
             result = 7;
-        }
-        if (result < -7) {
+        } else if (result < -7) {
             result = -7;
         }
         return result;

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
@@ -155,6 +155,13 @@ public class GeometryColumnEncoder {
      */
     private int getTWKBDigits(Double distance) {
         int result = -(int) Math.floor(Math.log10(distance));
+        // Prevent PostGIS ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or less than -7
+        if (result > 7) {
+            result = 7;
+        }
+        if (result < -7) {
+            result = -7;
+        }
         return result;
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryTest.java
@@ -48,6 +48,15 @@ public class PostgisSimplifiedGeometryTest extends JDBCTestSupport {
     }
 
     @Test
+    public void testPointSmallDistance() throws IOException, ParseException {
+        Geometry geom = getFirstGeometry("simplify_point", 6.191820034473494e-8);
+        // same point, but before the fix with TWKB parameters it would have
+        // thrown ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater
+        // than 7 or less than -7
+        assertGeometryEquals(geom, "POINT(-120 40)");
+    }
+
+    @Test
     public void testLine() throws IOException, ParseException {
         Geometry geom = getFirstGeometry("simplify_line", 20);
         // mid point gone


### PR DESCRIPTION
[![GEOT-6262](https://badgen.net/badge/JIRA/GEOT-6262/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6262) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or less than -7`

In GeoServer, in a linestring map layer from a PostGIS source, with the source's `Support on the fly geometry simplification` option set to its default value (`true`), when zooming in very far (scale around 1:50), the [ST_AsTWKB](https://postgis.net/docs/ST_AsTWKB.html) function is called with an invalid value (`8`) for the `decimaldigits_xy` parameter.
The rendering of the layer then fails.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->