### PR TITLE
[GEOT-7443] Remove JDK 11 profile and rename associated JDK 11 Test

### DIFF
--- a/modules/unsupported/javafx/src/test/java/org/geotools/javafx/FXMapTest.java
+++ b/modules/unsupported/javafx/src/test/java/org/geotools/javafx/FXMapTest.java
@@ -17,7 +17,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.testfx.framework.junit.ApplicationTest;
 
-public class FXMapJDK11Test extends ApplicationTest {
+public class FXMapTest extends ApplicationTest {
 
     private static FXMap map;
 
@@ -25,7 +25,7 @@ public class FXMapJDK11Test extends ApplicationTest {
     private static final int sceneWidth = 750;
 
     private static GeneralBounds initialBounds;
-    private static final Logger log = Logger.getLogger(FXMapJDK11Test.class.getName());
+    private static final Logger log = Logger.getLogger(FXMapTest.class.getName());
     private static final String mapEPSG = "EPSG:4326";
     private static final String wmsLayer = "OpenStreetMap WMS - by terrestris";
     private static final String wmsURL = "http://ows.terrestris.de/osm/service";

--- a/pom.xml
+++ b/pom.xml
@@ -440,9 +440,6 @@
   <!--     stress             Profile to activate tests which end  -->
   <!--                        in "StressTest.java"                 -->
   <!--                                                             -->
-  <!--     jdk11test          Profile to activate tests which end  -->
-  <!--                        in "JDK11Test.java"                  -->
-  <!--                                                             -->
   <!--     dependencycheck    Profile to check dependency versions -->
   <!--                                                             -->
   <!--   Example:                                                  -->
@@ -512,7 +509,6 @@
     <interactive.image>false</interactive.image>
     <interactive.tests>false</interactive.tests>
     <java.awt.headless>true</java.awt.headless>
-    <jdk11test.skip.pattern>**/*JDK11Test.java</jdk11test.skip.pattern>
     <jvm.opts></jvm.opts>
     <lint>deprecation,unchecked</lint>
     <logging-profile>quiet-logging</logging-profile>
@@ -1754,7 +1750,6 @@
             <exclude>${online.skip.pattern}</exclude>
             <exclude>${stress.skip.pattern}</exclude>
             <exclude>${test.exclude.pattern}</exclude>
-            <exclude>${jdk11test.skip.pattern}</exclude>
           </excludes>
           <systemPropertyVariables>
             <org.geotools.test.extensive>${extensive.tests}</org.geotools.test.extensive>
@@ -2314,12 +2309,6 @@
       </properties>
     </profile>
     <profile>
-      <id>jdk11test</id>
-      <properties>
-        <jdk11test.skip.pattern>disabled</jdk11test.skip.pattern>
-      </properties>
-    </profile>
-    <profile>
       <id>site.local</id>
       <distributionManagement>
         <site>
@@ -2411,9 +2400,6 @@
               <excludeRoots>
                 <excludeRoot>target/generated-sources</excludeRoot>
               </excludeRoots>
-              <excludes>
-                <exclude>**/*JDK11Test.java</exclude>
-              </excludes>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
[![GEOT-7443](https://badgen.net/badge/JIRA/GEOT-7443/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7443) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The build system has a JDK11Test profile. AFAICT (and it looks like I was the one that added it about three years ago - don't really remember it though), that isn't actually JDK 11 though - its really "not JDK 8" or "JDK 11 or later".


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [N/A] New unit tests have been added covering the changes.
- [N/A] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).