### PR TITLE
[GEOT-7405] Add option to disable GetFeatureInfo transforming raster layers

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/styling/FeatureTypeStyle.java
+++ b/modules/library/main/src/main/java/org/geotools/styling/FeatureTypeStyle.java
@@ -137,6 +137,16 @@ public interface FeatureTypeStyle extends org.opengis.style.FeatureTypeStyle {
     public static String SORT_BY_GROUP = "sortByGroup";
 
     /**
+     * Boolean value allowing to control whether rendering transformations should be evaluated when
+     * performing WMS GetFeatureInfo requests. This option applies only to transformations with a
+     * raster source (i.e., raster-to-raster and raster-to-vector). The default value can be
+     * configured by administrators in the global and workspace-specific WMS service settings
+     * (transformations will be evaluated by default) and this SLD vendor option can be used to
+     * override the service setting for a specific FeatureTypeStyle element within the SLD document.
+     */
+    public static String TRANSFORM_FEATURES = "transformFeatures";
+
+    /**
      * String value allowing to control whether an SLD element should be included when applying the
      * style to render maps or a legends. The option can be used also on Rule and all the
      * Symbolizers. Possible values are normal, legendOnly, mapOnly.


### PR DESCRIPTION
[![GEOT-7405](https://badgen.net/badge/JIRA/GEOT-7405/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7405) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds a vendor option to SLD FeatureTypeStyle elements to disable applying rendering transformations to raster data for WMS GetFeatureInfo requests.

I would like to get this into the 28.5 release if possible since I am supporting customers still using Java 8.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->