### PR TITLE
[Backport 30.x] [GEOT-7458] JDBCDataStore: Unique visitor not always compatible with sortBy

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -1430,6 +1430,16 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
             }
         }
 
+        // In the SQL standard distinct and order by can work only if all order by attributes also
+        // show up in the select
+        // Given the Unique visitor makes no promise regarding sorting, it's easier to just remove
+        // the sort
+        if (visitor instanceof UniqueVisitor
+                && query.getSortBy() != null
+                && query.getSortBy().length > 0) {
+            query.setSortBy();
+        }
+
         // if the visitor is limiting the result to a given start - max, we will
         // try to apply limits to the aggregate query
         LimitingVisitor limitingVisitor = null;
@@ -3153,6 +3163,7 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
 
         return sql.toString();
     }
+
     /**
      * Creates the prepared statement for a select from the geometry association table.
      *
@@ -5012,6 +5023,7 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
         }
         dataSource = null;
     }
+
     /**
      * Checks if geometry generalization required and makes sense
      *
@@ -5033,6 +5045,7 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
     protected boolean isSimplificationRequired(Hints hints, GeometryDescriptor gatt) {
         return isGeometryReduceRequired(hints, gatt, Hints.GEOMETRY_SIMPLIFICATION);
     }
+
     /**
      * Checks if reduction required and makes sense
      *

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCAggregateFunctionOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCAggregateFunctionOnlineTest.java
@@ -416,6 +416,25 @@ public abstract class JDBCAggregateFunctionOnlineTest extends JDBCTestSupport {
     }
 
     @Test
+    public void testUniqueWithNonMatchingSort() throws Exception {
+        assumeTrue(dataStore.getSQLDialect().isAggregatedSortSupported("distinct"));
+
+        FilterFactory ff = dataStore.getFilterFactory();
+        PropertyName p = ff.property(aname("stringProperty"));
+
+        UniqueVisitor v = new MyUniqueVisitor(p);
+        v.setStartIndex(0);
+        Query q = new Query(tname("ft1"));
+        PropertyName pNonMatching = ff.property(aname("doubleProperty"));
+        q.setSortBy(new SortByImpl(pNonMatching, ASCENDING));
+        // used to fail with an exception, because stringProperty was in order by, but not in select
+        dataStore.getFeatureSource(tname("ft1")).accepts(q, v, null);
+        assertFalse(visited);
+        Set result = v.getResult().toSet();
+        assertEquals(3, result.size());
+    }
+
+    @Test
     public void testStoreChecksVisitorLimits() throws Exception {
         assumeTrue(dataStore.getSQLDialect().isLimitOffsetSupported());
         assumeTrue(dataStore.getSQLDialect().isAggregatedSortSupported("distinct"));


### PR DESCRIPTION
[![GEOT-7458](https://badgen.net/badge/JIRA/GEOT-7458/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7458) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4497
 **Authored by:** @turingtestfail