### PR TITLE
[Backport 29.x] [GEOT-7416] org.geotools.feature.NameImpl.compareTo creates garbage objects

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/NameImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/NameImpl.java
@@ -157,6 +157,14 @@ public class NameImpl implements org.opengis.feature.type.Name, Serializable, Co
         if (other == null) {
             return 1; // we are greater than null!
         }
-        return getURI().compareTo(other.getURI());
+        int c = compare(getNamespaceURI(), other.getNamespaceURI());
+        return c != 0 ? c : compare(getLocalPart(), other.getLocalPart());
+    }
+
+    private int compare(String s1, String s2) {
+        if (s1 == null || s2 == null) {
+            return s1 == s2 ? 0 : s1 == null ? 1 : -1;
+        }
+        return s1.compareTo(s2);
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/feature/NameImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/NameImplTest.java
@@ -49,5 +49,9 @@ public class NameImplTest {
         assertTrue(scoped2.compareTo(scoped1) < 0);
 
         assertTrue(scoped2.compareTo(scoped1) < 0);
+
+        assertTrue(scoped1.compareTo(new NameImpl(null, scoped1.getLocalPart())) < 0);
+        assertTrue(new NameImpl(null, scoped1.getLocalPart()).compareTo(scoped1) > 0);
+        assertEquals(0, new NameImpl(null, "t").compareTo(new NameImpl(null, "t")));
     }
 }


### PR DESCRIPTION
[![GEOT-7416](https://badgen.net/badge/JIRA/GEOT-7416/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7416) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4416
 **Authored by:** @groldan