### PR TITLE
Added a utility method to test for JAXP 1.5 support.

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -16,7 +16,13 @@
  */
 package org.geotools.xml;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.validation.SchemaFactory;
+import org.xml.sax.SAXException;
 import org.xml.sax.helpers.NamespaceSupport;
 
 /**
@@ -25,6 +31,44 @@ import org.xml.sax.helpers.NamespaceSupport;
  * @author Andrea Aime - GeoSolutions
  */
 public class XMLUtils {
+
+    /**
+     * Tests whether the TransformerFactory and SchemaFactory implementations support JAXP 1.5
+     * properties to protect against XML external entity injection (XXE) attacks. The internal JDK
+     * XML processors starting with JDK 7u40 would support these properties but outdated versions of
+     * XML libraries (e.g., Xalan, Xerces) that do not support these properties may be included in
+     * GeoServer's classpath or provided by the web application server. This method is intended to
+     * support using third-party libraries (e.g., Hazelcast) that use these properties internally.
+     *
+     * @throws IllegalStateException if the JAXP 1.5 properties are not supported or if there was an
+     *     error checking for JAXP 1.5 support
+     */
+    public static void checkSupportForJAXP15Properties() {
+        List<String> classes = new ArrayList<>();
+        try {
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            try {
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            } catch (IllegalArgumentException e) {
+                classes.add(transformerFactory.getClass().getName());
+            }
+            SchemaFactory schemaFactory =
+                    SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            try {
+                schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            } catch (SAXException e) {
+                classes.add(schemaFactory.getClass().getName());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to check support for JAXP 1.5 properties", e);
+        }
+        if (!classes.isEmpty()) {
+            throw new IllegalStateException(
+                    "JAXP 1.5 properties are not supported by: " + String.join(", ", classes));
+        }
+    }
 
     /**
      * Checks the string for XML invalid chars, and in case any is found, create a copy with the


### PR DESCRIPTION
This PR adds a utility method to check whether the TransformerFactory and SchemaFactory implementations support JAXP 1.5.  This is intended to allow programmatically fixing an error caused by the recent Hazelcast upgrade in GeoServer/GeoWebcache that breaks the affected modules because Hazelcast is internally using JAXP 1.5 properties without having multiple copies of this code around.  There is a chance that this could potentially be useful with a lot of major dependency upgrades planned for next year.  There are no unit tests because the check depends on external XML libraries being on the classpath.  GeoTools does not add the Xalan or Xerces libraries and GeoServer uses the Xalan library while a couple of GeoServer extensions use the Xerces library.  Depending on how GeoServer is being installed, external XML libraries may be included in the classpath by the web application server.

If this PR is approved, it must be backported to 30.x to be able to fix the Hazelcast modules in GeoServer 2.24.x.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->