### PR TITLE
[Backport 28.x] [GEOT-7325] fix NPE on REST template requests with no operations

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/WebMapTileServer.java
@@ -306,11 +306,11 @@ public class WebMapTileServer extends AbstractOpenWebService<WMTSCapabilities, L
 
     /** The URL for RESTful can't be established at this point, but it can't be null either. */
     private URL findGetTileURL(OperationType operation) {
-        if (operation == null) {
-            return null;
-        }
         switch (type) {
             case KVP:
+                if (operation == null) {
+                    return null;
+                }
                 return operation.getGet() != null ? operation.getGet() : serverURL;
             case REST:
                 return serverURL;


### PR DESCRIPTION
[![GEOT-7325](https://badgen.net/badge/JIRA/GEOT-7325/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7325) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4234
 **Authored by:** @ianturton