### PR TITLE
[GEOT-7487] Allow ECQL to parse attribute names with spaces

### DIFF
--- a/modules/library/cql/src/main/jjtree/ECQLGrammar.jjt
+++ b/modules/library/cql/src/main/jjtree/ECQLGrammar.jjt
@@ -297,7 +297,7 @@ TOKEN [IGNORE_CASE]: /* Literals */
 
     < IDENTIFIER: (<LETTER> (<LETTER>|<DIGIT>)*) | <DOUBLE_QUOTE> (<ANY>)+ <DOUBLE_QUOTE> > |
 
-	< #ANY: ~[" ","\""] > |
+	< #ANY: ~["\""] > |
   	< #LETTER: [ "a"-"z", "A"-"Z" , "_"] > |
   	< #DIGIT: [ "0"-"9"] > |
   	< #EXPONENT: ["e","E"] (["+","-"])? (<DIGIT>)+ > |

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/CQLAttributeNameTest.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/cql2/CQLAttributeNameTest.java
@@ -122,7 +122,7 @@ public class CQLAttributeNameTest {
         testAttributeBetweenDoubleQuotes("\"環境\"");
     }
 
-    private void testAttributeBetweenDoubleQuotes(final String attSample) throws CQLException {
+    protected void testAttributeBetweenDoubleQuotes(final String attSample) throws CQLException {
 
         PropertyName attResult = parsePropertyName(attSample);
 

--- a/modules/library/cql/src/test/java/org/geotools/filter/text/ecql/ECQLAttributeNameTest.java
+++ b/modules/library/cql/src/test/java/org/geotools/filter/text/ecql/ECQLAttributeNameTest.java
@@ -19,6 +19,8 @@ package org.geotools.filter.text.ecql;
 
 import org.geotools.filter.text.commons.Language;
 import org.geotools.filter.text.cql2.CQLAttributeNameTest;
+import org.geotools.filter.text.cql2.CQLException;
+import org.junit.Test;
 
 /**
  * Test case for Attribute Name
@@ -37,5 +39,12 @@ import org.geotools.filter.text.cql2.CQLAttributeNameTest;
 public class ECQLAttributeNameTest extends CQLAttributeNameTest {
     public ECQLAttributeNameTest() {
         super(Language.ECQL);
+    }
+
+    @Test
+    public void spacesInAttributeName() throws CQLException {
+
+        testAttributeBetweenDoubleQuotes("\"población general\"");
+        testAttributeBetweenDoubleQuotes("\"statut de diffusion de l'établissement\"");
     }
 }


### PR DESCRIPTION
[![GEOT-7487](https://badgen.net/badge/JIRA/GEOT-7487/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7487) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Update the ECQL grammar to allow spaces in attribute names.
    
Changes the definition of `ANY` to not disallow spaces, but only  backslashes.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->