### PR TITLE
[Backport 29.x] [GEOT-7498] Upgrade DB2 JDBC driver from 11.5.6.0 to 11.5.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
     <!-- dependency management -->
     <batik.version>1.17</batik.version>
     <commons-beanutils.version>1.9.2</commons-beanutils.version>
-    <db2.jdbc.version>11.5.6.0</db2.jdbc.version>
+    <db2.jdbc.version>11.5.9.0</db2.jdbc.version>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>
     <elasticsearch.version>7.14.0</elasticsearch.version>
     <imageio.ext.version>1.4.7</imageio.ext.version>


### PR DESCRIPTION
[![GEOT-7498](https://badgen.net/badge/JIRA/GEOT-7498/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7498) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4564
 **Authored by:** @sikeoka