### PR TITLE
[GEOT-7485] modification for setFrameFromCenter

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -617,7 +617,7 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
         double heightDelta = Math.abs(corner.getY() - center.getY());
         super.init(
                 center.getX() - widthDelta, center.getX() + widthDelta,
-                center.getY() - heightDelta, getCenterY() + heightDelta);
+                center.getY() - heightDelta, center.getYX() + heightDelta);
     }
 
     public void setFrameFromDiagonal(Point2D lowerLeft, Point2D upperRight) {

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -617,7 +617,7 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
         double heightDelta = Math.abs(corner.getY() - center.getY());
         super.init(
                 center.getX() - widthDelta, center.getX() + widthDelta,
-                center.getY() - heightDelta, center.getYX() + heightDelta);
+                center.getY() - heightDelta, center.getY() + heightDelta);
     }
 
     public void setFrameFromDiagonal(Point2D lowerLeft, Point2D upperRight) {


### PR DESCRIPTION
[![GEOT-7485](https://badgen.net/badge/JIRA/GEOT-7485/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7485) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Modification to function setFrameFromCenter in file ReferencedEnvelope.java
Re : problems with zoomin/zoomout for Quickstart.java

Change :  getCenterY()  to  center.getY()

It is not  a new feature, just correcting an existing one (see line 620)



**FROM:**


    public void setFrameFromCenter(Point2D center, Point2D corner) {
        double widthDelta = Math.abs(corner.getX() - center.getX());
        double heightDelta = Math.abs(corner.getY() - center.getY());
        super.init(
                center.getX() - widthDelta, center.getX() + widthDelta,
                center.getY() - heightDelta, getCenterY() + heightDelta);
    }



**TO:**


    public void setFrameFromCenter(Point2D center, Point2D corner) {
        double widthDelta = Math.abs(corner.getX() - center.getX());
        double heightDelta = Math.abs(corner.getY() - center.getY());
        super.init(
                center.getX() - widthDelta, center.getX() + widthDelta,
                center.getY() - heightDelta, center.getY() + heightDelta);
    }

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
