### PR TITLE
[GEOT-7332] Resolve incompatibility between LGPL-2.1 and LGPL-3+

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometrySmoother.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometrySmoother.java
@@ -7,7 +7,7 @@
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
  *    License as published by the Free Software Foundation;
- *    version 2.1 of the License.
+ *    version 2.1 or any later versiun of the License.
  *
  *    This library is distributed in the hope that it will be useful,
  *    but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
Before this change, the file GeometrySmoother.java was licensed both with "LGPL-2.1 only" and "LGPL-3.0 or any later version", which is impossible to fulfill at the same time -- which license could be used for this file?

By changing "LGPL-2.1"to "LGPL-2.1 or any later version", it is possible to license this file under LGPL-3.0, hereby resolving this conflict.

# Checklist

- [x ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation). - Not needed, small change.
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes. - Not needed, only documentation change.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
