### PR TITLE
[GEOT-7427] Vector Mosaic add native filtering support when query is exclusively granule or index fields

### DIFF
--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureSource.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureSource.java
@@ -36,6 +36,7 @@ import org.geotools.data.DataStore;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureSource;
+import org.geotools.data.FilteringFeatureReader;
 import org.geotools.data.Query;
 import org.geotools.data.Repository;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -172,8 +173,11 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
     }
 
     @Override
+    // original instance is null, no need to clase at reassignment
+    @SuppressWarnings("PMD.CloseResource")
     protected FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(Query query)
             throws IOException {
+        FeatureReader<SimpleFeatureType, SimpleFeature> out = null;
         Name dsname = buildName(delegateStoreName);
         DataStore delegateDataStore = repository.dataStore(dsname);
         Filter splitFilterIndex =
@@ -181,7 +185,20 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
         SimpleFeatureSource delegateFeatureSource =
                 delegateDataStore.getFeatureSource(delegateStoreTypeName);
         SimpleFeatureCollection features = delegateFeatureSource.getFeatures(splitFilterIndex);
-        return new VectorMosaicFeatureReader(features, query, this);
+        out = new VectorMosaicFeatureReader(features, query, this);
+        if (query.getFilter() != null) {
+            Filter filter = query.getFilter();
+            boolean filterIsAllIndex =
+                    allFilterAttributesAreInType(delegateFeatureSource.getSchema(), filter);
+            SimpleFeatureType granuleType = getGranuleType();
+            boolean filterIsAllGranule = allFilterAttributesAreInType(granuleType, filter);
+            // filter is not all index and not all granule, so wrap in FilteringFeatureReader
+            if (!filterIsAllIndex && !filterIsAllGranule) {
+                out = new FilteringFeatureReader<>(out, filter);
+            }
+        }
+
+        return out;
     }
 
     /**
@@ -305,23 +322,50 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
         return dataStore;
     }
 
+    private DataStore getDataStoreByName(String typeName) {
+        Name dsname = buildName(typeName);
+        return repository.dataStore(dsname);
+    }
+
+    private Set<String> getAttributeNamesForType(String storeName, String typeName)
+            throws IOException {
+        DataStore dataStore = getDataStoreByName(storeName);
+        SimpleFeatureType featureType = dataStore.getSchema(typeName);
+        return getAttributeNamesForType(featureType);
+    }
+
+    private Set<String> getAttributeNamesForType(SimpleFeatureType featureType) throws IOException {
+        return featureType.getAttributeDescriptors().stream()
+                .map(AttributeDescriptor::getLocalName)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean allFilterAttributesAreInType(String storeName, String typeName, Filter filter)
+            throws IOException {
+        Set<String> indexAttributeNames = getAttributeNamesForType(storeName, typeName);
+        String[] filterAttributeNames = DataUtilities.attributeNames(filter);
+        return indexAttributeNames.containsAll(Arrays.asList(filterAttributeNames));
+    }
+
+    private boolean allFilterAttributesAreInType(SimpleFeatureType featureType, Filter filter)
+            throws IOException {
+        Set<String> indexAttributeNames = getAttributeNamesForType(featureType);
+        String[] filterAttributeNames = DataUtilities.attributeNames(filter);
+        return indexAttributeNames.containsAll(Arrays.asList(filterAttributeNames));
+    }
+
     @Override
     protected boolean handleVisitor(Query query, FeatureVisitor visitor) throws IOException {
         // check if visitor is aggregate visitor
         if (visitor instanceof MaxVisitor
                 || visitor instanceof MinVisitor
                 || visitor instanceof UniqueVisitor) {
-            Name dsname = buildName(delegateStoreName);
-            DataStore delegateDataStore = repository.dataStore(dsname);
-            SimpleFeatureType delegateSchema = delegateDataStore.getSchema(delegateStoreTypeName);
             Set<String> indexAttributeNames =
-                    delegateSchema.getAttributeDescriptors().stream()
-                            .map(AttributeDescriptor::getLocalName)
-                            .collect(Collectors.toSet());
+                    getAttributeNamesForType(delegateStoreName, delegateStoreTypeName);
             // check if all filter attributes are in index/delegate
             if (query.getFilter() != null) {
-                String[] filterAttributeNames = DataUtilities.attributeNames(query.getFilter());
-                if (!indexAttributeNames.containsAll(Arrays.asList(filterAttributeNames))) {
+                if (!allFilterAttributesAreInType(
+                        delegateStoreName, delegateStoreTypeName, query.getFilter())) {
                     return false;
                 }
             }
@@ -340,6 +384,7 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
             // this avoids query properties being set with granule attributes
             query.setPropertyNames(visitorExpressionFields);
             // visitor is aggregate type and all attributes are in index/delegate
+            DataStore delegateDataStore = getDataStoreByName(delegateStoreName);
             delegateDataStore
                     .getFeatureSource(delegateStoreTypeName)
                     .getFeatures(query)
@@ -368,6 +413,10 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
         }
     }
 
+    @Override
+    protected boolean canFilter() {
+        return true;
+    }
     /**
      * Validates and loads the connection string properties into the granule
      *


### PR DESCRIPTION
[![GEOT-7427](https://badgen.net/badge/JIRA/GEOT-7427/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7427) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…exclusively granule or index fields

cleanup

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->