### PR TITLE
[GEOT-7340] Avoid PAMParser init causing ImageMosaic to fail

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
@@ -154,8 +154,7 @@ public class GranuleDescriptor {
                     new VectorBinarizeRIF(),
                     Registry.JAI_TOOLS_PRODUCT);
         } catch (Throwable e) {
-            LOGGER.log(Level.SEVERE, "Error setting up GranuleDescriptor", e);
-            throw new RuntimeException("Error setting up GranuleDescriptor.", e);
+            LOGGER.log(Level.SEVERE, "Error when registering RIF for GranuleDescriptor.", e);
         }
     }
 

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
@@ -153,10 +153,9 @@ public class GranuleDescriptor {
                     new VectorBinarizeDescriptor(),
                     new VectorBinarizeRIF(),
                     Registry.JAI_TOOLS_PRODUCT);
-        } catch (Exception e) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, e.getLocalizedMessage());
-            }
+        } catch (Throwable e) {
+            LOGGER.log(Level.SEVERE, "Error setting up GranuleDescriptor", e);
+            throw new RuntimeException("Error setting up GranuleDescriptor.", e);
         }
     }
 
@@ -339,7 +338,7 @@ public class GranuleDescriptor {
         }
     }
 
-    private static PAMParser pamParser = PAMParser.getInstance();
+    private static PAMParser pamParser;
 
     ReferencedEnvelope granuleBBOX;
 
@@ -641,7 +640,16 @@ public class GranuleDescriptor {
         final File file = URLs.urlToFile(granuleUrl);
         final String path = file.getCanonicalPath();
         final File auxFile = new File(path + AUXFILE_EXT);
-        if (auxFile.exists()) pamDataset = pamParser.parsePAM(auxFile);
+        if (auxFile.exists()) {
+            if (pamParser == null) {
+                try {
+                    pamParser = PAMParser.getInstance();
+                } catch (Throwable e) {
+                    throw new RuntimeException("Couldn't initialize PAM parser.", e);
+                }
+            }
+            pamDataset = pamParser.parsePAM(auxFile);
+        }
     }
 
     public GranuleDescriptor(


### PR DESCRIPTION
[![GEOT-7340](https://badgen.net/badge/JIRA/GEOT-7340/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7340) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes an annoying exception in static part of class initialization when using ImageMosaic.

Related to class loading of javax.xml.bind.JAXBException, and how this is treated in it.geosolutions.imageio.pam.PAMParser.

Not sure how to write a test case for this one.


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->