### PR TITLE
[GEOT-7486] CSS literal single space squashed to empty string

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
@@ -876,7 +876,11 @@ public abstract class TransformerBase {
             start(element, atts);
 
             if (content != null) {
-                chars(content);
+                if (content.equals(" ")) {
+                    cdata(content);
+                } else {
+                    chars(content);
+                }
             }
 
             end(element);

--- a/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
@@ -876,7 +876,10 @@ public abstract class TransformerBase {
             start(element, atts);
 
             if (content != null) {
-                if (content.matches("^\\s+$")) {
+                int length = content.length();
+                if (length > 0
+                        && (Character.isWhitespace(content.charAt(0))
+                                || Character.isWhitespace(content.charAt(length - 1)))) {
                     cdata(content);
                 } else {
                     chars(content);

--- a/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
@@ -876,7 +876,7 @@ public abstract class TransformerBase {
             start(element, atts);
 
             if (content != null) {
-                if (content.equals(" ")) {
+                if (content.matches("^\\s+$")) {
                     cdata(content);
                 } else {
                     chars(content);

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDTransformerTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDTransformerTest.java
@@ -1550,6 +1550,31 @@ public class SLDTransformerTest extends XmlTestSupport {
     }
 
     @Test
+    public void testWhitespaceCDATA() throws TransformerException {
+        StyleBuilder sb = new StyleBuilder();
+        TextSymbolizer ts = sb.createTextSymbolizer();
+
+        ts.setGeometry(
+                ff.function(
+                        "geomFromWKT",
+                        ff.function(
+                                "Concatenate",
+                                ff.literal("POINT("),
+                                ff.property("lng"),
+                                ff.literal(" "), // this space needs to be encoded within CDATA
+                                ff.property("lat"),
+                                ff.literal(")"))));
+
+        StyledLayerDescriptor sld = buildSLDAroundSymbolizer(ts);
+
+        String xml = transformer.transform(sld);
+
+        // normalize-space() strips indentation, but also CDATA whitespace, so we resort to string
+        // comparisons here
+        assertTrue(xml.contains("<![CDATA[ ]]>"));
+    }
+
+    @Test
     public void testLabelCDataEnd() throws TransformerException {
         StyleBuilder sb = new StyleBuilder();
         TextSymbolizer ts = sb.createTextSymbolizer();


### PR DESCRIPTION
[![GEOT-7486](https://badgen.net/badge/JIRA/GEOT-7486/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7486) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fix now produces

`<ogc:Literal><![CDATA[ ]]></ogc:Literal>`

instead of the problematic `<ogc:Literal> </ogc:Literal>`

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->