### PR TITLE
[GEOT-7324] NPE on WMTS single tile request on missing GetTile operation in capabilities

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
@@ -265,12 +265,11 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
 
     /** The URL for RESTful can't be established at this point, but it can't be null either. */
     private URL findGetTileURL(OperationType operation) {
-        if (operation == null) {
-            return null;
-        }
         switch (type) {
             case KVP:
-                return operation.getGet() != null ? operation.getGet() : serverURL;
+                return operation != null && operation.getGet() != null
+                        ? operation.getGet()
+                        : serverURL;
             case REST:
                 return serverURL;
             default:

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WebMapTileServerTest.java
@@ -229,6 +229,27 @@ public class WebMapTileServerTest {
         assertNotNull(tileRequest.getFinalURL());
     }
 
+    @Test
+    public void testGetTileWithMissingOperationaMetadata() throws Exception {
+        WebMapTileServer server =
+                new WebMapTileServer(
+                        new URL("https://basemaps.linz.govt.nz/"),
+                        WMTSTestUtils.createCapabilities("linz_basemaps_capabilities.xml"));
+
+        GetTileRequest request = server.createGetTileRequest(false);
+        request.setLayer(server.getCapabilities().getLayer("aerial"));
+        request.setTileMatrixSet("EPSG:3857");
+        request.setTileMatrix("11");
+        request.setFormat("image/png");
+        request.setStyle("default");
+        request.setTileCol(1034);
+        request.setTileRow(98);
+        String finalUrl = request.getFinalURL().toExternalForm();
+        assertEquals(
+                "https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG%3A3857/11/1034/98.png?api=c01fs6b2h1d6n21skpfda8r9nas",
+                finalUrl);
+    }
+
     private static class CheckHeadersHttpClient extends AbstractHttpClient {
 
         @Override


### PR DESCRIPTION
[![GEOT-7324](https://badgen.net/badge/JIRA/GEOT-7324/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7324) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Make sure the url we're sending into GetRestTileRequest isn't null.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->