### PR TITLE
[Backport 28.x] [GEOT-7335] geojson-store fails StackOverflowError when empty feature…

### DIFF
--- a/modules/unsupported/geojson-store/src/main/java/org/geotools/data/geojson/store/GeoJSONDataStore.java
+++ b/modules/unsupported/geojson-store/src/main/java/org/geotools/data/geojson/store/GeoJSONDataStore.java
@@ -113,6 +113,10 @@ public class GeoJSONDataStore extends ContentDataStore implements FileDataStore 
         return schema;
     }
 
+    protected SimpleFeatureType getCurrentSchema() throws IOException {
+        return schema;
+    }
+
     @Override
     public void updateSchema(SimpleFeatureType featureType) throws IOException {
         schema = featureType;

--- a/modules/unsupported/geojson-store/src/main/java/org/geotools/data/geojson/store/GeoJSONFeatureSource.java
+++ b/modules/unsupported/geojson-store/src/main/java/org/geotools/data/geojson/store/GeoJSONFeatureSource.java
@@ -17,17 +17,21 @@
 package org.geotools.data.geojson.store;
 
 import java.io.IOException;
+import java.util.Collections;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.Query;
 import org.geotools.data.geojson.GeoJSONReader;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.feature.FeatureIterator;
+import org.geotools.feature.NameImpl;
+import org.geotools.feature.type.FeatureTypeFactoryImpl;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.FeatureTypeFactory;
 import org.opengis.filter.Filter;
 
 public class GeoJSONFeatureSource extends ContentFeatureSource {
@@ -119,10 +123,21 @@ public class GeoJSONFeatureSource extends ContentFeatureSource {
                  * been set in the datastore.
                  */
                 if (schema == null) {
-                    schema = getDataStore().getSchema();
+                    schema = getDataStore().getCurrentSchema();
+                    if (schema == null) {
+                        FeatureTypeFactory featureTypeFactory = new FeatureTypeFactoryImpl();
+                        schema =
+                                featureTypeFactory.createSimpleFeatureType(
+                                        new NameImpl(super.entry.getTypeName()),
+                                        Collections.emptyList(),
+                                        null,
+                                        false,
+                                        Collections.emptyList(),
+                                        null,
+                                        null);
+                    }
                 }
             }
-
             return schema;
         }
     }

--- a/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/GeoJSONDataStoreTest.java
+++ b/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/GeoJSONDataStoreTest.java
@@ -19,6 +19,7 @@ package org.geotools.data.geojson.store;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
@@ -167,5 +168,21 @@ public class GeoJSONDataStoreTest {
             }
         }
         assertEquals(1, cnt);
+    }
+
+    @Test
+    public void testEmptyFeatures() throws IOException {
+        URL url = TestData.url(GeoJSONDataStore.class, "empty-featureCollection.json");
+
+        GeoJSONDataStore fds = new GeoJSONDataStore(url);
+        String type = fds.getNames().get(0).getLocalPart();
+        try (FeatureReader<SimpleFeatureType, SimpleFeature> reader =
+                fds.getFeatureReader(new Query(type), null)) {
+            // No Feature to read, also no NullPointer exception
+            assertFalse(reader.hasNext());
+            SimpleFeatureType schema = reader.getFeatureType();
+            assertNotNull(schema);
+            assertEquals(0, reader.getFeatureType().getAttributeCount());
+        }
     }
 }

--- a/modules/unsupported/geojson-store/src/test/resources/org/geotools/data/geojson/store/test-data/empty-featureCollection.json
+++ b/modules/unsupported/geojson-store/src/test/resources/org/geotools/data/geojson/store/test-data/empty-featureCollection.json
@@ -1,0 +1,4 @@
+{
+  "type": "FeatureCollection",
+  "features": []
+}


### PR DESCRIPTION
[![GEOT-7335](https://badgen.net/badge/JIRA/GEOT-7335/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7335) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4363
 **Authored by:** @pratikbandalg