### PR TITLE
[Backport 28.x] [GEOT-7444] HanaGeographyOnlineTest.testBounds is failing in CI

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
@@ -19,7 +19,9 @@ package org.geotools.data.hana;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.JDBCGeographyOnlineTest;
 import org.geotools.jdbc.JDBCGeographyTestSetup;
 import org.geotools.jdbc.VirtualTable;
@@ -71,5 +73,14 @@ public class HanaGeographyOnlineTest extends JDBCGeographyOnlineTest {
                                 .getCoordinateReferenceSystem(),
                         false);
         assertEquals(4326, epsg);
+    }
+
+    @Override
+    public void testBounds() throws Exception {
+        assumeTrue(isGeographySupportAvailable());
+
+        ReferencedEnvelope env = dataStore.getFeatureSource(tname("geopoint")).getBounds();
+        ReferencedEnvelope expected = new ReferencedEnvelope(-110, 0, 29, 49, decodeEPSG(4326));
+        assertTrue(env.boundsEquals2D(expected, Math.ulp(1.0)));
     }
 }


### PR DESCRIPTION
[![GEOT-7444](https://badgen.net/badge/JIRA/GEOT-7444/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7444) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4484
 **Authored by:** @stefanuhrig