### PR TITLE
[Backport 28.x] Bump org.springframework.security:spring-security-core to 5.7.10

### DIFF
--- a/modules/unsupported/elasticsearch/pom.xml
+++ b/modules/unsupported/elasticsearch/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>5.1.13.RELEASE</version>
+      <version>5.7.10</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Backport #4437
 **Authored by:** @mprins