### PR TITLE
WIP: NetCDFImageReader: fix manual joining causing StringIndexOutOfBoundsException

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/NetCDFImageReader.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/NetCDFImageReader.java
@@ -51,6 +51,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.IIOException;
@@ -562,13 +563,11 @@ public class NetCDFImageReader extends GeoSpatialImageReader implements FileSetM
     private void settingTypeNames(DataStoreConfiguration datastoreConfiguration) {
         Map<String, Serializable> params = datastoreConfiguration.getParams();
         List<Name> coverages = ancillaryFileManager.getCoveragesNames();
-        StringBuilder builder = new StringBuilder();
+        StringJoiner joiner = new StringJoiner(",");
         for (Name coverage : coverages) {
-            builder.append(ancillaryFileManager.getTypeName(coverage.getLocalPart())).append(",");
+            joiner.add(ancillaryFileManager.getTypeName(coverage.getLocalPart()));
         }
-        String typeNames = builder.toString();
-        typeNames = typeNames.substring(0, typeNames.length() - 1);
-        params.put("TypeName", typeNames);
+        params.put("TypeName", joiner.toString());
     }
 
     /** Wraps a generic exception into a {@link IIOException}. */


### PR DESCRIPTION
In case of coverages being zero length, the following call would be made: `typeNames.substring(0, -1);`, causing out of bounds error.

Joining strings is typically handled by a StringJoiner which takes care of such edge cases.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users).
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).