### PR TITLE
[GEOT-6512] URLCheckers normalize location

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/ows/URLChecker.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/URLChecker.java
@@ -41,7 +41,10 @@ public interface URLChecker {
      * available, the location will be allowed if at least one URLChecker can confirm it is
      * permitted for use.
      *
-     * @param location Location expressed as URL, URI or path.
+     * <p>Location is normalized to remove all redundant {@code .} and {@code ..} path names, and
+     * provide absolute file references using empty host name {@code file:///path} approach.
+     *
+     * @param location Location expressed as normalized URL, URI or path.
      * @return {@code true} indicates the URLChecker can confirm the location is allowed for use,
      *     {@code false} indicates the URLChecker is unable to confirm.
      */


### PR DESCRIPTION
[![GEOT-6512](https://badgen.net/badge/JIRA/GEOT-6512/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-6512) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is a follow up to https://github.com/geoserver/geoserver/pull/6916 which highlighted the need to account for normalization of locations prior to checking.

URLChecker.normalize(location) is introduced to:
- remove any redundant current directory or parent directory references.
- Converts ``file:/path`` locations to ``file:///path`` representation.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->