### PR TITLE
[Backport 29.x] [GEOT-7434] ElasticSearch throws repeated point exceptions on small bbox filters

### DIFF
--- a/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
+++ b/modules/unsupported/elasticsearch/src/main/java/org/geotools/data/elasticsearch/FilterToElastic.java
@@ -19,6 +19,7 @@ package org.geotools.data.elasticsearch;
 import static org.geotools.process.elasticsearch.ElasticBucketVisitor.ES_AGGREGATE_BUCKET;
 import static org.geotools.util.factory.Hints.VIRTUAL_TABLE_PARAMETERS;
 
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.collect.ImmutableList;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.data.Query;
 import org.geotools.data.elasticsearch.date.DateFormat;
@@ -43,6 +45,7 @@ import org.geotools.util.Converters;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LinearRing;
@@ -1217,9 +1220,31 @@ class FilterToElastic implements FilterVisitor, ExpressionVisitor {
             final CoordinateSequence coordinates = linearRing.getCoordinateSequence();
             currentGeometry = factory.createLineString(coordinates);
         }
-
-        final String geoJson = GeoJSONWriter.toGeoJSON(currentGeometry);
+        int maxDecimals = getMaxDecimalsForEnvelope(currentGeometry.getEnvelopeInternal());
+        final String geoJson = GeoJSONWriter.toGeoJSON(currentGeometry, maxDecimals);
         currentShapeBuilder = mapReader.readValue(geoJson);
+    }
+
+    protected static int getMaxDecimalsForEnvelope(Envelope envelope) {
+        double min = Math.min(Math.abs(envelope.getWidth()), Math.abs(envelope.getHeight()));
+        if (min == 0) {
+            LOGGER.log(
+                    Level.WARNING,
+                    "BBox Geometry has no width or height, it is either a point or a line.");
+            return JtsModule.DEFAULT_MAX_DECIMALS;
+        }
+        double decimalPart = min - Math.floor(min);
+        // min dimension is whole number but the other dimension might have decimals
+        if (decimalPart == 0) {
+            return JtsModule.DEFAULT_MAX_DECIMALS;
+        }
+        double log = Math.log10(decimalPart);
+        int numDecimals = Math.abs((int) Math.floor(log) + 1);
+        if (numDecimals <= JtsModule.DEFAULT_MAX_DECIMALS) {
+            return JtsModule.DEFAULT_MAX_DECIMALS;
+        } else {
+            return numDecimals;
+        }
     }
 
     private Object visitBinarySpatialOperator(

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFeatureFilterIT.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFeatureFilterIT.java
@@ -166,6 +166,17 @@ public class ElasticFeatureFilterIT extends ElasticTestSupport {
     }
 
     @Test
+    public void testGetFeaturesWithVerySmallBboxFilter() throws Exception {
+        init();
+        FilterFactory ff = dataStore.getFilterFactory();
+        BBOX bbox = ff.bbox("geo", 1, 1, 1.00000001, 1.00000001, "EPSG:" + SOURCE_SRID);
+        SimpleFeatureCollection features = featureSource.getFeatures(bbox);
+        // If the GeoJSON precision is not adjusted, this will fail with an IllegalArgumentException
+        // from ES "top cannot be the same as the bottom"
+        assertEquals(0, features.size());
+    }
+
+    @Test
     public void testGetFeaturesWithORLogicFilter() throws Exception {
         init();
         FilterFactory ff = dataStore.getFilterFactory();

--- a/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFilterTest.java
+++ b/modules/unsupported/elasticsearch/src/test/java/org/geotools/data/elasticsearch/ElasticFilterTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -51,6 +52,7 @@ import org.geotools.util.factory.Hints;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
@@ -1573,5 +1575,31 @@ public class ElasticFilterTest {
     @Test(expected = UnsupportedOperationException.class)
     public void testUnsupportedLiteralTimePeriod() {
         builder.visitLiteralTimePeriod();
+    }
+
+    @Test
+    public void testGetMaxDecimalsForEnvelope() {
+        Envelope bigEnv = new Envelope(-180, 180, -90, 90);
+        assertEquals(
+                JtsModule.DEFAULT_MAX_DECIMALS, FilterToElastic.getMaxDecimalsForEnvelope(bigEnv));
+
+        Envelope superBigEnv = new Envelope(-18000, 18000, -9000, 9000);
+        assertEquals(
+                JtsModule.DEFAULT_MAX_DECIMALS,
+                FilterToElastic.getMaxDecimalsForEnvelope(superBigEnv));
+
+        Envelope bigEnvWithDec2 = new Envelope(-18000, 18999.1, -9000, 9999.1);
+        assertEquals(
+                JtsModule.DEFAULT_MAX_DECIMALS,
+                FilterToElastic.getMaxDecimalsForEnvelope(bigEnvWithDec2));
+
+        Envelope smallEnv = new Envelope(-180, -179.9999999, -90, -89.9999999);
+        assertEquals(7, FilterToElastic.getMaxDecimalsForEnvelope(smallEnv));
+
+        Envelope smallEnv2 = new Envelope(-180, -179.9999999999, -90, -89.9999999999);
+        assertEquals(10, FilterToElastic.getMaxDecimalsForEnvelope(smallEnv2));
+
+        Envelope smallestEnv = new Envelope(0, 0.00000000000000001, 0, 0.00000000000000001);
+        assertEquals(16, FilterToElastic.getMaxDecimalsForEnvelope(smallestEnv));
     }
 }

--- a/modules/unsupported/geojson-core/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule.java
+++ b/modules/unsupported/geojson-core/src/main/java/com/bedatadriven/jackson/datatype/jts/JtsModule.java
@@ -47,7 +47,7 @@ public class JtsModule extends SimpleModule {
     /** serialVersionUID */
     private static final long serialVersionUID = 3387512874441967803L;
 
-    public static int DEFAULT_MAX_DECIMALS = 4;
+    public static int DEFAULT_MAX_DECIMALS = 6;
     public static int DEFAULT_MIN_DECIMALS = 0;
     public static RoundingMode DEFAULT_ROUND_MODE = RoundingMode.HALF_UP;
 

--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
@@ -80,7 +80,7 @@ public class GeoJSONWriter implements AutoCloseable {
             FastDateFormat.getInstance(DEFAULT_DATE_FORMAT, DEFAULT_TIME_ZONE);
 
     /** Maximum number of decimal places (see https://xkcd.com/2170/ before changing it) */
-    private int maxDecimals = 4;
+    private int maxDecimals = JtsModule.DEFAULT_MAX_DECIMALS;
 
     private OutputStream out;
 
@@ -376,8 +376,16 @@ public class GeoJSONWriter implements AutoCloseable {
 
     /** Utility encoding a single JTS geometry in GeoJSON, and returning it as a string */
     public static String toGeoJSON(Geometry geometry) {
+        return toGeoJSON(geometry, JtsModule.DEFAULT_MAX_DECIMALS);
+    }
+
+    /**
+     * Utility encoding a single JTS geometry in GeoJSON with configurable max decimals, and
+     * returning it as a string
+     */
+    public static String toGeoJSON(Geometry geometry, int maxDecimals) {
         ObjectMapper lMapper = new ObjectMapper();
-        lMapper.registerModule(new JtsModule());
+        lMapper.registerModule(new JtsModule(maxDecimals));
         try {
             return lMapper.writeValueAsString(geometry);
         } catch (JsonProcessingException e) {

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
@@ -131,7 +131,7 @@ public class GeoJSONWriteTest {
         out = new ByteArrayOutputStream();
         writer = new GeoJSONWriter(out);
         writer.write(feature);
-        assertTrue("Incorrect number of decimals", out.toString().contains("[0.1235,1.2346]"));
+        assertTrue("Incorrect number of decimals", out.toString().contains("[0.123457,1.234568]"));
         out.close();
         writer.close();
         out = new ByteArrayOutputStream();
@@ -163,7 +163,7 @@ public class GeoJSONWriteTest {
 
         assertTrue(
                 "missing bbox in " + out.toString(),
-                out.toString().contains("\"bbox\":[-7.556,49.7687,-7.5536,49.7724]"));
+                out.toString().contains("\"bbox\":[-7.555983,49.768664,-7.553629,49.772378]"));
         out.close();
         writer.close();
     }

--- a/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/AxisOrderTest.java
+++ b/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/AxisOrderTest.java
@@ -130,7 +130,7 @@ public class AxisOrderTest {
         int index = contents.indexOf("coordinates");
         assertTrue("No Coordinates in output file", index > 0);
         String test = contents.substring(index + 17, index + 32);
-        assertTrue("bad coords", "-3.3496,56.8215".equalsIgnoreCase(test));
+        assertTrue("bad coords", "-3.349554,56.82".equalsIgnoreCase(test));
         String[] c = test.split(",");
         assertTrue(Double.parseDouble(c[0]) < Double.parseDouble(c[1]));
     }

--- a/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/GeoJSONWriteTest.java
+++ b/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/GeoJSONWriteTest.java
@@ -376,7 +376,7 @@ public class GeoJSONWriteTest {
         String contents =
                 "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\""
                         + ":{\"LAT\":45.52,\"LON\":-122.681944,\"CITY\":\"Portland\",\"NUMBER\":800,\"YEAR\":2014},"
-                        + "\"geometry\":{\"type\":\"Point\",\"coordinates\":[45.52,-122.6819]},\"id\":\"locations.0\"}]}";
+                        + "\"geometry\":{\"type\":\"Point\",\"coordinates\":[45.52,-122.681944]},\"id\":\"locations.0\"}]}";
         assertEquals(
                 "Ensure the file has only the one feature we created",
                 contents.trim(),
@@ -480,7 +480,8 @@ public class GeoJSONWriteTest {
         try (BufferedReader r = new BufferedReader(new FileReader(out))) {
             assertTrue(
                     "missing bbox",
-                    r.readLine().endsWith("\"bbox\":[-124.7314,24.956,-66.9698,49.3717]}"));
+                    r.readLine()
+                            .endsWith("\"bbox\":[-124.731422,24.955967,-66.969849,49.371735]}"));
         }
     }
 
@@ -524,7 +525,7 @@ public class GeoJSONWriteTest {
                     "missing bbox",
                     r.readLine()
                             .startsWith(
-                                    "{\"type\":\"FeatureCollection\",\"bbox\":[-124.7314,24.956,-66.9698,49.3717],"));
+                                    "{\"type\":\"FeatureCollection\",\"bbox\":[-124.731422,24.955967,-66.969849,49.371735],"));
         }
     }
 


### PR DESCRIPTION
[![GEOT-7434](https://badgen.net/badge/JIRA/GEOT-7434/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7434) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4513
 **Authored by:** @turingtestfail