### PR TITLE
[Backport 28.x] Bump jetty-server from 9.4.48.v20220622 to 9.4.51.v20230217 in /modules/extension/app-schema/app-schema

### DIFF
--- a/modules/extension/app-schema/app-schema/pom.xml
+++ b/modules/extension/app-schema/app-schema/pom.xml
@@ -202,7 +202,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.48.v20220622</version>
+      <version>9.4.51.v20230217</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Backport #4340
 **Authored by:** @dependabot[bot]