### PR TITLE
[Backport 29.x] Bump json from 20210307 to 20230227 in /modules/unsupported/flatgeobuf

### DIFF
--- a/modules/unsupported/flatgeobuf/pom.xml
+++ b/modules/unsupported/flatgeobuf/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20210307</version>
+      <version>20230227</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Backport #4262
 **Authored by:** @dependabot[bot]