### PR TITLE
[Backport 29.x] Bump `batik.version` from 1.16 to 1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <series>stable</series>
     <!-- dependency management -->
-    <batik.version>1.16</batik.version>
+    <batik.version>1.17</batik.version>
     <commons-beanutils.version>1.9.2</commons-beanutils.version>
     <db2.jdbc.version>11.5.6.0</db2.jdbc.version>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>


### PR DESCRIPTION
Backport #4446
 **Authored by:** @dependabot[bot]