### PR TITLE
[GEOT-7377] Corrected off-by-one-error to find upper left tile

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileFactory.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileFactory.java
@@ -110,8 +110,8 @@ public class WMTSTileFactory extends TileFactory {
         long xTile = origxTile;
         long yTile = origyTile;
 
-        if (xTile >= limits.getMaxcol()) xTile = limits.getMaxcol() - 1;
-        if (yTile >= limits.getMaxrow()) yTile = limits.getMaxrow() - 1;
+        if (xTile >= limits.getMaxcol()) xTile = limits.getMaxcol();
+        if (yTile >= limits.getMaxrow()) yTile = limits.getMaxrow();
 
         if (xTile < limits.getMincol()) xTile = limits.getMincol();
         if (yTile < limits.getMinrow()) yTile = limits.getMinrow();

--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/client/WMTSTileService.java
@@ -630,8 +630,8 @@ public class WMTSTileService extends TileService {
         long xTile = origxTile;
         long yTile = origyTile;
 
-        if (xTile >= limits.getMaxcol()) xTile = limits.getMaxcol() - 1;
-        if (yTile >= limits.getMaxrow()) yTile = limits.getMaxrow() - 1;
+        if (xTile >= limits.getMaxcol()) xTile = limits.getMaxcol();
+        if (yTile >= limits.getMaxrow()) yTile = limits.getMaxrow();
 
         if (xTile < limits.getMincol()) xTile = limits.getMincol();
         if (yTile < limits.getMinrow()) yTile = limits.getMinrow();


### PR DESCRIPTION
[![GEOT-7377](https://badgen.net/badge/JIRA/GEOT-7377/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7377) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

There was a off-by-one error in WMTSTileService and WMTSTileFactory whose result was that tiles were found which do not intersect the requested envelope.

An existing test was extended to check the intersections.

Fixes: https://osgeo-org.atlassian.net/browse/GEOT-7377

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project gt-wmts: Fatal error compiling: Illegal/unsupported escape sequence near index 3
[ERROR] C:\Users\gilles.baatz\git\gilles\geotools\modules\extension\wmts\target/generated-sources/.*
```

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->