### PR TITLE
[GEOT-7437] Avoid use of yield keyword for JDK 17 compatibility

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/xml/gml/FCBuffer.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/gml/FCBuffer.java
@@ -176,7 +176,7 @@ public class FCBuffer extends Thread implements FeatureReader<SimpleFeatureType,
         Date d = new Date(Calendar.getInstance().getTimeInMillis() + timeout);
 
         while ((ft == null) && ((state != FINISH) && (state != STOP))) {
-            yield(); // let the parser run ... this is being called from
+            Thread.yield(); // let the parser run ... this is being called from
 
             if (d.before(Calendar.getInstance().getTime())) {
                 exception = new SAXException("Timeout");
@@ -316,7 +316,7 @@ public class FCBuffer extends Thread implements FeatureReader<SimpleFeatureType,
         } catch (SAXException e) {
             exception = e;
             state = STOP;
-            yield();
+            Thread.yield();
         }
     }
 


### PR DESCRIPTION
[![GEOT-7437](https://badgen.net/badge/JIRA/GEOT-7437/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7437) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

JEP 361 (Switch expression - https://openjdk.org/jeps/361) makes `yield` into a restricted identifier.

The JEP says:

>  If there is a unary method yield in scope, then the expression yield(x) would be ambiguous (could be either a method call, or a yield statement whose operand is a parenthesized expression), and this ambiguity is resolved in favor of the yield statement. If the method invocation is preferred then the method should be qualified, with this for an instance method or the class name for a static method.


There are two places (single class) where that causes a problem in GeoTools for yield() , and this PR adds the class name for the static method.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [N/A] New unit tests have been added covering the changes.
- [N/A] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).