### PR TITLE
[Backport 30.x] [GEOT-7429] Vector Mosaic add native retyping support when query is exclusively granule or index fields

### DIFF
--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureReader.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureReader.java
@@ -209,12 +209,9 @@ public class VectorMosaicFeatureReader implements SimpleFeatureReader {
             String attributeName = mergedType.getDescriptor(i).getLocalName();
             if (contains(query.getPropertyNames(), attributeName)) {
                 typeBuilder.add(mergedType.getDescriptor(i));
-            }
-            if (mergedType
-                    .getDescriptor(i)
-                    .getLocalName()
-                    .equals(mergedType.getGeometryDescriptor().getLocalName())) {
-                geomAdded = true;
+                if (attributeName.equals(mergedType.getGeometryDescriptor().getLocalName())) {
+                    geomAdded = true;
+                }
             }
         }
         if (geomAdded) {


### PR DESCRIPTION
[![GEOT-7429](https://badgen.net/badge/JIRA/GEOT-7429/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7429) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4459
 **Authored by:** @turingtestfail