### PR TITLE
fix preemptive basic authentication behaviour

### DIFF
--- a/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java
+++ b/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java
@@ -16,23 +16,23 @@
  */
 package org.geotools.http.commons;
 
+import static org.apache.http.auth.AuthScope.*;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpException;
-import org.apache.http.HttpResponse;
-import org.apache.http.StatusLine;
+import org.apache.http.*;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
@@ -42,6 +42,8 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -171,6 +173,13 @@ public class MultithreadedHttpClient implements HTTPClient, HTTPConnectionPoolin
         HttpResponse resp;
         if (credsProvider != null) {
             localContext.setCredentialsProvider(credsProvider);
+            // see https://stackoverflow.com/a/21592593
+            AuthCache authCache = new BasicAuthCache();
+            URI target = method.getURI();
+            authCache.put(
+                    new HttpHost(target.getHost(), target.getPort(), target.getScheme()),
+                    new BasicScheme());
+            localContext.setAuthCache(authCache);
             resp = client.execute(method, localContext);
         } else {
             resp = client.execute(method);
@@ -243,7 +252,7 @@ public class MultithreadedHttpClient implements HTTPClient, HTTPConnectionPoolin
 
     private void resetCredentials() {
         if (user != null && password != null) {
-            AuthScope authscope = AuthScope.ANY;
+            AuthScope authscope = ANY;
             Credentials credentials = new UsernamePasswordCredentials(user, password);
             // TODO - check if this works for all types of auth or do we need to look it up?
             credsProvider = new BasicCredentialsProvider();


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-10906 for the motivation.

<!--Include a few sentences describing the overall goals for this Pull Request-->

As username and password are provided, we might not want to first get a 401 response from the remote http server before issuing a basic-authentication.

This patch aims to make sure the http client will provide a basic-authentication, without requiring to get a 401 before (what is usually called a "preemptive basic authentication").

This has been motivated by a behaviour change in GeoServer 2.22.2 described in the following issue:
https://osgeo-org.atlassian.net/browse/GEOS-10906

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->