### PR TITLE
[GEOT-7333] The result of linearization after creating circulararc counterclockwise is wrong

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/CircularArc.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/CircularArc.java
@@ -293,6 +293,12 @@ public class CircularArc {
                 double k1 = -(mx - sx) / (my - sy);
                 double k2 = -(ex - sx) / (ey - sy);
 
+                /* Check collinearity */
+                if (abs((k1 - k2)) < EPS) {
+                    radius = COLLINEARS;
+                    return;
+                }
+
                 centerX = (midY2 - midY1 - k2 * midX2 + k1 * midX1) / (k1 - k2);
                 centerY = midY1 + k1 * (midY2 - midY1 - k2 * midX2 + k2 * midX1) / (k1 - k2);
 

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/CircularArc.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/CircularArc.java
@@ -269,8 +269,6 @@ public class CircularArc {
 
     private void initializeCenterRadius() {
         if (Double.isNaN(radius)) {
-            double temp, bc, cd, determinate;
-
             final double sx = controlPoints[0];
             final double sy = controlPoints[1];
             final double mx = controlPoints[2];
@@ -285,19 +283,18 @@ public class CircularArc {
 
                 radius = sqrt((centerX - sx) * (centerX - sx) + (centerY - sy) * (centerY - sy));
             } else {
-                temp = mx * mx + my * my;
-                bc = (sx * sx + sy * sy - temp) / 2.0;
-                cd = (temp - ex * ex - ey * ey) / 2.0;
-                determinate = (sx - mx) * (my - ey) - (mx - ex) * (sy - my);
+                /* Find the center and radius of the circle through the intersection point of the perpendicular line between two points */
 
-                /* Check collinearity */
-                if (abs(determinate) < EPS) {
-                    radius = COLLINEARS;
-                    return;
-                }
-                determinate = 1.0 / determinate;
-                centerX = (bc * (my - ey) - cd * (sy - my)) * determinate;
-                centerY = ((sx - mx) * cd - (mx - ex) * bc) * determinate;
+                double midX1 = (mx + sx) / 2.0;
+                double midY1 = (my + sy) / 2.0;
+                double midX2 = (ex + sx) / 2.0;
+                double midY2 = (ey + sy) / 2.0;
+
+                double k1 = -(mx - sx) / (my - sy);
+                double k2 = -(ex - sx) / (ey - sy);
+
+                centerX = (midY2 - midY1 - k2 * midX2 + k1 * midX1) / (k1 - k2);
+                centerY = midY1 + k1 * (midY2 - midY1 - k2 * midX2 + k2 * midX1) / (k1 - k2);
 
                 radius = sqrt((centerX - sx) * (centerX - sx) + (centerY - sy) * (centerY - sy));
             }

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/CircularArcTest.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/CircularArcTest.java
@@ -98,6 +98,23 @@ public class CircularArcTest {
         assertEquals(envelopeFrom(arc), arc.getEnvelope());
         assertEquals(0, arc.getEnvelope().getArea(), 0d);
     }
+    
+    @Test
+    public void testCalCenter() {
+        CircularArc arc = new CircularArc(3.8576532966E7, 2544522.8998000007, 3.8576533116106E7, 2544523.27624, 3.85765334913E7, 2544523.338199999);
+        Coordinate center = arc.getCenter();
+        // Compare center point
+        assertEquals(new Coordinate(3.857653336096849E7, 2544522.960453221), center);
+
+        // Linearize the arc
+        double[] linearizedCoords = arc.linearize(0.01);
+        final GrowableOrdinateArray gar = new GrowableOrdinateArray();
+        gar.addAll(linearizedCoords);
+        GeometryFactory gf = new GeometryFactory();
+        LineString line = new LineString(gar.toCoordinateSequence(gf), gf);
+        // Output linearized wkt
+        System.out.println(line.toText());
+    }
 
     @Test
     public void testMinuscule() {


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
Fix the wrong calculation of the center of the circle when creating an circulararc counterclockwise.

Modify the calculation method of the circle center coordinates in the calculation CircularArc, and find the circle center and radius through the intersection of two perpendicular lines.

Test code:
```java
@Test
public void testCalCenter() {
    CircularArc arc = new CircularArc(3.8576532966E7, 2544522.8998000007, 3.8576533116106E7, 2544523.27624, 3.85765334913E7, 2544523.338199999);
    Coordinate center = arc.getCenter();
    // Compare center point
    assertEquals(new Coordinate(3.857653336096849E7, 2544522.960453221), center);

    // Linearize the arc
    double[] linearizedCoords = arc.linearize(0.01);
    final GrowableOrdinateArray gar = new GrowableOrdinateArray();
    gar.addAll(linearizedCoords);
    GeometryFactory gf = new GeometryFactory();
    LineString line = new LineString(gar.toCoordinateSequence(gf), gf);
    // Output linearized wkt
    System.out.println(line.toText());
}
```

Original graphics:
![image](https://user-images.githubusercontent.com/97273184/226272825-83cbb8af-dfc9-4539-98ff-832535242579.png)

Linearization result before repair:
![1679291914261_7BC59A00-1F50-4a12-A2A2-192E4D6AE968](https://user-images.githubusercontent.com/97273184/226270913-78d58db9-5e7f-41ef-85cf-4ed73ddc0824.png)

Linearized result after repair:
![1679291992401_121A1B8A-43A9-494d-8FF6-51B3252567DF](https://user-images.githubusercontent.com/97273184/226270983-b888128e-f572-453f-b00d-33ff6951bec4.png)

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
