### PR TITLE
Upgrade flatgeobuf to 3.26.2

### DIFF
--- a/modules/unsupported/flatgeobuf/pom.xml
+++ b/modules/unsupported/flatgeobuf/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.wololo</groupId>
       <artifactId>flatgeobuf</artifactId>
-      <version>3.26.1</version>
+      <version>3.26.2</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>

--- a/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/FlatGeobufDataStoreTest.java
+++ b/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/FlatGeobufDataStoreTest.java
@@ -881,7 +881,7 @@ public class FlatGeobufDataStoreTest {
             SimpleFeature f2 = it.next();
             assertEquals("countries.48", f2.getID());
             boolean hasNext = it.hasNext();
-            assertEquals(false, hasNext);
+            assertFalse(hasNext);
         }
     }
 

--- a/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/FlatGeobufDataStoreTest.java
+++ b/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/FlatGeobufDataStoreTest.java
@@ -876,12 +876,12 @@ public class FlatGeobufDataStoreTest {
         Query query = new Query(schema.getTypeName(), filter);
         SimpleFeatureCollection featureCollection = featureSource.getFeatures(query);
         try (SimpleFeatureIterator it = featureCollection.features()) {
-            int count = 0;
-            while (it.hasNext()) {
-                it.next();
-                count++;
-            }
-            assertEquals(2, count);
+            SimpleFeature f1 = it.next();
+            assertEquals("countries.46", f1.getID());
+            SimpleFeature f2 = it.next();
+            assertEquals("countries.48", f2.getID());
+            boolean hasNext = it.hasNext();
+            assertEquals(false, hasNext);
         }
     }
 


### PR DESCRIPTION
This patch release upgrade fixes an issue that spatial index search on FlatGeobuf produces a result with wrong feature ids.  It also adds a test cases that reproduces the issue and verifies the fix.

See https://github.com/flatgeobuf/flatgeobuf/pull/334.