### PR TITLE
[GEOT-7372] ImageMosaic SuggestedSPI ignored by GranuleDescriptor

### DIFF
--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/GranuleDescriptorTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/GranuleDescriptorTest.java
@@ -17,11 +17,14 @@
 package org.geotools.gce.imagemosaic;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.net.URL;
+import javax.imageio.spi.ImageReaderSpi;
 import org.geotools.data.DataUtilities;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.gce.imagemosaic.catalog.CatalogConfigurationBean;
 import org.geotools.util.URLs;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -62,5 +65,19 @@ public class GranuleDescriptorTest {
                 assertEquals(10, granuleBBOX.getMaximum(1), 0d);
             };
         };
+    }
+
+    /**
+     * Testing the ImageReaderSpi coming out of {@link CatalogConfigurationBean#suggestedSPI()}.
+     * Usually used when initializing GranuleDescriptor. ClassName put into
+     * CatalogConfigurationBean.setSuggestedSPI should be part of the classpath.
+     */
+    @Test
+    public void testSuggestedImageReaderSPI() throws Exception {
+        CatalogConfigurationBean config = new CatalogConfigurationBean();
+        config.setSuggestedSPI("it.geosolutions.imageioimpl.plugins.tiff.TIFFImageReaderSpi");
+
+        ImageReaderSpi readerSpi = config.suggestedSPI();
+        assertNotNull("suggestedSPI wasn't found", readerSpi);
     }
 }


### PR DESCRIPTION
[![GEOT-7372](https://badgen.net/badge/JIRA/GEOT-7372/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7372) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Using equals instead of == to check strings.

Wonder if this functionality should be placed somewhere else, or exists, but haven't found a suitable class.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->