### PR TITLE
Upgrade flatgeobuf to  3.26.1

### DIFF
--- a/modules/unsupported/flatgeobuf/pom.xml
+++ b/modules/unsupported/flatgeobuf/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.wololo</groupId>
       <artifactId>flatgeobuf</artifactId>
-      <version>3.26.0</version>
+      <version>3.26.1</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>


### PR DESCRIPTION
This patch release upgrade fixes a performance issue in spatial index search, see https://github.com/flatgeobuf/flatgeobuf/issues/274.