### PR TITLE
[GEOT-7461] Fix javadoc in swing module

### DIFF
--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/AbstractMapPane.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/AbstractMapPane.java
@@ -346,7 +346,7 @@ public abstract class AbstractMapPane extends JPanel
      *
      * @return true if the pane is currently accepting repaint requests; false if it is ignoring
      *     them
-     * @see #setRepaint(boolean)
+     * @see #setIgnoreRepaint(boolean)
      */
     public boolean isAcceptingRepaints() {
         return acceptRepaintRequests.get();

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/JMapFrame.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/JMapFrame.java
@@ -62,7 +62,7 @@ import org.geotools.swing.tool.ScrollWheelTool;
  * }</pre>
  *
  * @see MapLayerTable
- * @see StatusBar
+ * @see JMapStatusBar
  * @author Michael Bedward
  * @since 2.6
  * @version $Id$

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/MapLayerTable.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/MapLayerTable.java
@@ -127,15 +127,15 @@ public class MapLayerTable extends JPanel {
         doSetMapPane(mapPane);
     }
 
-    /**
-     * Helper for {@link #setMapPane(MapPane). This is just defined so that
-     * it can be called from the constructor without a warning from the compiler
-     * about calling a public overridable method.
-     *
-     * @param mapPane the map pane
-     */
     private Listener listener;
 
+    /**
+     * Helper for {@link #setMapPane(MapPane)}. This is just defined so that it can be called from
+     * the constructor without a warning from the compiler about calling a public overridable
+     * method.
+     *
+     * @param newMapPane the map pane
+     */
     private void doSetMapPane(MapPane newMapPane) {
         listener.disconnectFromMapPane();
         mapPane = newMapPane;

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/MapPane.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/MapPane.java
@@ -78,7 +78,7 @@ public interface MapPane {
      * Sets the area to display in world units.
      *
      * @param envelope the new display area
-     * @throws IllegalArgumentException if {@code envelope} is {@code null]
+     * @throws IllegalArgumentException if {@code envelope} is {@code null}
      */
     void setDisplayArea(Bounds envelope);
 
@@ -124,7 +124,7 @@ public interface MapPane {
 
     /**
      * Registers an object that wishes to receive {@code MapMouseEvent}s such as a {@linkplain
-     * StatusBar}.
+     * org.geotools.swing.control.JMapStatusBar}.
      *
      * @param listener the listener to add
      * @throws IllegalArgumentException if listener is null

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/data/JFileDataStoreChooser.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/data/JFileDataStoreChooser.java
@@ -114,7 +114,7 @@ public class JFileDataStoreChooser extends JFileChooser {
      * Creates a dialog based on the given file associations.
      *
      * <pre><code>
-     * Map<String, String> assoc = new HashMap<String, String>();
+     * Map&lt;String, String&gt; assoc = new HashMap&lt;&gt;();
      * assoc.put(".foo", "Foo data files (*.foo)");
      * assoc.put(".bar", "Bar data files (*.bar)");
      * JFileDataStoreChooser chooser = new JFileDataStoreChooser(assoc);

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/data/JParameterListWizard.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/data/JParameterListWizard.java
@@ -33,11 +33,11 @@ import org.geotools.util.URLs;
  * <p>Example of use (from the GeoTools example project):
  *
  * <pre><code>
- * List<Parameter<?>> list = new ArrayList<Parameter<?>>();
- * list.add(new Parameter<File>("image", File.class, "Image",
+ * List&lt;Parameter&lt;?&gt;&gt; list = new ArrayList&lt;Parameter&lt;?&gt;&gt;();
+ * list.add(new Parameter&lt;File&gt;("image", File.class, "Image",
  * "GeoTiff or World+Image to display as basemap",
  * new KVP( Parameter.EXT, "tif", Parameter.EXT, "jpg")));
- * list.add(new Parameter<File>("shape", File.class, "Shapefile",
+ * list.add(new Parameter&lt;File&gt;("shape", File.class, "Shapefile",
  * "Shapefile contents to display", new KVP(Parameter.EXT, "shp")));
  *
  * JParameterListWizard wizard = new JParameterListWizard("Image Lab",

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/dialog/JAboutDialog.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/dialog/JAboutDialog.java
@@ -57,7 +57,7 @@ import org.geotools.util.factory.GeoTools;
  *           "GeoFoo: Map your foos in real time %nVersion 0.0.1");
  *
  * SwingUtilities.invokeLater(new Runnable() {
- *     &#64Override
+ *     @Override
  *     public void run() {
  *         JAboutDialog dialog = new JAboutDialog("About", appInfo);
  *         DialogUtils.showCentred(dialog);

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/event/MapPaneKeyHandler.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/event/MapPaneKeyHandler.java
@@ -28,8 +28,9 @@ import org.geotools.swing.MapPane;
 
 /**
  * Handles keyboard events for a map pane. This is the default handler for classes derived from
- * {@linkplain AbstractMapPane}. It provides for keyboard-controlled scrolling and zooming of the
- * display. The default key bindings for actions should be suitable for most keyboards.
+ * {@linkplain org.geotools.swing.AbstractMapPane}. It provides for keyboard-controlled scrolling
+ * and zooming of the display. The default key bindings for actions should be suitable for most
+ * keyboards.
  *
  * <p>While the Java Swing toolkit provides its own mechanism for linking key events to actions,
  * this class is somewhat easier to use and provides a model that could be implemented in other
@@ -61,7 +62,7 @@ import org.geotools.swing.MapPane;
  * </code></pre>
  *
  * @see KeyInfo
- * @see AbstractMapPane#setKeyHandler(java.awt.event.KeyListener)
+ * @see org.geotools.swing.AbstractMapPane#setKeyHandler(KeyListener)
  * @author Michael Bedward
  * @since 8.0
  * @version $Id$

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/InfoToolHelper.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/InfoToolHelper.java
@@ -43,8 +43,8 @@ public abstract class InfoToolHelper implements MapBoundsListener {
     private static final Logger LOGGER = Logging.getLogger(InfoToolHelper.class);
 
     /**
-     * String key used for the position element in the {@code Map} passed to {@linkplain #getInfo(
-     * org.geotools.util.KVP )}.
+     * String key used for the position element in the {@code Map} passed to {@linkplain
+     * #getInfo(org.geotools.geometry.Position2D)}.
      */
     public static final String KEY_POSITION = "pos";
 
@@ -55,7 +55,7 @@ public abstract class InfoToolHelper implements MapBoundsListener {
     private MathTransform transform;
 
     /**
-     * CAlled by the helper lookup system when selecting a helper for a given layer.
+     * Called by the helper lookup system when selecting a helper for a given layer.
      *
      * @param layer the layer
      * @return {@code true} is this helper can handle the layer

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/InfoToolHelperUtils.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/InfoToolHelperUtils.java
@@ -50,7 +50,7 @@ public class InfoToolHelperUtils {
     }
 
     /**
-     * Convert the Object returned by {@linkplain GridCoverage2D#evaluate(DirectPosition)} into an
+     * Convert the Object returned by {@linkplain GridCoverage2D#evaluate(org.geotools.api.geometry.Position)  into an
      * array of {@code Numbers}.
      *
      * @param objArray an Object representing a primitive array

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/PanTool.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/PanTool.java
@@ -75,7 +75,8 @@ public class PanTool extends CursorTool {
     }
 
     /**
-     * Respond to a mouse dragged event. Calls {@link org.geotools.swing.MapPane#moveImage()}
+     * Respond to a mouse dragged event. Calls {@link org.geotools.swing.MapPane#moveImage(int,
+     * int)}
      *
      * @param ev the mouse event
      */

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomInTool.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomInTool.java
@@ -37,7 +37,7 @@ import org.geotools.swing.locale.LocaleUtils;
  *
  * <pre>   {@code len = len.old / z} </pre>
  *
- * where {@code z} is the linear zoom increment (>= 1.0)
+ * where {@code z} is the linear zoom increment (&ge; 1.0)
  *
  * <p>The tool also responds to the user drawing a box on the map mapPane with mouse click-and-drag
  * to define the zoomed-in area.

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomInTool.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomInTool.java
@@ -37,7 +37,7 @@ import org.geotools.swing.locale.LocaleUtils;
  *
  * <pre>   {@code len = len.old / z} </pre>
  *
- * where {@code z} is the linear zoom increment (&ge; 1.0)
+ * where {@code z} is the linear zoom increment {@code (>= 1.0)}
  *
  * <p>The tool also responds to the user drawing a box on the map mapPane with mouse click-and-drag
  * to define the zoomed-in area.

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomOutTool.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomOutTool.java
@@ -36,7 +36,7 @@ import org.geotools.swing.locale.LocaleUtils;
  *
  * <pre>   {@code len = len.old * z} </pre>
  *
- * where {@code z} is the linear zoom increment (>= 1.0)
+ * where {@code z} is the linear zoom increment (&ge; 1.0)
  *
  * @author Michael Bedward
  * @since 2.6

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomOutTool.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomOutTool.java
@@ -36,7 +36,7 @@ import org.geotools.swing.locale.LocaleUtils;
  *
  * <pre>   {@code len = len.old * z} </pre>
  *
- * where {@code z} is the linear zoom increment (&ge; 1.0)
+ * where {@code z} is the linear zoom increment  {@code (>= 1.0)}
  *
  * @author Michael Bedward
  * @since 2.6

--- a/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomOutTool.java
+++ b/modules/unsupported/swing/src/main/java/org/geotools/swing/tool/ZoomOutTool.java
@@ -36,7 +36,7 @@ import org.geotools.swing.locale.LocaleUtils;
  *
  * <pre>   {@code len = len.old * z} </pre>
  *
- * where {@code z} is the linear zoom increment  {@code (>= 1.0)}
+ * where {@code z} is the linear zoom increment {@code (>= 1.0)}
  *
  * @author Michael Bedward
  * @since 2.6


### PR DESCRIPTION
[![GEOT-7461](https://badgen.net/badge/JIRA/GEOT-7461/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7461) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Part of https://osgeo-org.atlassian.net/browse/GEOT-7447, this just addresses the swing module.

No code changes.
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->