### PR TITLE
[Backport 29.x] [GEOT-7418] Add a configuration parameter to the ElasticSearch plugin to support response greater than 100mb

### DIFF
--- a/docs/user/library/data/elasticsearch.rst
+++ b/docs/user/library/data/elasticsearch.rst
@@ -54,6 +54,8 @@ Available data store connection parameters are summarized in the following table
      - Whether to validate the server certificate during the SSL handshake for https connections
    * - default_max_features
      - Default used when maxFeatures is unlimited
+   * - response_buffer_limit
+     - Maximum number of bytes to buffer in memory when reading responses from Elasticsearch
    * - source_filtering_enabled
      - Whether to enable filtering of the _source field
    * - scroll_enabled

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStore.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStore.java
@@ -88,14 +88,20 @@ public class ElasticDataStore extends ContentDataStore {
     }
 
     public ElasticDataStore(RestClient restClient, String indexName) throws IOException {
-        this(restClient, null, indexName, false);
+        this(
+                restClient,
+                null,
+                indexName,
+                false,
+                (Integer) ElasticDataStoreFactory.RESPONSE_BUFFER_LIMIT.sample);
     }
 
     public ElasticDataStore(
             RestClient restClient,
             RestClient proxyRestClient,
             String indexName,
-            boolean enableRunAs)
+            boolean enableRunAs,
+            int responseBufferLimit)
             throws IOException {
         LOGGER.fine("Initializing data store for " + indexName);
 
@@ -106,7 +112,9 @@ public class ElasticDataStore extends ContentDataStore {
             if (proxyRestClient != null) {
                 checkRestClient(proxyRestClient);
             }
-            client = new RestElasticClient(restClient, proxyRestClient, enableRunAs);
+            client =
+                    new RestElasticClient(
+                            restClient, proxyRestClient, enableRunAs, responseBufferLimit);
         } catch (Exception e) {
             throw new IOException("Unable to create REST client", e);
         }

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStoreFactory.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/ElasticDataStoreFactory.java
@@ -193,6 +193,14 @@ public class ElasticDataStoreFactory implements DataStoreFactorySpi {
                     false,
                     0.05);
 
+    public static final Param RESPONSE_BUFFER_LIMIT =
+            new Param(
+                    "response_buffer_limit",
+                    Integer.class,
+                    "Maximum number of bytes to buffer in memory when reading responses from Elasticsearch",
+                    false,
+                    104857600);
+
     public static final Param[] PARAMS = {
         HOSTNAME,
         HOSTPORT,
@@ -210,7 +218,8 @@ public class ElasticDataStoreFactory implements DataStoreFactorySpi {
         DEFAULT_MAX_FEATURES,
         ARRAY_ENCODING,
         GRID_SIZE,
-        GRID_THRESHOLD
+        GRID_THRESHOLD,
+        RESPONSE_BUFFER_LIMIT
     };
 
     @Override
@@ -277,6 +286,7 @@ public class ElasticDataStoreFactory implements DataStoreFactorySpi {
         final String indexName = (String) INDEX_NAME.lookUp(params);
         final String arrayEncoding = getValue(ARRAY_ENCODING, params);
         final boolean runAsGeoServerUser = getValue(RUNAS_GEOSERVER_USER, params);
+        final int responseBufferLimit = getValue(RESPONSE_BUFFER_LIMIT, params);
         if (isForceRunas() && !runAsGeoServerUser) {
             throw new IllegalArgumentException(
                     RUNAS_GEOSERVER_USER.key
@@ -291,7 +301,8 @@ public class ElasticDataStoreFactory implements DataStoreFactorySpi {
         }
 
         final ElasticDataStore dataStore =
-                new ElasticDataStore(client, proxyClient, indexName, runAsGeoServerUser);
+                new ElasticDataStore(
+                        client, proxyClient, indexName, runAsGeoServerUser, responseBufferLimit);
         dataStore.setDefaultMaxFeatures(getValue(DEFAULT_MAX_FEATURES, params));
         dataStore.setSourceFilteringEnabled(getValue(SOURCE_FILTERING_ENABLED, params));
         dataStore.setScrollEnabled(getValue(SCROLL_ENABLED, params));
@@ -395,7 +406,6 @@ public class ElasticDataStoreFactory implements DataStoreFactorySpi {
 
                         httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
                     }
-
                     return httpClientBuilder;
                 });
 

--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/RestElasticClient.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/RestElasticClient.java
@@ -39,6 +39,7 @@ import java.util.regex.Pattern;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
+import org.elasticsearch.client.HttpAsyncResponseConsumerFactory;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -63,17 +64,24 @@ public class RestElasticClient implements ElasticClient {
 
     private final boolean enableRunAs;
 
+    private final int responseBufferLimit;
+
     private final ObjectMapper mapper;
 
     private Double version;
 
     public RestElasticClient(RestClient client) {
-        this(client, null, false);
+        this(client, null, false, (Integer) ElasticDataStoreFactory.RESPONSE_BUFFER_LIMIT.sample);
     }
 
-    public RestElasticClient(RestClient client, RestClient proxyClient, boolean enableRunAs) {
+    public RestElasticClient(
+            RestClient client,
+            RestClient proxyClient,
+            boolean enableRunAs,
+            int responseBufferLimit) {
         this.client = client;
         this.proxyClient = proxyClient;
+        this.responseBufferLimit = responseBufferLimit;
         this.mapper = new ObjectMapper();
         this.mapper.setDateFormat(DATE_FORMAT);
         this.enableRunAs = enableRunAs;
@@ -263,7 +271,11 @@ public class RestElasticClient implements ElasticClient {
 
         final Request request = new Request(method, path);
         request.setEntity(entity);
-
+        final RequestOptions.Builder optionsBuilder = RequestOptions.DEFAULT.toBuilder();
+        // Set the response buffer limit, default is 100MB
+        optionsBuilder.setHttpAsyncResponseConsumerFactory(
+                new HttpAsyncResponseConsumerFactory.HeapBufferedResponseConsumerFactory(
+                        responseBufferLimit));
         if (!isAdmin && enableRunAs) {
             final SecurityContext ctx = SecurityContextHolder.getContext();
             final Authentication auth = ctx.getAuthentication();
@@ -274,15 +286,14 @@ public class RestElasticClient implements ElasticClient {
                 throw new IllegalStateException(
                         String.format("User is not authenticated: %s", auth.getName()));
             }
-            final RequestOptions.Builder optionsBuilder = RequestOptions.DEFAULT.toBuilder();
             optionsBuilder.addHeader(RUN_AS, auth.getName());
-            request.setOptions(optionsBuilder);
             LOGGER.fine(String.format("Performing request on behalf of user %s", auth.getName()));
         } else {
             LOGGER.fine(
                     String.format(
                             "Performing request with %s credentials", isAdmin ? "user" : "proxy"));
         }
+        request.setOptions(optionsBuilder);
         final Response response = client.performRequest(request);
         if (response.getStatusLine().getStatusCode() >= 400) {
             throw new IOException(

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticDataStoreFactoryIT.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticDataStoreFactoryIT.java
@@ -1,0 +1,55 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.elasticsearch;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+import org.junit.Test;
+
+/** Tests for {@link ElasticDataStoreFactory}. */
+public class ElasticDataStoreFactoryIT extends ElasticTestSupport {
+
+    @Test(expected = IOException.class)
+    public void testExceedsResponseBufferLimit() throws Exception {
+        Map<String, Serializable> params = createConnectionParams();
+        params.put(ElasticDataStoreFactory.RESPONSE_BUFFER_LIMIT.key, 1);
+        ElasticDataStoreFactory factory = new ElasticDataStoreFactory();
+        ElasticDataStore dataStore = (ElasticDataStore) factory.createDataStore(params);
+        try (ElasticClient elasticClient = dataStore.getClient()) {
+            createIndices(elasticClient, "test1");
+        } finally {
+            dataStore.dispose();
+        }
+    }
+
+    @Test
+    public void testLessThanResponseBufferLimit() throws Exception {
+        Map<String, Serializable> params = createConnectionParams();
+        params.put(ElasticDataStoreFactory.RESPONSE_BUFFER_LIMIT.key, 1000);
+        ElasticDataStoreFactory factory = new ElasticDataStoreFactory();
+        ElasticDataStore dataStore = (ElasticDataStore) factory.createDataStore(params);
+        try (ElasticClient elasticClient = dataStore.getClient()) {
+            createIndices(elasticClient, "test2");
+            assertTrue(elasticClient.getTypes(indexName).size() > 0);
+        } finally {
+            dataStore.dispose();
+        }
+    }
+}

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticDataStoreFinderIT.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticDataStoreFinderIT.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.Node;
+import org.elasticsearch.client.RestClient;
 import org.geotools.data.DataStore;
 import org.junit.Test;
 
@@ -171,11 +172,15 @@ public class ElasticDataStoreFinderIT extends ElasticTestSupport {
     }
 
     private List<HttpHost> getHosts(String hosts) throws IOException {
+        return getRestClient(hosts).getNodes().stream()
+                .map(Node::getHost)
+                .collect(Collectors.toList());
+    }
+
+    private RestClient getRestClient(String hosts) throws IOException {
         Map<String, Serializable> params = createConnectionParams();
         params.put(ElasticDataStoreFactory.HOSTNAME.key, hosts);
         ElasticDataStoreFactory factory = new ElasticDataStoreFactory();
-        return factory.createRestClient(params).getNodes().stream()
-                .map(Node::getHost)
-                .collect(Collectors.toList());
+        return factory.createRestClient(params);
     }
 }

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticDataStoreIT.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticDataStoreIT.java
@@ -84,7 +84,13 @@ public class ElasticDataStoreIT extends ElasticTestSupport {
         HttpHost httpHost = new HttpHost(host, port, "http");
         try (RestClient client = RestClient.builder(httpHost).build()) {
 
-            DataStore dataStore = new ElasticDataStore(client, client, indexName, false);
+            DataStore dataStore =
+                    new ElasticDataStore(
+                            client,
+                            client,
+                            indexName,
+                            false,
+                            (Integer) ElasticDataStoreFactory.RESPONSE_BUFFER_LIMIT.sample);
             String[] typeNames = dataStore.getTypeNames();
             assertTrue(typeNames.length > 0);
         }
@@ -127,7 +133,12 @@ public class ElasticDataStoreIT extends ElasticTestSupport {
         final AtomicInteger count = new AtomicInteger(0);
         when(mockStatusLine.getStatusCode())
                 .thenAnswer((invocation) -> count.getAndIncrement() == 0 ? 200 : 400);
-        new ElasticDataStore(mockClient, mockClient, indexName, false);
+        new ElasticDataStore(
+                mockClient,
+                mockClient,
+                indexName,
+                false,
+                (Integer) ElasticDataStoreFactory.RESPONSE_BUFFER_LIMIT.sample);
     }
 
     @Test

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticTestSupport.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticTestSupport.java
@@ -130,7 +130,7 @@ public class ElasticTestSupport {
         client.close();
     }
 
-    private void createIndices() throws IOException {
+    protected void createIndices(ElasticClient client, String indexName) throws IOException {
         // create index and add mappings
         Map<String, Object> settings = new HashMap<>();
         settings.put(
@@ -158,7 +158,7 @@ public class ElasticTestSupport {
                 }
             }
         }
-        performRequest("PUT", "/" + indexName, settings);
+        performRequest(client, "PUT", "/" + indexName, settings);
 
         // add alias
         Map<String, Object> aliases =
@@ -167,7 +167,11 @@ public class ElasticTestSupport {
                         ImmutableList.of(
                                 ImmutableMap.of(
                                         "index", indexName, "alias", indexName + "_alias")));
-        performRequest("PUT", "/_alias", aliases);
+        performRequest(client, "PUT", "/_alias", aliases);
+    }
+
+    private void createIndices() throws IOException {
+        createIndices(client, indexName);
     }
 
     private void indexDocuments(String status) throws IOException {
@@ -248,6 +252,12 @@ public class ElasticTestSupport {
     }
 
     private void performRequest(String method, String endpoint, Map<String, Object> body)
+            throws IOException {
+        performRequest(client, method, endpoint, body);
+    }
+
+    protected void performRequest(
+            ElasticClient client, String method, String endpoint, Map<String, Object> body)
             throws IOException {
         ((RestElasticClient) client).performRequest(method, endpoint, body);
     }

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/RestElasticClientTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/RestElasticClientTest.java
@@ -99,7 +99,12 @@ public class RestElasticClientTest {
         SecurityContextHolder.setContext(mockStx);
 
         client = new RestElasticClient(mockRestClient);
-        proxyClient = new RestElasticClient(mockRestClient, mockProxyRestClient, true);
+        proxyClient =
+                new RestElasticClient(
+                        mockRestClient,
+                        mockProxyRestClient,
+                        true,
+                        (Integer) ElasticDataStoreFactory.RESPONSE_BUFFER_LIMIT.sample);
 
         InputStream inputStream = new ByteArrayInputStream("{}".getBytes());
         when(mockEntity.getContent()).thenReturn(inputStream);
@@ -138,7 +143,8 @@ public class RestElasticClientTest {
                         + "{\"properties\": {\"status_s\": {\"type\": \"keyword\"}}}}}";
         InputStream inputStream = new ByteArrayInputStream(content.getBytes());
         when(mockEntity.getContent()).thenReturn(inputStream);
-        when(mockRestClient.performRequest(new Request("GET", "/status_s/_mapping")))
+        when(mockRestClient.performRequest(
+                        (argThat((req) -> "/status_s/_mapping".equals(req.getEndpoint())))))
                 .thenReturn(mockResponse);
 
         List<String> names = client.getTypes("status_s");
@@ -153,7 +159,8 @@ public class RestElasticClientTest {
         InputStream inputStream = new ByteArrayInputStream(content.getBytes());
         when(mockEntity.getContent()).thenReturn(inputStream);
         mockVersion("6.0.0");
-        when(mockRestClient.performRequest(new Request("GET", "/status_s/_mapping")))
+        when(mockRestClient.performRequest(
+                        (argThat((req) -> "/status_s/_mapping".equals(req.getEndpoint())))))
                 .thenReturn(mockResponse);
 
         List<String> names = client.getTypes("status_s");
@@ -168,7 +175,8 @@ public class RestElasticClientTest {
                         + "{\"properties\": {\"status_s\": {\"type\": \"keyword\"}}}}}";
         InputStream inputStream = new ByteArrayInputStream(content.getBytes());
         when(mockEntity.getContent()).thenReturn(inputStream);
-        when(mockRestClient.performRequest(new Request("GET", "/status_s/_mapping")))
+        when(mockRestClient.performRequest(
+                        (argThat((req) -> "/status_s/_mapping".equals(req.getEndpoint())))))
                 .thenReturn(mockResponse);
 
         Map<String, Map<String, String>> expected =
@@ -184,7 +192,8 @@ public class RestElasticClientTest {
         InputStream inputStream = new ByteArrayInputStream(content.getBytes());
         when(mockEntity.getContent()).thenReturn(inputStream);
         mockVersion("6.0.0");
-        when(mockRestClient.performRequest(new Request("GET", "/status_s/_mapping/active")))
+        when(mockRestClient.performRequest(
+                        (argThat((req) -> "/status_s/_mapping/active".equals(req.getEndpoint())))))
                 .thenReturn(mockResponse);
 
         Map<String, Map<String, String>> expected =
@@ -199,7 +208,8 @@ public class RestElasticClientTest {
                         + "{\"properties\": {\"status_s\": {\"type\": \"keyword\"}}}}}}";
         InputStream inputStream = new ByteArrayInputStream(content.getBytes());
         when(mockEntity.getContent()).thenReturn(inputStream);
-        when(mockRestClient.performRequest(new Request("GET", "/status_s/_mapping")))
+        when(mockRestClient.performRequest(
+                        (argThat((req) -> "/status_s/_mapping".equals(req.getEndpoint())))))
                 .thenReturn(mockResponse);
         when(mockRestClient.performRequest(new Request("GET", "/_alias/status_s")))
                 .thenThrow(IOException.class);
@@ -214,7 +224,8 @@ public class RestElasticClientTest {
         String content = "{}";
         InputStream inputStream = new ByteArrayInputStream(content.getBytes());
         when(mockEntity.getContent()).thenReturn(inputStream);
-        when(mockRestClient.performRequest(new Request("GET", "/status_s/_mapping")))
+        when(mockRestClient.performRequest(
+                        (argThat((req) -> "/status_s/_mapping".equals(req.getEndpoint())))))
                 .thenReturn(mockResponse);
         when(mockRestClient.performRequest(new Request("GET", "/_alias/status_s")))
                 .thenThrow(IOException.class);
@@ -229,9 +240,9 @@ public class RestElasticClientTest {
                         + "{\"properties\": {\"status_s\": {\"type\": \"keyword\"}}}}}";
         InputStream inputStream = new ByteArrayInputStream(content.getBytes());
         when(mockEntity.getContent()).thenReturn(inputStream);
-        when(mockRestClient.performRequest(new Request("GET", "/status_s/_mapping")))
+        when(mockRestClient.performRequest(
+                        (argThat((req) -> "/status_s/_mapping".equals(req.getEndpoint())))))
                 .thenReturn(mockResponse);
-
         Map<String, Map<String, String>> expected =
                 ImmutableMap.of("status_s", ImmutableMap.of("type", "keyword"));
         assertEquals(expected, client.getMapping("status_s", "active"));


### PR DESCRIPTION
[![GEOT-7418](https://badgen.net/badge/JIRA/GEOT-7418/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7418) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4431
 **Authored by:** @turingtestfail