### PR TITLE
[GEOT-7411] App-schema performance improvement in setting attribute values

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/ComplexAttributeImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/ComplexAttributeImpl.java
@@ -19,6 +19,9 @@ package org.geotools.feature;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.geotools.api.feature.ComplexAttribute;
 import org.geotools.api.feature.Property;
 import org.geotools.api.feature.type.AttributeDescriptor;
@@ -46,7 +49,7 @@ public class ComplexAttributeImpl extends AttributeImpl implements ComplexAttrib
     @Override
     public Collection<? extends Property> getValue() {
         @SuppressWarnings("unchecked")
-        Collection<? extends Property> cast = (Collection<? extends Property>) super.getValue();
+        List<? extends Property> cast = (List<? extends Property>) super.getValue();
         return FeatureImplUtils.unmodifiable(cast);
     }
 
@@ -61,14 +64,15 @@ public class ComplexAttributeImpl extends AttributeImpl implements ComplexAttrib
      * Internal helper method for getting at the properties without wrapping in unmodifiable
      * collection.
      */
-    protected Collection properties() {
-        return (Collection) super.getValue();
+    @SuppressWarnings("unchecked")
+    protected List<Property> properties() {
+        return (List<Property>) super.getValue();
     }
 
     @Override
     public Collection<Property> getProperties(Name name) {
         List<Property> matches = new ArrayList<>();
-        for (Property property : getValue()) {
+        for (Property property : properties()) {
             if (property.getName().equals(name)) {
                 matches.add(property);
             }
@@ -77,11 +81,39 @@ public class ComplexAttributeImpl extends AttributeImpl implements ComplexAttrib
         return matches;
     }
 
+    /**
+     * @return the first property in {@link #getProperties()} reverse order whose {@link
+     *     Property#getName() name} equals the given {@code name}
+     */
+    public Optional<Property> findLast(Name name) {
+        List<Property> properties = properties();
+        for (int i = properties.size() - 1; i > -1; i--) {
+            Property p = properties.get(i);
+            if (name.equals(p.getName())) {
+                return Optional.of(p);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * @return all properties that match the provided predicate, may be empty, never {@code null}
+     */
+    public Stream<Property> findAll(Predicate<? super Property> predicate) {
+        return properties().stream().filter(predicate);
+    }
+
+    /**
+     * @return the first property that matches the provided predicate, or {@code Optional.empty()}
+     */
+    public Optional<Property> find(Predicate<? super Property> predicate) {
+        return properties().stream().filter(predicate).findFirst();
+    }
+
     @Override
     public Collection<Property> getProperties(String name) {
         List<Property> matches = new ArrayList<>();
-        for (Object o : properties()) {
-            Property property = (Property) o;
+        for (Property property : properties()) {
             if (property.getName().getLocalPart().equals(name)) {
                 matches.add(property);
             }
@@ -92,8 +124,7 @@ public class ComplexAttributeImpl extends AttributeImpl implements ComplexAttrib
 
     @Override
     public Property getProperty(Name name) {
-        for (Object o : properties()) {
-            Property property = (Property) o;
+        for (Property property : properties()) {
             if (property.getName().equals(name)) {
                 return property;
             }
@@ -122,19 +153,25 @@ public class ComplexAttributeImpl extends AttributeImpl implements ComplexAttrib
 
     @Override
     public void setValue(Collection<Property> newValue) {
-        super.setValue(cloneProperties(newValue));
+        List<Property> props = cloneProperties(newValue);
+        super.setValue(props);
+    }
+
+    /**
+     * Appends a property to this attribute's property list without incurring in unnecessary object
+     * allocation such as safe-copying the values list as in {@link #setValue(Collection)}
+     */
+    public void addValue(Property value) {
+        properties().add(value);
     }
 
     /** helper method to clone the property collection. */
-    private static <T> Collection<T> cloneProperties(Collection<T> original) {
+    private static <T> List<T> cloneProperties(Collection<T> original) {
         if (original == null) {
             return null;
         }
 
-        Collection<T> clone = new ArrayList<>();
-
-        clone.addAll(original);
-        return clone;
+        return new ArrayList<>(original);
     }
 
     //    public List<Property>get(Name name) {

--- a/modules/library/main/src/main/java/org/geotools/feature/PropertyImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/PropertyImpl.java
@@ -34,14 +34,12 @@ public abstract class PropertyImpl implements Property {
     protected Object value;
     /** descriptor of the property */
     protected PropertyDescriptor descriptor;
-    /** user data */
-    protected final Map<Object, Object> userData;
+    /** user data, lazily initialized at {@link #getUserData()} / {@link #getUserData(Object)} */
+    private Map<Object, Object> userData;
 
     protected PropertyImpl(Object value, PropertyDescriptor descriptor) {
         this.value = value;
         this.descriptor = descriptor;
-        userData = new HashMap<>();
-
         if (descriptor == null) {
             throw new NullPointerException("descriptor");
         }
@@ -79,7 +77,13 @@ public abstract class PropertyImpl implements Property {
 
     @Override
     public Map<Object, Object> getUserData() {
+        if (userData == null) userData = new HashMap<>();
         return userData;
+    }
+
+    public Object getUserData(Object key) {
+        Map<Object, Object> ud = userData;
+        return ud == null ? null : ud.get(key);
     }
 
     @Override


### PR DESCRIPTION
[![GEOT-7411](https://badgen.net/badge/JIRA/GEOT-7411/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7411) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

While building a complex attribute with a large sequence of children, XPath.set(...) incurs in a huge performance penalty due to excessive collections allocation and the inherent inefficiency of `ComplexAttributeImpl.getProperties(Name)` and
`ComplexAttributeImpl.setValue(Collection<Property>)`.

This is a pure refactoring patch on app-schema's `XPath` class, and the addition of the following non-api methods to gt-main's complex features implementation classes:
- `ComplexAttributeImpl.find(Name):Optional<Property>`
- `ComplexAttributeImpl.findLast(Name):Optional<Property>`
- `ComplexAttributeImpl.find(Predicate<Property>):Optional<Property>`
- `ComplexAttributeImpl.findAll(Name):Stream<Property>`
- `ComplexAttributeImpl.addValue(Property value):void`
- `PropertyImpl.getUserData(Object):Object`

With this in place, avoiding millions of object allocations, a use case where a WFS GetFeature request for a single complex feature contains over a hundred thousand related properties passed to take 2 seconds instead of 17 minutes, with `XPath.set(...)` taking only 7% of the whole request processing, where it used to take 95%.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->