### PR TITLE
[GEOT-10906] Authentication not sent if connection pooling activated

### DIFF
--- a/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java
+++ b/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java
@@ -16,10 +16,13 @@
  */
 package org.geotools.http.commons;
 
+import static org.apache.http.auth.AuthScope.ANY;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -28,11 +31,13 @@ import java.util.zip.GZIPInputStream;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
@@ -42,6 +47,8 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -171,6 +178,13 @@ public class MultithreadedHttpClient implements HTTPClient, HTTPConnectionPoolin
         HttpResponse resp;
         if (credsProvider != null) {
             localContext.setCredentialsProvider(credsProvider);
+            // see https://stackoverflow.com/a/21592593
+            AuthCache authCache = new BasicAuthCache();
+            URI target = method.getURI();
+            authCache.put(
+                    new HttpHost(target.getHost(), target.getPort(), target.getScheme()),
+                    new BasicScheme());
+            localContext.setAuthCache(authCache);
             resp = client.execute(method, localContext);
         } else {
             resp = client.execute(method);
@@ -243,7 +257,7 @@ public class MultithreadedHttpClient implements HTTPClient, HTTPConnectionPoolin
 
     private void resetCredentials() {
         if (user != null && password != null) {
-            AuthScope authscope = AuthScope.ANY;
+            AuthScope authscope = ANY;
             Credentials credentials = new UsernamePasswordCredentials(user, password);
             // TODO - check if this works for all types of auth or do we need to look it up?
             credsProvider = new BasicCredentialsProvider();

--- a/modules/plugin/http-commons/src/test/java/org/geotools/http/commons/MultithreadedHttpClientTest.java
+++ b/modules/plugin/http-commons/src/test/java/org/geotools/http/commons/MultithreadedHttpClientTest.java
@@ -81,6 +81,25 @@ public class MultithreadedHttpClientTest {
         wireMockProxyRule.verify(getRequestedFor(urlEqualTo("/fred")));
     }
 
+    @Test
+    public void testWithBasicAuthProvided() throws Exception {
+        wireMockRule.addStubMapping(
+                stubFor(
+                        get(urlEqualTo("/testba"))
+                                .withBasicAuth("flup", "top")
+                                .willReturn(
+                                        aResponse()
+                                                .withStatus(200)
+                                                .withHeader("Content-Type", "text/xml")
+                                                .withBody("<ok>authorized</ok>"))));
+
+        try (MultithreadedHttpClient toTest = new MultithreadedHttpClient()) {
+            toTest.setUser("flup");
+            toTest.setPassword("top");
+            toTest.get(new URL("http://localhost:" + wireMockRule.port() + "/testba"));
+        }
+    }
+
     /** Verifies that the nonProxyConfig is used when a GET is executed, matching a nonProxyHost. */
     @Test
     public void testGetWithMatchingNonProxyHost() throws HttpException, IOException {


### PR DESCRIPTION
[![GEOT-10906](https://badgen.net/badge/JIRA/GEOT-10906/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-10906) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR aims to fix [GEOT-10906](https://osgeo-org.atlassian.net/browse/GEOT-7337) by harmonizing the behaviour of the gt-http-commons module, by preemptively sending a basic authentication, if authentication is provided.  


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).