### PR TITLE
[Backport 27.x] [GEOT-7316] Child feature ClientProperties are replicated on GML parent container elements

### DIFF
--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/FeaturePropertyTypeBinding.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/FeaturePropertyTypeBinding.java
@@ -139,8 +139,6 @@ public class FeaturePropertyTypeBinding extends AbstractComplexBinding {
         if (object instanceof ComplexAttribute) {
             ComplexAttribute complex = (ComplexAttribute) object;
             checkXlinkHref(complex);
-            GML3EncodingUtils.encodeClientProperties(complex, value);
-            GML3EncodingUtils.encodeSimpleContent(complex, document, value);
         }
         return value;
     }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3EncodingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3EncodingTest.java
@@ -17,6 +17,8 @@
 package org.geotools.gml3;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -25,6 +27,7 @@ import java.util.Map;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.geotools.data.DataUtilities;
+import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.gml2.SrsSyntax;
@@ -39,9 +42,12 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.WKTReader;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.Name;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.Attributes;
 
 public class GML3EncodingTest {
 
@@ -215,5 +221,22 @@ public class GML3EncodingTest {
 
         Document dom = XMLUnit.buildControlDocument(result);
         assertXpathEvaluatesTo("One  test", "//test:data", dom);
+    }
+
+    @Test
+    public void testEncodeFeatureMemberAttributes() throws Exception {
+        SimpleFeature feature = GML3MockData.feature();
+        Map<Name, Object> attributesMap = new HashMap<>();
+        attributesMap.put(new NameImpl("example"), "123");
+        feature.getUserData().put(Attributes.class, attributesMap);
+        GMLConfiguration configuration = new GMLConfiguration();
+
+        Encoder encoder = new Encoder(configuration);
+        Document dom = encoder.encodeAsDOM(feature, GML.featureMember);
+        Node featureNode = dom.getDocumentElement().getFirstChild();
+        assertTrue(featureNode instanceof Element);
+        Element featureElement = (Element) featureNode;
+        assertTrue(featureElement.hasAttribute("example"));
+        assertFalse(dom.getDocumentElement().hasAttribute("example"));
     }
 }


### PR DESCRIPTION
[![GEOT-7316](https://badgen.net/badge/JIRA/GEOT-7316/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7316) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4208
 **Authored by:** @fernandor777