### PR TITLE
[GEOT-7241] Addng column comment tests on H2 too

### DIFF
--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DataStoreAPITest.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DataStoreAPITest.java
@@ -16,8 +16,16 @@
  */
 package org.geotools.data.h2;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.jdbc.JDBCDataStoreAPIOnlineTest;
 import org.geotools.jdbc.JDBCDataStoreAPITestSetup;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.AttributeType;
 
 public class H2DataStoreAPITest extends JDBCDataStoreAPIOnlineTest {
     @Override
@@ -33,5 +41,18 @@ public class H2DataStoreAPITest extends JDBCDataStoreAPIOnlineTest {
     @Override
     public void testGetFeatureWriterConcurrency() throws Exception {
         // Blocks and times out
+    }
+
+    @Test
+    public void testGetComments() throws Exception {
+        // H2 comment retrieval is always on, so this should work
+        ContentFeatureSource featureSource = dataStore.getFeatureSource(tname("lake"));
+        SimpleFeatureType simpleFeatureType = featureSource.getSchema();
+        AttributeDescriptor attributeDescriptor = simpleFeatureType.getDescriptor("name");
+        AttributeType attributeType = attributeDescriptor.getType();
+        assertEquals("This is a text column", attributeType.getDescription().toString());
+        AttributeDescriptor attributeDescriptor2 = simpleFeatureType.getDescriptor("geom");
+        AttributeType attributeType2 = attributeDescriptor2.getType();
+        assertNull(attributeType2.getDescription()); // no comment on GEOM
     }
 }

--- a/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DataStoreAPITestSetup.java
+++ b/modules/plugin/jdbc/jdbc-h2/src/test/java/org/geotools/data/h2/H2DataStoreAPITestSetup.java
@@ -72,6 +72,10 @@ public class H2DataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
                 "INSERT INTO \"lake\" (\"id\",\"geom\",\"name\") VALUES ( 0,"
                         + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
                         + "'muddy')");
+
+        // Add column comments
+        String sql = "COMMENT ON COLUMN \"lake\".\"name\" IS 'This is a text column'";
+        run(sql);
     }
 
     @Override


### PR DESCRIPTION
Just adding more testing, ensuring that H2 can also handle column comments in preparation for a GeoServer test.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
