### PR TITLE
[GEOT-7485] Double Check ReferencedEnvelope against Rectangle2D.Double() expectations

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -620,14 +620,26 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
         super.init(toJTSEnvelope(bbox));
     }
 
+    /**
+     * Initialize the bounding box using a line from the center to a corner.
+     *
+     * @param center location of the new bounding box
+     * @param corner location of a corner establishing the extent of the bounding box
+     */
     public void setFrameFromCenter(Point2D center, Point2D corner) {
         double widthDelta = Math.abs(corner.getX() - center.getX());
         double heightDelta = Math.abs(corner.getY() - center.getY());
         super.init(
                 center.getX() - widthDelta, center.getX() + widthDelta,
-                center.getY() - heightDelta, getCenterY() + heightDelta);
+                center.getY() - heightDelta, center.getY() + heightDelta);
     }
 
+    /**
+     * Initialize the bounding box using a line from the lower left to upper right corners.
+     *
+     * @param lowerLeft Lower left extent of the new bounding box
+     * @param upperRight Upper right extent of the new bounding box
+     */
     public void setFrameFromDiagonal(Point2D lowerLeft, Point2D upperRight) {
         super.init(lowerLeft.getX(), upperRight.getX(), lowerLeft.getY(), upperRight.getY());
     }
@@ -1026,10 +1038,10 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
             return new ReferencedEnvelope(crs);
         }
         return new ReferencedEnvelope(
-                rectangle.getX(),
-                rectangle.getWidth(),
-                rectangle.getY(),
-                rectangle.getHeight(),
+                rectangle.getMinX(),
+                rectangle.getMaxX(),
+                rectangle.getMinY(),
+                rectangle.getMaxY(),
                 crs);
     }
 

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import org.geotools.api.geometry.MismatchedReferenceSystemException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -241,5 +242,42 @@ public class ReferencedEnvelopeTest {
         assertEquals(180, re.getMaxX(), 0d);
         assertEquals(20, re.getMinY(), 0d);
         assertEquals(40, re.getMaxY(), 0d);
+    }
+
+    /**
+     * This method tests the different ways of initializing a ReferencedEnvelope in a manner
+     * consistent with behavior of {@link Rectangle2D}
+     */
+    @Test
+    public void testRectangle2DBehaviour() throws Exception {
+        Rectangle2D rectangle = new Rectangle2D.Double(10.0, 10.0, 40.0, 30.0);
+        ReferencedEnvelope envelope =
+                ReferencedEnvelope.rect(10.0, 10.0, 40.0, 30.0, DefaultEngineeringCRS.CARTESIAN_2D);
+        assertEquals(
+                "rect",
+                ReferencedEnvelope.rect(rectangle, DefaultEngineeringCRS.CARTESIAN_2D),
+                envelope);
+
+        assertEquals("x", rectangle.getMinX(), envelope.getMinX(), 0.0);
+        assertEquals("height", rectangle.getHeight(), envelope.getHeight(), 0.0);
+
+        Point2D center = new Point2D.Double(50.0, 50.0);
+        Point2D outer = new Point2D.Double(85.0, 15.0);
+        rectangle.setFrameFromCenter(center, outer);
+        envelope.setFrameFromCenter(center, outer);
+        assertEquals(
+                "setFrameFromCenter",
+                ReferencedEnvelope.rect(rectangle, DefaultEngineeringCRS.CARTESIAN_2D),
+                envelope);
+
+        Point2D lower = new Point2D.Double(10.0, 10.0);
+        Point2D upper = new Point2D.Double(40.0, 30.0);
+
+        rectangle.setFrameFromDiagonal(lower, upper);
+        envelope.setFrameFromDiagonal(lower, upper);
+        assertEquals(
+                "setFrameFromDiagonal",
+                ReferencedEnvelope.rect(rectangle, DefaultEngineeringCRS.CARTESIAN_2D),
+                envelope);
     }
 }


### PR DESCRIPTION
[![GEOT-7485](https://badgen.net/badge/JIRA/GEOT-7485/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7485) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Checked the following:

* [x] rectangle(rectangle,crs)
* [x] setFrameFromCenter
* [x] setFrameFromDiagonal

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->