### PR TITLE
[GEOT-7318] Unit of measure not escaped in DWithin filter

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaFilterToSQL.java
@@ -231,9 +231,8 @@ public class HanaFilterToSQL extends PreparedFilterToSQL {
                 out.write(", 'meter'");
             } else {
                 out.write(Double.toString(filter.getDistance()));
-                out.write(", '");
-                out.write(filter.getDistanceUnits());
-                out.write("'");
+                out.write(", ");
+                out.write(HanaUtil.toStringLiteral(filter.getDistanceUnits()));
             }
             out.write(")");
             if ((filter instanceof DWithin) != swapped) {

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaFilterToSqlTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaFilterToSqlTest.java
@@ -1,0 +1,44 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.spatial.DWithin;
+
+/** @author Stefan Uhrig, SAP SE */
+public class HanaFilterToSqlTest {
+
+    @Test
+    public void testDWithinFilterWithUnitEscaping() throws Exception {
+        HanaFilterToSQL encoder = new HanaFilterToSQL(null, true, null);
+        FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
+        GeometryFactory gf = new GeometryFactory();
+
+        Coordinate coordinate = new Coordinate();
+        DWithin dwithin =
+                ff.dwithin(
+                        ff.property("GEOM"), ff.literal(gf.createPoint(coordinate)), 10.0, "'FOO");
+        String encoded = encoder.encodeToString(dwithin);
+        assertEquals("WHERE GEOM.ST_WithinDistance(?, 10.0, '''FOO') = 1", encoded);
+    }
+}


### PR DESCRIPTION
[![GEOT-7318](https://badgen.net/badge/JIRA/GEOT-7318/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7318) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The unit of measure string literal is not properly escaped in the DWithin filter.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).