### PR TITLE
[GEOT-7463] Fix javadoc in teradata unsupported module

### DIFF
--- a/modules/unsupported/jdbc-teradata/src/main/java/org/geotools/data/teradata/TeradataDataStoreFactory.java
+++ b/modules/unsupported/jdbc-teradata/src/main/java/org/geotools/data/teradata/TeradataDataStoreFactory.java
@@ -58,7 +58,7 @@ public class TeradataDataStoreFactory extends JDBCDataStoreFactory {
                     false,
                     Boolean.FALSE);
 
-    /** enables using && in bbox queries */
+    /** enables using &amp;&amp; in bbox queries */
     public static final Param LOOSEBBOX =
             new Param(
                     "Loose bbox",

--- a/modules/unsupported/jdbc-teradata/src/main/java/org/geotools/data/teradata/WKBAttributeIO.java
+++ b/modules/unsupported/jdbc-teradata/src/main/java/org/geotools/data/teradata/WKBAttributeIO.java
@@ -87,7 +87,6 @@ public class WKBAttributeIO {
         }
     }
 
-    /** @see org.geotools.data.jdbc.attributeio.AttributeIO#read(java.sql.ResultSet, int) */
     public Geometry read(ResultSet rs, String columnName) throws IOException {
         try {
             return read(rs, rs.findColumn(columnName));
@@ -97,7 +96,6 @@ public class WKBAttributeIO {
         }
     }
 
-    /** @see org.geotools.data.jdbc.attributeio.AttributeIO#read(java.sql.ResultSet, int) */
     public Geometry read(ResultSet rs, int columnIndex) throws IOException {
         try {
             switch (rs.getMetaData().getColumnType(columnIndex)) {
@@ -111,7 +109,6 @@ public class WKBAttributeIO {
         }
     }
 
-    /** @see org.geotools.data.jdbc.attributeio.AttributeIO#read(java.sql.ResultSet, int) */
     private Geometry readFromBytes(ResultSet rs, int columnIndex) throws IOException {
         try {
             return wkb2Geometry(rs.getBytes(columnIndex));
@@ -143,10 +140,6 @@ public class WKBAttributeIO {
         }
     }
 
-    /**
-     * @see org.geotools.data.jdbc.attributeio.AttributeIO#write(java.sql.PreparedStatement, int,
-     *     java.lang.Object)
-     */
     public void write(PreparedStatement ps, int position, Object value) throws IOException {
         try {
             if (value == null) {


### PR DESCRIPTION
[![GEOT-7463](https://badgen.net/badge/JIRA/GEOT-7463/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7463) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Part of https://osgeo-org.atlassian.net/browse/GEOT-7447, this just addresses the teradata JDBC module.

No code changes

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->