### PR TITLE
Speed up evaluation of symbolizer properties during rendering

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/IDFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/IDFunction.java
@@ -22,6 +22,7 @@ import org.geotools.filter.capability.FunctionNameImpl;
 import org.opengis.feature.Attribute;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.filter.capability.FunctionName;
+import org.opengis.filter.expression.VolatileFunction;
 
 /**
  * Allow access to the value of Feature.getID() as an expression
@@ -29,7 +30,7 @@ import org.opengis.filter.capability.FunctionName;
  * @author Jody Garnett
  * @since 2.2, 2.5
  */
-public class IDFunction extends FunctionExpressionImpl {
+public class IDFunction extends FunctionExpressionImpl implements VolatileFunction {
 
     public static FunctionName NAME = new FunctionNameImpl("id", String.class);
 

--- a/modules/library/main/src/main/java/org/geotools/filter/function/InterpolateFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/InterpolateFunction.java
@@ -335,15 +335,17 @@ public class InterpolateFunction implements Function {
         /*
          * TODO: is this the correct way to handle the rasterdata option ?
          */
-        String lookupString = lookup.evaluate(object, String.class);
-        if (lookupString == null) {
-            return null;
-        }
-        if (lookupString.equalsIgnoreCase(RASTER_DATA)) {
+        // This should be safe. Rationale: raster mode assumes the lookup expression evaluates to
+        // Rasterdata, and then the input object is considered to be a number. While the lookup
+        // could dynamically evaluate to "Rasterdata" in a non-raster context (feature input),
+        // the input object would not be a number and the following cast would fail.
+        if (lookup instanceof Literal
+                && RASTER_DATA.equalsIgnoreCase(lookup.evaluate(object, String.class))) {
             lookupValue = ((Number) object).doubleValue();
         } else {
-            lookupValue = Double.valueOf(lookupString);
+            lookupValue = lookup.evaluate(object, Double.class);
         }
+        if (lookupValue == null) return null;
 
         /** Degenerate case: a single interpolation point. Evaluate it directly. */
         if (interpPoints.size() == 1) {

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/SimplifyingFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/SimplifyingFilterVisitor.java
@@ -44,10 +44,14 @@ import org.opengis.filter.PropertyIsLike;
 import org.opengis.filter.PropertyIsNil;
 import org.opengis.filter.PropertyIsNotEqualTo;
 import org.opengis.filter.PropertyIsNull;
+import org.opengis.filter.expression.Add;
+import org.opengis.filter.expression.Divide;
 import org.opengis.filter.expression.Expression;
 import org.opengis.filter.expression.Literal;
+import org.opengis.filter.expression.Multiply;
 import org.opengis.filter.expression.NilExpression;
 import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.expression.Subtract;
 import org.opengis.filter.expression.VolatileFunction;
 import org.opengis.filter.identity.FeatureId;
 import org.opengis.filter.identity.GmlObjectId;
@@ -614,6 +618,50 @@ public class SimplifyingFilterVisitor extends DuplicatingFilterVisitor {
         } else {
             return clone;
         }
+    }
+
+    @Override
+    public Object visit(Add expression, Object extraData) {
+        Expression expr1 = visit(expression.getExpression1(), extraData);
+        Expression expr2 = visit(expression.getExpression2(), extraData);
+        Add result = getFactory(extraData).add(expr1, expr2);
+        if (expr1 instanceof Literal && expr2 instanceof Literal) {
+            return getFactory(extraData).literal(result.evaluate(null));
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(Divide expression, Object extraData) {
+        Expression expr1 = visit(expression.getExpression1(), extraData);
+        Expression expr2 = visit(expression.getExpression2(), extraData);
+        Divide result = getFactory(extraData).divide(expr1, expr2);
+        if (expr1 instanceof Literal && expr2 instanceof Literal) {
+            return getFactory(extraData).literal(result.evaluate(null));
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(Subtract expression, Object extraData) {
+        Expression expr1 = visit(expression.getExpression1(), extraData);
+        Expression expr2 = visit(expression.getExpression2(), extraData);
+        Subtract result = getFactory(extraData).subtract(expr1, expr2);
+        if (expr1 instanceof Literal && expr2 instanceof Literal) {
+            return getFactory(extraData).literal(result.evaluate(null));
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(Multiply expression, Object extraData) {
+        Expression expr1 = visit(expression.getExpression1(), extraData);
+        Expression expr2 = visit(expression.getExpression2(), extraData);
+        Multiply result = getFactory(extraData).multiply(expr1, expr2);
+        if (expr1 instanceof Literal && expr2 instanceof Literal) {
+            return getFactory(extraData).literal(result.evaluate(null));
+        }
+        return result;
     }
 
     public boolean isRangeSimplicationEnabled() {

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/SimplifyingFilterVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/SimplifyingFilterVisitorTest.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.filter.visitor;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -77,79 +79,79 @@ public class SimplifyingFilterVisitorTest {
     @Test
     public void testIncludeAndInclude() {
         Filter result = (Filter) ff.and(Filter.INCLUDE, Filter.INCLUDE).accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.INCLUDE, result);
+        assertEquals(Filter.INCLUDE, result);
     }
 
     @Test
     public void testIncludeAndExclude() {
         Filter result = (Filter) ff.and(Filter.INCLUDE, Filter.EXCLUDE).accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.EXCLUDE, result);
+        assertEquals(Filter.EXCLUDE, result);
     }
 
     @Test
     public void testExcludeAndExclude() {
         Filter result = (Filter) ff.and(Filter.EXCLUDE, Filter.EXCLUDE).accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.EXCLUDE, result);
+        assertEquals(Filter.EXCLUDE, result);
     }
 
     @Test
     public void testIncludeAndProperty() {
         Filter result = (Filter) ff.and(Filter.INCLUDE, property).accept(simpleVisitor, null);
-        Assert.assertEquals(property, result);
+        assertEquals(property, result);
     }
 
     @Test
     public void testExcludeAndProperty() {
         Filter result = (Filter) ff.or(Filter.EXCLUDE, property).accept(simpleVisitor, null);
-        Assert.assertEquals(property, result);
+        assertEquals(property, result);
     }
 
     @Test
     public void testIncludeOrInclude() {
         Filter result = (Filter) ff.or(Filter.INCLUDE, Filter.INCLUDE).accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.INCLUDE, result);
+        assertEquals(Filter.INCLUDE, result);
     }
 
     @Test
     public void testIncludeOrExclude() {
         Filter result = (Filter) ff.or(Filter.INCLUDE, Filter.EXCLUDE).accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.INCLUDE, result);
+        assertEquals(Filter.INCLUDE, result);
     }
 
     @Test
     public void testExcludeOrExclude() {
         Filter result = (Filter) ff.or(Filter.EXCLUDE, Filter.EXCLUDE).accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.EXCLUDE, result);
+        assertEquals(Filter.EXCLUDE, result);
     }
 
     @Test
     public void testIncludeOrProperty() {
         Filter result = (Filter) ff.or(Filter.INCLUDE, property).accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.INCLUDE, result);
+        assertEquals(Filter.INCLUDE, result);
     }
 
     @Test
     public void testExcludeOrProperty() {
         Filter result = (Filter) ff.or(Filter.EXCLUDE, property).accept(simpleVisitor, null);
-        Assert.assertEquals(property, result);
+        assertEquals(property, result);
     }
 
     @Test
     public void testEmptyFid() {
         Filter result = (Filter) emptyFid.accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.EXCLUDE, result);
+        assertEquals(Filter.EXCLUDE, result);
     }
 
     @Test
     public void testRecurseAnd() {
         Filter test = ff.and(Filter.INCLUDE, ff.or(property, Filter.EXCLUDE));
-        Assert.assertEquals(property, test.accept(simpleVisitor, null));
+        assertEquals(property, test.accept(simpleVisitor, null));
     }
 
     @Test
     public void testRecurseOr() {
         Filter test = ff.or(Filter.EXCLUDE, ff.and(property, Filter.INCLUDE));
-        Assert.assertEquals(property, test.accept(simpleVisitor, null));
+        assertEquals(property, test.accept(simpleVisitor, null));
     }
 
     @Test
@@ -160,7 +162,7 @@ public class SimplifyingFilterVisitorTest {
         ids.add(ff.featureId("notPass"));
         Id filter = ff.id(ids);
 
-        Assert.assertEquals(Filter.EXCLUDE, filter.accept(simpleVisitor, null));
+        assertEquals(Filter.EXCLUDE, filter.accept(simpleVisitor, null));
 
         ids.add(ff.featureId("pass1"));
         ids.add(ff.featureId("pass2"));
@@ -170,7 +172,7 @@ public class SimplifyingFilterVisitorTest {
         validIds.add(ff.featureId("pass2"));
         validIds.add(ff.featureId("pass1"));
         Filter expected = ff.id(validIds);
-        Assert.assertEquals(expected, filter.accept(simpleVisitor, null));
+        assertEquals(expected, filter.accept(simpleVisitor, null));
     }
 
     @Test
@@ -187,7 +189,7 @@ public class SimplifyingFilterVisitorTest {
         Filter result = (Filter) filter.accept(simpleVisitor, null);
         Filter expected = ff.id(Collections.singleton(ff.featureId("abc.123")));
 
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
     }
 
     @Test
@@ -206,57 +208,57 @@ public class SimplifyingFilterVisitorTest {
         Filter result = (Filter) filter.accept(simpleVisitor, null);
         Filter expected = ff.id(Collections.singleton(ff.featureId("states.123")));
 
-        Assert.assertEquals(expected, result);
+        assertEquals(expected, result);
     }
 
     @Test
     public void testNegateEquals() {
         Filter f = ff.not(ff.equals(ff.property("prop"), ff.literal(10)));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(ff.notEqual(ff.property("prop"), ff.literal(10)), result);
+        assertEquals(ff.notEqual(ff.property("prop"), ff.literal(10)), result);
         // not simplified for complex features
         result = (Filter) f.accept(complexVisitor, null);
-        Assert.assertEquals(f, result);
+        assertEquals(f, result);
     }
 
     @Test
     public void testNegateGreater() {
         Filter f = ff.not(ff.greater(ff.property("prop"), ff.literal(10)));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(ff.lessOrEqual(ff.property("prop"), ff.literal(10)), result);
+        assertEquals(ff.lessOrEqual(ff.property("prop"), ff.literal(10)), result);
         // not simplified for complex features
         result = (Filter) f.accept(complexVisitor, null);
-        Assert.assertEquals(f, result);
+        assertEquals(f, result);
     }
 
     @Test
     public void testNegateGreaterOrEqual() {
         Filter f = ff.not(ff.greaterOrEqual(ff.property("prop"), ff.literal(10)));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(ff.less(ff.property("prop"), ff.literal(10)), result);
+        assertEquals(ff.less(ff.property("prop"), ff.literal(10)), result);
         // not simplified for complex features
         result = (Filter) f.accept(complexVisitor, null);
-        Assert.assertEquals(f, result);
+        assertEquals(f, result);
     }
 
     @Test
     public void testNegateLess() {
         Filter f = ff.not(ff.less(ff.property("prop"), ff.literal(10)));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(ff.greaterOrEqual(ff.property("prop"), ff.literal(10)), result);
+        assertEquals(ff.greaterOrEqual(ff.property("prop"), ff.literal(10)), result);
         // not simplified for complex features
         result = (Filter) f.accept(complexVisitor, null);
-        Assert.assertEquals(f, result);
+        assertEquals(f, result);
     }
 
     @Test
     public void testNegateLessOrEqual() {
         Filter f = ff.not(ff.lessOrEqual(ff.property("prop"), ff.literal(10)));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(ff.greater(ff.property("prop"), ff.literal(10)), result);
+        assertEquals(ff.greater(ff.property("prop"), ff.literal(10)), result);
         // not simplified for complex features
         result = (Filter) f.accept(complexVisitor, null);
-        Assert.assertEquals(f, result);
+        assertEquals(f, result);
     }
 
     @Test
@@ -266,7 +268,7 @@ public class SimplifyingFilterVisitorTest {
         Literal l20 = ff.literal(20);
         Filter f = ff.not(ff.between(prop, l10, l20));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(
+        assertEquals(
                 ff.or(Arrays.asList(ff.less(prop, l10), ff.greater(prop, l20), ff.isNull(prop))),
                 result);
     }
@@ -286,7 +288,7 @@ public class SimplifyingFilterVisitorTest {
         Literal l20 = ff.literal(20);
         Filter f = ff.not(ff.between(prop, l10, l20));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(
+        assertEquals(
                 ff.or(Arrays.asList(ff.less(prop, l10), ff.greater(prop, l20), ff.isNull(prop))),
                 result);
 
@@ -295,7 +297,7 @@ public class SimplifyingFilterVisitorTest {
         prop = ff.property("prop");
         f = ff.not(ff.between(prop, l10, l20));
         result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(
+        assertEquals(
                 ff.or(Arrays.asList(ff.less(prop, l10), ff.greater(prop, l20), ff.isNull(prop))),
                 result);
 
@@ -303,8 +305,7 @@ public class SimplifyingFilterVisitorTest {
         prop = ff.property("prop2");
         f = ff.not(ff.between(prop, l10, l20));
         result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(
-                ff.or(Arrays.asList(ff.less(prop, l10), ff.greater(prop, l20))), result);
+        assertEquals(ff.or(Arrays.asList(ff.less(prop, l10), ff.greater(prop, l20))), result);
     }
 
     @Test
@@ -312,7 +313,7 @@ public class SimplifyingFilterVisitorTest {
         PropertyIsEqualTo equal = ff.equals(ff.property("prop"), ff.literal(10));
         Filter f = ff.not(ff.not(equal));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(equal, result);
+        assertEquals(equal, result);
     }
 
     @Test
@@ -320,7 +321,7 @@ public class SimplifyingFilterVisitorTest {
         PropertyIsEqualTo equal = ff.equals(ff.property("prop"), ff.literal(10));
         Filter f = ff.not(ff.not(ff.not(equal)));
         Filter result = (Filter) f.accept(simpleVisitor, null);
-        Assert.assertEquals(ff.notEqual(ff.property("prop"), ff.literal(10)), result);
+        assertEquals(ff.notEqual(ff.property("prop"), ff.literal(10)), result);
     }
 
     @Test
@@ -330,7 +331,7 @@ public class SimplifyingFilterVisitorTest {
 
         Expression result = (Expression) f.accept(simpleVisitor, null);
         Assert.assertTrue(result instanceof Literal);
-        Assert.assertEquals("123", result.evaluate(null, String.class));
+        assertEquals("123", result.evaluate(null, String.class));
     }
 
     @Test
@@ -349,14 +350,14 @@ public class SimplifyingFilterVisitorTest {
 
         Function result = (Function) f.accept(simpleVisitor, null);
         // main function not simplified out
-        Assert.assertEquals("pow", result.getName());
+        assertEquals("pow", result.getName());
         // first argument not simplified out
         Function param1 = (Function) result.getParameters().get(0);
-        Assert.assertEquals("random", param1.getName());
+        assertEquals("random", param1.getName());
         // second argument simplified out
         Expression param2 = result.getParameters().get(1);
         Assert.assertTrue(param2 instanceof Literal);
-        Assert.assertEquals(Integer.valueOf(3), param2.evaluate(null, Integer.class));
+        assertEquals(Integer.valueOf(3), param2.evaluate(null, Integer.class));
     }
 
     @Test
@@ -365,7 +366,7 @@ public class SimplifyingFilterVisitorTest {
         PropertyIsEqualTo filter = ff.equal(f, ff.literal("test"), false);
 
         Filter simplified = (Filter) filter.accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.EXCLUDE, simplified);
+        assertEquals(Filter.EXCLUDE, simplified);
     }
 
     @Test
@@ -375,30 +376,28 @@ public class SimplifyingFilterVisitorTest {
         PropertyIsEqualTo filter = ff.equal(f, ff.literal("test"), false);
 
         Filter simplified = (Filter) filter.accept(simpleVisitor, null);
-        Assert.assertEquals(Filter.INCLUDE, simplified);
+        assertEquals(Filter.INCLUDE, simplified);
     }
 
     @Test
     public void testSimplifyStaticExclude() {
-        Assert.assertEquals(Filter.EXCLUDE, simplify(ff.greater(ff.literal(3), ff.literal(5))));
-        Assert.assertEquals(
-                Filter.EXCLUDE, simplify(ff.greaterOrEqual(ff.literal(3), ff.literal(5))));
-        Assert.assertEquals(Filter.EXCLUDE, simplify(ff.less(ff.literal(5), ff.literal(3))));
-        Assert.assertEquals(Filter.EXCLUDE, simplify(ff.lessOrEqual(ff.literal(5), ff.literal(3))));
-        Assert.assertEquals(Filter.EXCLUDE, simplify(ff.equal(ff.literal(5), ff.literal(3), true)));
-        Assert.assertEquals(
+        assertEquals(Filter.EXCLUDE, simplify(ff.greater(ff.literal(3), ff.literal(5))));
+        assertEquals(Filter.EXCLUDE, simplify(ff.greaterOrEqual(ff.literal(3), ff.literal(5))));
+        assertEquals(Filter.EXCLUDE, simplify(ff.less(ff.literal(5), ff.literal(3))));
+        assertEquals(Filter.EXCLUDE, simplify(ff.lessOrEqual(ff.literal(5), ff.literal(3))));
+        assertEquals(Filter.EXCLUDE, simplify(ff.equal(ff.literal(5), ff.literal(3), true)));
+        assertEquals(
                 Filter.EXCLUDE, simplify(ff.between(ff.literal(3), ff.literal(1), ff.literal(2))));
     }
 
     @Test
     public void testSimplifyStaticInclude() {
-        Assert.assertEquals(Filter.INCLUDE, simplify(ff.less(ff.literal(3), ff.literal(5))));
-        Assert.assertEquals(Filter.INCLUDE, simplify(ff.lessOrEqual(ff.literal(3), ff.literal(5))));
-        Assert.assertEquals(Filter.INCLUDE, simplify(ff.greater(ff.literal(5), ff.literal(3))));
-        Assert.assertEquals(
-                Filter.INCLUDE, simplify(ff.greaterOrEqual(ff.literal(5), ff.literal(3))));
-        Assert.assertEquals(Filter.INCLUDE, simplify(ff.equal(ff.literal(5), ff.literal(5), true)));
-        Assert.assertEquals(
+        assertEquals(Filter.INCLUDE, simplify(ff.less(ff.literal(3), ff.literal(5))));
+        assertEquals(Filter.INCLUDE, simplify(ff.lessOrEqual(ff.literal(3), ff.literal(5))));
+        assertEquals(Filter.INCLUDE, simplify(ff.greater(ff.literal(5), ff.literal(3))));
+        assertEquals(Filter.INCLUDE, simplify(ff.greaterOrEqual(ff.literal(5), ff.literal(3))));
+        assertEquals(Filter.INCLUDE, simplify(ff.equal(ff.literal(5), ff.literal(5), true)));
+        assertEquals(
                 Filter.INCLUDE, simplify(ff.between(ff.literal(3), ff.literal(1), ff.literal(4))));
     }
 
@@ -414,8 +413,8 @@ public class SimplifyingFilterVisitorTest {
         And nested = ff.and(Arrays.asList(ff.and(Arrays.asList(eq, gt)), lt));
 
         And simplified = (And) nested.accept(simpleVisitor, null);
-        Assert.assertEquals(3, simplified.getChildren().size());
-        Assert.assertEquals(ff.and(Arrays.asList(eq, gt, lt)), simplified);
+        assertEquals(3, simplified.getChildren().size());
+        assertEquals(ff.and(Arrays.asList(eq, gt, lt)), simplified);
     }
 
     @Test
@@ -426,8 +425,8 @@ public class SimplifyingFilterVisitorTest {
         Or nested = ff.or(Arrays.asList(ff.or(Arrays.asList(eq, gt)), lt));
 
         Or simplified = (Or) nested.accept(simpleVisitor, null);
-        Assert.assertEquals(3, simplified.getChildren().size());
-        Assert.assertEquals(ff.or(Arrays.asList(eq, gt, lt)), simplified);
+        assertEquals(3, simplified.getChildren().size());
+        assertEquals(ff.or(Arrays.asList(eq, gt, lt)), simplified);
     }
 
     @Test
@@ -437,7 +436,7 @@ public class SimplifyingFilterVisitorTest {
                         Arrays.asList(
                                 ff.not(ff.equal(ff.property("a"), ff.literal(3), true)),
                                 ff.equal(ff.property("a"), ff.literal(3), true)));
-        Assert.assertEquals(Filter.INCLUDE, or.accept(simpleVisitor, null));
+        assertEquals(Filter.INCLUDE, or.accept(simpleVisitor, null));
     }
 
     @Test
@@ -447,7 +446,7 @@ public class SimplifyingFilterVisitorTest {
                         Arrays.asList(
                                 ff.not(ff.equal(ff.property("a"), ff.literal(3), true)),
                                 ff.equal(ff.property("a"), ff.literal(3), true)));
-        Assert.assertEquals(Filter.EXCLUDE, original.accept(simpleVisitor, null));
+        assertEquals(Filter.EXCLUDE, original.accept(simpleVisitor, null));
     }
 
     @Test
@@ -456,7 +455,7 @@ public class SimplifyingFilterVisitorTest {
                 ff.and(
                         Arrays.asList(
                                 ff.not(ff.isNull(ff.property("a"))), ff.isNull(ff.property("a"))));
-        Assert.assertEquals(Filter.EXCLUDE, original.accept(simpleVisitor, null));
+        assertEquals(Filter.EXCLUDE, original.accept(simpleVisitor, null));
     }
 
     @Test
@@ -465,7 +464,7 @@ public class SimplifyingFilterVisitorTest {
                 ff.or(
                         Arrays.asList(
                                 ff.not(ff.isNull(ff.property("a"))), ff.isNull(ff.property("a"))));
-        Assert.assertEquals(Filter.INCLUDE, original.accept(simpleVisitor, null));
+        assertEquals(Filter.INCLUDE, original.accept(simpleVisitor, null));
     }
 
     @Test
@@ -474,25 +473,25 @@ public class SimplifyingFilterVisitorTest {
         Filter f2 = ff.equal(ff.property("a"), ff.literal(3), false);
 
         Filter s1 = (Filter) ff.and(f1, f2).accept(simpleVisitor, null);
-        Assert.assertEquals(f1, s1);
+        assertEquals(f1, s1);
         Filter s2 = (Filter) ff.or(f1, f2).accept(simpleVisitor, null);
-        Assert.assertEquals(f1, s2);
+        assertEquals(f1, s2);
 
         Filter f3 = ff.greater(ff.property("a"), ff.property("b"));
 
         Filter s3 = (Filter) ff.and(Arrays.asList(f1, f2, f3)).accept(simpleVisitor, null);
-        Assert.assertEquals(ff.and(Arrays.asList(f1, f3)), s3);
+        assertEquals(ff.and(Arrays.asList(f1, f3)), s3);
         Filter s4 = (Filter) ff.and(Arrays.asList(f3, f1, f2)).accept(simpleVisitor, null);
-        Assert.assertEquals(ff.and(Arrays.asList(f3, f1)), s4);
+        assertEquals(ff.and(Arrays.asList(f3, f1)), s4);
         Filter s5 = (Filter) ff.and(Arrays.asList(f1, f3, f2)).accept(simpleVisitor, null);
-        Assert.assertEquals(ff.and(Arrays.asList(f1, f3)), s5);
+        assertEquals(ff.and(Arrays.asList(f1, f3)), s5);
 
         Filter s6 = (Filter) ff.or(Arrays.asList(f1, f2, f3)).accept(simpleVisitor, null);
-        Assert.assertEquals(ff.or(Arrays.asList(f1, f3)), s6);
+        assertEquals(ff.or(Arrays.asList(f1, f3)), s6);
         Filter s7 = (Filter) ff.or(Arrays.asList(f3, f1, f2)).accept(simpleVisitor, null);
-        Assert.assertEquals(ff.or(Arrays.asList(f3, f1)), s7);
+        assertEquals(ff.or(Arrays.asList(f3, f1)), s7);
         Filter s8 = (Filter) ff.or(Arrays.asList(f1, f3, f2)).accept(simpleVisitor, null);
-        Assert.assertEquals(ff.or(Arrays.asList(f1, f3)), s8);
+        assertEquals(ff.or(Arrays.asList(f1, f3)), s8);
     }
 
     @Test
@@ -515,11 +514,11 @@ public class SimplifyingFilterVisitorTest {
                         ff.greater(ff.property("a"), ff.literal(max)),
                         ff.less(ff.property("a"), ff.literal(min)));
         Filter simplified = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(original, simplified);
+        assertEquals(original, simplified);
 
         visitor.setFeatureType(schema);
         Filter simplified2 = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(Filter.EXCLUDE, simplified2);
+        assertEquals(Filter.EXCLUDE, simplified2);
     }
 
     @Test
@@ -542,7 +541,7 @@ public class SimplifyingFilterVisitorTest {
                         ff.greater(ff.property("a"), ff.literal(max)),
                         ff.less(ff.property("a"), ff.literal(min)));
         Filter simplified = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(original, simplified);
+        assertEquals(original, simplified);
     }
 
     @Test
@@ -566,7 +565,7 @@ public class SimplifyingFilterVisitorTest {
                         ff.greaterOrEqual(ff.property("a"), ff.literal(value)),
                         ff.lessOrEqual(ff.property("a"), ff.literal(value)));
         Filter simplified = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(ff.equal(ff.property("a"), ff.literal(value), false), simplified);
+        assertEquals(ff.equal(ff.property("a"), ff.literal(value), false), simplified);
     }
 
     @Test
@@ -590,7 +589,7 @@ public class SimplifyingFilterVisitorTest {
                         ff.greaterOrEqual(ff.property("a"), ff.literal(value)),
                         ff.lessOrEqual(ff.property("a"), ff.literal(value)));
         Filter simplified = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(Filter.INCLUDE, simplified);
+        assertEquals(Filter.INCLUDE, simplified);
     }
 
     @Test
@@ -618,7 +617,7 @@ public class SimplifyingFilterVisitorTest {
                                 ff.less(ff.property("a"), ff.literal(mid))));
 
         Filter simplified = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(
+        assertEquals(
                 ff.and(
                         ff.greater(ff.property("a"), ff.literal(min)), //
                         ff.less(ff.property("a"), ff.literal(mid))),
@@ -649,7 +648,7 @@ public class SimplifyingFilterVisitorTest {
                                 ff.greater(ff.property("a"), ff.literal(max))));
 
         Filter simplified = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(ff.greater(ff.property("a"), ff.literal(min)), simplified);
+        assertEquals(ff.greater(ff.property("a"), ff.literal(min)), simplified);
     }
 
     @Test
@@ -678,8 +677,7 @@ public class SimplifyingFilterVisitorTest {
                                 ff.lessOrEqual(ff.property("a"), ff.literal(mid))));
 
         Filter simplified = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(
-                ff.between(ff.property("a"), ff.literal(min), ff.literal(mid)), simplified);
+        assertEquals(ff.between(ff.property("a"), ff.literal(min), ff.literal(mid)), simplified);
     }
 
     @Test
@@ -708,7 +706,7 @@ public class SimplifyingFilterVisitorTest {
                                 ff.lessOrEqual(ff.property("a"), ff.literal(min))));
 
         Filter simplified = (Filter) original.accept(visitor, null);
-        Assert.assertEquals(ff.lessOrEqual(ff.property("a"), ff.literal(max)), simplified);
+        assertEquals(ff.lessOrEqual(ff.property("a"), ff.literal(max)), simplified);
     }
 
     @Test
@@ -723,7 +721,7 @@ public class SimplifyingFilterVisitorTest {
         Filter or = ff.or(f1, f2);
 
         Filter simplified = (Filter) or.accept(visitor, null);
-        Assert.assertEquals(ff.lessOrEqual(func, ff.literal(50000)), simplified);
+        assertEquals(ff.lessOrEqual(func, ff.literal(50000)), simplified);
     }
 
     @Test
@@ -735,6 +733,38 @@ public class SimplifyingFilterVisitorTest {
         SimpleFeatureType schema = DataUtilities.createType("test", "pop:String");
         visitor.setFeatureType(schema);
         Filter simplified = (Filter) negated.accept(visitor, null);
-        Assert.assertEquals(Filter.INCLUDE, simplified);
+        assertEquals(Filter.INCLUDE, simplified);
+    }
+
+    @Test
+    public void testAdd() {
+        EnvFunction.setLocalValue("var", "123");
+        Expression e = ff.add(ff.function("env", ff.literal("var")), ff.literal(10));
+        Expression result = (Expression) e.accept(simpleVisitor, null);
+        assertEquals(ff.literal(133), result);
+    }
+
+    @Test
+    public void testSubtract() {
+        EnvFunction.setLocalValue("var", "123");
+        Expression e = ff.subtract(ff.function("env", ff.literal("var")), ff.literal(10));
+        Expression result = (Expression) e.accept(simpleVisitor, null);
+        assertEquals(ff.literal(113), result);
+    }
+
+    @Test
+    public void testMultiply() {
+        EnvFunction.setLocalValue("var", "123");
+        Expression e = ff.multiply(ff.function("env", ff.literal("var")), ff.literal(10));
+        Expression result = (Expression) e.accept(simpleVisitor, null);
+        assertEquals(ff.literal(1230), result);
+    }
+
+    @Test
+    public void testDivide() {
+        EnvFunction.setLocalValue("var", "123");
+        Expression e = ff.divide(ff.function("env", ff.literal("var")), ff.literal(10));
+        Expression result = (Expression) e.accept(simpleVisitor, null);
+        assertEquals(ff.literal(12.3), result);
     }
 }

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/SimplifyingStyleVisitor.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/SimplifyingStyleVisitor.java
@@ -1,0 +1,85 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.lite;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.visitor.SimplifyingFilterVisitor;
+import org.geotools.styling.FeatureTypeStyle;
+import org.geotools.styling.FeatureTypeStyleImpl;
+import org.geotools.styling.Rule;
+import org.geotools.styling.visitor.DuplicatingStyleVisitor;
+
+/**
+ * A style visitor returning a simplified copy of the style, in particular, simplfying filters and
+ * the expressions used in symbolizer properties, when they are found to be static within the
+ * context of the current rendering evaluation. It's used inside {@link StreamingRenderer} to
+ * simplify the styles before they are used for the current render.
+ *
+ * <p>Implementation has a quirk: rendering transformations cannot be simplified, they can look
+ * static but will be evaluated against the input feature collection/coverage, so they are preserved
+ * as-is.
+ */
+class SimplifyingStyleVisitor extends DuplicatingStyleVisitor {
+
+    SimplifyingStyleVisitor() {
+        super(
+                CommonFactoryFinder.getStyleFactory(null),
+                CommonFactoryFinder.getFilterFactory2(null),
+                new SimplifyingFilterVisitor());
+    }
+
+    @Override
+    public void visit(FeatureTypeStyle fts) {
+
+        FeatureTypeStyle copy = new FeatureTypeStyleImpl(fts);
+
+        List<Rule> rulesCopy =
+                fts.rules().stream()
+                        .filter(r -> r != null)
+                        .map(
+                                r -> {
+                                    r.accept(this);
+                                    return !pages.isEmpty() ? (Rule) pages.pop() : null;
+                                })
+                        .filter(r -> r != null)
+                        .collect(Collectors.toList());
+
+        copy.rules().clear();
+        copy.rules().addAll(rulesCopy);
+
+        // this one is preserved without simplification, not the usual function,
+        // will accept a grid coverage or a collection, needs to be evaluated at runtime
+        if (fts.getTransformation() != null) {
+            copy.setTransformation(fts.getTransformation());
+        }
+
+        if (fts.getOnlineResource() != null) {
+            copy.setOnlineResource(fts.getOnlineResource());
+        }
+        copy.getOptions().clear();
+        copy.getOptions().putAll(fts.getOptions());
+
+        if (STRICT && !copy.equals(fts)) {
+            throw new IllegalStateException(
+                    "Was unable to duplicate provided FeatureTypeStyle:" + fts);
+        }
+
+        pages.push(copy);
+    }
+}

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -2005,6 +2005,11 @@ public class StreamingRenderer implements GTRenderer {
 
         for (FeatureTypeStyle fts : style.featureTypeStyles()) {
             if (isFeatureTypeStyleActive(layer.getFeatureSource().getSchema(), fts)) {
+
+                SimplifyingStyleVisitor simplifier = new SimplifyingStyleVisitor();
+                fts.accept(simplifier);
+                fts = (FeatureTypeStyle) simplifier.getCopy();
+
                 // DJB: this FTS is compatible with this FT.
 
                 // get applicable rules at the current scale

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/SimplifyingStyleVisitorTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/SimplifyingStyleVisitorTest.java
@@ -1,0 +1,42 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.lite;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.filter.text.cql2.CQL;
+import org.geotools.styling.LineSymbolizer;
+import org.geotools.styling.Rule;
+import org.geotools.styling.Style;
+import org.junit.Test;
+
+public class SimplifyingStyleVisitorTest {
+
+    @Test
+    public void testSimplify() throws Exception {
+        Style style = RendererBaseTest.loadStyle(this, "simplify.sld");
+        SimplifyingStyleVisitor visitor = new SimplifyingStyleVisitor();
+        style.accept(visitor);
+
+        Style copy = (Style) visitor.getCopy();
+        Rule rule = copy.featureTypeStyles().get(0).rules().get(0);
+        // filter has been simplified
+        assertEquals(CQL.toFilter("value = 11"), rule.getFilter());
+        LineSymbolizer symbolizer = (LineSymbolizer) rule.symbolizers().get(0);
+        assertEquals(CQL.toExpression("65536"), symbolizer.getStroke().getWidth());
+    }
+}

--- a/modules/library/render/src/test/resources/org/geotools/renderer/lite/test-data/simplify.sld
+++ b/modules/library/render/src/test/resources/org/geotools/renderer/lite/test-data/simplify.sld
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+                       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+                       xmlns="http://www.opengis.net/sld"
+                       xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <NamedLayer>
+        <Name>Simplify me</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>value</ogc:PropertyName>
+                            <ogc:Add>
+                                <ogc:Literal>10</ogc:Literal>
+                                <ogc:Function name="env">
+                                    <ogc:Literal>test</ogc:Literal>
+                                    <ogc:Literal>1</ogc:Literal>
+                                </ogc:Function>
+                            </ogc:Add>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#0000</CssParameter>
+                            <CssParameter name="stroke-width">
+                                <ogc:Function name="pow">
+                                    <ogc:Literal>2</ogc:Literal>
+                                    <ogc:Literal>16</ogc:Literal>
+                                </ogc:Function>
+                            </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
See the two tickets for details:
* [Avoid needless type conversions in InterpolateFunction](https://osgeo-org.atlassian.net/browse/GEOT-7413) (pure optimization, no change in behavior, cannot add new tests, existing ones guard against regression)
* [Speed up style evaluation during rendering, by simplifying its expressions before execution](https://osgeo-org.atlassian.net/browse/GEOT-7414) (this one is also an optimization, but has testable changes in simplifier visitor)

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->