### PR TITLE
[Backport 28.x] [GEOT-7304] DateTimeParser parse fails with negative year and Norwegian locale

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/DateTimeParser.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/DateTimeParser.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeSet;
@@ -151,7 +152,7 @@ public class DateTimeParser {
         }
 
         public SimpleDateFormat getFormat() {
-            SimpleDateFormat sdf = new SimpleDateFormat(format);
+            SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ROOT);
             sdf.setTimeZone(UTC_TZ);
             return sdf;
         }
@@ -599,7 +600,7 @@ public class DateTimeParser {
         if (parsed == null && isFlagSet(FLAG_IS_LENIENT)) {
             for (String lenientFormat : f.getLenientFormats()) {
                 // rebuild formats at each parse since date formats are not thread safe
-                final SimpleDateFormat format = new SimpleDateFormat(lenientFormat);
+                final SimpleDateFormat format = new SimpleDateFormat(lenientFormat, Locale.ROOT);
                 format.setTimeZone(UTC_TZ);
                 // The lenientFormat is already somehow a lenient version of the
                 // official format. no need to have it lenient too.


### PR DESCRIPTION
[![GEOT-7304](https://badgen.net/badge/JIRA/GEOT-7304/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7304) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4179
 **Authored by:** @roarbra