### PR TITLE
[Backport 28.x] Bump ch.qos.logback:logback-classic from 1.2.11 to 1.3.12 in /release/src/it/logback

### DIFF
--- a/modules/library/metadata/src/it/commons/pom.xml
+++ b/modules/library/metadata/src/it/commons/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.deploy.skip>true</maven.deploy.skip>
     <geotools.version>28-SNAPSHOT</geotools.version>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.3.12</logback.version>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/library/metadata/src/it/logback/pom.xml
+++ b/modules/library/metadata/src/it/logback/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.deploy.skip>true</maven.deploy.skip>
     <geotools.version>28-SNAPSHOT</geotools.version>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.3.12</logback.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Backport #4569
