### PR TITLE
[GEOT-7485] setFrameFromCenter(...) returns wrong coordinates for zoomin/zoomout

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -617,7 +617,7 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
         double heightDelta = Math.abs(corner.getY() - center.getY());
         super.init(
                 center.getX() - widthDelta, center.getX() + widthDelta,
-                center.getY() - heightDelta, getCenterY() + heightDelta);
+                center.getY() - heightDelta, center.getYX() + heightDelta);
     }
 
     public void setFrameFromDiagonal(Point2D lowerLeft, Point2D upperRight) {

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -617,7 +617,7 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
         double heightDelta = Math.abs(corner.getY() - center.getY());
         super.init(
                 center.getX() - widthDelta, center.getX() + widthDelta,
-                center.getY() - heightDelta, center.getYX() + heightDelta);
+                center.getY() - heightDelta, center.getY() + heightDelta);
     }
 
     public void setFrameFromDiagonal(Point2D lowerLeft, Point2D upperRight) {


### PR DESCRIPTION
[![GEOT-7485](https://badgen.net/badge/JIRA/GEOT-7485/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7485) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Modification to function setFrameFromCenter in file ReferencedEnvelope.java
Re problems with zoomin/zoomout (JMapFrame)