### PR TITLE
[GEOT-7234] Implement #getOptimizedBounds(...) in SQLServerDialect

### DIFF
--- a/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/main/java/org/geotools/data/sqlserver/SQLServerDataStoreFactory.java
@@ -84,7 +84,16 @@ public class SQLServerDataStoreFactory extends JDBCDataStoreFactory {
             new Param(
                     "Force spatial index usage via hints",
                     Boolean.class,
-                    "When enabled, spatial filters will be accompained by a WITH INDEX sql hint forcing the usage of the spatial index.",
+                    "When enabled, spatial filters will be accompanied by a WITH INDEX sql hint forcing the usage of the spatial index.",
+                    false,
+                    Boolean.FALSE);
+
+    /** parameter that enables estimated extends instead of exact ones */
+    public static final Param ESTIMATED_EXTENTS =
+            new Param(
+                    "Estimated extents",
+                    Boolean.class,
+                    "Use the spatial index information to quickly get an estimate of the data bounds",
                     false,
                     Boolean.FALSE);
 
@@ -218,6 +227,11 @@ public class SQLServerDataStoreFactory extends JDBCDataStoreFactory {
         Boolean forceSpatialIndexes = (Boolean) FORCE_SPATIAL_INDEX.lookUp(params);
         if (forceSpatialIndexes != null) {
             dialect.setForceSpatialIndexes(forceSpatialIndexes);
+        }
+
+        Boolean estimatedExtentsEnabled = (Boolean) ESTIMATED_EXTENTS.lookUp(params);
+        if (estimatedExtentsEnabled != null) {
+            dialect.setEstimatedExtentsEnabled(estimatedExtentsEnabled);
         }
 
         String tableHints = (String) TABLE_HINTS.lookUp(params);

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDialectOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDialectOnlineTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.geotools.data.sqlserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.sql.Connection;
+import java.util.List;
+import org.geotools.api.data.Transaction;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.junit.Test;
+
+public class SQLServerDialectOnlineTest extends JDBCTestSupport {
+
+    private final String testTypeName = "multiGeom";
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new SQLServerDialectTestSetup();
+    }
+
+    @Test
+    public void testOptimizedBounds() throws Exception {
+        ((SQLServerDialect) dialect).setEstimatedExtentsEnabled(true);
+
+        final ReferencedEnvelope expectedBounds =
+                new ReferencedEnvelope(
+                        132782,
+                        132975,
+                        457575,
+                        457666,
+                        dataStore.getSchema(testTypeName).getCoordinateReferenceSystem());
+        final ReferencedEnvelope expectedBounds2 =
+                new ReferencedEnvelope(
+                        132400,
+                        132600,
+                        457400,
+                        457600,
+                        dataStore.getSchema(testTypeName).getCoordinateReferenceSystem());
+
+        try (Connection cx = dataStore.getConnection(Transaction.AUTO_COMMIT)) {
+            List<ReferencedEnvelope> bounds =
+                    dialect.getOptimizedBounds(null, dataStore.getSchema(testTypeName), cx);
+
+            assertEquals(
+                    "Expected a bounds record for each geometry column in the table",
+                    3,
+                    bounds.size());
+            assertEquals("", expectedBounds, bounds.get(0));
+            assertEquals("", expectedBounds2, bounds.get(1));
+            assertNull("Expecting null bounds for geom_noindex", bounds.get(2));
+        }
+    }
+
+    @Test
+    public void testOptimizedBoundsNoEstimatedExtents() throws Exception {
+        ((SQLServerDialect) dialect).setEstimatedExtentsEnabled(false);
+
+        try (Connection cx = dataStore.getConnection(Transaction.AUTO_COMMIT)) {
+            List<ReferencedEnvelope> bounds =
+                    dialect.getOptimizedBounds(null, dataStore.getSchema(testTypeName), cx);
+            assertNull("Expecting no bounds with estimatedExtentsEnabled set to false", bounds);
+        }
+    }
+}

--- a/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDialectTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-sqlserver/src/test/java/org/geotools/data/sqlserver/SQLServerDialectTestSetup.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.geotools.data.sqlserver;
+
+public class SQLServerDialectTestSetup extends SQLServerTestSetup {
+
+    @Override
+    protected void setUpData() throws Exception {
+        runSafe("DROP TABLE multiGeom");
+
+        String sql =
+                "CREATE TABLE multiGeom (id int IDENTITY(0,1) PRIMARY KEY, geometry geometry, name varchar(255), polygon_geom geometry, geom_noindex geometry)";
+        run(sql);
+
+        // change column collation to support case-insensitive comparison
+        sql = "ALTER TABLE multiGeom ALTER COLUMN name VARCHAR(255) COLLATE Latin1_General_CS_AS";
+        run(sql);
+
+        sql =
+                "INSERT INTO multiGeom (geometry,name,polygon_geom) VALUES "
+                        + "(geometry::STGeomFromText('POINT (132782 457575)',28992), 'Atoomweg 45', geometry::STGeomFromText('POLYGON ((132781 457574, 132783 457575, 132781 457578, 132779 457576, 132781 457574))',28992));";
+        run(sql);
+
+        sql =
+                "INSERT INTO multiGeom (geometry,name,polygon_geom) VALUES "
+                        + "(geometry::STGeomFromText('POINT (132975 457666)',28992), 'Atoomweg 48', geometry::STGeomFromText('POLYGON ((132973 457701, 132971 457700, 132972 457698, 132974 457699, 132973 457701))',28992));";
+        run(sql);
+
+        sql =
+                "INSERT INTO multiGeom (geometry,name,polygon_geom) VALUES "
+                        + "(geometry::STGeomFromText('POINT (132974 457620)',28992), 'Atoomweg 46', geometry::STGeomFromText('POLYGON ((132974 457622, 132972 457620, 132974 457618, 132976 457619, 132974 457622))',28992));";
+        run(sql);
+
+        // create the spatial index on the geometry and geom column; create a second spatial index
+        // on the geom column
+        run(
+                "CREATE SPATIAL INDEX _multiGeom_geometry_index on multiGeom(geometry) WITH (BOUNDING_BOX = (132782, 457575, 132975, 457666))");
+        run(
+                "CREATE SPATIAL INDEX _multiGeom_geom_index on multiGeom(polygon_geom) WITH (BOUNDING_BOX = (132400, 457400, 132600, 457600))");
+        run(
+                "CREATE SPATIAL INDEX _multiGeom_geom_index2 on multiGeom(polygon_geom) WITH (BOUNDING_BOX = (132000, 457000, 133000, 458000))");
+    }
+}


### PR DESCRIPTION
[![GEOT-7234](https://badgen.net/badge/JIRA/GEOT-7234/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7234) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Query the (first) spatial index defined on a column to get the bounds, the option to use the fast-track is enabled using the `estimatedExtentsEnabled` feature flag.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->