### PR TITLE
GEOT-7422 Update javax.measure.unit to version 2.2 and replace Metric…

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/measure/PrefixDefinitions.java
+++ b/modules/library/metadata/src/main/java/org/geotools/measure/PrefixDefinitions.java
@@ -20,8 +20,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static javax.measure.MetricPrefix.ATTO;
 import static javax.measure.MetricPrefix.CENTI;
+import static javax.measure.MetricPrefix.DECA;
 import static javax.measure.MetricPrefix.DECI;
-import static javax.measure.MetricPrefix.DEKA;
 import static javax.measure.MetricPrefix.EXA;
 import static javax.measure.MetricPrefix.FEMTO;
 import static javax.measure.MetricPrefix.GIGA;
@@ -59,7 +59,7 @@ public final class PrefixDefinitions {
                             PrefixDefinition.of(MEGA),
                             PrefixDefinition.of(KILO),
                             PrefixDefinition.of(HECTO),
-                            PrefixDefinition.of(DEKA),
+                            PrefixDefinition.of(DECA),
                             PrefixDefinition.of(DECI),
                             PrefixDefinition.of(CENTI),
                             PrefixDefinition.of(MILLI),
@@ -89,7 +89,7 @@ public final class PrefixDefinitions {
                             PrefixDefinition.of(MEGA),
                             // no kilo
                             PrefixDefinition.of(HECTO),
-                            PrefixDefinition.of(DEKA),
+                            PrefixDefinition.of(DECA),
                             PrefixDefinition.of(DECI),
                             PrefixDefinition.of(CENTI),
                             PrefixDefinition.of(MILLI),

--- a/pom.xml
+++ b/pom.xml
@@ -573,7 +573,7 @@
       <dependency>
         <groupId>javax.measure</groupId>
         <artifactId>unit-api</artifactId>
-        <version>2.1.3</version>
+        <version>2.2</version>
       </dependency>
 
       <!-- Java Advanced Imaging (JAI) -->


### PR DESCRIPTION
[![GEOT-7422](https://badgen.net/badge/JIRA/GEOT-7422/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7422) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR for GEOT-7422

Update javax.measure.unit to version 2.2 and replace MetricPrefix.DEKA (American spelling) with MetricPrefix.DECA (International spelling)