### PR TITLE
[GEOT-7322] WFSContentComplexFeatureCollection.subCollection doesn't use the filter

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/ComplexGetFeatureResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/ComplexGetFeatureResponse.java
@@ -43,7 +43,16 @@ public class ComplexGetFeatureResponse extends WFSResponse {
         this.parser = parser;
     }
 
-    /** Should only be called once. Call close() after use. */
+    /**
+     * The parser that will be used to extract features from the http response.
+     *
+     * <p>Should only be called before calling {@link #features()}
+     */
+    public XmlComplexFeatureParser getParser() {
+        return this.parser;
+    }
+
+    /** Should only be called once. Call {@link FeatureIterator#close()} after use. */
     public FeatureIterator<Feature> features() {
         return new ComplexFeatureIteratorImpl(parser);
     }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSContentComplexFeatureCollection.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSContentComplexFeatureCollection.java
@@ -69,7 +69,7 @@ public class WFSContentComplexFeatureCollection
     /** Making a feature collection based on a request for a type without any filter. */
     public WFSContentComplexFeatureCollection(
             GetFeatureRequest request, FeatureType schema, QName name, WFSClient client) {
-        this(request, schema, name, Filter.INCLUDE, client);
+        this(request, schema, name, null, client);
     }
 
     /** Making a feature collection based on a request for a type with a filter. */
@@ -99,6 +99,7 @@ public class WFSContentComplexFeatureCollection
                 return new ComplexFeatureIteratorImpl(parser);
             } else {
                 ComplexGetFeatureResponse response = client.issueComplexRequest(request);
+                response.getParser().setFilter(filter);
                 return response.features();
             }
         } catch (IOException e) {

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlComplexFeatureParser.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlComplexFeatureParser.java
@@ -136,6 +136,11 @@ public class XmlComplexFeatureParser extends XmlFeatureParser<FeatureType, Featu
         this.filter = filter;
     }
 
+    /** Sets a filter that is evaluated against the returned features. */
+    public void setFilter(Filter filter) {
+        this.filter = filter;
+    }
+
     /** Search for and parse the next feature. */
     @Override
     public Feature parse() throws IOException {


### PR DESCRIPTION
[![GEOT-7322](https://badgen.net/badge/JIRA/GEOT-7322/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7322) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The constructor that takes a filter is used by the subCollection function. This will only be used by the old methods, that are supposed to go away.

This change will set that filter on the parser in the same manner as the old method.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->