### PR TITLE
Docs: Fix package ordering in GT 30x upgrade guide

### DIFF
--- a/docs/user/welcome/upgrade.rst
+++ b/docs/user/welcome/upgrade.rst
@@ -97,9 +97,9 @@ should now be named:
 
 .. code-block:: 
 
-   org.geotools.data.api.DataAccessFactory
-   org.geotools.data.api.DataStoreFactorySpi
-   org.geotools.data.api.FileDataStoreFactorySpi
+   org.geotools.api.data.DataAccessFactory
+   org.geotools.api.data.DataStoreFactorySpi
+   org.geotools.api.data.FileDataStoreFactorySpi
 
 The upgrade script should take care of this change.
 


### PR DESCRIPTION
Small fix for documentation: Packages mentioned in upgrade guide for GT 30.x:
https://docs.geotools.org/stable/userguide/welcome/upgrade.html#geotools-30-x

I have not created a JIRA issue for this.
  
# Checklist

- [ x ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ x ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ x ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ x ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ x ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

**Source code has not been changed**

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->