### PR TITLE
[Backport 28.x] [GEOT-7363] ParseException if returning POLYGON EMPTY

### DIFF
--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEmptyGeometryOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCEmptyGeometryOnlineTest.java
@@ -69,12 +69,13 @@ public abstract class JDBCEmptyGeometryOnlineTest extends JDBCTestSupport {
         WKTReader reader = new WKTReader();
         Geometry emptyGeometry = reader.read(type.toUpperCase() + " EMPTY");
 
+        String emptyGeometryName = aname("geom_" + type.toLowerCase());
         try (Transaction tx = new DefaultTransaction();
                 FeatureWriter<SimpleFeatureType, SimpleFeature> writer =
                         dataStore.getFeatureWriterAppend(tname("empty"), tx)) {
             SimpleFeature feature = writer.next();
             feature.setAttribute(aname("id"), Integer.valueOf(100));
-            feature.setAttribute(aname("geom_" + type.toLowerCase()), emptyGeometry);
+            feature.setAttribute(emptyGeometryName, emptyGeometry);
             feature.setAttribute(aname("name"), new String("empty " + type));
             writer.write();
             writer.close();
@@ -85,9 +86,15 @@ public abstract class JDBCEmptyGeometryOnlineTest extends JDBCTestSupport {
         assertEquals(1, fc.size());
         try (SimpleFeatureIterator fi = fc.features()) {
             SimpleFeature nf = fi.next();
-            Geometry geometry = (Geometry) nf.getDefaultGeometry();
-            // either null or empty, we don't really care
-            assertTrue(geometry == null || geometry.isEmpty());
+            Geometry geometry = (Geometry) nf.getAttribute(emptyGeometryName);
+            assertEmptyGeometry(geometry);
         }
+    }
+
+    /**
+     * By default checks the geometry is either null or empty, subclasses can change this behavior
+     */
+    protected void assertEmptyGeometry(Geometry geometry) {
+        assertTrue(geometry == null || geometry.isEmpty());
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/WKBReader.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/WKBReader.java
@@ -261,6 +261,13 @@ public class WKBReader {
 
     private Point readPoint() throws IOException, ParseException {
         CoordinateSequence pts = readCoordinateSequence(1);
+        boolean empty = true;
+        for (int i = 0; i < pts.getDimension(); i++) {
+            if (!Double.isNaN(pts.getOrdinate(0, i))) {
+                empty = false;
+            }
+        }
+        if (empty) return factory.createPoint();
         return factory.createPoint(pts);
     }
 
@@ -296,6 +303,8 @@ public class WKBReader {
 
     protected Polygon readPolygon() throws IOException, ParseException {
         int numRings = dis.readInt();
+        if (numRings == 0) return factory.createPolygon();
+
         LinearRing[] holes = null;
         if (numRings > 1) holes = new LinearRing[numRings - 1];
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -1371,7 +1371,7 @@ public class PostGISDialect extends BasicSQLDialect {
     @Override
     public void encodeGeometryValue(Geometry value, int dimension, int srid, StringBuffer sql)
             throws IOException {
-        if (value == null || value.isEmpty()) {
+        if (value == null) {
             sql.append("NULL");
         } else {
             if (value instanceof LinearRing && !(value instanceof CurvedRing)) {

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
@@ -244,7 +244,7 @@ public class PostGISPSDialect extends PreparedStatementSQLDialect {
     public void setGeometryValue(
             Geometry g, int dimension, int srid, Class binding, PreparedStatement ps, int column)
             throws SQLException {
-        if (g != null && !g.isEmpty()) {
+        if (g != null) {
             if (g instanceof LinearRing) {
                 // postgis does not handle linear rings, convert to just a line string
                 g = g.getFactory().createLineString(((LinearRing) g).getCoordinateSequence());

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISEmptyGeometryOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISEmptyGeometryOnlineTest.java
@@ -16,13 +16,22 @@
  */
 package org.geotools.data.postgis;
 
+import static org.junit.Assert.assertTrue;
+
 import org.geotools.jdbc.JDBCEmptyGeometryOnlineTest;
 import org.geotools.jdbc.JDBCEmptyGeometryTestSetup;
+import org.locationtech.jts.geom.Geometry;
 
 public class PostGISEmptyGeometryOnlineTest extends JDBCEmptyGeometryOnlineTest {
 
     @Override
     protected JDBCEmptyGeometryTestSetup createTestSetup() {
         return new PostGISEmptyGeometryTestSetup(new PostGISTestSetup());
+    }
+
+    @Override
+    protected void assertEmptyGeometry(Geometry geometry) {
+        // strict, we insert an empty geometry and want one back, not a null
+        assertTrue(geometry.isEmpty());
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostGISEmptyGeometryOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostGISEmptyGeometryOnlineTest.java
@@ -16,14 +16,23 @@
  */
 package org.geotools.data.postgis.ps;
 
+import static org.junit.Assert.assertTrue;
+
 import org.geotools.data.postgis.PostGISEmptyGeometryTestSetup;
 import org.geotools.jdbc.JDBCEmptyGeometryOnlineTest;
 import org.geotools.jdbc.JDBCEmptyGeometryTestSetup;
+import org.locationtech.jts.geom.Geometry;
 
 public class PostGISEmptyGeometryOnlineTest extends JDBCEmptyGeometryOnlineTest {
 
     @Override
     protected JDBCEmptyGeometryTestSetup createTestSetup() {
         return new PostGISEmptyGeometryTestSetup(new PostGISPSTestSetup());
+    }
+
+    @Override
+    protected void assertEmptyGeometry(Geometry geometry) {
+        // strict, we insert an empty geometry and want one back, not a null
+        assertTrue(geometry.isEmpty());
     }
 }


### PR DESCRIPTION
Backport #4419
 **Authored by:** @aaime