### PR TITLE
[GEOT-7429] Vector Mosaic add native retyping support when query is exclusively granule or index fields

### DIFF
--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureReader.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureReader.java
@@ -209,12 +209,9 @@ public class VectorMosaicFeatureReader implements SimpleFeatureReader {
             String attributeName = mergedType.getDescriptor(i).getLocalName();
             if (contains(query.getPropertyNames(), attributeName)) {
                 typeBuilder.add(mergedType.getDescriptor(i));
-            }
-            if (mergedType
-                    .getDescriptor(i)
-                    .getLocalName()
-                    .equals(mergedType.getGeometryDescriptor().getLocalName())) {
-                geomAdded = true;
+                if (attributeName.equals(mergedType.getGeometryDescriptor().getLocalName())) {
+                    geomAdded = true;
+                }
             }
         }
         if (geomAdded) {


### PR DESCRIPTION
[![GEOT-7429](https://badgen.net/badge/JIRA/GEOT-7429/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7429) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…xclusively granule or index fields

clean

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->