### PR TITLE
[Backport 28.x] Bump ch.qos.logback:logback-classic from 1.2.11 to 1.3.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -492,7 +492,7 @@
     <jtds.jdbc.version>1.3.1</jtds.jdbc.version>
     <jts.version>1.19.0</jts.version>
     <log4j2.version>2.17.2</log4j2.version>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.3.12</logback.version>
     <mockito.core.version>3.12.4</mockito.core.version>
     <mssql-jdbc.version>9.4.0.jre8</mssql-jdbc.version>
     <mysql-connector-java.version>8.0.28</mysql-connector-java.version>


### PR DESCRIPTION
Backport #4569
 **Authored by:** @dependabot[bot]