### PR TITLE
[Backport 28.x] [GEOT-7331] ContentFeatureSource reprojection requirement check fails to resolve to false with two WGS84 CRS instances

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/FeatureTypes.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/FeatureTypes.java
@@ -422,7 +422,7 @@ public class FeatureTypes {
         for (int i = 0; i < schema.getDescriptors().size(); i++) {
             if (schema.getDescriptor(i) instanceof GeometryDescriptor) {
                 GeometryDescriptor descr = (GeometryDescriptor) schema.getDescriptor(i);
-                if (!crs.equals(descr.getCoordinateReferenceSystem())
+                if (!CRS.equalsIgnoreMetadata(crs, descr.getCoordinateReferenceSystem())
                         && CRS.isCompatible(descr.getCoordinateReferenceSystem(), crs, false)) {
                     return true;
                 }


### PR DESCRIPTION
[![GEOT-7331](https://badgen.net/badge/JIRA/GEOT-7331/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7331) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4233
 **Authored by:** @fernandor777