### PR TITLE
[GEOT-7465] GML2EncodingUtils.toURI fails with the Web Service authority

### DIFF
--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/bindings/GML2EncodingUtils.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/bindings/GML2EncodingUtils.java
@@ -128,10 +128,9 @@ public class GML2EncodingUtils {
         // not an EPSG code? figure out separate authority and code then
         if (code == null) {
             for (ReferenceIdentifier referenceIdentifier : crs.getIdentifiers()) {
-                Identifier id = (Identifier) referenceIdentifier;
-                if (id.getAuthority() != null) {
-                    authority = id.getAuthority().getTitle().toString();
-                    code = id.getCode();
+                if (referenceIdentifier.getAuthority() != null) {
+                    authority = referenceIdentifier.getCodeSpace();
+                    code = referenceIdentifier.getCode();
                     break;
                 }
             }

--- a/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/bindings/GML2EncodingUtilsTest.java
+++ b/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/bindings/GML2EncodingUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gml2.bindings;
+
+import static org.geotools.gml2.bindings.GML2EncodingUtils.toURI;
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.gml2.SrsSyntax;
+import org.geotools.referencing.CRS;
+import org.junit.Test;
+
+public class GML2EncodingUtilsTest {
+
+    @Test
+    public void testCRS84() throws Exception {
+        CoordinateReferenceSystem crs84 = CRS.decode("CRS:84");
+        assertEquals("CRS:84", toURI(crs84, SrsSyntax.AUTH_CODE, false));
+        assertEquals(
+                "http://www.opengis.net/def/crs/CRS/0/84",
+                toURI(crs84, SrsSyntax.OGC_HTTP_URI, false));
+        assertEquals("urn:ogc:def:crs:CRS::84", toURI(crs84, SrsSyntax.OGC_URN, false));
+    }
+}


### PR DESCRIPTION
[![GEOT-7465](https://badgen.net/badge/JIRA/GEOT-7465/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7465) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket. Found by community testing of GeoServer 2.24-RC

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->