### PR TITLE
[GEOT-7471] WMTS Reader needs a debug flag for 404 tiles

### DIFF
--- a/modules/extension/tile-client/src/main/java/org/geotools/tile/Tile.java
+++ b/modules/extension/tile-client/src/main/java/org/geotools/tile/Tile.java
@@ -42,6 +42,7 @@ import org.geotools.util.logging.Logging;
 public abstract class Tile implements ImageLoader {
 
     protected static final Logger LOGGER = Logging.getLogger("org.geotools.tile.loader");
+    public static final String DEBUG_FLAG = "SHOW_DEBUG_TILES";
 
     /**
      * These are the states of the tile. This state represents if the tile needs to be re-rendered
@@ -199,7 +200,7 @@ public abstract class Tile implements ImageLoader {
 
     /**
      * Returns true if the image has been correctly loaded and the render state is {@link
-     * RenderState.RENDERED}.
+     * RenderState}.
      *
      * @return the tile image
      */
@@ -210,19 +211,23 @@ public abstract class Tile implements ImageLoader {
     /** Gets an image showing an error, possibly indicating a failure to load the tile image. */
     protected BufferedImage createErrorImage(final String message) {
 
+        String flag = System.getProperty(DEBUG_FLAG);
+        boolean showMessage = flag == null || !"no".equalsIgnoreCase(flag);
         final int size = getTileSize();
         BufferedImage buffImage = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
 
         Graphics2D graphics = buffImage.createGraphics();
-        graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) 0.5));
+        if (showMessage) {
+            graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) 0.5));
 
-        graphics.setColor(Color.WHITE);
-        graphics.fillRect(0, 0, size, size);
-        graphics.setColor(Color.RED);
-        graphics.drawLine(0, 0, size, size);
-        graphics.drawLine(0, size, size, 0);
-        int mesgWidth = graphics.getFontMetrics().stringWidth(message);
-        graphics.drawString(message, (size - mesgWidth) / 2, size / 2);
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, size, size);
+            graphics.setColor(Color.RED);
+            graphics.drawLine(0, 0, size, size);
+            graphics.drawLine(0, size, size, 0);
+            int mesgWidth = graphics.getFontMetrics().stringWidth(message);
+            graphics.drawString(message, (size - mesgWidth) / 2, size / 2);
+        }
         graphics.dispose();
 
         return buffImage;

--- a/modules/extension/tile-client/src/test/java/org/geotools/tile/TileTest.java
+++ b/modules/extension/tile-client/src/test/java/org/geotools/tile/TileTest.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.tile;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -66,6 +67,26 @@ public class TileTest {
         Assert.assertNotNull(img);
         Assert.assertEquals(256, img.getHeight());
         Assert.assertEquals(256, img.getWidth());
+        int pix = img.getRGB(20, 10);
+        Assert.assertTrue(checkColor(Color.white.getRGB(), pix));
+        System.setProperty(Tile.DEBUG_FLAG, "no");
+        img = this.tile.createErrorImage("Failed:" + this.tile.getId());
+        Assert.assertNotNull(img);
+        Assert.assertEquals(256, img.getHeight());
+        Assert.assertEquals(256, img.getWidth());
+        pix = img.getRGB(20, 10);
+        Assert.assertFalse(checkColor(Color.white.getRGB(), pix));
+    }
+
+    private boolean checkColor(int expected, int observed) {
+        int blueExpected = expected & 0xff;
+        int greenExpected = (expected & 0xff00) >> 8;
+        int redExpected = (expected & 0xff0000) >> 16;
+
+        int blue = observed & 0xff;
+        int green = (observed & 0xff00) >> 8;
+        int red = (observed & 0xff0000) >> 16;
+        return (blue == blueExpected && red == redExpected && green == greenExpected);
     }
 
     @Test

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/internal/Quickstart.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/internal/Quickstart.java
@@ -5,16 +5,13 @@ import java.net.URL;
 import org.geotools.api.data.FileDataStore;
 import org.geotools.api.data.FileDataStoreFinder;
 import org.geotools.api.data.SimpleFeatureSource;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.style.Style;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.map.FeatureLayer;
 import org.geotools.map.Layer;
 import org.geotools.map.MapContent;
 import org.geotools.ows.wmts.WebMapTileServer;
 import org.geotools.ows.wmts.map.WMTSMapLayer;
 import org.geotools.ows.wmts.model.WMTSLayer;
-import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.styling.SLD;
 import org.geotools.swing.JMapFrame;
 
@@ -34,31 +31,27 @@ public class Quickstart {
 
         map.setTitle("Quickstart");
 
-        CoordinateReferenceSystem crs = DefaultGeographicCRS.WGS84;
-        ReferencedEnvelope env = new ReferencedEnvelope(-180, 180, -90, 90, crs);
-        /*
-         * crs = CRS.decode("epsg:3857"); env = env.transform(crs, true);
-         */
-
-        map.getViewport().setCoordinateReferenceSystem(crs);
-        map.getViewport().setBounds(env);
         URL serverURL =
                 new URL(
                         "http://astun-desktop:8080/geoserver/gwc/service/wmts?REQUEST=GetCapabilities");
-        serverURL = new URL("http://raspberrypi:9000/wmts/1.0.0/WMTSCapabilities.xml");
+        serverURL =
+                new URL(
+                        "http://spectrum.mapinfoservices.com/rest/Spatial/WMTS/1.0.0/WMTSCapabilities.xml");
         WebMapTileServer server = new WebMapTileServer(serverURL);
-        String name = "osm";
+        String name = "USA_WMTS_Layer_ID1";
         WMTSLayer wlayer = server.getCapabilities().getLayer(name);
         // System.out.println(wlayer.getLatLonBoundingBox());
         WMTSMapLayer mapLayer = new WMTSMapLayer(server, wlayer);
         map.addLayer(mapLayer);
-        // System.out.println(mapLayer.getBounds());
-        File file = new File("/data/natural_earth/110m_physical/110m_coastline.shp");
+
+        File file = new File("/home/ian/Data/states/states.shp");
         FileDataStore store = FileDataStoreFinder.getDataStore(file);
-        SimpleFeatureSource featureSource = store.getFeatureSource();
-        Style style = SLD.createSimpleStyle(featureSource.getSchema());
-        Layer layer = new FeatureLayer(featureSource, style);
-        map.addLayer(layer);
+        if (store != null) {
+            SimpleFeatureSource featureSource = store.getFeatureSource();
+            Style style = SLD.createSimpleStyle(featureSource.getSchema());
+            Layer layer = new FeatureLayer(featureSource, style);
+            map.addLayer(layer);
+        }
         JMapFrame frame = new JMapFrame();
         frame.setSize(800, 450);
         // map.getViewport().setScreenArea(new Rectangle(800,400));

--- a/modules/extension/xsd/xsd-gml3/pom.xml
+++ b/modules/extension/xsd/xsd-gml3/pom.xml
@@ -98,6 +98,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-shapefile</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/modules/extension/xsd/xsd-gml3/pom.xml
+++ b/modules/extension/xsd/xsd-gml3/pom.xml
@@ -98,12 +98,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-shapefile</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
@@ -260,6 +260,7 @@ class WFSFeatureSource extends ContentFeatureSource {
         String srsName = getSupportedSrsName(request, query);
 
         request.setSrsName(srsName);
+        LOGGER.fine("request = " + request.toString());
         return request;
     }
 
@@ -273,6 +274,7 @@ class WFSFeatureSource extends ContentFeatureSource {
             throws IOException {
 
         if (Filter.EXCLUDE.equals(localQuery.getFilter())) {
+            LOGGER.fine("Filter is EXCLUDE returning empty collection");
             return new EmptyFeatureReader<>(getSchema());
         }
 
@@ -282,9 +284,9 @@ class WFSFeatureSource extends ContentFeatureSource {
         final SimpleFeatureType contentType =
                 getQueryType(localQuery, (SimpleFeatureType) request.getFullType());
         request.setQueryType(contentType);
-
+        LOGGER.fine("request = "+request);
         GetFeatureResponse response = client.issueRequest(request);
-
+        LOGGER.fine("response = " + response);
         GeometryFactory geometryFactory = findGeometryFactory(localQuery.getHints());
         GetParser<SimpleFeature> features = response.getSimpleFeatures(geometryFactory);
 


### PR DESCRIPTION
Adds a System property `SHOW_DEBUG_TILES` that when set to `no` disables the display of an error tile for missing tiles. The default is `yes` so existing clients will not be affected by this change but users who are trying to access "broken" WMTS services with missing tiles within the bounding box will be able to turn off the error messages.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
