### PR TITLE
[GEOT-7266] WMTSCapabilities throws NPE for missing title

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
@@ -330,20 +330,29 @@ public class WMTSCapabilities extends Capabilities {
     }
 
     private WMTSLayer parseLayer(LayerType layerType) {
-        String title = ((LanguageStringType) layerType.getTitle().get(0)).getValue();
-        WMTSLayer layer = new WMTSLayer(title);
-        layer.setName(layerType.getIdentifier().getValue());
 
-        // The Abstract is of Type LanguageStringType, not String.
-        StringBuilder sb = new StringBuilder();
-        for (Object line : layerType.getAbstract()) {
-            if (line instanceof LanguageStringType) {
-                sb.append(((LanguageStringType) line).getValue());
-            } else {
-                sb.append(line);
-            }
-        } // end of for
-        layer.set_abstract(sb.toString());
+        String name = layerType.getIdentifier().getValue();
+        String title =
+                layerType.getTitle().size() > 0
+                        ? ((LanguageStringType) layerType.getTitle().get(0)).getValue()
+                        : name;
+
+        WMTSLayer layer = new WMTSLayer(title);
+        layer.setName(name);
+
+        // The Abstract is of Type LanguageStringType, not String. We're choosing the first one.
+        if (layerType.getAbstract().size() > 0) {
+            StringBuilder sb = new StringBuilder();
+            for (Object line : layerType.getAbstract()) {
+                if (line instanceof LanguageStringType) {
+                    sb.append(((LanguageStringType) line).getValue());
+                    break;
+                } else {
+                    sb.append(line);
+                }
+            } // end of for
+            layer.set_abstract(sb.toString());
+        }
 
         EList<TileMatrixSetLinkType> tmsLinks = layerType.getTileMatrixSetLink();
         for (TileMatrixSetLinkType linkType : tmsLinks) {

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
@@ -327,6 +327,23 @@ public class WMTSCapabilitiesTest {
         Assert.assertNotNull(tileServer);
     }
 
+    /**
+     * Testing WMTSCapabilities parseLayer and it's support for missing Title, multiple Title
+     * elements with different xml:lang, and multiple abstracts.
+     */
+    @Test
+    public void testMultilanguageCapabilities() throws Exception {
+        WMTSCapabilities capabilities = createCapabilities("multilang.getcapa.xml");
+        WMTSLayer layer = capabilities.getLayer("plz");
+        Assert.assertEquals("Post Code", layer.getTitle());
+
+        WMTSLayer layer2 = capabilities.getLayer("isolines");
+        Assert.assertEquals("isolines", layer2.getTitle());
+
+        WMTSLayer layer3 = capabilities.getLayer("overlay-all");
+        Assert.assertEquals("Map overlay with all layers.", layer3.get_abstract());
+    }
+
     protected WebMapTileServer getCustomWMS(URL featureURL)
             throws SAXException, URISyntaxException, IOException {
         return new WebMapTileServer(featureURL);

--- a/modules/extension/wmts/src/test/resources/test-data/multilang.getcapa.xml
+++ b/modules/extension/wmts/src/test/resources/test-data/multilang.getcapa.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+    <ows:ServiceIdentification>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+    </ows:ServiceIdentification>
+    <ows:OperationsMetadata>
+        <ows:Operation name="GetCapabilities">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="http://wmsx.zamg.ac.at/mapcacheStatmap/wmts?">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>KVP</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="GetTile">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="http://wmsx.zamg.ac.at/mapcacheStatmap/wmts?">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>KVP</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="GetFeatureInfo">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="http://wmsx.zamg.ac.at/mapcacheStatmap/wmts?">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>KVP</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+    </ows:OperationsMetadata>
+    <Contents>
+        <Layer>
+        	<ows:Title xml:lang="eng">Post Code</ows:Title>
+        	<ows:Title xml:lang="ger">Postleitzahl</ows:Title>
+            <ows:Identifier>plz</ows:Identifier>
+            <Style isDefault="true">
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>statmap</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="http://wmsx.zamg.ac.at/mapcacheStatmap/wmts/1.0.0/plz/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+        </Layer>
+        <Layer>
+            <ows:Identifier>isolines</ows:Identifier>
+            <Style isDefault="true">
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>statmap</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="http://wmsx.zamg.ac.at/mapcacheStatmap/wmts/1.0.0/isolines/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+        </Layer>
+        <Layer>
+            <ows:Identifier>grey</ows:Identifier>
+            <Style isDefault="true">
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>statmap</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="http://wmsx.zamg.ac.at/mapcacheStatmap/wmts/1.0.0/grey/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+        </Layer>
+        <Layer>
+            <ows:Abstract xml:lang="eng">Map overlay with all layers.</ows:Abstract>
+            <ows:Abstract xml:lang="ger">Kartenüberlagerung mit allen Ebenen.</ows:Abstract>
+            <ows:Identifier>overlay-all</ows:Identifier>
+            <Style isDefault="true">
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>statmap</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="http://wmsx.zamg.ac.at/mapcacheStatmap/wmts/1.0.0/overlay-all/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+        </Layer>
+        <TileMatrixSet>
+            <ows:Identifier>statmap</ows:Identifier>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.3:31287">
+                <ows:LowerCorner>-2000000.000000 -1000000.000000</ows:LowerCorner>
+                <ows:UpperCorner>2400000.000000 3200000.000000</ows:UpperCorner>
+            </ows:BoundingBox>
+            <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.3:31287</ows:SupportedCRS>
+            <TileMatrix>
+                <ows:Identifier>0</ows:Identifier>
+                <ScaleDenominator>29257142.85714285820722579956</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>2</MatrixWidth>
+                <MatrixHeight>1</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>1</ows:Identifier>
+                <ScaleDenominator>14628571.42857142910361289978</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>3</MatrixWidth>
+                <MatrixHeight>2</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>2</ows:Identifier>
+                <ScaleDenominator>7314285.71428571455180644989</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>5</MatrixWidth>
+                <MatrixHeight>4</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>3</ows:Identifier>
+                <ScaleDenominator>3657142.85714285727590322495</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>9</MatrixWidth>
+                <MatrixHeight>9</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>4</ows:Identifier>
+                <ScaleDenominator>1828571.42857142863795161247</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>17</MatrixWidth>
+                <MatrixHeight>17</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>5</ows:Identifier>
+                <ScaleDenominator>914285.71428571431897580624</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>34</MatrixWidth>
+                <MatrixHeight>33</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>6</ows:Identifier>
+                <ScaleDenominator>457142.85714285715948790312</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>68</MatrixWidth>
+                <MatrixHeight>65</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>7</ows:Identifier>
+                <ScaleDenominator>228571.42857142857974395156</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>135</MatrixWidth>
+                <MatrixHeight>129</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>8</ows:Identifier>
+                <ScaleDenominator>114285.71428571428987197578</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>269</MatrixWidth>
+                <MatrixHeight>257</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>9</ows:Identifier>
+                <ScaleDenominator>57142.85714285714493598789</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>538</MatrixWidth>
+                <MatrixHeight>513</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>10</ows:Identifier>
+                <ScaleDenominator>28571.42857142857246799394</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>1075</MatrixWidth>
+                <MatrixHeight>1026</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>11</ows:Identifier>
+                <ScaleDenominator>14285.71428571428623399697</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>2149</MatrixWidth>
+                <MatrixHeight>2051</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>12</ows:Identifier>
+                <ScaleDenominator>7142.85714285714311699849</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>4297</MatrixWidth>
+                <MatrixHeight>4102</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>13</ows:Identifier>
+                <ScaleDenominator>3571.42857142857155849924</ScaleDenominator>
+                <TopLeftCorner>3200000.000000 -2000000.000000</TopLeftCorner>
+                <TileWidth>512</TileWidth>
+                <TileHeight>512</TileHeight>
+                <MatrixWidth>8594</MatrixWidth>
+                <MatrixHeight>8204</MatrixHeight>
+            </TileMatrix>
+        </TileMatrixSet>
+    </Contents>
+</Capabilities>


### PR DESCRIPTION
[![GEOT-7266](https://badgen.net/badge/JIRA/GEOT-7266/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7266) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

closes #4050 

This one with a test and an alternative way of handling abstracts.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->