### PR TITLE
GeoTools docbuild - support maintenance (again?) (28.x)

### DIFF
--- a/docs/site/update_site.sh
+++ b/docs/site/update_site.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
-#
-# Last update 2011-04-10 MB: 
-#   The zip files are now uploaded to ~/stable or ~/latest.
-#   Move xxx.zip to xxx.old.zip after unpacking.
-#
 
-if [ "$1" != "stable" ] && [ "$1" != "latest" ]; then
-  echo "Usage $0 <stable|latest>"
+if [ "$1" != "maintenance" ] && [ "$1" != "stable" ] && [ "$1" != "latest" ]; then
+  echo "Usage $0 <maintenance|stable|latest>"
   exit 1
 fi
 


### PR DESCRIPTION
So, for some reason, geotools-28.x-docs [fails on the new version of  update_site.sh](https://build.geoserver.org/view/geotools/job/geotools-28.x-docs/92/console): 

```
+ ssh -oStrictHostKeyChecking=no -p 2223 geotools@geo-docs.geoserver.org cd  /var/www/geotools/docs/maintenance/../ && ./update_site.sh maintenance
Usage ./update_site.sh <stable|latest>
```

However, the code that appears to be the culprit hasn't been changed since at least 2011.

The old maintenance builds were [working fine passing in maintenance](https://build.geoserver.org/view/geotools/job/geotools-28.x-docs/91/console), so I can only surmise we've been using an even older version of the script, or one with uncommitted changes, for the past several years. 

Does anyone have more insight into this? If there's another version of update_site.sh lurking around, I'd like to make sure there aren't any other missing features hiding in it...


Strictly speaking this should be opened against master before being backported to 28.x, but this is the only branch that is actually affected right now - I can forwardport this instead after merging.

In the interim, I've also manually extracted the maintenance docs on the new server, so that they'll actually be there when we switch over servers.