### PR TITLE
[Backport 28.x] [GEOT-7302] Escape user inputs in SQL queries

### DIFF
--- a/docs/src/main/java/org/geotools/jdbc/JDBCExamples.java
+++ b/docs/src/main/java/org/geotools/jdbc/JDBCExamples.java
@@ -63,6 +63,8 @@ public class JDBCExamples {
         params.put("database", "database");
         params.put("user", "postgres");
         params.put("passwd", "postgres");
+        params.put("preparedStatements", true);
+        params.put("encode functions", true);
 
         DataStore dataStore = DataStoreFinder.getDataStore(params);
         // postgisExample end

--- a/docs/user/library/jdbc/postgis.rst
+++ b/docs/user/library/jdbc/postgis.rst
@@ -24,17 +24,19 @@ Note that the ``groupId`` is ``org.geotools.jdbc`` for this and other JDBC plugi
 Connection Parameters
 ^^^^^^^^^^^^^^^^^^^^^
 
-============== ============================================
-Parameter      Description
-============== ============================================
-``dbtype``       Must be the string ``postgis``
-``host``         Machine name or IP address to connect to
-``port``         Port number to connect to, default 5432
-``schema``       The database schema to access
-``database``     The database to connect to
-``user``         User name
-``passwd``       Password
-============== ============================================
+====================== ============================================
+Parameter              Description
+====================== ============================================
+``dbtype``             Must be the string ``postgis``
+``host``               Machine name or IP address to connect to
+``port``               Port number to connect to, default 5432
+``schema``             The database schema to access
+``database``           The database to connect to
+``user``               User name
+``passwd``             Password
+``preparedStatements`` Use 
+``encode functions``   
+====================== ============================================
 
 Creation
 ^^^^^^^^
@@ -58,11 +60,14 @@ Advanced
 | ``preparedStatements`` | Flag controlling whether prepared statements   |
 |                        | are used, default is false                     |
 +------------------------+------------------------------------------------+
+| ``encode functions``   | Flag controlling if some common functions can  |
+|                        | be encoded into their SQL equivalent           |
++------------------------+------------------------------------------------+
 
 Example use::
   
-  params.put(PostgisDataStoreFactory.LOOSEBBOX, true );
-  params.put(PostgisDataStoreFactory.PREPARED_STATEMENTS, true );
+  params.put(PostgisNGDataStoreFactory.LOOSEBBOX, true );
+  params.put(PostgisNGDataStoreFactory.PREPARED_STATEMENTS, true );
   
 Configuration Flags
 ^^^^^^^^^^^^^^^^^^^

--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -45,6 +45,7 @@ import org.geotools.filter.capability.FunctionNameImpl;
 import org.geotools.filter.function.InFunction;
 import org.geotools.filter.spatial.BBOXImpl;
 import org.geotools.jdbc.EnumMapper;
+import org.geotools.jdbc.EscapeSql;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JoinId;
 import org.geotools.jdbc.JoinPropertyName;
@@ -230,6 +231,9 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
     /** Whether the encoder should try to encode "in" function into a SQL IN operator */
     protected boolean inEncodingEnabled = true;
 
+    /** Whether to escape backslash characters in string literals */
+    protected boolean escapeBackslash = false;
+
     /** Default constructor */
     public FilterToSQL() {}
 
@@ -263,6 +267,16 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
      */
     public void setInEncodingEnabled(boolean inEncodingEnabled) {
         this.inEncodingEnabled = inEncodingEnabled;
+    }
+
+    /** @return whether to escape backslash characters in string literals */
+    public boolean isEscapeBackslash() {
+        return escapeBackslash;
+    }
+
+    /** @param escapeBackslash whether to escape backslash characters in string literals */
+    public void setEscapeBackslash(boolean escapeBackslash) {
+        this.escapeBackslash = escapeBackslash;
     }
 
     /**
@@ -529,7 +543,8 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
             literal += multi;
         }
 
-        String pattern = LikeFilterImpl.convertToSQL92(esc, multi, single, matchCase, literal);
+        String pattern =
+                LikeFilterImpl.convertToSQL92(esc, multi, single, matchCase, literal, false);
 
         try {
             if (!matchCase) {
@@ -539,13 +554,12 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
             att.accept(this, extraData);
 
             if (!matchCase) {
-                out.write(") LIKE '");
+                out.write(") LIKE ");
             } else {
-                out.write(" LIKE '");
+                out.write(" LIKE ");
             }
 
-            out.write(pattern);
-            out.write("' ");
+            writeLiteral(pattern);
         } catch (java.io.IOException ioe) {
             throw new RuntimeException(IO_ERROR, ioe);
         }
@@ -1170,11 +1184,8 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
                         out.write(".");
                     }
                     out.write(escapeName(columns.get(j).getName()));
-                    out.write(" = '");
-                    out.write(
-                            attValues.get(j).toString()); // DJB: changed this to attValues[j] from
-                    // attValues[i].
-                    out.write("'");
+                    out.write(" = ");
+                    writeLiteral(attValues.get(j));
 
                     if (j < (attValues.size() - 1)) {
                         out.write(" AND ");
@@ -1747,10 +1758,15 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
                 encoding = literal.toString();
             }
 
-            // sigle quotes must be escaped to have a valid sql string
-            String escaped = encoding.replaceAll("'", "''");
+            // single quotes must be escaped to have a valid sql string
+            String escaped = escapeLiteral(encoding);
             out.write("'" + escaped + "'");
         }
+    }
+
+    /** Escapes the string literal. */
+    public String escapeLiteral(String literal) {
+        return EscapeSql.escapeLiteral(literal, escapeBackslash, false);
     }
 
     /**

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/EscapeSql.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/EscapeSql.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.jdbc;
 
+import java.util.regex.Pattern;
+
 /**
  * Perform basic SQL validation on input string. This is to allow safe encoding of parameters that
  * must contain quotes, while still protecting users from SQL injection.
@@ -24,6 +26,28 @@ package org.geotools.jdbc;
  * quotes. Backslashes are too risky to allow so are removed completely
  */
 public class EscapeSql {
+
+    private static final Pattern SINGLE_QUOTE_PATTERN = Pattern.compile("'");
+
+    private static final Pattern DOUBLE_QUOTE_PATTERN = Pattern.compile("\"");
+
+    private static final Pattern BACKSLASH_PATTERN = Pattern.compile("\\\\");
+
+    public static String escapeLiteral(
+            String literal, boolean escapeBackslash, boolean escapeDoubleQuote) {
+        // ' --> ''
+        String escaped = SINGLE_QUOTE_PATTERN.matcher(literal).replaceAll("''");
+        if (escapeBackslash) {
+            // \ --> \\
+            escaped = BACKSLASH_PATTERN.matcher(escaped).replaceAll("\\\\\\\\");
+        }
+        if (escapeDoubleQuote) {
+            // " --> \"
+            escaped = DOUBLE_QUOTE_PATTERN.matcher(escaped).replaceAll("\\\\\"");
+        }
+        return escaped;
+    }
+
     public static String escapeSql(String str) {
 
         // ' --> ''

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
@@ -28,6 +28,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.data.Join.Type;
 import org.geotools.data.Query;
+import org.geotools.data.jdbc.datasource.DataSourceFinder;
+import org.geotools.data.jdbc.datasource.UnWrapper;
 import org.geotools.feature.visitor.AverageVisitor;
 import org.geotools.feature.visitor.CountVisitor;
 import org.geotools.feature.visitor.FeatureAttributeVisitor;
@@ -163,6 +166,41 @@ public abstract class SQLDialect {
                     addType(NativeFilter.class);
                 }
             };
+
+    /**
+     * Sentinel value used to mark that the unwrapper lookup happened already, and an unwrapper was
+     * not found
+     */
+    protected static final UnWrapper UNWRAPPER_NOT_FOUND =
+            new UnWrapper() {
+
+                @Override
+                public Statement unwrap(Statement statement) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Connection unwrap(Connection conn) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public boolean canUnwrap(Statement st) {
+                    return false;
+                }
+
+                @Override
+                public boolean canUnwrap(Connection conn) {
+                    return false;
+                }
+            };
+
+    /**
+     * Map of {@code UnWrapper} objects keyed by the class of {@code Connection} it is an unwrapper
+     * for. This avoids the overhead of searching the {@code DataSourceFinder} service registry at
+     * each unwrap.
+     */
+    protected final Map<Class<? extends Connection>, UnWrapper> uwMap = new HashMap<>();
 
     /** The datastore using the dialect */
     protected JDBCDataStore dataStore;
@@ -1414,5 +1452,53 @@ public abstract class SQLDialect {
      */
     public Class<?> getMapping(String sqlTypeName) {
         return null;
+    }
+
+    /** Obtains the native connection object given a database connection. */
+    @SuppressWarnings("PMD.CloseResource")
+    protected <T extends Connection> T unwrapConnection(Connection cx, Class<T> clazz)
+            throws SQLException {
+        if (clazz.isInstance(cx)) {
+            return clazz.cast(cx);
+        }
+        try {
+            // Unwrap the connection multiple levels as necessary to get at the underlying
+            // connection. Maintain a map of UnWrappers to avoid searching the registry
+            // every time we need to unwrap.
+            Connection testCon = cx;
+            Connection toUnwrap;
+            do {
+                UnWrapper unwrapper = uwMap.get(testCon.getClass());
+                if (unwrapper == null) {
+                    unwrapper = DataSourceFinder.getUnWrapper(testCon);
+                    if (unwrapper == null) {
+                        unwrapper = UNWRAPPER_NOT_FOUND;
+                    }
+                    uwMap.put(testCon.getClass(), unwrapper);
+                }
+                if (unwrapper == UNWRAPPER_NOT_FOUND) {
+                    // give up and do Java unwrap below
+                    break;
+                }
+                toUnwrap = testCon;
+                testCon = unwrapper.unwrap(testCon);
+                if (clazz.isInstance(testCon)) {
+                    return clazz.cast(cx);
+                }
+            } while (testCon != null && testCon != toUnwrap);
+            // try to use Java unwrapping
+            try {
+                if (cx.isWrapperFor(clazz)) {
+                    return cx.unwrap(clazz);
+                }
+            } catch (Throwable t) {
+                // not a mistake, old DBCP versions will throw an Error here, we need to catch it
+                LOGGER.log(Level.FINER, "Failed to unwrap connection using Java facilities", t);
+            }
+        } catch (IOException e) {
+            throw new SQLException(
+                    "Could not obtain " + clazz.getName() + " from " + cx.getClass(), e);
+        }
+        throw new SQLException("Could not obtain " + clazz.getName() + " from " + cx.getClass());
     }
 }

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/SQLDialect.java
@@ -1483,7 +1483,7 @@ public abstract class SQLDialect {
                 toUnwrap = testCon;
                 testCon = unwrapper.unwrap(testCon);
                 if (clazz.isInstance(testCon)) {
-                    return clazz.cast(cx);
+                    return clazz.cast(testCon);
                 }
             } while (testCon != null && testCon != toUnwrap);
             // try to use Java unwrapping

--- a/modules/library/jdbc/src/test/java/org/geotools/data/jdbc/FilterToSQLTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/data/jdbc/FilterToSQLTest.java
@@ -465,4 +465,18 @@ public class FilterToSQLTest {
         encoder.setSqlNameEscape("");
         Assert.assertEquals("abc", encoder.escapeName("abc"));
     }
+
+    @Test
+    public void testLikeEscaping() throws Exception {
+        Filter filter = ff.like(ff.property("testString"), "\\'FOO", "%", "-", "\\", true);
+        FilterToSQL encoder = new FilterToSQL(output);
+        Assert.assertEquals("WHERE testString LIKE '''FOO'", encoder.encodeToString(filter));
+    }
+
+    @Test
+    public void testIdEscaping() throws Exception {
+        Id id = ff.id(Collections.singleton(ff.featureId("'FOO")));
+        encoder.encode(id);
+        Assert.assertEquals("WHERE (id = '''FOO')", output.toString());
+    }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/FilterTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/FilterTest.java
@@ -187,29 +187,37 @@ public class FilterTest {
     @Test
     public void testLikeToSQL() {
         Assert.assertEquals(
-                "BroadWay%", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "BroadWay*"));
+                "BroadWay%", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "BroadWay*", true));
         Assert.assertEquals(
-                "broad#ay", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broad#ay"));
+                "broad#ay", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broad#ay", true));
         Assert.assertEquals(
-                "broadway", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broadway"));
+                "broadway", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broadway", true));
 
         Assert.assertEquals(
-                "broad_ay", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broad.ay"));
+                "broad_ay", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broad.ay", true));
         Assert.assertEquals(
-                "broad.ay", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broad!.ay"));
+                "broad.ay", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broad!.ay", true));
 
         Assert.assertEquals(
-                "broa''dway", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broa'dway"));
+                "broa''dway",
+                LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broa'dway", true));
         Assert.assertEquals(
                 "broa''''dway",
-                LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broa" + "''dway"));
+                LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broa" + "''dway", true));
+        Assert.assertEquals(
+                "broa'dway",
+                LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broa'dway", false));
+        Assert.assertEquals(
+                "broa''dway",
+                LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broa" + "''dway", false));
 
         Assert.assertEquals(
-                "broadway_", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broadway."));
+                "broadway_", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broadway.", true));
         Assert.assertEquals(
-                "broadway", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broadway!"));
+                "broadway", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broadway!", true));
         Assert.assertEquals(
-                "broadway!", LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broadway!!"));
+                "broadway!",
+                LikeFilterImpl.convertToSQL92('!', '*', '.', true, "broadway!!", true));
     }
 
     /**

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectBasic.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectBasic.java
@@ -246,7 +246,12 @@ public class MySQLDialectBasic extends BasicSQLDialect {
 
     @Override
     public FilterToSQL createFilterToSQL() {
-        return new MySQLFilterToSQL(delegate.getUsePreciseSpatialOps());
+        MySQLFilterToSQL fts = new MySQLFilterToSQL(delegate.getUsePreciseSpatialOps());
+        // see https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_backslash_escapes
+        // NOTE: for future enhancement, do not escape backslashes when the NO_BACKSLASH_ESCAPES
+        // mode is enabled since that would create an incorrect string in the SQL
+        fts.setEscapeBackslash(true);
+        return fts;
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLFilterToSQLTest.java
@@ -1,0 +1,48 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mysql;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.data.jdbc.SQLFilterTestSupport;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.SchemaException;
+import org.junit.Before;
+import org.junit.Test;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.PropertyIsEqualTo;
+
+public class MySQLFilterToSQLTest extends SQLFilterTestSupport {
+
+    private static FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+
+    private MySQLFilterToSQL filterToSql;
+
+    @Override
+    @Before
+    public void setUp() throws SchemaException {
+        filterToSql = (MySQLFilterToSQL) new MySQLDialectBasic(null).createFilterToSQL();
+        filterToSql.setFeatureType(testSchema);
+    }
+
+    @Test
+    public void testEncodeEqualToWithSpecialCharacters() throws Exception {
+        PropertyIsEqualTo expr = ff.equals(ff.property("testString"), ff.literal("\\'FOO"));
+        String actual = filterToSql.encodeToString(expr);
+        assertEquals("WHERE testString = '\\\\''FOO'", actual);
+    }
+}

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleDialect.java
@@ -26,7 +26,6 @@ import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
 import java.sql.Types;
-import java.sql.Wrapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,8 +40,6 @@ import java.util.regex.Pattern;
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleStruct;
 import org.geotools.data.jdbc.FilterToSQL;
-import org.geotools.data.jdbc.datasource.DataSourceFinder;
-import org.geotools.data.jdbc.datasource.UnWrapper;
 import org.geotools.data.oracle.sdo.GeometryConverter;
 import org.geotools.data.oracle.sdo.SDOSqlDumper;
 import org.geotools.data.oracle.sdo.TT;
@@ -84,34 +81,6 @@ import org.opengis.util.GenericName;
  */
 public class OracleDialect extends PreparedStatementSQLDialect {
 
-    /**
-     * Sentinel value used to mark that the unwrapper lookup happened already, and an unwrapper was
-     * not found
-     */
-    UnWrapper UNWRAPPER_NOT_FOUND =
-            new UnWrapper() {
-
-                @Override
-                public Statement unwrap(Statement statement) {
-                    throw new UnsupportedOperationException();
-                }
-
-                @Override
-                public Connection unwrap(Connection conn) {
-                    throw new UnsupportedOperationException();
-                }
-
-                @Override
-                public boolean canUnwrap(Statement st) {
-                    return false;
-                }
-
-                @Override
-                public boolean canUnwrap(Connection conn) {
-                    return false;
-                }
-            };
-
     private static final int DEFAULT_AXIS_MAX = 10000000;
 
     private static final int DEFAULT_AXIS_MIN = -10000000;
@@ -120,13 +89,6 @@ public class OracleDialect extends PreparedStatementSQLDialect {
 
     /** Marks a geometry column as geodetic */
     public static final String GEODETIC = "geodetic";
-
-    /**
-     * Map of {@code UnWrapper} objects keyed by the class of {@code Connection} it is an unwrapper
-     * for. This avoids the overhead of searching the {@code DataSourceFinder} service registry at
-     * each unwrap.
-     */
-    Map<Class<? extends Connection>, UnWrapper> uwMap = new HashMap<>();
 
     private int nameLenghtLimit = 30;
 
@@ -653,62 +615,8 @@ public class OracleDialect extends PreparedStatementSQLDialect {
     }
 
     /** Obtains the native oracle connection object given a database connection. */
-    @SuppressWarnings("PMD.CloseResource")
     OracleConnection unwrapConnection(Connection cx) throws SQLException {
-        if (cx == null) {
-            return null;
-        }
-
-        if (cx instanceof OracleConnection) {
-            return (OracleConnection) cx;
-        }
-
-        try {
-            // Unwrap the connection multiple levels as necessary to get at the underlying
-            // OracleConnection. Maintain a map of UnWrappers to avoid searching
-            // the registry every time we need to unwrap.
-            Connection testCon = cx;
-            Connection toUnwrap;
-            do {
-                UnWrapper unwrapper = uwMap.get(testCon.getClass());
-                if (unwrapper == null) {
-                    unwrapper = DataSourceFinder.getUnWrapper(testCon);
-                    if (unwrapper == null) {
-                        unwrapper = UNWRAPPER_NOT_FOUND;
-                    }
-                    uwMap.put(testCon.getClass(), unwrapper);
-                }
-                if (unwrapper == UNWRAPPER_NOT_FOUND) {
-                    // give up and do Java 6 unwrap below
-                    break;
-                }
-                toUnwrap = testCon;
-                testCon = unwrapper.unwrap(testCon);
-                if (testCon instanceof OracleConnection) {
-                    return (OracleConnection) testCon;
-                }
-            } while (testCon != null && testCon != toUnwrap);
-
-            if (cx instanceof Wrapper) {
-                // try to use java 6 unwrapping
-                try {
-                    Wrapper w = cx;
-                    if (w.isWrapperFor(OracleConnection.class)) {
-                        return w.unwrap(OracleConnection.class);
-                    }
-                } catch (Throwable t) {
-                    // not a mistake, old DBCP versions will throw an Error here, we need to catch
-                    // it
-                    LOGGER.log(
-                            Level.FINER, "Failed to unwrap connection using java 6 facilities", t);
-                }
-            }
-        } catch (IOException e) {
-            throw (SQLException)
-                    new SQLException("Could not obtain native oracle connection.").initCause(e);
-        }
-
-        throw new SQLException("Could not obtain native oracle connection for " + cx.getClass());
+        return unwrapConnection(cx, OracleConnection.class);
     }
 
     public FilterToSQL createFilterToSQL() {

--- a/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-oracle/src/main/java/org/geotools/data/oracle/OracleFilterToSQL.java
@@ -546,9 +546,10 @@ public class OracleFilterToSQL extends PreparedFilterToSQL {
         e2.accept(this, extraData);
 
         // encode the unit verbatim when available
-        if (unit != null && !"".equals(unit.trim()))
+        if (unit != null && !"".equals(unit.trim())) {
+            unit = escapeLiteral(unit);
             out.write(",'distance=" + distance + " unit=" + unit + "') = '" + within + "' ");
-        else out.write(",'distance=" + distance + "') = '" + within + "' ");
+        } else out.write(",'distance=" + distance + "') = '" + within + "' ");
     }
 
     /**
@@ -625,10 +626,10 @@ public class OracleFilterToSQL extends PreparedFilterToSQL {
 
         String[] pointers = jsonPath.getValue().toString().split("/");
         if (pointers.length > 0) {
-            String strJsonPath = String.join(".", pointers);
+            String strJsonPath = escapeLiteral(String.join(".", pointers));
+            String strExpected = escapeLiteral(expected.evaluate(null, String.class));
             return String.format(
-                    "json_exists(%s, '$%s?(@ == \"%s\")')",
-                    columnName, strJsonPath, expected.evaluate(null));
+                    "json_exists(%s, '$%s?(@ == \"%s\")')", columnName, strJsonPath, strExpected);
         } else {
             throw new IllegalArgumentException(
                     "Cannot encode filter Invalid pointer " + jsonPath.getValue());

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
@@ -263,6 +263,7 @@ public class PostGISPSDialect extends PreparedStatementSQLDialect {
         fts.setFunctionEncodingEnabled(delegate.isFunctionEncodingEnabled());
         fts.setLooseBBOXEnabled(delegate.isLooseBBOXEnabled());
         fts.setEncodeBBOXFilterAsEnvelope(delegate.isEncodeBBOXFilterAsEnvelope());
+        fts.setEscapeBackslash(delegate.isEscapeBackslash());
         return fts;
     }
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisNGDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisNGDataStoreFactory.java
@@ -29,6 +29,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.geotools.data.Parameter;
+import org.geotools.data.Transaction;
 import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.jdbc.SQLDialect;
@@ -259,6 +260,15 @@ public class PostgisNGDataStoreFactory extends JDBCDataStoreFactory {
         }
         dialect.setEncodeBBOXFilterAsEnvelope(Boolean.TRUE.equals(encodeBBOXAsEnvelope));
 
+        Connection cx = dataStore.getConnection(Transaction.AUTO_COMMIT);
+        try {
+            // creating a new connection will internally call
+            // org.geotools.data.postgis.PostGISDialect.initializeConnection(Connection)
+            // the following line is really just to prevent empty try block PMD violation
+            LOGGER.finest("escaping backslashes: " + dialect.isEscapeBackslash());
+        } finally {
+            dataStore.closeSafe(cx);
+        }
         return dataStore;
     }
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisNGDataStoreFactoryTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisNGDataStoreFactoryTest.java
@@ -1,0 +1,163 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import static org.geotools.data.postgis.PostgisNGDataStoreFactory.PREPARED_STATEMENTS;
+import static org.geotools.jdbc.JDBCDataStoreFactory.DATASOURCE;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.SQLDialect;
+import org.geotools.util.Version;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.postgresql.jdbc.PgConnection;
+
+public class PostgisNGDataStoreFactoryTest {
+
+    @Mock private DataSource ds = null;
+
+    @Mock private Connection conn = null;
+
+    @Mock private PgConnection pgConn = null;
+
+    @Mock private DatabaseMetaData md = null;
+
+    @Mock private Statement st1 = null;
+
+    @Mock private Statement st2 = null;
+
+    @Mock private ResultSet rs1 = null;
+
+    @Mock private ResultSet rs2 = null;
+
+    private JDBCDataStore store = null;
+
+    private AutoCloseable mocks = null;
+
+    @Before
+    public void setUp() throws Exception {
+        this.mocks = MockitoAnnotations.openMocks(this);
+        when(this.ds.getConnection()).thenReturn(this.conn);
+        when(this.conn.getMetaData()).thenReturn(this.md);
+        when(this.md.getDatabaseMajorVersion()).thenReturn(15);
+        when(this.md.getDatabaseMinorVersion()).thenReturn(1);
+        when(this.conn.createStatement()).thenReturn(this.st1, this.st2);
+        when(this.st1.executeQuery("select PostGIS_Lib_Version()")).thenReturn(this.rs1);
+        when(this.rs1.next()).thenReturn(true);
+        when(this.rs1.getString(1)).thenReturn("3.3.2");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (this.mocks != null) {
+            this.mocks.close();
+            this.mocks = null;
+        }
+        if (this.store != null) {
+            this.store.dispose();
+        }
+    }
+
+    @Test
+    public void testStandardConformingStringsOnFromConnection() throws Exception {
+        verifyFilterToSqlSettings(false, false, false);
+    }
+
+    @Test
+    public void testStandardConformingStringsOffFromConnection() throws Exception {
+        verifyFilterToSqlSettings(true, false, false);
+    }
+
+    @Test
+    public void testStandardConformingStringsOnFromQuery() throws Exception {
+        verifyFilterToSqlSettings(false, false, true);
+    }
+
+    @Test
+    public void testStandardConformingStringsOffFromQuery() throws Exception {
+        verifyFilterToSqlSettings(true, false, true);
+    }
+
+    @Test
+    public void testStandardConformingStringsOnWithPSFromConnection() throws Exception {
+        verifyFilterToSqlSettings(false, true, false);
+    }
+
+    @Test
+    public void testStandardConformingStringsOffWithPSFromConnection() throws Exception {
+        verifyFilterToSqlSettings(true, true, false);
+    }
+
+    @Test
+    public void testStandardConformingStringsOnWithPSFromQuery() throws Exception {
+        verifyFilterToSqlSettings(false, true, true);
+    }
+
+    @Test
+    public void testStandardConformingStringsOffWithPSFromQuery() throws Exception {
+        verifyFilterToSqlSettings(true, true, true);
+    }
+
+    private void verifyFilterToSqlSettings(
+            boolean escapeBackslash, boolean withPS, boolean withQuery) throws Exception {
+        if (withQuery) {
+            when(this.st2.executeQuery("SHOW standard_conforming_strings")).thenReturn(this.rs2);
+            when(this.rs2.next()).thenReturn(true);
+            when(this.rs2.getString(1)).thenReturn(escapeBackslash ? "off" : "on");
+        } else {
+            when(this.conn.isWrapperFor(PgConnection.class)).thenReturn(true);
+            when(this.conn.unwrap(PgConnection.class)).thenReturn(this.pgConn);
+            when(this.pgConn.getStandardConformingStrings()).thenReturn(!escapeBackslash);
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put(DATASOURCE.key, this.ds);
+        params.put(PREPARED_STATEMENTS.key, withPS);
+        this.store = new PostgisNGDataStoreFactory().createDataStore(params);
+        assertNotNull(this.store);
+        SQLDialect dialect = this.store.getSQLDialect();
+        assertThat(dialect, instanceOf(withPS ? PostGISPSDialect.class : PostGISDialect.class));
+        PostGISDialect pgDialect =
+                withPS ? ((PostGISPSDialect) dialect).getDelegate() : (PostGISDialect) dialect;
+        assertEquals(new Version("15.1"), pgDialect.getPostgreSQLVersion(this.conn));
+        assertEquals(new Version("3.3.2"), pgDialect.getVersion(this.conn));
+        assertEquals(escapeBackslash, pgDialect.isEscapeBackslash());
+        verify(this.conn, withQuery ? times(2) : times(1)).createStatement();
+        verify(this.conn).close();
+        verify(this.st1).close();
+        verify(this.rs1).close();
+        verify(this.st2, withQuery ? times(1) : never()).close();
+        verify(this.rs2, withQuery ? times(1) : never()).close();
+    }
+}


### PR DESCRIPTION
[![GEOT-7302](https://badgen.net/badge/JIRA/GEOT-7302/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7302) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
Backporting PR from @sikeoka along with a minor documentation improvement.

Authored by: @sikeoka