### PR TITLE
[Backport 27.x] [GEOT-7373] Bump hsqldb from 2.7.1 to 2.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1030,7 +1030,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <classifier>jdk8</classifier>
       </dependency>
       <dependency>


### PR DESCRIPTION
[![GEOT-7373](https://badgen.net/badge/JIRA/GEOT-7373/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7373) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4307