### PR TITLE
[Backport 28.x] [GEOT-6262] Zooming in a lot (around 1:10 scale) can make TWKB transfer fail

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
@@ -155,11 +155,11 @@ public class GeometryColumnEncoder {
      */
     private int getTWKBDigits(Double distance) {
         int result = -(int) Math.floor(Math.log10(distance));
-        // Prevent PostGIS ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or less than -7
+        // Prevent PostGIS ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or
+        // less than -7
         if (result > 7) {
             result = 7;
-        }
-        if (result < -7) {
+        } else if (result < -7) {
             result = -7;
         }
         return result;

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
@@ -155,6 +155,13 @@ public class GeometryColumnEncoder {
      */
     private int getTWKBDigits(Double distance) {
         int result = -(int) Math.floor(Math.log10(distance));
+        // Prevent PostGIS ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or less than -7
+        if (result > 7) {
+            result = 7;
+        }
+        if (result < -7) {
+            result = -7;
+        }
         return result;
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryTest.java
@@ -48,6 +48,15 @@ public class PostgisSimplifiedGeometryTest extends JDBCTestSupport {
     }
 
     @Test
+    public void testPointSmallDistance() throws IOException, ParseException {
+        Geometry geom = getFirstGeometry("simplify_point", 6.191820034473494e-8);
+        // same point, but before the fix with TWKB parameters it would have
+        // thrown ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater
+        // than 7 or less than -7
+        assertGeometryEquals(geom, "POINT(-120 40)");
+    }
+
+    @Test
     public void testLine() throws IOException, ParseException {
         Geometry geom = getFirstGeometry("simplify_line", 20);
         // mid point gone


### PR DESCRIPTION
[![GEOT-6262](https://badgen.net/badge/JIRA/GEOT-6262/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6262) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4181
 **Authored by:** @wscherphof