### PR TITLE
[GEOT-7307] Calling getSchema on GeoJSONDataStore gives NullPointerException

### DIFF
--- a/modules/unsupported/geojson-store/src/main/java/org/geotools/data/geojson/store/GeoJSONDataStore.java
+++ b/modules/unsupported/geojson-store/src/main/java/org/geotools/data/geojson/store/GeoJSONDataStore.java
@@ -53,11 +53,11 @@ public class GeoJSONDataStore extends ContentDataStore implements FileDataStore 
     private boolean quick = true;
 
     public GeoJSONDataStore(URL url) {
-        this.setUrl(url);
+        this.url = url;
     }
 
     public GeoJSONDataStore(File f) {
-        this.setUrl(URLs.fileToUrl(f));
+        this(URLs.fileToUrl(f));
     }
 
     GeoJSONReader read() throws IOException {
@@ -108,6 +108,9 @@ public class GeoJSONDataStore extends ContentDataStore implements FileDataStore 
     @Override
     public SimpleFeatureType getSchema() throws IOException {
         if (schema == null) {
+            if (typeName == null) {
+                createTypeNames();
+            }
             schema = getSchema(typeName);
         }
         return schema;
@@ -134,6 +137,7 @@ public class GeoJSONDataStore extends ContentDataStore implements FileDataStore 
 
     public void setUrl(URL url) {
         this.url = url;
+        this.typeName = null;
     }
 
     @Override
@@ -146,7 +150,6 @@ public class GeoJSONDataStore extends ContentDataStore implements FileDataStore 
 
     @Override
     public FeatureReader<SimpleFeatureType, SimpleFeature> getFeatureReader() throws IOException {
-
         return new GeoJSONFeatureSource(this).getReader();
     }
 

--- a/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/GeoJSONDataStoreTest.java
+++ b/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/GeoJSONDataStoreTest.java
@@ -168,4 +168,12 @@ public class GeoJSONDataStoreTest {
         }
         assertEquals(1, cnt);
     }
+
+    @Test
+    public void testDirectSchemaAccess() throws Exception {
+        URL url = TestData.url(this.getClass(), "locations.json");
+        GeoJSONDataStore store = new GeoJSONDataStore(url);
+        SimpleFeatureType schema = store.getSchema();
+        assertEquals("locations", schema.getTypeName());
+    }
 }


### PR DESCRIPTION
[![GEOT-7307](https://badgen.net/badge/JIRA/GEOT-7307/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7307) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Make sure typeName is set before using it.


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->