### PR TITLE
[GEOT-7314] Add OGC authority so that GeoTools can parse URIs such as "http://www.opengis.net/def/crs/OGC/1.3/CRS84"

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/wms/OGCAPICRSFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/wms/OGCAPICRSFactory.java
@@ -1,0 +1,33 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.referencing.factory.wms;
+
+import org.geotools.metadata.iso.citation.Citations;
+import org.opengis.metadata.citation.Citation;
+
+/**
+ * Similar to the OGC CRS factory, but with a different authority name, designed to support URNs
+ * coming from the OGC API - Features - Part 1: Core specification (e.g.,
+ * "http://www.opengis.net/def/crs/OGC/1.3/CRS84").
+ */
+public class OGCAPICRSFactory extends WebCRSFactory {
+
+    @Override
+    public Citation getAuthority() {
+        return Citations.OGC;
+    }
+}

--- a/modules/library/referencing/src/main/resources/META-INF/services/org.opengis.referencing.crs.CRSAuthorityFactory
+++ b/modules/library/referencing/src/main/resources/META-INF/services/org.opengis.referencing.crs.CRSAuthorityFactory
@@ -3,6 +3,7 @@ org.geotools.referencing.factory.epsg.LongitudeFirstFactory
 org.geotools.referencing.factory.epsg.CartesianAuthorityFactory
 org.geotools.referencing.factory.wms.AutoCRSFactory
 org.geotools.referencing.factory.wms.WebCRSFactory
+org.geotools.referencing.factory.wms.OGCAPICRSFactory
 org.geotools.referencing.factory.URN_AuthorityFactory
 org.geotools.referencing.factory.HTTP_AuthorityFactory
 org.geotools.referencing.factory.HTTP_URI_AuthorityFactory

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/factory/HTTP_URI_AuthorityFactoryTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/factory/HTTP_URI_AuthorityFactoryTest.java
@@ -115,4 +115,13 @@ public class HTTP_URI_AuthorityFactoryTest {
                         DefaultGeographicCRS.WGS84,
                         CRS.decode("http://www.opengis.net/def/crs/CRS/0/84")));
     }
+
+    @Test
+    public void testOGCAPI() throws FactoryException {
+        CRSAuthorityFactory factory =
+                ReferencingFactoryFinder.getCRSAuthorityFactory("http://www.opengis.net/def", null);
+        GeographicCRS crs =
+                factory.createGeographicCRS("http://www.opengis.net/def/crs/OGC/1.3/CRS84");
+        assertTrue(CRS.equalsIgnoreMetadata(crs, DefaultGeographicCRS.WGS84));
+    }
 }

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/factory/wms/OGCAPITest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/factory/wms/OGCAPITest.java
@@ -1,0 +1,188 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.referencing.factory.wms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.geotools.metadata.iso.citation.Citations;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.referencing.factory.AbstractAuthorityFactory;
+import org.geotools.referencing.factory.CachedCRSAuthorityDecorator;
+import org.geotools.referencing.factory.IdentifiedObjectFinder;
+import org.junit.Before;
+import org.junit.Test;
+import org.opengis.metadata.citation.Citation;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.crs.GeographicCRS;
+
+public class OGCAPITest {
+
+    private WebCRSFactory factory;
+
+    /** Initializes the factory to test. */
+    @Before
+    public void setUp() {
+        factory = new OGCAPICRSFactory();
+    }
+
+    @Test
+    public void testAuthority() {
+        final Citation authority = factory.getAuthority();
+        assertTrue(Citations.identifierMatches(authority, "OGC"));
+        assertFalse(Citations.identifierMatches(authority, "CRS"));
+        assertFalse(Citations.identifierMatches(authority, "EPSG"));
+        assertFalse(Citations.identifierMatches(authority, "AUTO"));
+        assertFalse(Citations.identifierMatches(authority, "AUTO2"));
+    }
+
+    /** Tests the CRS:84 code. */
+    @Test
+    public void testCRS84() throws FactoryException {
+        GeographicCRS crs = factory.createGeographicCRS("OGC:84");
+        assertSame(crs, factory.createGeographicCRS("84"));
+        assertSame(crs, factory.createGeographicCRS("CRS84"));
+        assertSame(crs, factory.createGeographicCRS("OGC:CRS84"));
+        assertSame(crs, factory.createGeographicCRS("ogc : crs84"));
+        assertNotSame(crs, factory.createGeographicCRS("OGC:83"));
+        assertNotEquals(DefaultGeographicCRS.WGS84, crs);
+        assertTrue(CRS.equalsIgnoreMetadata(DefaultGeographicCRS.WGS84, crs));
+    }
+
+    @Test
+    public void testCRS83() throws FactoryException {
+        GeographicCRS crs = factory.createGeographicCRS("OGC:83");
+        assertSame(crs, factory.createGeographicCRS("83"));
+        assertSame(crs, factory.createGeographicCRS("CRS83"));
+        assertSame(crs, factory.createGeographicCRS("OGC:CRS83"));
+        assertNotSame(crs, factory.createGeographicCRS("OGC:84"));
+        assertFalse(CRS.equalsIgnoreMetadata(DefaultGeographicCRS.WGS84, crs));
+    }
+
+    /** Tests the {@link IdentifiedObjectFinder#find} method. */
+    @Test
+    public void testFind() throws FactoryException {
+        final GeographicCRS CRS84 = factory.createGeographicCRS("OGC:84");
+        final IdentifiedObjectFinder finder =
+                factory.getIdentifiedObjectFinder(CoordinateReferenceSystem.class);
+        assertTrue("Newly created finder should default to full scan.", finder.isFullScanAllowed());
+
+        finder.setFullScanAllowed(false);
+        assertSame(
+                "Should find without the need for scan, since we can use the CRS:84 identifier.",
+                CRS84,
+                finder.find(CRS84));
+
+        finder.setFullScanAllowed(true);
+        assertSame(
+                "Allowing scanning should not make any difference for this CRS84 instance.",
+                CRS84,
+                finder.find(CRS84));
+
+        assertNotSame("Required condition for next test.", CRS84, DefaultGeographicCRS.WGS84);
+        assertNotEquals("Required condition for next test.", CRS84, DefaultGeographicCRS.WGS84);
+        assertTrue(
+                "Required condition for next test.",
+                CRS.equalsIgnoreMetadata(CRS84, DefaultGeographicCRS.WGS84));
+
+        finder.setFullScanAllowed(false);
+        assertNull(
+                "Should not find WGS84 without a full scan, since it doesn't contains the CRS:84 identifier.",
+                finder.find(DefaultGeographicCRS.WGS84));
+
+        finder.setFullScanAllowed(true);
+        assertSame(
+                "A full scan should allow us to find WGS84, since it is equals ignoring metadata to CRS:84.",
+                CRS84,
+                finder.find(DefaultGeographicCRS.WGS84));
+
+        finder.setFullScanAllowed(false);
+        assertNull(
+                "The scan result should not be cached.", finder.find(DefaultGeographicCRS.WGS84));
+
+        // --------------------------------------------------
+        // Same test than above, using a CRS created from WKT
+        // --------------------------------------------------
+
+        String wkt =
+                "GEOGCS[\"WGS 84\",\n"
+                        + "  DATUM[\"WGS84\",\n"
+                        + "    SPHEROID[\"WGS 84\", 6378137.0, 298.257223563]],\n"
+                        + "  PRIMEM[\"Greenwich\", 0.0],\n"
+                        + "  UNIT[\"degree\", 0.017453292519943295]]";
+        CoordinateReferenceSystem search = CRS.parseWKT(wkt);
+        assertNotEquals("Required condition for next test.", CRS84, search);
+        assertTrue("Required condition for next test.", CRS.equalsIgnoreMetadata(CRS84, search));
+
+        finder.setFullScanAllowed(false);
+        assertNull(
+                "Should not find WGS84 without a full scan, since it doesn't contains the CRS:84 identifier.",
+                finder.find(search));
+
+        finder.setFullScanAllowed(true);
+        assertSame(
+                "A full scan should allow us to find WGS84, since it is equals ignoring metadata to CRS:84.",
+                CRS84,
+                finder.find(search));
+
+        assertEquals("OGC:84", finder.findIdentifier(search));
+    }
+
+    /**
+     * Tests the {@link IdentifiedObjectFinder#find} method through a buffered authority factory.
+     * The objects found are expected to be cached.
+     */
+    @Test
+    public void testBufferedFind() throws FactoryException {
+        final AbstractAuthorityFactory factory = new CachedCRSAuthorityDecorator(this.factory);
+        final GeographicCRS CRS84 = factory.createGeographicCRS("OGC:84");
+        final IdentifiedObjectFinder finder =
+                factory.getIdentifiedObjectFinder(CoordinateReferenceSystem.class);
+
+        finder.setFullScanAllowed(false);
+        assertSame(
+                "Should find without the need for scan, since we can use the CRS:84 identifier.",
+                CRS84,
+                finder.find(CRS84));
+
+        finder.setFullScanAllowed(false);
+        assertNull(
+                "Should not find WGS84 without a full scan, since it doesn't contains the CRS:84 identifier.",
+                finder.find(DefaultGeographicCRS.WGS84));
+
+        finder.setFullScanAllowed(true);
+        assertSame(
+                "A full scan should allow us to find WGS84, since it is equals ignoring metadata to CRS:84.",
+                CRS84,
+                finder.find(DefaultGeographicCRS.WGS84));
+
+        finder.setFullScanAllowed(false);
+        assertSame(
+                "At the contrary of testFind(), the scan result should be cached.",
+                CRS84,
+                finder.find(DefaultGeographicCRS.WGS84));
+
+        assertEquals("OGC:84", finder.findIdentifier(DefaultGeographicCRS.WGS84));
+    }
+}


### PR DESCRIPTION
[![GEOT-7314](https://badgen.net/badge/JIRA/GEOT-7314/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7314) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->