### PR TITLE
[Backport 28.x] [GEOT-7367] Missing null-check in GeoPackage spatial index creation

### DIFF
--- a/modules/plugin/geopkg/src/main/resources/org/geotools/geopkg/gpkg_spatial_index.sql
+++ b/modules/plugin/geopkg/src/main/resources/org/geotools/geopkg/gpkg_spatial_index.sql
@@ -2,7 +2,7 @@ CREATE VIRTUAL TABLE "rtree_${t}_${c}" USING rtree(id, minx, maxx, miny, maxy);
 
 INSERT OR REPLACE INTO "rtree_${t}_${c}"
   SELECT "${i}", ST_MinX("${c}"), ST_MaxX("${c}"), ST_MinY("${c}"), ST_MaxY("${c}") FROM "${t}"
-  WHERE NOT ST_IsEmpty("${c}");
+  WHERE "${c}" NOT NULL AND NOT ST_IsEmpty("${c}");
 
 -- Conditions: Insertion of non-empty geometry
 --   Actions   : Insert record into rtree 


### PR DESCRIPTION
[![GEOT-7367](https://badgen.net/badge/JIRA/GEOT-7367/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7367) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4311
 **Authored by:** @aaime