### PR TITLE
[GEOT-7287] integration check no longer requires the remove-opengis.xml api refactor

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,7 @@ jobs:
 #        echo "Checking out GeoFence"
 #        mkdir geofence
 #        git clone https://github.com/geoserver/geofence.git geofence
-#        echo "Checking out mapfish-print-v2"
+        echo "Checking out mapfish-print-v2"
         mkdir mapfish-print-v2
         git clone https://github.com/mapfish/mapfish-print-v2.git mapfish-print-v2
         echo "Checking out mapfish-print-v3"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,40 +46,43 @@ jobs:
         echo "Checking out GeoServer"
         mkdir geoserver
         git clone https://github.com/geoserver/geoserver.git geoserver
-        echo "Checking out GeoFence"
-        mkdir geofence
-        git clone https://github.com/geoserver/geofence.git geofence
-        echo "Checking out mapfish-print-v2"
+# uncomment when geofence is building against geotools snapshot
+#        echo "Checking out GeoFence"
+#        mkdir geofence
+#        git clone https://github.com/geoserver/geofence.git geofence
+#        echo "Checking out mapfish-print-v2"
         mkdir mapfish-print-v2
         git clone https://github.com/mapfish/mapfish-print-v2.git mapfish-print-v2
         echo "Checking out mapfish-print-v3"
-        mkdir mapfish-print-v3
-        git clone -b opengis-migration https://github.com/mapfish/mapfish-print.git mapfish-print-v3
-    - name: Apply org.opengis removal scripts
-      run: |
-        cd ~
-        find . -name "remove-opengis.xml"
-        cd ~/geowebcache/geowebcache
-        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
-        ant -noinput -buildfile remove-opengis.xml
-        cd ~/geoserver/src
-        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
-        ant -noinput -buildfile remove-opengis.xml
-        cd ~/geofence        
-        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
-        ant -noinput -buildfile remove-opengis.xml
-        cd ~/mapfish-print-v2
-        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
-        ant -noinput -buildfile remove-opengis.xml
-        cd ~/mapfish-print-v3/core/src
-        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
-        ant -noinput -buildfile remove-opengis.xml
-        cd ~/mapfish-print-v3/docs/src
-        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
-        ant -noinput -buildfile remove-opengis.xml
-        cd ~/mapfish-print-v3/examples/src
-        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
-        ant -noinput -buildfile remove-opengis.xml
+# additional check during remove-opengis activity
+#        mkdir mapfish-print-v3
+#        git clone -b opengis-migration https://github.com/mapfish/mapfish-print.git mapfish-print-v3
+# additional check during remove-opengis activity
+#    - name: Apply org.opengis removal scripts
+#      run: |
+#        cd ~
+#        find . -name "remove-opengis.xml"
+#        cd ~/geowebcache/geowebcache
+#        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
+#        ant -noinput -buildfile remove-opengis.xml
+#        cd ~/geoserver/src
+#        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
+#        ant -noinput -buildfile remove-opengis.xml
+#        cd ~/geofence        
+#        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
+#        ant -noinput -buildfile remove-opengis.xml
+#        cd ~/mapfish-print-v2
+#        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
+#        ant -noinput -buildfile remove-opengis.xml
+#        cd ~/mapfish-print-v3/core/src
+#        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
+#        ant -noinput -buildfile remove-opengis.xml
+#        cd ~/mapfish-print-v3/docs/src
+#        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
+#        ant -noinput -buildfile remove-opengis.xml
+#        cd ~/mapfish-print-v3/examples/src
+#        cp ~/work/geotools/geotools/docs/user/welcome/files/remove-opengis.xml .
+#        ant -noinput -buildfile remove-opengis.xml
     - name: Build Mapfish-print v2 with tests
       run: |
         cd ~
@@ -92,13 +95,14 @@ jobs:
         cd ~
         mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f geowebcache/geowebcache/pom.xml install -nsu -Dspotless.apply.skip=true -DskipTests -T2
         mvn -B -f geowebcache/geowebcache/pom.xml test -fae -nsu -T2 -Dspotless.apply.skip=true
-    - name: Build GeoFence with tests
-      run: |
-        export TEST_OPTS="-XX:+UseStringDeduplication -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10"
-        export MAVEN_OPTS="-Xmx1024m $TEST_OPTS"
-        cd ~
-        sed -i "s/<gt-version>29.2<\/gt-version>/<gt-version>30-SNAPSHOT<\/gt-version>/g" geofence/src/services/pom.xml
-        mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f geofence/src/pom.xml install -nsu -T2
+# uncomment when geofence is building against geotools snapshot
+#    - name: Build GeoFence with tests
+#      run: |
+#        export TEST_OPTS="-XX:+UseStringDeduplication -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10"
+#        export MAVEN_OPTS="-Xmx1024m $TEST_OPTS"
+#        cd ~
+#        sed -i "s/<gt-version>29.2<\/gt-version>/<gt-version>30-SNAPSHOT<\/gt-version>/g" geofence/src/services/pom.xml
+#        mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f geofence/src/pom.xml install -nsu -T2
     - name: Build GeoServer with tests
       run: |
         echo "Building GeoServer"
@@ -110,17 +114,18 @@ jobs:
         mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f geoserver/src/pom.xml install -nsu -Prelease -Dspotless.apply.skip=true -DskipTests -T2
         mvn -B -f geoserver/src/community/pom.xml install -nsu -DcommunityRelease -Dspotless.apply.skip=true -DskipTests -T2
         mvn -B -f geoserver/src/pom.xml test -fae -T2 -nsu -Dtest.maxHeapSize=512m -Djvm.opts="$TEST_OPTS" -Prelease -Dspotless.apply.skip=true
-    - name: Build Mapfish-print v3 with tests
-      run: |
-        cd ~/mapfish-print-v3/
-        touch CI.asc
-        echo "staging ~/.m2/repository folder"
-        mkdir -p m2/repository/org
-        cp -r ~/.m2/repository/org/geotools m2/repository/org/geotools
-        make build
-        # make acceptance-tests-up
-        # make acceptance-tests-run
-        # make acceptance-tests-down
+# additional check during remove-opengis activity
+#    - name: Build Mapfish-print v3 with tests
+#      run: |
+#        cd ~/mapfish-print-v3/
+#        touch CI.asc
+#        echo "staging ~/.m2/repository folder"
+#        mkdir -p m2/repository/org
+#        cp -r ~/.m2/repository/org/geotools m2/repository/org/geotools
+#        make build
+#        # make acceptance-tests-up
+#        # make acceptance-tests-run
+#        # make acceptance-tests-down
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {} 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,8 +53,8 @@ jobs:
         echo "Checking out mapfish-print-v2"
         mkdir mapfish-print-v2
         git clone https://github.com/mapfish/mapfish-print-v2.git mapfish-print-v2
-        echo "Checking out mapfish-print-v3"
 # additional check during remove-opengis activity
+#        echo "Checking out mapfish-print-v3"
 #        mkdir mapfish-print-v3
 #        git clone -b opengis-migration https://github.com/mapfish/mapfish-print.git mapfish-print-v3
 # additional check during remove-opengis activity


### PR DESCRIPTION
[![GEOT-7287](https://badgen.net/badge/JIRA/GEOT-7287/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7287) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

During the remove-opengis activity we setup extended integration tests that made use of an ant script update a selection of downstream projects that had setup branches to test with GeoTools SNAPSHOT jars. Now that 30-RC is out, and the downstream projects have completed their api refactor these additional checks are no longer needed.

This is a build change and does not warrant its own JIRA issue.

Now that this activity is completed we can simplify:

- geofence test is no longer required as it is not using SNAPSHOT jars
- mapfish-print-v3 test is not required

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->