### PR TITLE
[Backport 28.x] [GEOT-7425] Add support for extended colorMap in CSS

### DIFF
--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
@@ -1455,6 +1455,13 @@ public class CssTranslator {
                             throw new IllegalArgumentException("Invalid color map type " + type);
                         }
                     }
+
+                    String extended = getLiteral(values, "raster-color-map-extended", i, null);
+                    if (extended != null) {
+                        cmb.extended(Boolean.valueOf(extended));
+                    } else if (cm.values.size() > 255) {
+                        cmb.extended(true);
+                    }
                 }
             }
 


### PR DESCRIPTION
[![GEOT-7425](https://badgen.net/badge/JIRA/GEOT-7425/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7425) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4434
 **Authored by:** @aaime