### PR TITLE
[GEOT-7416] org.geotools.feature.NameImpl.compareTo creates garbage objects

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/NameImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/NameImpl.java
@@ -157,6 +157,14 @@ public class NameImpl implements org.opengis.feature.type.Name, Serializable, Co
         if (other == null) {
             return 1; // we are greater than null!
         }
-        return getURI().compareTo(other.getURI());
+        int c = compare(getNamespaceURI(), other.getNamespaceURI());
+        return c != 0 ? c : compare(getLocalPart(), other.getLocalPart());
+    }
+
+    private int compare(String s1, String s2) {
+        if (s1 == null || s2 == null) {
+            return s1 == s2 ? 0 : s1 == null ? 1 : -1;
+        }
+        return s1.compareTo(s2);
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/feature/NameImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/NameImplTest.java
@@ -49,5 +49,9 @@ public class NameImplTest {
         assertTrue(scoped2.compareTo(scoped1) < 0);
 
         assertTrue(scoped2.compareTo(scoped1) < 0);
+
+        assertTrue(scoped1.compareTo(new NameImpl(null, scoped1.getLocalPart())) < 0);
+        assertTrue(new NameImpl(null, scoped1.getLocalPart()).compareTo(scoped1) > 0);
+        assertEquals(0, new NameImpl(null, "t").compareTo(new NameImpl(null, "t")));
     }
 }


### PR DESCRIPTION
[![GEOT-7416](https://badgen.net/badge/JIRA/GEOT-7416/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7416) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Avoid creating garbage objects (StringBuffer/String) when comparing to another NameImpl, by comparing the namespace URI and the localPart separatedly.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->