### PR TITLE
Mongo DWITHIN implementation using $near

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -34,9 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.measure.Unit;
-import javax.measure.UnitConverter;
-import javax.measure.quantity.Length;
+import org.geotools.data.util.DistanceBufferUtil;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.FunctionImpl;
@@ -51,11 +49,9 @@ import org.geotools.jdbc.JoinId;
 import org.geotools.jdbc.JoinPropertyName;
 import org.geotools.jdbc.PrimaryKey;
 import org.geotools.jdbc.PrimaryKeyColumn;
-import org.geotools.referencing.CRS;
 import org.geotools.util.ConverterFactory;
 import org.geotools.util.Converters;
 import org.geotools.util.factory.Hints;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -124,11 +120,8 @@ import org.opengis.filter.temporal.TContains;
 import org.opengis.filter.temporal.TEquals;
 import org.opengis.filter.temporal.TOverlaps;
 import org.opengis.parameter.Parameter;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.opengis.referencing.crs.GeographicCRS;
 import org.opengis.temporal.Instant;
 import org.opengis.temporal.Period;
-import si.uom.SI;
 
 /**
  * Encodes a filter into a SQL WHERE statement. It should hopefully be generic enough that any SQL
@@ -165,23 +158,6 @@ import si.uom.SI;
  *
  */
 public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
-
-    /** Conversion factor from common units to meter */
-    private static final Map<String, Double> UNITS_MAP =
-            Map.ofEntries(
-                    entry("kilometers", 1000.0),
-                    entry("kilometer", 1000.0),
-                    entry("km", 1000.0),
-                    entry("m", 1.0),
-                    entry("meter", 1.0),
-                    entry("mm", 0.001),
-                    entry("millimeter", 0.001),
-                    entry("mi", 1609.344),
-                    entry("miles", 1609.344),
-                    entry("nm", 1852d),
-                    entry("feet", 0.3048),
-                    entry("ft", 0.3048),
-                    entry("in", 0.0254));
 
     /** error message for exceptions */
     protected static final String IO_ERROR = "io problem writing filter";
@@ -2133,74 +2109,12 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
     }
 
     /**
-     * Converts the distance of the operator in meters, or returns the current value if there is no
-     * units distance
-     */
-    protected double getDistanceInMeters(DistanceBufferOperator operator) {
-        double distance = operator.getDistance();
-        String units = operator.getDistanceUnits();
-        // no units or no SRID, no party, return value as-is
-        if (units == null || UNITS_MAP.get(units.toLowerCase()) == null) {
-            return distance;
-        }
-
-        double factor = UNITS_MAP.get(units.toLowerCase());
-        return distance * factor;
-    }
-
-    /**
      * Rough evaluation of distance in the units of the current SRID, assuming that the SRID maps to
      * a known EPSG code. Will use a rather imprecise transformation for distances over degrees, but
      * better than nothing.
      */
     protected double getDistanceInNativeUnits(DistanceBufferOperator operator) {
-        if (currentSRID == null) {
-            return operator.getDistance();
-        }
-        try {
-            CoordinateReferenceSystem crs = CRS.getHorizontalCRS(CRS.decode("EPSG:" + currentSRID));
-            double distanceMeters = getDistanceInMeters(operator);
-            if (crs instanceof GeographicCRS) {
-                double sizeDegree = 110574.2727;
-                Coordinate center = getReferenceGeometryCentroid(operator);
-                if (center != null) {
-                    double cosLat = Math.cos(Math.PI * center.y / 180.0);
-                    double latAdjustment = Math.sqrt(1 + cosLat * cosLat) / Math.sqrt(2.0);
-                    sizeDegree *= latAdjustment;
-                }
-
-                return distanceMeters / sizeDegree;
-            } else {
-                @SuppressWarnings("unchecked")
-                Unit<Length> unit = (Unit<Length>) crs.getCoordinateSystem().getAxis(0).getUnit();
-                if (unit == null) {
-                    return distanceMeters;
-                } else {
-                    UnitConverter converter = SI.METRE.getConverterTo(unit);
-                    return converter.convert(distanceMeters);
-                }
-            }
-        } catch (Exception e) {
-            LOGGER.log(
-                    Level.FINE,
-                    "Failed to turn the distance of spatial "
-                            + "filter into native units, using it as a pure number instead",
-                    e);
-            // tried, fall back on pure value
-            return operator.getDistance();
-        }
-    }
-
-    /** Returns the center of the reference geometry of the distance buffer operator, in case */
-    protected Coordinate getReferenceGeometryCentroid(DistanceBufferOperator operator) {
-        Geometry geom = operator.getExpression1().evaluate(null, Geometry.class);
-        if (geom == null) {
-            geom = operator.getExpression2().evaluate(null, Geometry.class);
-        }
-        if (geom == null) {
-            return null;
-        }
-        return geom.getCentroid().getCoordinate();
+        return DistanceBufferUtil.getDistanceInNativeUnits(operator, currentSRID);
     }
 
     @Override

--- a/modules/library/main/src/main/java/org/geotools/data/util/DistanceBufferUtil.java
+++ b/modules/library/main/src/main/java/org/geotools/data/util/DistanceBufferUtil.java
@@ -1,0 +1,124 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.util;
+
+import static java.util.Map.entry;
+
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.measure.Unit;
+import javax.measure.UnitConverter;
+import javax.measure.quantity.Length;
+import org.geotools.referencing.CRS;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.filter.spatial.DistanceBufferOperator;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.crs.GeographicCRS;
+import si.uom.SI;
+
+/** Utility class for DistanceBufferOperations */
+public class DistanceBufferUtil {
+
+    /** Standard java logger */
+    protected static Logger LOGGER =
+            org.geotools.util.logging.Logging.getLogger(DistanceBufferUtil.class);
+
+    private static final Map<String, Double> UNITS_MAP =
+            Map.ofEntries(
+                    entry("kilometers", 1000.0),
+                    entry("kilometer", 1000.0),
+                    entry("km", 1000.0),
+                    entry("m", 1.0),
+                    entry("meter", 1.0),
+                    entry("mm", 0.001),
+                    entry("millimeter", 0.001),
+                    entry("mi", 1609.344),
+                    entry("miles", 1609.344),
+                    entry("nm", 1852d),
+                    entry("feet", 0.3048),
+                    entry("ft", 0.3048),
+                    entry("in", 0.0254));
+
+    public static double getDistanceInNativeUnits(
+            DistanceBufferOperator operator, Integer currentSRID) {
+        if (currentSRID == null) {
+            return operator.getDistance();
+        }
+        try {
+            CoordinateReferenceSystem crs = CRS.getHorizontalCRS(CRS.decode("EPSG:" + currentSRID));
+            double distanceMeters = getDistanceInMeters(operator);
+            if (crs instanceof GeographicCRS) {
+                double sizeDegree = 110574.2727;
+                Coordinate center = getReferenceGeometryCentroid(operator);
+                if (center != null) {
+                    double cosLat = Math.cos(Math.PI * center.y / 180.0);
+                    double latAdjustment = Math.sqrt(1 + cosLat * cosLat) / Math.sqrt(2.0);
+                    sizeDegree *= latAdjustment;
+                }
+
+                return distanceMeters / sizeDegree;
+            } else {
+                @SuppressWarnings("unchecked")
+                Unit<Length> unit = (Unit<Length>) crs.getCoordinateSystem().getAxis(0).getUnit();
+                if (unit == null) {
+                    return distanceMeters;
+                } else {
+                    UnitConverter converter = SI.METRE.getConverterTo(unit);
+                    return converter.convert(distanceMeters);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(
+                    Level.FINE,
+                    "Failed to turn the distance of spatial "
+                            + "filter into native units, using it as a pure number instead",
+                    e);
+            // tried, fall back on pure value
+            return operator.getDistance();
+        }
+    }
+
+    /** Returns the center of the reference geometry of the distance buffer operator, in case */
+    private static Coordinate getReferenceGeometryCentroid(DistanceBufferOperator operator) {
+        Geometry geom = operator.getExpression1().evaluate(null, Geometry.class);
+        if (geom == null) {
+            geom = operator.getExpression2().evaluate(null, Geometry.class);
+        }
+        if (geom == null) {
+            return null;
+        }
+        return geom.getCentroid().getCoordinate();
+    }
+
+    /**
+     * Converts the distance of the operator in meters, or returns the current value if there is no
+     * units distance
+     */
+    public static double getDistanceInMeters(DistanceBufferOperator operator) {
+        double distance = operator.getDistance();
+        String units = operator.getDistanceUnits();
+        // no units or no SRID, no party, return value as-is
+        if (units == null || UNITS_MAP.get(units.toLowerCase()) == null) {
+            return distance;
+        }
+
+        double factor = UNITS_MAP.get(units.toLowerCase());
+        return distance * factor;
+    }
+}

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.geotools.data.jdbc.FilterToSQL;
 import org.geotools.data.postgis.filter.FilterFunction_pgNearest;
+import org.geotools.data.util.DistanceBufferUtil;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.LengthFunction;
@@ -269,11 +270,7 @@ class FilterToSqlHelper {
         double distance;
         if (isCurrentGeography()) {
             // need the value in meters
-            if (delegate instanceof PostgisPSFilterToSql) {
-                distance = ((PostgisPSFilterToSql) delegate).getDistanceInMeters(operator);
-            } else {
-                distance = ((PostgisFilterToSQL) delegate).getDistanceInMeters(operator);
-            }
+            distance = DistanceBufferUtil.getDistanceInMeters(operator);
         } else {
             // need the value in native units
             if (delegate instanceof PostgisPSFilterToSql) {

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
@@ -167,11 +167,6 @@ public class PostgisFilterToSQL extends FilterToSQL {
     }
 
     @Override
-    public double getDistanceInMeters(DistanceBufferOperator operator) {
-        return super.getDistanceInMeters(operator);
-    }
-
-    @Override
     public double getDistanceInNativeUnits(DistanceBufferOperator operator) {
         return super.getDistanceInNativeUnits(operator);
     }

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisPSFilterToSql.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisPSFilterToSql.java
@@ -93,11 +93,6 @@ public class PostgisPSFilterToSql extends PreparedFilterToSQL {
     }
 
     @Override
-    public double getDistanceInMeters(DistanceBufferOperator operator) {
-        return super.getDistanceInMeters(operator);
-    }
-
-    @Override
     public double getDistanceInNativeUnits(DistanceBufferOperator operator) {
         return super.getDistanceInNativeUnits(operator);
     }

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoCollectionMeta.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoCollectionMeta.java
@@ -1,0 +1,38 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb;
+
+import java.util.Collections;
+import java.util.Map;
+
+/** Class used to store metadata of mongo collection */
+public class MongoCollectionMeta {
+
+    // Map with index information where key is name of the indexed field and value is its type
+    private final Map<String, String> indexeMap;
+
+    public MongoCollectionMeta(Map<String, String> indexes) {
+        this.indexeMap = indexes;
+    }
+
+    public Map<String, String> getIndexes() {
+        if (indexeMap == null) {
+            return Collections.emptyMap();
+        }
+        return indexeMap;
+    }
+}

--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFilterSplitter.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFilterSplitter.java
@@ -22,6 +22,8 @@ import org.geotools.data.mongodb.complex.JsonSelectFunction;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.visitor.ClientTransactionAccessor;
 import org.geotools.filter.visitor.PostPreProcessFilterSplittingVisitor;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.BinaryComparisonOperator;
 import org.opengis.filter.PropertyIsLike;
@@ -84,7 +86,7 @@ public class MongoFilterSplitter extends PostPreProcessFilterSplittingVisitor {
         Expression expression2 = filter.getExpression2();
         if (filter instanceof DWithin
                 && expression2 != null
-                && expression2.toString().toUpperCase().startsWith("POINT")) {
+                && expression2.evaluate(null, Geometry.class) instanceof Point) {
             if (mongoCollectionMeta != null
                     && StringUtils.equalsAny(
                             mongoCollectionMeta

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFilterSplitterTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFilterSplitterTest.java
@@ -1,0 +1,66 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.mongodb;
+
+import java.util.Collections;
+import org.geotools.filter.AttributeExpressionImpl;
+import org.geotools.filter.FilterCapabilities;
+import org.geotools.filter.LiteralExpressionImpl;
+import org.geotools.filter.spatial.DWithinImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opengis.filter.spatial.DWithin;
+
+public class MongoFilterSplitterTest {
+
+    private static final DWithinImpl D_WITHIN =
+            new DWithinImpl(
+                    new AttributeExpressionImpl("geometry"),
+                    new LiteralExpressionImpl("POINT (5.006253 60.701807)"));
+    private static final FilterCapabilities FCS = new FilterCapabilities(DWithin.class);
+
+    @Test
+    public void testDWithinSplitWithCorrectIndex() {
+        MongoFilterSplitter splitter =
+                new MongoFilterSplitter(
+                        FCS,
+                        null,
+                        null,
+                        new MongoCollectionMeta(Collections.singletonMap("geometry", "2dsphere")));
+        splitter.visit(D_WITHIN, null);
+        Assert.assertEquals(D_WITHIN, splitter.getFilterPre());
+    }
+
+    @Test
+    public void testDWithinSplitIncorrectIndex() {
+        MongoFilterSplitter splitter =
+                new MongoFilterSplitter(
+                        FCS,
+                        null,
+                        null,
+                        new MongoCollectionMeta(Collections.singletonMap("_id", "1")));
+        splitter.visit(D_WITHIN, null);
+        Assert.assertEquals(D_WITHIN, splitter.getFilterPost());
+    }
+
+    @Test
+    public void testDWithinSplitWithoutIndex() {
+        MongoFilterSplitter splitter = new MongoFilterSplitter(FCS, null, null, null);
+        splitter.visit(D_WITHIN, null);
+        Assert.assertEquals(D_WITHIN, splitter.getFilterPost());
+    }
+}

--- a/modules/unsupported/jdbc-h2gis/src/main/java/org/h2gis/geotools/H2GISPSFilterToSql.java
+++ b/modules/unsupported/jdbc-h2gis/src/main/java/org/h2gis/geotools/H2GISPSFilterToSql.java
@@ -79,11 +79,6 @@ public class H2GISPSFilterToSql extends PreparedFilterToSQL {
     }
 
     @Override
-    public double getDistanceInMeters(DistanceBufferOperator operator) {
-        return super.getDistanceInMeters(operator);
-    }
-
-    @Override
     public double getDistanceInNativeUnits(DistanceBufferOperator operator) {
         return super.getDistanceInNativeUnits(operator);
     }


### PR DESCRIPTION
[[GEOT-7360] DWITHIN support for mongo DB](https://osgeo-org.atlassian.net/browse/GEOT-7360)
  
Using DWITHIN in cql was executing operation in memory, instead of delegating it to mongoDB $near
Added support for DWITHIN for mongodb plugin

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->