### PR TITLE
[GEOT-7464] Fix javadoc in sample data module

### DIFF
--- a/modules/library/sample-data/src/main/java/org/geotools/TestData.java
+++ b/modules/library/sample-data/src/main/java/org/geotools/TestData.java
@@ -127,7 +127,7 @@ public final class TestData extends org.geotools.test.TestData {
      * org/geotools/foo/test-data/foo.txt} (in the {@code foo} module).
      *
      * <p>This method is useful when a test case needs to access a resource through a {@link File},
-     * for example because it want to open it using {@link java.io.RandomAccess}. Because the
+     * for example because it want to open it using {@link java.util.RandomAccess}. Because the
      * resources provided in the {@code sample-data} module are available to other modules as a JAR
      * file, other modules can only access them through an {@link URL} unless they copy them in
      * their own {@code test-data} directory.
@@ -138,8 +138,8 @@ public final class TestData extends org.geotools.test.TestData {
      *
      * <p>The file will be {@linkplain File#deleteOnExit deleted on exit} if and only if it has been
      * modified. Callers don't need to worry about cleanup, because the files are copied in the
-     * {@code target/.../test-data} directory, which is not versionned by SVN and is cleaned by
-     * Maven on {@code mvn clean} execution.
+     * {@code target/.../test-data} directory, which is not versioned by Git and is cleaned by Maven
+     * on {@code mvn clean} execution.
      *
      * @param caller Calling class or object used to locate the destination {@code test-data}.
      * @param name Path to file in {@code org/geotools/test-data}.


### PR DESCRIPTION
[![GEOT-7464](https://badgen.net/badge/JIRA/GEOT-7464/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7464) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Part of https://osgeo-org.atlassian.net/browse/GEOT-7447, this just addresses the sample-data module.

No code changes.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->