### PR TITLE
[GEOT-7353] GeostationarySatellite does not account for the ESRI WKT parameters "Height" and "Option"

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeostationarySatellite.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeostationarySatellite.java
@@ -326,11 +326,23 @@ public abstract class GeostationarySatellite extends MapProjection {
                 createDescriptor(
                         new NamedIdentifier[] {
                             new NamedIdentifier(Citations.OGC, "satellite_height"),
+                            new NamedIdentifier(Citations.ESRI, "Height"),
                         },
                         35785831, // default
                         0.0, // minimum
                         Double.POSITIVE_INFINITY, // maximum
                         SI.METRE);
+
+        // The ESRI version of the projection has an additional parameter "Option" which is ignored.
+        static final ParameterDescriptor OPTION =
+                createDescriptor(
+                        new NamedIdentifier[] {
+                            new NamedIdentifier(Citations.ESRI, "Option"),
+                        },
+                        0, // default
+                        0, // minimum
+                        Double.POSITIVE_INFINITY, // maximum
+                        null);
 
         static final ParameterDescriptorGroup PARAMETERS =
                 createDescriptorGroup(
@@ -344,7 +356,8 @@ public abstract class GeostationarySatellite extends MapProjection {
                             CENTRAL_MERIDIAN,
                             SATELLITE_HEIGHT,
                             FALSE_EASTING,
-                            FALSE_NORTHING
+                            FALSE_NORTHING,
+                            OPTION,
                         });
 
         public Provider() {

--- a/modules/library/referencing/src/test/java/org/geotools/referencing/operation/projection/GeostationarySatelliteTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/referencing/operation/projection/GeostationarySatelliteTest.java
@@ -61,6 +61,20 @@ public class GeostationarySatelliteTest {
                     + "    PARAMETER[\"false_northing\",0],"
                     + "    UNIT[\"meter\", 1]]";
 
+    public static final String esriGeosWKT =
+            "PROJCS[\"unknown\","
+                    + "  GEOGCS[\"GCS_unknown\","
+                    + "    DATUM[\"D_WGS_1984\","
+                    + "      SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],"
+                    + "    PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],"
+                    + "    PROJECTION[\"Geostationary_Satellite\"],"
+                    + "    PARAMETER[\"False_Easting\",0.0],"
+                    + "    PARAMETER[\"False_Northing\",0.0],"
+                    + "    PARAMETER[\"Longitude_Of_Center\",0.0],"
+                    + "    PARAMETER[\"Height\",35785863.0],"
+                    + "    PARAMETER[\"Option\",0.0],"
+                    + "    UNIT[\"Meter\",1.0]]";
+
     static CoordinateReferenceSystem sphericalGeosCRS;
     static MathTransform sphericalGeosToGeog;
     static MathTransform geogToSphericalGeos;
@@ -68,6 +82,10 @@ public class GeostationarySatelliteTest {
     static CoordinateReferenceSystem ellipsoidalGeosCRS;
     static MathTransform ellipsoidalGeosToGeog;
     static MathTransform geogToEllipsoidalGeos;
+
+    static CoordinateReferenceSystem esriGeosCRS;
+    static MathTransform esriGeosToGeog;
+    static MathTransform geogToEsriGeos;
 
     @BeforeClass
     public static void setupClass() throws FactoryException, TransformException {
@@ -84,6 +102,14 @@ public class GeostationarySatelliteTest {
                         CRS.getProjectedCRS(ellipsoidalGeosCRS).getBaseCRS(),
                         true);
         geogToEllipsoidalGeos = ellipsoidalGeosToGeog.inverse();
+
+        esriGeosCRS = CRS.parseWKT(esriGeosWKT);
+        esriGeosToGeog =
+                CRS.findMathTransform(
+                        esriGeosCRS,
+                        CRS.getProjectedCRS(esriGeosCRS).getBaseCRS(),
+                        true);
+        geogToEsriGeos = esriGeosToGeog.inverse();
     }
 
     @Test
@@ -100,6 +126,14 @@ public class GeostationarySatelliteTest {
                 CRS.getMapProjection(ellipsoidalGeosCRS).getParameterValues();
         double satelliteHeight = parameters.parameter("satellite_height").doubleValue();
         assertThat(satelliteHeight, is(35785831.0));
+    }
+
+    @Test
+    public void testEsriWKTParameters() {
+        ParameterValueGroup parameters =
+            CRS.getMapProjection(esriGeosCRS).getParameterValues();
+        double satelliteHeight = parameters.parameter("satellite_height").doubleValue();
+        assertThat(satelliteHeight, is(35785863.0));
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7353](https://badgen.net/badge/JIRA/GEOT-7353/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7353) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The major difference is that in ESRI WKT, the "satellite_height" parameter is named "Height". ESRI WKT also includes an "Option" parameter, which is unused but must be present in the `ParameterDescriptorGroup` so that parsing succeeds.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->