### PR TITLE
[GEOT-7431] Support custom HTTP headers for WFS-Client and HTTP-Client

### DIFF
--- a/modules/library/http/pom.xml
+++ b/modules/library/http/pom.xml
@@ -60,6 +60,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>

--- a/modules/library/http/src/main/java/org/geotools/http/DelegateHTTPClient.java
+++ b/modules/library/http/src/main/java/org/geotools/http/DelegateHTTPClient.java
@@ -36,6 +36,13 @@ public class DelegateHTTPClient implements HTTPClient {
     }
 
     @Override
+    public HTTPResponse post(
+            URL url, InputStream postContent, String postContentType, Map<String, String> headers)
+            throws IOException {
+        return delegate.post(url, postContent, postContentType, headers);
+    }
+
+    @Override
     public HTTPResponse get(URL url) throws IOException {
         return delegate.get(url);
     }

--- a/modules/library/http/src/main/java/org/geotools/http/HTTPClient.java
+++ b/modules/library/http/src/main/java/org/geotools/http/HTTPClient.java
@@ -54,6 +54,35 @@ public interface HTTPClient {
     HTTPResponse post(URL url, InputStream postContent, String postContentType) throws IOException;
 
     /**
+     * Executes an HTTP POST request against the provided URL, sending the contents of {@code
+     * postContent} as the POST method body and setting the Content-Type request header to {@code
+     * postContentType} if given, and returns the server response.
+     *
+     * <p>If an HTTP authentication {@link #getUser() user} and {@link #getPassword() password} is
+     * set, the appropriate authentication HTTP header will be sent with the request.
+     *
+     * <p>If a {@link #getConnectTimeout() connection timeout} is set, the http connection will be
+     * set to respect that timeout.
+     *
+     * <p>If a {@link #getReadTimeout() read timeout} is set, the http connection will be set to
+     * respect it.
+     *
+     * <p>header parameter contains additional headers to add to the request.
+     *
+     * @param url the URL against which to execute the POST request
+     * @param postContent an input stream with the contents of the POST body
+     * @param postContentType the MIME type of the contents sent as the request POST body, can be
+     *     {@code null}
+     * @param headers a list of custom headers to add to the request.
+     * @return the {@link HTTPResponse} encapsulating the response to the HTTP POST request
+     */
+    default HTTPResponse post(
+            URL url, InputStream postContent, String postContentType, Map<String, String> headers)
+            throws IOException {
+        return post(url, postContent, postContentType);
+    }
+
+    /**
      * Executes an HTTP GET request against the provided URL and returns the server response.
      *
      * <p>If an HTTP authentication {@link #getUser() user} and {@link #getPassword() password} is

--- a/modules/library/http/src/main/java/org/geotools/http/LoggingHTTPClient.java
+++ b/modules/library/http/src/main/java/org/geotools/http/LoggingHTTPClient.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.util.logging.Logging;
@@ -65,10 +66,40 @@ public class LoggingHTTPClient extends DelegateHTTPClient {
     }
 
     @Override
+    public HTTPResponse post(
+            URL url, InputStream postContent, String postContentType, Map<String, String> headers)
+            throws IOException {
+        final int myCount = ++counter;
+        LOGGER.info(
+                String.format(
+                        "POST Request #%d URL with additional headers %s : %s",
+                        myCount, headers, url));
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            copy(postContent, out);
+            LOGGER.finest("POST Request Body: \n" + out.toString(charsetName));
+
+            postContent = new ByteArrayInputStream(out.toByteArray());
+        }
+        return new LoggingHTTPResponse(
+                delegate.post(url, postContent, postContentType, headers), charsetName, myCount);
+    }
+
+    @Override
     public HTTPResponse get(URL url) throws IOException {
         final int myCount = ++counter;
         LOGGER.info(String.format("GET Request #%d URL: %s", myCount, url));
         return new LoggingHTTPResponse(delegate.get(url), charsetName, myCount);
+    }
+
+    @Override
+    public HTTPResponse get(URL url, Map<String, String> headers) throws IOException {
+        final int myCount = ++counter;
+        LOGGER.info(
+                String.format(
+                        "GET Request #%d URL with additional headers %s : %s",
+                        myCount, headers, url));
+        return new LoggingHTTPResponse(delegate.get(url, headers), charsetName, myCount);
     }
 
     static void copy(InputStream input, OutputStream output) throws IOException {

--- a/modules/library/http/src/test/java/org/geotools/http/DefaultHTTPClientFactoryTest.java
+++ b/modules/library/http/src/test/java/org/geotools/http/DefaultHTTPClientFactoryTest.java
@@ -17,13 +17,33 @@ package org.geotools.http;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
 import java.util.LinkedList;
 import org.geotools.util.factory.Hints;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /** @author Roar Brænden */
 public class DefaultHTTPClientFactoryTest {
+
+    private URL url;
+    private ByteArrayInputStream postBody = new ByteArrayInputStream("GeoTools".getBytes());
+    private HTTPResponse mockResponse = Mockito.mock(HTTPResponse.class);
+    private HTTPClient mockClient = Mockito.mock(HTTPClient.class);
+
+    @Before
+    public void setUp() throws MalformedURLException {
+        url = new URL("http://dummy");
+    }
 
     @Test
     public void testBasicUsage() throws Exception {
@@ -33,11 +53,36 @@ public class DefaultHTTPClientFactoryTest {
         assertTrue(client instanceof SimpleHttpClient);
     }
 
+    /**
+     * Tests if 1) hint for logging produces expected client and 2) client calls expected API of
+     * delegate, to pass on headers. Also covers {@link DelegateHTTPClient}.
+     *
+     * @throws Exception
+     */
     @Test
     public void testLoggingUsage() throws Exception {
         HTTPClientFactory factory = new DefaultHTTPClientFactory();
         HTTPClient client =
                 factory.createClient(new Hints(Hints.HTTP_LOGGING, "TRUE"), new LinkedList<>());
         assertTrue(client instanceof LoggingHTTPClient);
+
+        LoggingHTTPClient loggingClient = (LoggingHTTPClient) client;
+
+        when(mockClient.get(any())).thenReturn(mockResponse);
+        when(mockClient.get(any(), any())).thenReturn(mockResponse);
+        when(mockClient.post(any(), any(), any())).thenReturn(mockResponse);
+        when(mockClient.post(any(), any(), any(), any())).thenReturn(mockResponse);
+
+        loggingClient.delegate = mockClient;
+
+        loggingClient.get(url);
+        loggingClient.get(url, Collections.emptyMap());
+        loggingClient.post(url, postBody, "text/plain");
+        loggingClient.post(url, postBody, "text/plain", Collections.emptyMap());
+
+        verify(mockClient, times(1)).get(any());
+        verify(mockClient, times(1)).get(any(), any());
+        verify(mockClient, times(1)).post(any(), any(), any());
+        verify(mockClient, times(1)).post(any(), any(), any(), any());
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/data/ows/AbstractOpenWebService.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/AbstractOpenWebService.java
@@ -360,7 +360,7 @@ public abstract class AbstractOpenWebService<C extends Capabilities, R extends O
         if (exception != null) {
             IOException e =
                     new IOException(
-                            "Could not establish version neogitation: " + exception.getMessage(),
+                            "Could not establish version negotiation: " + exception.getMessage(),
                             exception);
             throw e;
         } else {
@@ -448,7 +448,11 @@ public abstract class AbstractOpenWebService<C extends Capabilities, R extends O
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 request.performPostOutput(out);
                 try (InputStream in = getStream(out)) {
-                    httpResponse = httpClient.post(finalURL, in, postContentType);
+                    if (headers == null) {
+                        httpResponse = httpClient.post(finalURL, in, postContentType);
+                    } else {
+                        httpResponse = httpClient.post(finalURL, in, postContentType, headers);
+                    }
                 }
             } else {
                 if (headers == null) {

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
@@ -127,7 +127,7 @@ public class WFSDataAccessFactory implements DataAccessFactory {
     }
 
     /** Access with {@link WFSDataStoreFactory#getParametersInfo()  */
-    private static final WFSFactoryParam<?>[] parametersInfo = new WFSFactoryParam[23];
+    private static final WFSFactoryParam<?>[] parametersInfo = new WFSFactoryParam[24];
 
     private static final int GMLComplianceLevel = 2;
 
@@ -574,6 +574,22 @@ public class WFSDataAccessFactory implements DataAccessFactory {
                 SCHEMA_CACHE_LOCATION =
                         new WFSFactoryParam<>(
                                 name, String.class, title, description, null, "program");
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static final WFSFactoryParam<Map> ADDITIONAL_HEADERS;
+
+    static {
+        String name = "WFSDataStoreFactory:ADDITIONAL_HEADERS";
+        String title = "Set additional HTTP request headers.";
+        String description =
+                "The given HTTP headers will be set on HTTP requests in addition to "
+                        + "the regular GeoTools managed headers (like Accept-Enconding, Content-type, "
+                        + "User-Agent, Authorization). Provided values must not conflict with GeoTools "
+                        + "managed headers. Parameters must use String keys and values.";
+        parametersInfo[23] =
+                ADDITIONAL_HEADERS =
+                        new WFSFactoryParam<>(name, Map.class, title, description, null, "program");
     }
 
     /**

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
@@ -78,7 +78,8 @@ public class WFSClient extends AbstractOpenWebService<WFSGetCapabilities, QName>
                 httpClient,
                 capabilities,
                 Collections.singletonMap(
-                        XMLHandlerHints.ENTITY_RESOLVER, config.getEntityResolver()));
+                        XMLHandlerHints.ENTITY_RESOLVER, config.getEntityResolver()),
+                config.additionalHeaders);
         this.config = config;
         super.specification = determineCorrectStrategy();
         ((WFSStrategy) specification).setCapabilities(super.capabilities);


### PR DESCRIPTION
[![GEOT-7431](https://badgen.net/badge/JIRA/GEOT-7431/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7431) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

From [GEOT-7431](https://osgeo-org.atlassian.net/browse/GEOT-7431): 

GeoTools WFS-Client should support sending custom HTTP request headers for GET and POST requests.

This is useful for various scenarios, for example for sending custom authentication and authorization headers (bearer tokens etc).

This includes the following tasks:

    WFSClient inherits an headers field already, but there is no way to init -> provide further constructor

    WFSClient.headers must be passed on the HTTPClient. Done for GET requests -> implement for POST

    HTTPClient provides an API for additional HTTP headers for GET only -> implement accordingly for POST.

 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).