### PR TITLE
[Backport 30.x] [GEOT-7490] WPS Intersection NPE when the Return Value Should be a Point

### DIFF
--- a/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/IntersectionFeatureCollection.java
+++ b/modules/unsupported/process-feature/src/main/java/org/geotools/process/vector/IntersectionFeatureCollection.java
@@ -757,6 +757,9 @@ public class IntersectionFeatureCollection implements VectorProcess {
                 for (int i = 0; i < n; i++) array[i] = (Point) collection.get(i);
                 return factory.createMultiPoint(array);
             }
+            if (Point.class.isAssignableFrom(binding) && !collection.isEmpty()) {
+                return (Point) collection.get(0);
+            }
             return null;
         }
     }


### PR DESCRIPTION
[![GEOT-7490](https://badgen.net/badge/JIRA/GEOT-7490/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7490) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4544
 **Authored by:** @turingtestfail