### PR TITLE
[Backport 28.x] [GEOT-6512] Control remote HTTP requests sent by GeoTools

### DIFF
--- a/docs/developer/conventions/code/code.rst
+++ b/docs/developer/conventions/code/code.rst
@@ -11,4 +11,5 @@ Source Code
    exception
    assumptions
    url
+   urlchecker
    assert

--- a/docs/developer/conventions/code/urlchecker.rst
+++ b/docs/developer/conventions/code/urlchecker.rst
@@ -1,0 +1,30 @@
+Checking user provided location
+-------------------------------
+
+GeoTools provides a ``URLChecker`` Service Provider Interface that library users can implement
+to assert control over user provided locations (remote or otherwise) before they are actually
+accessed.
+
+Code implementing access to such resources can use the ``URLCheckers`` utility class to verify
+that the user provided location is valid before attempting to access it. An ``URLCheckerException`` 
+will be thrown in case access to such location is denied. For example:
+
+.. code-block:: java
+
+    URL url = new URL("http://www.acme.com/myfile.txt");
+    URLCheckers.checkURL(url);
+
+    String path = "/home/john/myfile.txt";
+    URLCheckers.checkFile(path);
+
+At the time of writing, GeoTools provides no default implementation of the ``URLChecker`` SPI, 
+which means that all user provided locations are considered valid. However, downstream
+projects may implement their own, for example, GeoServer does.
+
+Any place in the code that accesses potentially user provided locations should use the 
+``URLCheckers`` utility to validate the location before attempting to access it.
+At the time of writing, implementation of ``MarkFactory`` and ``ExternalGraphicFactory`` are
+using ``URLCheckers``, as dynamic, remote icons are often used. 
+
+In time, more GeoTools classes will start implementing this pattern (e..g, WMS and WFS
+cascading might use it to validate the backlinks provided in capabilities documents).

--- a/docs/user/library/main/index.rst
+++ b/docs/user/library/main/index.rst
@@ -50,3 +50,4 @@ The ``gt-main`` module is responsible for:
    datastore
    repository
    sld
+   urlchecker

--- a/docs/user/library/main/urlchecker.rst
+++ b/docs/user/library/main/urlchecker.rst
@@ -1,0 +1,35 @@
+``URLChecker``
+--------------
+
+``URLChecker`` is an SPI extension point allowing to plug-in a custom URL checker.
+URL checks can be implemented whenever the code is going to access a location that
+might be externally provided, either because the input is used provided, or because
+it's part of remote access in a distributed system. 
+
+
+.. literalinclude:: /../../modules/library/main/src/main/java/org/geotools/data/ows/URLChecker.java
+   :language: java
+   :start-after: doc-begin
+   :end-before: doc-end
+
+
+Examples of this situation are:
+
+* Accessing a remote icon as part of a user provided style (e.g., SLD) or though a dynamic portion
+  of a system provided style (e.g. dynamic symbolizers, general usage of ``env`` function in styles).
+* Accessing a remote style (e.g., dynamic SLD in WMS GetMap).
+* Accessing a dynamically provided WFS source in WMS "feature portrayal" mode.
+* Accessing a remote input in a WPS process.
+
+URL checks can be performed using the ``URLCheckers`` class, which will look up the plugged in
+chekers and run them one by one, until one of them accepts the target location, or failing the
+check if none of them does.
+
+At the time of writing, inside GeoTools remote icon access is the only case where a URL check 
+is performed, but more might be added in the future. More extensive checks are implemented
+downstreams, in GeoServer, where most of the user provided remote locations are used.
+
+Also, by default, GeoTools contains no URLChecker implementation, meaning that out of the
+box it will accept any URL. This is done because each implementation will have its own
+specific requirements to controlling remote access. The downstreams GeoServer project
+provides an example of how a configurable ``URLChecker`` may be implemented.

--- a/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/sprite/SpriteGraphicFactory.java
+++ b/modules/extension/mbstyle/src/main/java/org/geotools/mbstyle/sprite/SpriteGraphicFactory.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+import org.geotools.data.ows.URLCheckers;
 import org.geotools.http.HTTPClient;
 import org.geotools.http.HTTPClientFinder;
 import org.geotools.http.HTTPResponse;
@@ -112,6 +113,10 @@ public class SpriteGraphicFactory implements ExternalGraphicFactory, GraphicCach
 
         URL loc = url.evaluate(feature, URL.class);
         URL baseUrl = parseBaseUrl(loc);
+
+        // validate the icon can actually be fetched, it may go to a random
+        // local filesystem location, or a remote server
+        URLCheckers.confirm(loc);
 
         Map<String, String> paramsMap = parseFragmentParams(loc);
         String iconName = paramsMap.get("icon");

--- a/modules/library/main/src/main/java/org/geotools/data/ows/URLChecker.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/URLChecker.java
@@ -1,0 +1,50 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.ows;
+
+/**
+ * Checks URIs/URLs/locations to confirm if they are allowed for use. Used to restrict access to
+ * remote servers, e.g. to prevent access to untrusted servers or local resources, as many OGC
+ * services either allow users to provide links to remote resources, or provide links that are not
+ * restricted to their original host. <br>
+ * Implementations should be registered using SPI in <code>META-INF/services/org.geotools.data
+ * .ows.URLChecker</code>.
+ */
+// doc-begin
+public interface URLChecker {
+
+    /** @return URLChecker name that best describes its purpose (e.g. GML Schema evaluator etc) */
+    String getName();
+
+    /** @return Boolean flag indicating if this URLChecker should be used */
+    boolean isEnabled();
+
+    /**
+     * Used to confirm location is allowed for use.
+     *
+     * <p>URLChecker is used to confirm if a location is allowed for use, returning {@true} when
+     * they recognize a location as permitted. Several URLChecker instances are expected to be
+     * available, the location will be allowed if at least one URLChecker can confirm it is
+     * permitted for use.
+     *
+     * @param location Location expressed as URL, URI or path.
+     * @return {@code true} indicates the URLChecker can confirm the location is allowed for use,
+     *     {@code false} indicates the URLChecker is unable to confirm.
+     */
+    boolean confirm(String location);
+}
+// doc-end

--- a/modules/library/main/src/main/java/org/geotools/data/ows/URLCheckerException.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/URLCheckerException.java
@@ -1,0 +1,24 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.ows;
+
+public class URLCheckerException extends RuntimeException {
+
+    public URLCheckerException(String message) {
+        super(message);
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/data/ows/URLCheckers.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/URLCheckers.java
@@ -1,0 +1,120 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.ows;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.geotools.util.factory.FactoryCreator;
+import org.geotools.util.factory.FactoryRegistry;
+import org.geotools.util.factory.GeoTools;
+
+/**
+ * Scans for all available URLChecker implementations, allows to register new ones, and provides a
+ * convenient method to apply them on a given location.
+ */
+public class URLCheckers {
+
+    /** The service registry for {@link URLCheckers}. Will be initialized only when first needed. */
+    private static FactoryRegistry registry;
+
+    private static FactoryRegistry getServiceRegistry() {
+        synchronized (URLChecker.class) {
+            if (registry == null) {
+                registry = new FactoryCreator(URLChecker.class);
+            }
+        }
+        return registry;
+    }
+
+    /** Re-initializes all static state, in particular, the {@link URLChecker} service registry */
+    public static synchronized void reset() {
+        if (registry == null) {
+            // nothing to do
+            return;
+        }
+        registry.deregisterAll();
+        registry.scanForPlugins();
+    }
+
+    /**
+     * Dynamically register a new URLChecker. The operation removes all instances of the same
+     * classes already present in the registry, if multiple instances are needed, one can use
+     * subclasses (eventually, anonymous inner classes) so that the instances are not sharing
+     * exactly the same class.
+     */
+    public static void register(URLChecker checker) {
+        getServiceRegistry().registerFactory(checker, URLChecker.class);
+    }
+
+    /**
+     * Dynamically removes a new URLChecker, that might have been registered using the {@link
+     * #register(URLChecker)} method.
+     */
+    public static void deregister(URLChecker checker) {
+        getServiceRegistry().deregisterFactory(checker, URLChecker.class);
+    }
+
+    /** @return enabled list of org.geotools.data.ows.URLChecker implementations */
+    public static List<URLChecker> getEnabledURLCheckers() {
+        return getServiceRegistry()
+                .getFactories(URLChecker.class, null, GeoTools.getDefaultHints())
+                .filter(u -> u.isEnabled())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Confirm the URL against all enabled URLChecker
+     *
+     * @param url to confirm using all available URLCheckers
+     * @throws URLCheckerException if the URL is not allowed for use
+     */
+    public static void confirm(URL url) throws URLCheckerException {
+        confirm(url.toExternalForm());
+    }
+
+    /**
+     * Confirms URI against all enabled URLChecker
+     *
+     * @param uri to evaluate using all available URLCheckers
+     * @throws URLCheckerException if the URI is not allowed for use
+     */
+    public static void confirm(URI uri) throws URLCheckerException {
+        confirm(uri.toString());
+    }
+
+    /**
+     * Confirm the location against all enabled URLChecker
+     *
+     * @param location String(URI/URI/path) to evaluate using all available URLCheckers
+     * @throws URLCheckerException if the location is not allowed for use
+     */
+    public static void confirm(String location) throws URLCheckerException {
+        // get enabled URLChecker only
+        List<URLChecker> checkers = getEnabledURLCheckers();
+        // no enabled checkers, the system is not configured... don't do anything
+        if (checkers.isEmpty()) return;
+        // evaluate using all available implementations
+        for (URLChecker urlChecker : checkers) {
+            if (urlChecker.confirm(location)) return;
+        }
+        // no URLChecker evaluated the passed URL/URI
+        throw new URLCheckerException(
+                "Evaluation Failure: " + location + " was not accepted by external URL checks");
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/data/ows/MockURLChecker.java
+++ b/modules/library/main/src/test/java/org/geotools/data/ows/MockURLChecker.java
@@ -1,0 +1,57 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.ows;
+
+import java.util.function.Function;
+
+/** A mock URLChecker implementation for testing purposes. */
+public class MockURLChecker implements URLChecker {
+
+    private String name = "MockURLChecker";
+    private boolean enabled = true;
+    private Function<String, Boolean> checker;
+
+    public MockURLChecker(String name, Function<String, Boolean> checker) {
+        this.name = name;
+        this.checker = checker;
+    }
+
+    public MockURLChecker(String name, boolean enabled, Function<String, Boolean> checker) {
+        this.name = name;
+        this.enabled = enabled;
+        this.checker = checker;
+    }
+
+    public MockURLChecker(Function<String, Boolean> checker) {
+        this.checker = checker;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public boolean confirm(String location) {
+        return checker.apply(location);
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/data/ows/URLCheckersTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/ows/URLCheckersTest.java
@@ -1,0 +1,89 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.ows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Test;
+
+public class URLCheckersTest {
+
+    @After
+    public void tearDown() throws Exception {
+        URLCheckers.reset();
+    }
+
+    @Test
+    public void testEmptyChecker() {
+        assertThat(URLCheckers.getEnabledURLCheckers(), Matchers.empty());
+        URLCheckers.confirm("myFakeLocation");
+        URLCheckers.confirm("http://www.geoserver.org");
+        URLCheckers.confirm("ftp://www.sf.net");
+    }
+
+    @Test
+    public void testDisabledChecker() {
+        URLCheckers.register(new MockURLChecker("disabled", false, s -> false));
+        assertThat(URLCheckers.getEnabledURLCheckers(), Matchers.empty());
+    }
+
+    @Test
+    public void testReset() {
+        // initial state, empty
+        assertThat(URLCheckers.getEnabledURLCheckers(), Matchers.empty());
+
+        // register
+        MockURLChecker mockChecker = new MockURLChecker("enabled", true, s -> true);
+        URLCheckers.register(mockChecker);
+        assertThat(URLCheckers.getEnabledURLCheckers(), Matchers.hasItems(mockChecker));
+
+        // reset and check has been removed
+        URLCheckers.reset();
+        assertThat(URLCheckers.getEnabledURLCheckers(), Matchers.empty());
+    }
+
+    @Test
+    public void testMultipleCheckers() {
+        // the registry cannot have multiple instances of the same class. Curly brace trick here,
+        // creating anonymous inner classes for each checker, so that they can all be added at
+        // the same time
+        MockURLChecker fileChecker =
+                new MockURLChecker("enabled", true, s -> s.matches("file:///data/.*")) {};
+        MockURLChecker gtChecker =
+                new MockURLChecker(
+                        "enabled", true, s -> s.matches("https?://www.geotools.org/.*")) {};
+        MockURLChecker gsChecker =
+                new MockURLChecker(
+                        "enabled", true, s -> s.matches("https?://www.geoserver.org/.*")) {};
+        URLCheckers.register(fileChecker);
+        URLCheckers.register(gtChecker);
+        URLCheckers.register(gsChecker);
+
+        // invalid references
+        assertThrows(URLCheckerException.class, () -> URLCheckers.confirm("http://google.com"));
+        assertThrows(URLCheckerException.class, () -> URLCheckers.confirm("http://nyt.com"));
+        assertThrows(URLCheckerException.class, () -> URLCheckers.confirm("file:///tmp"));
+
+        // valid references
+        URLCheckers.confirm("https://www.geoserver.org/logo.png");
+        URLCheckers.confirm("http://www.geotools.org/sld.xsd");
+        URLCheckers.confirm("file:///data/dem.tif");
+    }
+}

--- a/modules/library/render/pom.xml
+++ b/modules/library/render/pom.xml
@@ -192,6 +192,13 @@
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-main</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/modules/library/render/src/main/java/org/geotools/renderer/style/ImageGraphicFactory.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/style/ImageGraphicFactory.java
@@ -29,6 +29,7 @@ import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+import org.geotools.data.ows.URLCheckers;
 import org.geotools.image.io.ImageIOExt;
 import org.geotools.util.SoftValueHashMap;
 import org.geotools.util.logging.Logging;
@@ -64,6 +65,10 @@ public class ImageGraphicFactory implements ExternalGraphicFactory, GraphicCache
         if (location == null)
             throw new IllegalArgumentException(
                     "The provided expression cannot be evaluated to a URL");
+
+        // validate the icon can actually be fetched, it may go to a random
+        // local filesystem location, or a remote server
+        URLCheckers.confirm(location);
 
         // get the image from the cache, or load it
         BufferedImage image = imageCache.get(location);

--- a/modules/plugin/svg/pom.xml
+++ b/modules/plugin/svg/pom.xml
@@ -106,6 +106,13 @@
       <artifactId>batik-codec</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-main</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/modules/plugin/svg/src/main/java/org/geotools/renderer/style/svg/RenderableSVGCache.java
+++ b/modules/plugin/svg/src/main/java/org/geotools/renderer/style/svg/RenderableSVGCache.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.util.XMLResourceDescriptor;
+import org.geotools.data.ows.URLCheckers;
 import org.geotools.util.Converters;
 import org.geotools.util.SoftValueHashMap;
 import org.opengis.feature.Feature;
@@ -81,6 +82,10 @@ public class RenderableSVGCache {
                 throw new IllegalArgumentException("Invalid URL: " + svgfile);
             }
         }
+
+        // validate the icon can actually be fetched, it may go to a random
+        // local filesystem location, or a remote server
+        URLCheckers.confirm(svgfile);
 
         // turn the svg into a document and cache results
         RenderableSVG svg = glyphCache.get(svgfile);

--- a/modules/plugin/svg/src/main/java/org/geotools/renderer/style/svg/SVGGraphicFactory.java
+++ b/modules/plugin/svg/src/main/java/org/geotools/renderer/style/svg/SVGGraphicFactory.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import javax.swing.Icon;
 import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.util.XMLResourceDescriptor;
+import org.geotools.data.ows.URLCheckers;
 import org.geotools.renderer.style.ExternalGraphicFactory;
 import org.geotools.renderer.style.GraphicCache;
 import org.geotools.util.CanonicalSet;
@@ -114,6 +115,11 @@ public class SVGGraphicFactory implements Factory, ExternalGraphicFactory, Graph
                 svgUri = svgfile.substring(0, idx);
             }
         }
+
+        // validate the icon can actually be fetched, it may go to a random
+        // local filesystem location, or a remote server
+        URLCheckers.confirm(svgUri);
+
         Document doc = f.createDocument(svgUri);
         Map<String, String> parameters = getParametersFromUrl(svgfile);
         if (!parameters.isEmpty() || hasParameters(doc.getDocumentElement())) {


### PR DESCRIPTION
[![GEOT-6512](https://badgen.net/badge/JIRA/GEOT-6512/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6512) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4272
 **Authored by:** @aaime