### PR TITLE
[Backport 28.x] [GEOT-7396] Upgrade wiremock to 2.35.0

### DIFF
--- a/modules/extension/wms/pom.xml
+++ b/modules/extension/wms/pom.xml
@@ -149,12 +149,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>2.18.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <type>jar</type>

--- a/modules/library/http/pom.xml
+++ b/modules/library/http/pom.xml
@@ -51,8 +51,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>2.18.0</version>
+      <artifactId>wiremock-jre8-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/library/main/pom.xml
+++ b/modules/library/main/pom.xml
@@ -261,12 +261,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>2.18.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>

--- a/modules/library/main/src/test/java/org/geotools/filter/CapabilitiesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/CapabilitiesTest.java
@@ -18,6 +18,7 @@ package org.geotools.filter;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.TimeZone;
 import org.geotools.factory.CommonFactoryFinder;
@@ -35,7 +36,6 @@ import org.opengis.filter.temporal.After;
 import org.opengis.filter.temporal.BegunBy;
 import org.opengis.temporal.Instant;
 import org.opengis.temporal.Period;
-import wiremock.com.google.common.collect.Lists;
 
 /**
  * Unit test for FilterCapabilities.
@@ -103,7 +103,7 @@ public class CapabilitiesTest {
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
         Filter filter =
                 ff.and(
-                        Lists.newArrayList(
+                        Arrays.asList(
                                 ff.greater(ff.property("a"), ff.literal(2)),
                                 ff.greaterOrEqual(ff.property("a"), ff.literal(2)),
                                 ff.less(ff.property("a"), ff.literal(2)),

--- a/modules/library/main/src/test/java/org/geotools/filter/function/ListFunctionsTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/ListFunctionsTest.java
@@ -19,11 +19,11 @@ package org.geotools.filter.function;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.List;
 import org.geotools.filter.FilterFactoryImpl;
 import org.junit.Test;
 import org.opengis.filter.expression.Function;
-import wiremock.com.google.common.collect.Lists;
 
 /**
  * Unit tests for FilterFunction_lappy FilterFunction_size FilterFunction_literate
@@ -37,7 +37,7 @@ public class ListFunctionsTest {
     @Test
     public void testSize() {
 
-        List<Integer> list = Lists.newArrayList(1, 2, 3, 4);
+        List<Integer> list = Arrays.asList(1, 2, 3, 4);
 
         Function exp = ff.function("size", ff.property("."));
         Object value = exp.evaluate(list);
@@ -48,7 +48,7 @@ public class ListFunctionsTest {
     @Test
     public void testLitem() {
 
-        List<Integer> list = Lists.newArrayList(1, 2, 3, 4);
+        List<Integer> list = Arrays.asList(1, 2, 3, 4);
 
         Function exp = ff.function("litem", ff.property("."), ff.literal(2));
         Object value = exp.evaluate(list);
@@ -59,13 +59,13 @@ public class ListFunctionsTest {
     @Test
     public void testLapply() {
 
-        List<Integer> list = Lists.newArrayList(1, 2, 3, 4);
+        List<Integer> list = Arrays.asList(1, 2, 3, 4);
 
         Function exp =
                 ff.function(
                         "lapply", ff.property("."), ff.multiply(ff.property("."), ff.literal(2)));
         Object value = exp.evaluate(list);
         assertTrue(value instanceof List);
-        assertEquals(Lists.newArrayList(2.0, 4.0, 6.0, 8.0), value);
+        assertEquals(Arrays.asList(2.0, 4.0, 6.0, 8.0), value);
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/temporal/object/DefaultDateAndTimeTest.java
+++ b/modules/library/main/src/test/java/org/geotools/temporal/object/DefaultDateAndTimeTest.java
@@ -16,11 +16,11 @@
  */
 package org.geotools.temporal.object;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static wiremock.org.hamcrest.CoreMatchers.equalTo;
 
 import org.geotools.metadata.iso.citation.Citations;
 import org.geotools.referencing.NamedIdentifier;

--- a/modules/plugin/http-commons/pom.xml
+++ b/modules/plugin/http-commons/pom.xml
@@ -67,7 +67,6 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8-standalone</artifactId>
-      <version>2.29.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/unsupported/stac-store/pom.xml
+++ b/modules/unsupported/stac-store/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8-standalone</artifactId>
-      <version>2.29.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1428,6 +1428,11 @@
         <artifactId>java-vector-tile</artifactId>
         <version>1.3.9</version>
       </dependency>
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock-jre8-standalone</artifactId>
+        <version>2.35.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
[![GEOT-7396](https://badgen.net/badge/JIRA/GEOT-7396/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7396) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4391
 **Authored by:** @sikeoka