### PR TITLE
[Backport 28.x] [GEOT-7333] The result of linearization after creating circulararc is wrong

### DIFF
--- a/modules/library/main/pom.xml
+++ b/modules/library/main/pom.xml
@@ -238,6 +238,11 @@
       <version>1.6</version>
     </dependency>
     <dependency>
+      <groupId>org.ejml</groupId>
+      <artifactId>ejml-ddense</artifactId>
+      <!-- The version number is specified in the parent POM. -->
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <!-- The version number is specified in the parent POM. -->

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/CircularArcTest.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/CircularArcTest.java
@@ -295,4 +295,46 @@ public class CircularArcTest {
         CoordinateArraySequence cs = new CoordinateArraySequence(coords);
         return new LineString(cs, new GeometryFactory());
     }
+
+    @Test
+    public void testGeot7333() {
+        // Correctly rounded center and radius computed with an arbitrary precision library
+        Coordinate CENTER = new Coordinate(3.85765333609684929e+07, 2.54452296045322483e+06);
+        double RADIUS = 3.99598457401221629e-01;
+
+        // We test 3 permutations of the control points to cover all branches in the center
+        // computation routine.
+        CircularArc arc1 =
+                new CircularArc(
+                        3.8576532966E7,
+                        2544522.8998000007,
+                        3.8576533116106E7,
+                        2544523.27624,
+                        3.85765334913E7,
+                        2544523.338199999);
+        assertCoordinateEquals(CENTER, arc1.getCenter());
+        assertEquals(RADIUS, arc1.getRadius(), 5e-9);
+
+        CircularArc arc2 =
+                new CircularArc(
+                        3.8576532966E7,
+                        2544522.8998000007,
+                        3.85765334913E7,
+                        2544523.338199999,
+                        3.8576533116106E7,
+                        2544523.27624);
+        assertCoordinateEquals(CENTER, arc2.getCenter());
+        assertEquals(RADIUS, arc2.getRadius(), 5e-9);
+
+        CircularArc arc3 =
+                new CircularArc(
+                        3.8576533116106E7,
+                        2544523.27624,
+                        3.8576532966E7,
+                        2544522.8998000007,
+                        3.85765334913E7,
+                        2544523.338199999);
+        assertCoordinateEquals(CENTER, arc3.getCenter());
+        assertEquals(RADIUS, arc3.getRadius(), 5e-9);
+    }
 }


### PR DESCRIPTION
[![GEOT-7333](https://badgen.net/badge/JIRA/GEOT-7333/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7333) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4244
 **Authored by:** @stefanuhrig