### PR TITLE
[Backport 28.x] [GEOT-7491] ShapeFileDataStore should use GeometryFactory of DataStore

### DIFF
--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileFeatureSource.java
@@ -426,7 +426,8 @@ class ShapefileFeatureSource extends ContentFeatureSource {
     protected GeometryFactory getGeometryFactory(Query query) {
         // if no hints, use the default geometry factory
         if (query == null || query.getHints() == null) {
-            return new GeometryFactory();
+            final GeometryFactory geometryFactory = entry.getDataStore().getGeometryFactory();
+            return geometryFactory != null ? geometryFactory : new GeometryFactory();
         }
 
         // grab a geometry factory... check for a special hint
@@ -439,6 +440,8 @@ class ShapefileFeatureSource extends ContentFeatureSource {
 
             if (csFactory != null) {
                 geometryFactory = new GeometryFactory(csFactory);
+            } else {
+                geometryFactory = entry.getDataStore().getGeometryFactory();
             }
         }
 

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreSetGeometryFactoryTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreSetGeometryFactoryTest.java
@@ -1,0 +1,67 @@
+package org.geotools.data.shapefile;
+
+import static org.geotools.data.Transaction.AUTO_COMMIT;
+import static org.geotools.data.shapefile.ShapefileDataStoreFactory.URLP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.geotools.TestData;
+import org.geotools.data.FeatureReader;
+import org.geotools.data.Query;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+/**
+ * @version $Id$
+ * @author Burkhard Strauss
+ */
+public final class ShapefileDataStoreSetGeometryFactoryTest {
+
+    private static final String BASE = "mzvalues/mpoints";
+    private static final String[] NAMES = {
+        BASE + ".dbf", BASE + ".prj", BASE + ".shp", BASE + ".shx"
+    };
+
+    private static final Map<String, Serializable> PARAMS = new HashMap<>();
+
+    @Before
+    public void beforeShapefileDataStoreSetGeometryFactoryTest() throws IOException {
+
+        for (final String name : NAMES) {
+            assertTrue(TestData.copy(this, name).canRead());
+        }
+        final URL url = TestData.file(this, NAMES[2]).toURI().toURL();
+        PARAMS.put(URLP.key, url);
+    }
+
+    @Test
+    public void testSetGeometryFactory() throws IOException {
+
+        final int mySrid = 12345;
+        final GeometryFactory myGeometryFactory = new GeometryFactory(new PrecisionModel(), mySrid);
+        final ShapefileDataStore dataStore =
+                (ShapefileDataStore) new ShapefileDataStoreFactory().createDataStore(PARAMS);
+        final String typeName = dataStore.getTypeNames()[0];
+        dataStore.setGeometryFactory(myGeometryFactory);
+        final Query query = new Query(typeName);
+        try (FeatureReader<SimpleFeatureType, SimpleFeature> reader =
+                dataStore.getFeatureReader(query, AUTO_COMMIT)) {
+            assertTrue(reader.hasNext());
+            final SimpleFeature feature = reader.next();
+            final Object geometry = feature.getDefaultGeometry();
+            assertTrue(geometry instanceof Geometry);
+            final GeometryFactory factory = ((Geometry) geometry).getFactory();
+            assertEquals(mySrid, factory.getSRID());
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-7491](https://badgen.net/badge/JIRA/GEOT-7491/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7491) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4552
 **Authored by:** @bestrauss