### PR TITLE
[GEOT-7444] HanaGeographyOnlineTest.testBounds is failing in CI

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
@@ -19,9 +19,11 @@ package org.geotools.data.hana;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.GeometryDescriptor;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.JDBCGeographyOnlineTest;
 import org.geotools.jdbc.JDBCGeographyTestSetup;
 import org.geotools.jdbc.VirtualTable;
@@ -71,5 +73,14 @@ public class HanaGeographyOnlineTest extends JDBCGeographyOnlineTest {
                                 .getCoordinateReferenceSystem(),
                         false);
         assertEquals(4326, epsg);
+    }
+
+    @Override
+    public void testBounds() throws Exception {
+        assumeTrue(isGeographySupportAvailable());
+
+        ReferencedEnvelope env = dataStore.getFeatureSource(tname("geopoint")).getBounds();
+        ReferencedEnvelope expected = new ReferencedEnvelope(-110, 0, 29, 49, decodeEPSG(4326));
+        assertTrue(env.boundsEquals2D(expected, Math.ulp(1.0)));
     }
 }


### PR DESCRIPTION
Recent changes in geography bounding box computations might return bounding boxes that are slightly off compared to the actual values. This is a result of spheroid projection and unprojection.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).
