### PR TITLE
[Backport 29.x] [GEOT-7383] Distance element of DWithin filter should have an attribute "uom"

### DIFF
--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/FESParseEncodeUtil.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/FESParseEncodeUtil.java
@@ -19,6 +19,7 @@ package org.geotools.filter.v2_0.bindings;
 import java.util.ArrayList;
 import java.util.List;
 import javax.xml.namespace.QName;
+import org.geotools.filter.v1_0.DistanceUnits;
 import org.geotools.filter.v2_0.FES;
 import org.geotools.gml3.v3_2.GML;
 import org.geotools.xsd.Node;
@@ -78,8 +79,11 @@ public class FESParseEncodeUtil {
         List<Object[]> l = new ArrayList<>();
         l.add(distanceBufferOpProperty(op.getExpression1()));
         l.add(distanceBufferOpProperty(op.getExpression2()));
-
-        l.add(new Object[] {new QName(FES.NAMESPACE, "Distance"), op.getDistance()});
+        l.add(
+                new Object[] {
+                    new QName(FES.NAMESPACE, "Distance"),
+                    DistanceUnits.of(op.getDistance(), op.getDistanceUnits())
+                });
         return l;
     }
 

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/MeasureTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/MeasureTypeBinding.java
@@ -17,7 +17,6 @@
 package org.geotools.filter.v2_0.bindings;
 
 import javax.xml.namespace.QName;
-import net.opengis.fes20.MeasureType;
 import org.geotools.filter.v1_0.DistanceUnits;
 import org.geotools.filter.v2_0.FES;
 import org.geotools.xsd.AbstractComplexBinding;
@@ -25,6 +24,8 @@ import org.geotools.xsd.ElementInstance;
 import org.geotools.xsd.Node;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.FilterFactory2;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 /**
  * Binding object for the type http://www.opengis.net/fes/2.0:MeasureType.
@@ -77,7 +78,7 @@ public class MeasureTypeBinding extends AbstractComplexBinding {
      */
     @Override
     public Class getType() {
-        return MeasureType.class;
+        return DistanceUnits.class;
     }
 
     @Override
@@ -85,11 +86,31 @@ public class MeasureTypeBinding extends AbstractComplexBinding {
         return AFTER;
     }
 
+    /** Parse MeasureType element, allowing attribute "uom" and "units". */
     @Override
     public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
         Object uom = node.getAttributeValue("uom");
+        Object units = node.getAttributeValue("units");
         DistanceUnits distanceUnits =
-                DistanceUnits.of((Double) value, uom != null ? uom.toString() : null);
+                DistanceUnits.of(
+                        (Double) value,
+                        uom != null ? uom.toString() : units != null ? units.toString() : null);
         return distanceUnits;
+    }
+
+    @Override
+    public Element encode(Object object, Document document, Element value) throws Exception {
+        DistanceUnits measure = (DistanceUnits) object;
+        value.appendChild(document.createTextNode(Double.toString(measure.getDistance())));
+        return value;
+    }
+
+    @Override
+    public Object getProperty(Object object, QName name) throws Exception {
+        if ("uom".equals(name.getLocalPart())) {
+            DistanceUnits measure = (DistanceUnits) object;
+            return measure.getUnits();
+        }
+        return null;
     }
 }

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/DWithinBindingTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/DWithinBindingTest.java
@@ -2,7 +2,10 @@ package org.geotools.filter.v2_0.bindings;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import javax.xml.namespace.QName;
+import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.LiteralExpressionImpl;
 import org.geotools.filter.v1_1.FilterMockData;
@@ -12,15 +15,28 @@ import org.geotools.gml3.v3_2.GML;
 import org.geotools.xsd.Encoder;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
+import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.spatial.DWithin;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 public class DWithinBindingTest extends FESTestSupport {
+    static FilterFactory2 filterFact = (FilterFactory2) CommonFactoryFinder.getFilterFactory(null);
+
     @Test
     public void testEncode() throws Exception {
         DWithin dwithin = FilterMockData.dwithin();
-        encode(dwithin, FES.DWithin);
-        // print(dom);
+        Document encodedDom = encode(dwithin, FES.DWithin);
+
+        Element distanceElem =
+                this.getElementByQName(encodedDom, new QName(FES.NAMESPACE, "Distance"));
+        assertNotNull(distanceElem);
+
+        String unit = distanceElem.getAttribute("uom");
+        assertEquals("m", unit);
+
+        String distance = distanceElem.getTextContent();
+        assertEquals("1.0", distance);
     }
 
     @Test
@@ -35,7 +51,7 @@ public class DWithinBindingTest extends FESTestSupport {
                         + "</gml:Polygon>"
                         + "</gml:surfaceMember>"
                         + "</gml:MultiSurface>"
-                        + "<fes:Distance units=\"dd\">0.00005</fes:Distance>"
+                        + "<fes:Distance uom=\"dd\">0.00005</fes:Distance>"
                         + "</fes:DWithin>";
 
         buildDocument(dwithinStr);
@@ -47,6 +63,12 @@ public class DWithinBindingTest extends FESTestSupport {
         Geometry geometry =
                 (Geometry) ((LiteralExpressionImpl) dwithin.getExpression2()).getValue();
         assertEquals("MultiSurface", geometry.getGeometryType());
+
+        String unit = dwithin.getDistanceUnits();
+        assertEquals("dd", unit);
+
+        double distance = dwithin.getDistance();
+        assertEquals(0.00005, distance, 0.00001);
 
         Encoder encoder = new Encoder(createConfiguration());
         Document encodedDWithin = encoder.encodeAsDOM(dwithin, FES.DWithin);
@@ -61,5 +83,63 @@ public class DWithinBindingTest extends FESTestSupport {
                 encodedDWithin
                         .getElementsByTagNameNS(GML.NAMESPACE, GML.MultiSurface.getLocalPart())
                         .getLength());
+    }
+
+    @Test
+    public void testEncodeNullUnit() throws Exception {
+        DWithin filter =
+                filterFact.dwithin(
+                        filterFact.property("the_geom"),
+                        filterFact.literal(FilterMockData.geometry()),
+                        2.0,
+                        null);
+        Document encodedDom = encode(filter, FES.DWithin);
+
+        Element distanceElem =
+                this.getElementByQName(encodedDom, new QName(FES.NAMESPACE, "Distance"));
+        String unit = distanceElem.getAttribute("uom");
+        assertEquals("", unit);
+    }
+
+    @Test
+    public void testParseUnitsAttribute() throws Exception {
+        String dwithinStr =
+                "<fes:DWithin xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:fes='http://www.opengis.net/fes/2.0' xmlns:gml='http://www.opengis.net/gml/3.2'>"
+                        + "<fes:ValueReference>geom</fes:ValueReference>"
+                        + "<gml:MultiSurface>"
+                        + "<gml:surfaceMember>"
+                        + "<gml:Polygon>"
+                        + "<gml:exterior><gml:LinearRing><gml:posList srsDimension=\"2\">-3.47846563793341 48.722720523382868 -3.477146216817613 48.723266017150742 -3.476979820867556 48.723105499136544 -3.478344351997081 48.722562935940601 -3.47846563793341 48.722720523382868</gml:posList></gml:LinearRing></gml:exterior>"
+                        + "</gml:Polygon>"
+                        + "</gml:surfaceMember>"
+                        + "</gml:MultiSurface>"
+                        + "<fes:Distance units=\"dd\">0.00005</fes:Distance>"
+                        + "</fes:DWithin>";
+        buildDocument(dwithinStr);
+        DWithin dwithin = (DWithin) parse();
+
+        String unit = dwithin.getDistanceUnits();
+        assertEquals("dd", unit);
+    }
+
+    @Test
+    public void testParseNonUomAttribute() throws Exception {
+        String dwithinStr =
+                "<fes:DWithin xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:fes='http://www.opengis.net/fes/2.0' xmlns:gml='http://www.opengis.net/gml/3.2'>"
+                        + "<fes:ValueReference>geom</fes:ValueReference>"
+                        + "<gml:MultiSurface>"
+                        + "<gml:surfaceMember>"
+                        + "<gml:Polygon>"
+                        + "<gml:exterior><gml:LinearRing><gml:posList srsDimension=\"2\">-3.47846563793341 48.722720523382868 -3.477146216817613 48.723266017150742 -3.476979820867556 48.723105499136544 -3.478344351997081 48.722562935940601 -3.47846563793341 48.722720523382868</gml:posList></gml:LinearRing></gml:exterior>"
+                        + "</gml:Polygon>"
+                        + "</gml:surfaceMember>"
+                        + "</gml:MultiSurface>"
+                        + "<fes:Distance>1.2</fes:Distance>"
+                        + "</fes:DWithin>";
+        buildDocument(dwithinStr);
+        DWithin dwithin = (DWithin) parse();
+
+        String unit = dwithin.getDistanceUnits();
+        assertNull(unit);
     }
 }


### PR DESCRIPTION
[![GEOT-7383](https://badgen.net/badge/JIRA/GEOT-7383/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7383) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4352
 **Authored by:** @roarbra