### PR TITLE
Update update_site.sh for the new doc server configuration

### DIFF
--- a/docs/site/update_site.sh
+++ b/docs/site/update_site.sh
@@ -10,10 +10,10 @@ if [ "$1" != "stable" ] && [ "$1" != "latest" ]; then
   exit 1
 fi
 
-WWW=/osgeo/geotools/htdocs
+WWW=/var/www/geotools
 pushd $WWW/docs/$1 &&
 
-if [ -e ~/$1/userguide.zip ]; then
+if [ -e userguide.zip ]; then
   if [ -e userguide.old ]; then
      rm -rf userguide.old
   fi
@@ -23,11 +23,11 @@ if [ -e ~/$1/userguide.zip ]; then
   if [ ! -e userguide ]; then
      mkdir userguide
   fi
-  unzip -d userguide ~/$1/userguide.zip
-  mv ~/$1/userguide.zip ~/$1/userguide.old.zip
+  unzip -d userguide userguide.zip
+  mv userguide.zip userguide.old.zip
 fi
 
-if [ "$1" == "latest" ] && [ -e ~/$1/developer.zip ]; then
+if [ "$1" == "latest" ] && [ -e developer.zip ]; then
   if [ -e developer.old ]; then
     rm -rf developer.old
   fi
@@ -37,33 +37,33 @@ if [ "$1" == "latest" ] && [ -e ~/$1/developer.zip ]; then
   if [ ! -e developer ]; then
     mkdir developer
   fi
-  unzip -d developer ~/$1/developer.zip
-  mv ~/$1/developer.zip ~/$1/developer.old.zip
+  unzip -d developer developer.zip
+  mv developer.zip developer.old.zip
 fi
 
-if [ -e ~/$1/javadocs.zip ]; then
+if [ -e javadocs.zip ]; then
   if [ -e javadocs ]; then
      rm -rf javadocs
   fi
   mkdir javadocs
-  unzip -d javadocs ~/$1/javadocs.zip
-  mv ~/$1/javadocs.zip ~/$1/javadocs.old.zip
+  unzip -d javadocs javadocs.zip
+  mv javadocs.zip javadocs.old.zip
 fi
 
-if [ -e ~/$1/tutorial.zip ]; then
+if [ -e tutorial.zip ]; then
   if [ -e tutorials ]; then
      rm -rf tutorials 
   fi
   mkdir tutorials
-  unzip -d tutorials ~/$1/tutorial.zip
-  mv ~/$1/tutorial.zip ~/$1/tutorial.old.zip
+  unzip -d tutorials tutorial.zip
+  mv tutorial.zip tutorial.old.zip
 fi
 
 popd
 
 pushd $WWW &&
 
-if [ "$1" == "latest" ] && [ -e ~/$1/web.zip ]; then
+if [ "$1" == "latest" ] && [ -e docs/$1/web.zip ]; then
   if [ -e web.old ]; then 
     rm -rf web.old
   fi
@@ -73,13 +73,13 @@ if [ "$1" == "latest" ] && [ -e ~/$1/web.zip ]; then
   if [ ! -e web ]; then
     mkdir web
   fi
-  unzip -d web ~/$1/web.zip 
-  mv ~/$1/web.zip ~/$1/web.old.zip
+  unzip -d web docs/$1/web.zip 
+  mv docs/$1/web.zip web.old.zip
 fi
 
-if [ "$1" == "latest" ] && [ -e ~/$1/index.zip ]; then
-  unzip -o -d docs ~/$1/index.zip 
-  mv ~/$1/index.zip ~/$1/index.old.zip
+if [ "$1" == "latest" ] && [ -e docs/$1/index.zip ]; then
+  unzip -o -d docs docs/$1/index.zip 
+  mv docs/$1/index.zip index.old.zip
 fi
 
 popd


### PR DESCRIPTION
28.x Backport of #3995

docs.geotools.org will be switching over to the new site later today, and this will be needed to support the [28.x docbuild](https://build.geoserver.org/view/geotools/job/geotools-28.x-docs/)