### PR TITLE
[Backport 28.x] Bump sqlite-jdbc from 3.34.0 to 3.41.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1396,7 +1396,7 @@
       <dependency>
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
-        <version>3.34.0</version>
+        <version>3.41.2.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
Backport #4297
 **Authored by:** @dependabot[bot]