### PR TITLE
[Backport 29.x] [GEOT-7373] Bump hsqldb from 2.7.1 to 2.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1042,7 +1042,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
       </dependency>
       <dependency>
         <groupId>org.openplans</groupId>


### PR DESCRIPTION
Backport #4307
 **Authored by:** @mprins