### PR TITLE
[GEOT-7421] Caching WKT parsing results

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
@@ -183,6 +183,9 @@ public final class CRS {
     private static SoftValueHashMap<String, CoordinateReferenceSystem> xyCache =
             new SoftValueHashMap<>();
 
+    private static SoftValueHashMap<String, CoordinateReferenceSystem> wktCache =
+            new SoftValueHashMap<>();
+
     /** Registers a listener automatically invoked when the system-wide configuration changed. */
     static {
         GeoTools.addChangeListener(
@@ -195,6 +198,7 @@ public final class CRS {
                             strictFactory = null;
                             lenientFactory = null;
                             xyCache.clear();
+                            wktCache.clear();
                             defaultCache.clear();
                         }
                     }
@@ -562,7 +566,12 @@ public final class CRS {
      * </blockquote>
      */
     public static CoordinateReferenceSystem parseWKT(final String wkt) throws FactoryException {
-        return ReferencingFactoryFinder.getCRSFactory(null).createFromWKT(wkt);
+        CoordinateReferenceSystem result = wktCache.get(wkt);
+        if (result == null) {
+            result = ReferencingFactoryFinder.getCRSFactory(null).createFromWKT(wkt);
+            wktCache.put(wkt, result);
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
[![GEOT-7421](https://badgen.net/badge/JIRA/GEOT-7421/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7421) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Replacement for https://github.com/geoserver/geoserver/pull/7050, follows the same pattern as the other CRS caches.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->