### PR TITLE
[Backport 28.x] [GEOT-7318] Unit of measure not escaped in DWithin filter

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
@@ -229,9 +229,8 @@ public class HanaFilterToSQL extends PreparedFilterToSQL {
                 out.write(", 'meter'");
             } else {
                 out.write(Double.toString(filter.getDistance()));
-                out.write(", '");
-                out.write(filter.getDistanceUnits());
-                out.write("'");
+                out.write(", ");
+                out.write(HanaUtil.toStringLiteral(filter.getDistanceUnits()));
             }
             out.write(")");
             if ((filter instanceof DWithin) != swapped) {

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaFilterToSqlTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaFilterToSqlTest.java
@@ -1,0 +1,44 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.spatial.DWithin;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaFilterToSqlTest {
+
+    @Test
+    public void testDWithinFilterWithUnitEscaping() throws Exception {
+        HanaFilterToSQL encoder = new HanaFilterToSQL(null, true, null);
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        GeometryFactory gf = new GeometryFactory();
+
+        Coordinate coordinate = new Coordinate();
+        DWithin dwithin =
+                ff.dwithin(
+                        ff.property("GEOM"), ff.literal(gf.createPoint(coordinate)), 10.0, "'FOO");
+        String encoded = encoder.encodeToString(dwithin);
+        assertEquals("WHERE GEOM.ST_WithinDistance(?, 10.0, '''FOO') = 1", encoded);
+    }
+}


### PR DESCRIPTION
[![GEOT-7318](https://badgen.net/badge/JIRA/GEOT-7318/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7318) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4215
 **Authored by:** @stefanuhrig