### PR TITLE
[Backport 30.x] [GEOT-7497] gt-wfs-ng ignores maxFeatures on WFS 2.0 

### DIFF
--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/FESConfiguration.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/FESConfiguration.java
@@ -56,6 +56,7 @@ import org.geotools.filter.v2_0.bindings.GeometryOperandsType_GeometryOperandBin
 import org.geotools.filter.v2_0.bindings.Id_CapabilitiesTypeBinding;
 import org.geotools.filter.v2_0.bindings.IntersectsBinding;
 import org.geotools.filter.v2_0.bindings.LiteralBinding;
+import org.geotools.filter.v2_0.bindings.LowerBoundaryTypeBinding;
 import org.geotools.filter.v2_0.bindings.MatchActionBinding;
 import org.geotools.filter.v2_0.bindings.MeasureTypeBinding;
 import org.geotools.filter.v2_0.bindings.MeetsBinding;
@@ -85,6 +86,7 @@ import org.geotools.filter.v2_0.bindings.TContainsBinding;
 import org.geotools.filter.v2_0.bindings.TEqualsBinding;
 import org.geotools.filter.v2_0.bindings.TOverlapsBinding;
 import org.geotools.filter.v2_0.bindings.TouchesBinding;
+import org.geotools.filter.v2_0.bindings.UpperBoundaryTypeBinding;
 import org.geotools.filter.v2_0.bindings.ValueReferenceBinding;
 import org.geotools.filter.v2_0.bindings.VersionTypeBinding;
 import org.geotools.filter.v2_0.bindings.WithinBinding;
@@ -178,7 +180,8 @@ public class FESConfiguration extends Configuration {
         //
         // container.registerComponentImplementation(FES.LogicOpsType,LogicOpsTypeBinding.class);
         //
-        // container.registerComponentImplementation(FES.LowerBoundaryType,LowerBoundaryTypeBinding.class);
+        container.registerComponentImplementation(
+                FES.LowerBoundaryType, LowerBoundaryTypeBinding.class);
         //
         // container.registerComponentImplementation(FES.MatchActionType,MatchActionTypeBinding.class);
 
@@ -225,7 +228,8 @@ public class FESConfiguration extends Configuration {
         //
         // container.registerComponentImplementation(FES.UnaryLogicOpType,UnaryLogicOpTypeBinding.class);
         //
-        // container.registerComponentImplementation(FES.UpperBoundaryType,UpperBoundaryTypeBinding.class);
+        container.registerComponentImplementation(
+                FES.UpperBoundaryType, UpperBoundaryTypeBinding.class);
         //
         // container.registerComponentImplementation(FES.VersionActionTokens,VersionActionTokensBinding.class);
         container.registerComponentImplementation(FES.VersionType, VersionTypeBinding.class);

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/LowerBoundaryTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/LowerBoundaryTypeBinding.java
@@ -1,0 +1,67 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.v2_0.bindings;
+
+import javax.xml.namespace.QName;
+import org.geotools.api.filter.expression.Expression;
+import org.geotools.filter.v2_0.FES;
+import org.geotools.xsd.AbstractComplexBinding;
+import org.geotools.xsd.ElementInstance;
+import org.geotools.xsd.Node;
+
+/** Binding object for the lower boundary of a property is between filter */
+public class LowerBoundaryTypeBinding extends AbstractComplexBinding {
+    /** @generated */
+    @Override
+    public QName getTarget() {
+        return FES.LowerBoundaryType;
+    }
+
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    @Override
+    public Class getType() {
+        return Expression.class;
+    }
+
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    @Override
+    public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
+        return node.getChildValue(Expression.class);
+    }
+
+    @Override
+    public Object getProperty(Object object, QName name) throws Exception {
+        // &lt;xsd:element ref="ogc:expression"/&gt;
+        if (FES.expression.equals(name)) {
+            return object;
+        }
+
+        return null;
+    }
+}

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/PropertyIsBetweenTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/PropertyIsBetweenTypeBinding.java
@@ -18,6 +18,7 @@ package org.geotools.filter.v2_0.bindings;
 
 import javax.xml.namespace.QName;
 import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.PropertyIsBetween;
 import org.geotools.filter.v1_0.OGCPropertyIsBetweenTypeBinding;
 import org.geotools.filter.v2_0.FES;
 
@@ -54,5 +55,15 @@ public class PropertyIsBetweenTypeBinding extends OGCPropertyIsBetweenTypeBindin
     @Override
     public QName getTarget() {
         return FES.PropertyIsBetweenType;
+    }
+
+    @Override
+    public Object getProperty(Object object, QName name) throws Exception {
+        if (FES.expression.equals(name)) {
+            PropertyIsBetween between = (PropertyIsBetween) object;
+            return between.getExpression();
+        }
+
+        return super.getProperty(object, name);
     }
 }

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/UpperBoundaryTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/UpperBoundaryTypeBinding.java
@@ -1,0 +1,67 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.v2_0.bindings;
+
+import javax.xml.namespace.QName;
+import org.geotools.api.filter.expression.Expression;
+import org.geotools.filter.v2_0.FES;
+import org.geotools.xsd.AbstractComplexBinding;
+import org.geotools.xsd.ElementInstance;
+import org.geotools.xsd.Node;
+
+/** Binding object for the upper boundary of a property is between filter. */
+public class UpperBoundaryTypeBinding extends AbstractComplexBinding {
+    /** @generated */
+    @Override
+    public QName getTarget() {
+        return FES.UpperBoundaryType;
+    }
+
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    @Override
+    public Class getType() {
+        return Expression.class;
+    }
+
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    @Override
+    public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
+        return node.getChildValue(Expression.class);
+    }
+
+    @Override
+    public Object getProperty(Object object, QName name) throws Exception {
+        // &lt;xsd:element ref="ogc:expression"/&gt;
+        if (FES.expression.equals(name)) {
+            return object;
+        }
+
+        return null;
+    }
+}

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/PropertyIsBetweenBindingTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/PropertyIsBetweenBindingTest.java
@@ -1,0 +1,57 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.v2_0.bindings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.geotools.filter.v1_1.FilterMockData;
+import org.geotools.filter.v2_0.FES;
+import org.geotools.filter.v2_0.FESTestSupport;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class PropertyIsBetweenBindingTest extends FESTestSupport {
+
+    @Test
+    public void testEncode() throws Exception {
+        Document doc = encode(FilterMockData.propertyIsBetween(), FES.Filter);
+        assertEquals("fes:Filter", doc.getDocumentElement().getNodeName());
+        print(doc);
+
+        Element between = getElementByQName(doc, FES.PropertyIsBetween);
+        assertNotNull(between);
+        NodeList children = between.getChildNodes();
+        assertEquals(3, children.getLength());
+        Node valueReference = children.item(0);
+        assertEquals("fes:ValueReference", valueReference.getNodeName());
+        assertEquals("foo", valueReference.getTextContent());
+
+        assertEquals("fes:LowerBoundary", children.item(1).getNodeName());
+        Node lowerLiteral = children.item(1).getFirstChild();
+        assertEquals("fes:Literal", lowerLiteral.getNodeName());
+        assertEquals("10", lowerLiteral.getTextContent());
+
+        assertEquals("fes:UpperBoundary", children.item(2).getNodeName());
+        Node upperLiteral = children.item(2).getFirstChild();
+        assertEquals("fes:Literal", upperLiteral.getNodeName());
+        assertEquals("20", upperLiteral.getTextContent());
+    }
+}

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/FilterMockData.java
@@ -25,6 +25,7 @@ import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.Id;
 import org.geotools.api.filter.Not;
 import org.geotools.api.filter.Or;
+import org.geotools.api.filter.PropertyIsBetween;
 import org.geotools.api.filter.PropertyIsEqualTo;
 import org.geotools.api.filter.PropertyIsGreaterThan;
 import org.geotools.api.filter.PropertyIsGreaterThanOrEqualTo;
@@ -205,6 +206,10 @@ public class FilterMockData {
 
     public static PropertyIsGreaterThanOrEqualTo propertyIsGreaterThanOrEqualTo() {
         return f.greaterOrEqual(propertyName(), literal());
+    }
+
+    public static PropertyIsBetween propertyIsBetween() {
+        return f.between(propertyName(), literal(10), literal(20));
     }
 
     public static Element binaryComparisonOp(Document document, Node parent, QName name) {

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
@@ -67,6 +67,7 @@ import org.geotools.api.filter.identity.Identifier;
 import org.geotools.api.filter.spatial.Intersects;
 import org.geotools.data.wfs.internal.GetFeatureRequest.ResultType;
 import org.geotools.filter.Capabilities;
+import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.filter.visitor.CapabilitiesFilterSplitter;
 import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.geotools.util.Version;
@@ -154,6 +155,38 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
      * different WFS versions may use different operation names (specially namespaces).
      */
     protected abstract QName getOperationName(WFSOperationType operation);
+
+    /**
+     * If needed, expands the set of requested property names to include the ones needed to evaluate
+     * the unsupported filter.
+     *
+     * @param request
+     * @param unsupportedFilter
+     */
+    protected void updatePropertyNames(GetFeatureRequest request, Filter unsupportedFilter) {
+        if (Filter.INCLUDE.equals(unsupportedFilter)) return;
+
+        String[] propertyNames = request.getPropertyNames();
+        if (propertyNames != null) {
+            Set<String> propertyNamesSet = new HashSet<>(Arrays.asList(propertyNames));
+            FilterAttributeExtractor extractor = new FilterAttributeExtractor();
+            unsupportedFilter.accept(extractor, null);
+            Set<String> extraAttributes =
+                    new HashSet<>(Arrays.asList(extractor.getAttributeNames()));
+            propertyNamesSet.addAll(extraAttributes);
+            // update the property names if needed
+            if (propertyNames.length < propertyNamesSet.size()) {
+                propertyNames = propertyNamesSet.toArray(new String[propertyNamesSet.size()]);
+                request.setPropertyNames(propertyNames);
+                // Also unset the query type, it's no longer representative of the query
+                // the parser will be configured with the full type in this case
+                // which does not appear to cause problems, other than maybe a few more
+                // loops searching for attributse that are not there. Recomputing the query
+                // type here is no possible, as we're dealing with potentially non simple types
+                request.setQueryType(null);
+            }
+        }
+    }
 
     /**
      * Creates the EMF object to be encoded with the {@link #getWfsConfiguration() WFS
@@ -248,25 +281,9 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
         map.put("OUTPUTFORMAT", outputFormat);
         map.put("RESULTTYPE", request.getResultType().name());
 
-        if (request.getMaxFeatures() != null) {
-            map.put("MAXFEATURES", String.valueOf(request.getMaxFeatures()));
-        }
-
         QName typeName = request.getTypeName();
         String queryTypeName = getPrefixedTypeName(typeName);
         map.put("TYPENAME", queryTypeName);
-
-        if (request.getPropertyNames() != null && request.getPropertyNames().length > 0) {
-            List<String> propertyNames = Arrays.asList(request.getPropertyNames());
-            StringBuilder pnames = new StringBuilder();
-            for (Iterator<String> it = propertyNames.iterator(); it.hasNext(); ) {
-                pnames.append(it.next());
-                if (it.hasNext()) {
-                    pnames.append(',');
-                }
-            }
-            map.put("PROPERTYNAME", encodePropertyName(pnames.toString()));
-        }
 
         final String srsName = request.getSrsName();
         if (srsName != null) {
@@ -287,7 +304,13 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
                     unsupportedFilter);
         }
 
+        // in case of unsupported filter, we need to expand the property names and
+        // remove the max features limit
         request.setUnsupportedFilter(unsupportedFilter);
+        updatePropertyNames(request, unsupportedFilter);
+        if (!Filter.INCLUDE.equals(unsupportedFilter)) {
+            request.setMaxFeatures(null);
+        }
 
         if (supportedFilter instanceof Id) {
             final Set<Identifier> identifiers = ((Id) supportedFilter).getIdentifiers();
@@ -312,6 +335,22 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
                 throw new RuntimeException(e);
             }
             map.put("FILTER", xmlEncodedFilter);
+        }
+
+        if (request.getMaxFeatures() != null) {
+            map.put("MAXFEATURES", String.valueOf(request.getMaxFeatures()));
+        }
+
+        if (request.getPropertyNames() != null && request.getPropertyNames().length > 0) {
+            List<String> propertyNames = Arrays.asList(request.getPropertyNames());
+            StringBuilder pnames = new StringBuilder();
+            for (Iterator<String> it = propertyNames.iterator(); it.hasNext(); ) {
+                pnames.append(it.next());
+                if (it.hasNext()) {
+                    pnames.append(',');
+                }
+            }
+            map.put("PROPERTYNAME", encodePropertyName(pnames.toString()));
         }
 
         return map;

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
@@ -223,7 +223,9 @@ public class WFSClient extends AbstractOpenWebService<WFSGetCapabilities, QName>
             } else if (uri.toLowerCase().contains("/arcgis/services/")
                     && Versions.v2_0_0.equals(capsVersion)) {
                 strategy = new ArcGisStrategy_2_0();
-            } else if (uri.contains("mapserver") || uri.contains("map=")) {
+            } else if ((uri.contains("mapserver") || uri.contains("map="))
+                    && !Versions.v2_0_0.equals(capsVersion)) {
+                // v 1.x strategy, won't work with WFS 2.0
                 strategy = new MapServerWFSStrategy(capabilitiesDoc);
             }
         }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v1_x/StrictWFS_1_x_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v1_x/StrictWFS_1_x_Strategy.java
@@ -181,8 +181,10 @@ public class StrictWFS_1_x_Strategy extends AbstractWFSStrategy {
         }
 
         query.setUnsupportedFilter(unsupportedFilter);
+        updatePropertyNames(query, unsupportedFilter);
 
         if (!Filter.INCLUDE.equals(supportedFilter)) {
+            // the unsupported filter must be able to run in memory afterwards
             wfsQuery.setFilter(supportedFilter);
         }
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -185,15 +185,6 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
     }
 
     @Override
-    /**
-     * Currently the wfs-ng client is unable to handle max features and filters. Setting canLimit to
-     * false is inefficient but gives correct results.
-     */
-    public boolean canLimit() {
-        return false;
-    }
-
-    @Override
     public Version getServiceVersion() {
         return Versions.v2_0_0;
     }
@@ -242,6 +233,7 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
             Filter originalFilter = query.getFilter();
 
             query.setUnsupportedFilter(originalFilter);
+            updatePropertyNames(query, originalFilter);
 
             Map<String, String> viewParams = null;
             if (query.getRequestHints() != null) {
@@ -350,6 +342,7 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
 
             // The query filter must be processed locally in full
             query.setUnsupportedFilter(query.getFilter());
+            updatePropertyNames(query, query.getFilter());
 
             Map<String, String> viewParams = null;
             StoredQueryConfiguration config = null;
@@ -386,6 +379,7 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
             }
 
             query.setUnsupportedFilter(unsupportedFilter);
+            updatePropertyNames(query, unsupportedFilter);
 
             if (!Filter.INCLUDE.equals(supportedFilter)) {
                 wfsQuery.setFilter(supportedFilter);

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/ArcServerWFSOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/ArcServerWFSOnlineTest.java
@@ -16,8 +16,8 @@
  */
 package org.geotools.data.wfs.online;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -26,11 +26,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
-import java.util.TreeSet;
 import org.geotools.api.data.DataStoreFinder;
 import org.geotools.api.data.Query;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -40,58 +40,11 @@ import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.test.OnlineTestSupport;
 import org.geotools.util.factory.GeoTools;
-import org.junit.Before;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 /** @author ian */
 public class ArcServerWFSOnlineTest extends OnlineTestSupport {
-
-    TreeSet<String> expected = new TreeSet<>();
-
-    @Before
-    public void setup() {
-        String[] expectedA = {
-            "ARMS.209",
-            "ARMS.755",
-            "ARMS.852",
-            "ARMS.866",
-            "ARMS.1333",
-            "ARMS.1881",
-            "ARMS.1887",
-            "ARMS.3426",
-            "ARMS.2241",
-            "ARMS.6427",
-            "ARMS.6428",
-            "ARMS.8456",
-            "ARMS.9018",
-            "ARMS.10881",
-            "ARMS.15184",
-            "ARMS.13564",
-            "ARMS.15468",
-            "ARMS.17342",
-            "ARMS.19371",
-            "ARMS.18651",
-            "ARMS.20556",
-            "ARMS.20557",
-            "ARMS.21690",
-            "ARMS.22392",
-            "ARMS.25485",
-            "ARMS.26036",
-            "ARMS.27089",
-            "ARMS.27090",
-            "ARMS.26381",
-            "ARMS.29412",
-            "ARMS.29413",
-            "ARMS.28654",
-            "ARMS.28584",
-            "ARMS.28590",
-            "ARMS.31125",
-            "ARMS.31126",
-            "ARMS.34517",
-            "ARMS.34302"
-        };
-        expected.addAll(Arrays.asList(expectedA));
-    }
 
     @Test
     public void testArcMapWFSFilter_V1_get() throws IOException, NoSuchElementException {
@@ -122,6 +75,7 @@ public class ArcServerWFSOnlineTest extends OnlineTestSupport {
     public void testArcMapWFSFilter_V2_post() throws IOException, NoSuchElementException {
         arcMapTest("2.0.0", false);
     }
+
     /** */
     private void arcMapTest(String version, boolean get) throws IOException {
 
@@ -153,31 +107,52 @@ public class ArcServerWFSOnlineTest extends OnlineTestSupport {
         query.setFilter(filter);
         SimpleFeatureCollection features = source.getFeatures(query);
         int size = features.size();
-        // System.out.println(size);
-        assertSame("Wrong number of features", size, 79);
+        assertTrue("Wrong number of features", size > 10);
         // Iterator through all the features and print them out.
         int count = 0;
         try (SimpleFeatureIterator iterator = features.features()) {
-            while (iterator.hasNext() && count < 10) {
+            while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();
-                // System.out.println(feature.getID());
-                assertTrue(expected.contains(feature.getID()));
+                assertThat((String) feature.getAttribute("NBAFR"), CoreMatchers.startsWith("YON"));
                 count++;
             }
         }
+        assertTrue(count > 10);
 
+        // check max-features is working properly
         query.setMaxFeatures(10);
         features = source.getFeatures(query);
         size = features.size();
         assertEquals(10, size);
         // Iterator through all the features and print them out.
+        count = 0;
         try (SimpleFeatureIterator iterator = features.features()) {
             while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();
-
-                assertTrue(expected.contains(feature.getID()));
+                assertThat((String) feature.getAttribute("NBAFR"), CoreMatchers.startsWith("YON"));
+                count++;
             }
         }
+        assertEquals(10, count);
+
+        // set up an un-encodable filter using property selection
+        query.setPropertyNames(Arrays.asList("NBAFR"));
+        Filter functionFilter =
+                ff.greater(ff.function("abs", ff.property("OBJECTID")), ff.literal(50));
+        query.setFilter(ff.and(filter, functionFilter));
+        features = source.getFeatures(query);
+        SimpleFeatureType schema = features.getSchema();
+        assertEquals(1, schema.getAttributeCount());
+        assertEquals("NBAFR", schema.getDescriptor(0).getLocalName());
+        count = 0;
+        try (SimpleFeatureIterator iterator = features.features()) {
+            while (iterator.hasNext()) {
+                SimpleFeature feature = iterator.next();
+                assertThat((String) feature.getAttribute("NBAFR"), CoreMatchers.startsWith("YON"));
+                count++;
+            }
+        }
+        assertEquals(10, count);
     }
 
     @Override

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/GeoServerWFSOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/GeoServerWFSOnlineTest.java
@@ -27,59 +27,47 @@ import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import org.geotools.api.data.DataStoreFinder;
 import org.geotools.api.data.Query;
 import org.geotools.api.data.SimpleFeatureSource;
-import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.PropertyIsEqualTo;
+import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
-import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.wfs.WFSDataStore;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.test.OnlineTestSupport;
 import org.geotools.util.factory.GeoTools;
-import org.junit.Before;
 import org.junit.Test;
 
 /** @author ian */
 public class GeoServerWFSOnlineTest extends OnlineTestSupport {
-    /** Results expected for Version 1.x */
-    TreeSet<String> expected1 = new TreeSet<>();
-    /** Results expected for Version 2.x */
-    TreeSet<String> expected2 = new TreeSet<>();
 
-    @Before
-    public void setup() {
-        String[] expectedA = {
-            "states.1",
-            "states.7",
-            "states.9",
-            "states.13",
-            "states.14",
-            "states.17",
-            "states.18",
-            "states.19",
-            "states.21",
-            "states.22"
-        };
-        expected1.addAll(Arrays.asList(expectedA));
-
-        String[] expectedB = {
-            "states.1",
-            "states.13",
-            "states.14",
-            "states.17",
-            "states.18",
-            "states.19",
-            "states.21",
-            "states.22",
-            "states.23",
-            "states.24",
-        };
-        expected2.addAll(Arrays.asList(expectedB));
-    }
+    /** All states with LAND_KM between 100,000 and 150,000 */
+    TreeSet<String> expected =
+            new TreeSet<>(
+                    Arrays.asList(
+                            "states.1",
+                            "states.7",
+                            "states.9",
+                            "states.13",
+                            "states.14",
+                            "states.17",
+                            "states.18",
+                            "states.19",
+                            "states.21",
+                            "states.22",
+                            "states.23",
+                            "states.24",
+                            "states.30",
+                            "states.36",
+                            "states.39",
+                            "states.40",
+                            "states.48"));
 
     @Test
     public void testGeoServerWFSFilter_V1_get() throws IOException, NoSuchElementException {
@@ -103,20 +91,16 @@ public class GeoServerWFSOnlineTest extends OnlineTestSupport {
 
     @Test
     public void testGeoServerWFSFilter_V2_get() throws IOException, NoSuchElementException {
-        geoServerTest("2.0.0", true, expected2);
+        geoServerTest("2.0.0", true);
     }
 
     @Test
     public void testGeoServerWFSFilter_V2_post() throws IOException, NoSuchElementException {
-        geoServerTest("2.0.0", false, expected2);
+        geoServerTest("2.0.0", false);
     }
 
-    private void geoServerTest(String version, boolean get) throws IOException {
-        geoServerTest(version, get, expected1);
-    }
     /** */
-    private void geoServerTest(String version, boolean get, Set<String> expected)
-            throws IOException {
+    private void geoServerTest(String version, boolean get) throws IOException {
         Properties fixture = getFixture();
 
         String getCapabilities =
@@ -151,34 +135,53 @@ public class GeoServerWFSOnlineTest extends OnlineTestSupport {
         Query query = new Query();
         query.setTypeName(typeName);
 
+        // simple filter
         query.setFilter(filter);
         SimpleFeatureCollection features = source.getFeatures(query);
-        int size = features.size();
+        assertEquals(expected.size(), features.size());
+        assertEquals(expected, collectIds(features));
 
-        assertTrue(size > 10);
-        // Iterator through all the features and print them out.
-        int count = 0;
-        try (SimpleFeatureIterator iterator = features.features()) {
-            while (iterator.hasNext() && count < 10) {
-                SimpleFeature feature = iterator.next();
-                assertTrue(
-                        "unexpected feature " + feature.getID(),
-                        expected.contains(feature.getID()));
-                count++;
-            }
-        }
-
+        // adding paging
         query.setMaxFeatures(10);
         features = source.getFeatures(query);
-        size = features.size();
-        assertEquals(10, size);
-        // Iterator through all the features and print them out.
-        try (SimpleFeatureIterator iterator = features.features()) {
-            while (iterator.hasNext()) {
-                SimpleFeature feature = iterator.next();
-                assertTrue(expected.contains(feature.getID()));
-            }
-        }
+        assertEquals(10, features.size());
+        assertTrue(expected.containsAll(collectIds(features)));
+
+        // and now a non-encodable filter too, to check how it interacts with paging
+        // (only 2 features match the filter)
+        PropertyIsEqualTo functionFilter =
+                ff.equal(
+                        ff.function(
+                                "strSubstring",
+                                ff.property("STATE_NAME"),
+                                ff.literal(0),
+                                ff.literal(1)),
+                        ff.literal("A"),
+                        true);
+        query.setFilter(ff.and(filter, functionFilter));
+        features = source.getFeatures(query);
+        assertEquals(2, features.size());
+        TreeSet<String> expectedFF = new TreeSet<>(Arrays.asList("states.17", "states.21"));
+        assertEquals(expectedFF, collectIds(features));
+
+        // finally, make sure that property selection works with a non-encodable filter
+        // (the attribute chosen is not part of either filters)
+        query.setPropertyNames(new String[] {"STATE_ABBR"});
+        features = source.getFeatures(query);
+        SimpleFeatureType schema = features.getSchema();
+        assertEquals(1, schema.getAttributeCount());
+        assertEquals("STATE_ABBR", schema.getDescriptor(0).getLocalName());
+        Set<String> names =
+                DataUtilities.list(features).stream()
+                        .map(f -> (String) f.getAttribute("STATE_ABBR"))
+                        .collect(Collectors.toSet());
+        assertEquals(new TreeSet<>(Arrays.asList("AR", "AL")), names);
+    }
+
+    private static Set<String> collectIds(SimpleFeatureCollection features) {
+        return DataUtilities.list(features).stream()
+                .map(f -> f.getID())
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/MapServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/MapServerOnlineTest.java
@@ -17,8 +17,10 @@
  */
 package org.geotools.data.wfs.online;
 
+import static java.util.logging.Level.SEVERE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -26,6 +28,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.logging.Logger;
 import org.geotools.api.data.DataStore;
 import org.geotools.api.data.Query;
 import org.geotools.api.data.SimpleFeatureSource;
@@ -34,6 +37,7 @@ import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.GeometryDescriptor;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.PropertyIsEqualTo;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
@@ -43,11 +47,14 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.util.factory.GeoTools;
+import org.geotools.util.logging.Logging;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class MapServerOnlineTest {
+
+    static final Logger LOGGER = Logging.getLogger(MapServerOnlineTest.class);
 
     public static final String SERVER_URL_100 =
             "http://demo.mapserver.org/cgi-bin/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities";
@@ -77,36 +84,43 @@ public class MapServerOnlineTest {
         url_100 = new URL(SERVER_URL_100);
         url_110 = new URL(SERVER_URL_110);
         url_200 = new URL(SERVER_URL_200);
-        if (url_100 != null) {
-            try {
-                Map<String, Serializable> params = new HashMap<>();
-                params.put(WFSDataStoreFactory.URL.key, url_100);
-                params.put(WFSDataStoreFactory.WFS_STRATEGY.key, "mapserver");
-                params.put(WFSDataStoreFactory.GML_COMPATIBLE_TYPENAMES.key, Boolean.TRUE);
-                wfs100 = new WFSDataStoreFactory().createDataStore(params);
+        try {
+            Map<String, Serializable> params = new HashMap<>();
+            params.put(WFSDataStoreFactory.URL.key, url_100);
+            params.put(WFSDataStoreFactory.WFS_STRATEGY.key, "mapserver");
+            params.put(WFSDataStoreFactory.GML_COMPATIBLE_TYPENAMES.key, Boolean.TRUE);
+            wfs100 = new WFSDataStoreFactory().createDataStore(params);
 
-                params = new HashMap<>();
-                params.put(WFSDataStoreFactory.URL.key, url_110);
-                params.put(WFSDataStoreFactory.WFS_STRATEGY.key, "mapserver");
-                params.put(WFSDataStoreFactory.GML_COMPATIBLE_TYPENAMES.key, Boolean.TRUE);
-                wfs110 = new WFSDataStoreFactory().createDataStore(params);
+            params = new HashMap<>();
+            params.put(WFSDataStoreFactory.URL.key, url_110);
+            params.put(WFSDataStoreFactory.WFS_STRATEGY.key, "mapserver");
+            params.put(WFSDataStoreFactory.GML_COMPATIBLE_TYPENAMES.key, Boolean.TRUE);
+            wfs110 = new WFSDataStoreFactory().createDataStore(params);
 
-                params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
-                wfs110_with_get = new WFSDataStoreFactory().createDataStore(params);
+            params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
+            wfs110_with_get = new WFSDataStoreFactory().createDataStore(params);
 
-                params = new HashMap<>();
-                params.put(WFSDataStoreFactory.URL.key, url_200);
-                params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
-                wfs200 = new WFSDataStoreFactory().createDataStore(params);
+            assertEquals("1.0.0", wfs100.getInfo().getVersion());
+            assertEquals("1.1.0", wfs110.getInfo().getVersion());
+            assertEquals("1.1.0", wfs110_with_get.getInfo().getVersion());
+        } catch (Exception e) {
+            LOGGER.log(
+                    SEVERE, "WFS 1.0 and 1.1 tests disabled, server not available: " + url_100, e);
+            url_100 = null;
+            url_110 = null;
+        }
 
-                assertEquals("1.0.0", wfs100.getInfo().getVersion());
-                assertEquals("1.1.0", wfs110.getInfo().getVersion());
-                assertEquals("1.1.0", wfs110_with_get.getInfo().getVersion());
-                assertEquals("2.0.0", wfs200.getInfo().getVersion());
-            } catch (Exception e) {
-                // System.err.println("Server is not available. test disabled ");
-                url_100 = null;
-            }
+        try {
+            Map<String, Serializable> params = new HashMap<>();
+            params = new HashMap<>();
+            params.put(WFSDataStoreFactory.URL.key, url_200);
+            params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
+            wfs200 = new WFSDataStoreFactory().createDataStore(params);
+
+            assertEquals("2.0.0", wfs200.getInfo().getVersion());
+        } catch (Exception e) {
+            LOGGER.log(SEVERE, "WFS 2.0 tests disabled, server not available: " + url_200, e);
+            url_200 = null;
         }
     }
 
@@ -115,6 +129,9 @@ public class MapServerOnlineTest {
         if (url_100 != null) {
             wfs100.dispose();
             wfs110.dispose();
+        }
+        if (url_200 != null) {
+            wfs200.dispose();
         }
     }
 
@@ -183,13 +200,11 @@ public class MapServerOnlineTest {
     }
 
     private void testSingleType2(DataStore wfs) throws IOException, NoSuchElementException {
-        if (url_100 == null) return;
+        if (url_200 == null) return;
 
         String typeName = "ms:rt_cartoteca.ctr10k.dxf";
 
         SimpleFeatureType type = wfs.getSchema(typeName);
-        type.getTypeName();
-        type.getName().getNamespaceURI();
         assertEquals(typeName, type.getName().getLocalPart());
 
         SimpleFeatureSource source = wfs.getFeatureSource(typeName);
@@ -212,18 +227,44 @@ public class MapServerOnlineTest {
         query.setTypeName(typeName);
         query.setFilter(filter);
         // test property names
-        query.setPropertyNames("codice", "nome");
+        query.setPropertyNames("idrt", "origine");
+        query.setMaxFeatures(10);
 
         features = source.getFeatures(query);
 
         int size = features.size();
-        assertEquals(308, size);
+        assertTrue("Got more features than expected: " + size, size <= 10);
+        SimpleFeatureType schema = features.getSchema();
+        assertEquals(2, schema.getAttributeCount());
+        assertEquals("idrt", schema.getDescriptor(0).getLocalName());
+        assertEquals("origine", schema.getDescriptor(1).getLocalName());
 
         try (SimpleFeatureIterator iterator = features.features()) {
             while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();
                 assertNotNull(feature.getID());
+                assertNotNull(feature.getAttribute("idrt"));
+                assertNotNull(feature.getAttribute("origine"));
             }
         }
+
+        // test un-encodable filter
+        PropertyIsEqualTo functionFilter =
+                ff.equal(
+                        ff.function(
+                                "strSubstring",
+                                ff.property("nome_fog"), // property not in selection
+                                ff.literal(0),
+                                ff.literal(5)),
+                        ff.literal("ISOLA"),
+                        true);
+        query.setFilter(ff.and(filter, functionFilter));
+        query.setMaxFeatures(5); // there are 7 matching at the time of writing
+        features = source.getFeatures(query);
+        assertEquals(5, features.size()); // but only 7 returned
+        schema = features.getSchema();
+        assertEquals(2, schema.getAttributeCount());
+        assertEquals("idrt", schema.getDescriptor(0).getLocalName());
+        assertEquals("origine", schema.getDescriptor(1).getLocalName());
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
@@ -25,6 +25,7 @@ import org.geotools.api.filter.FilterFactory;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.online.AbstractWfsDataStoreOnlineTest;
 import org.geotools.factory.CommonFactoryFinder;
+import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LinearRing;
@@ -51,15 +52,21 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
     public static Filter createSpatialFilter() {
         GeometryFactory gf = new GeometryFactory();
         Coordinate[] coordinates = {
-            new Coordinate(39, -107),
-            new Coordinate(38, -107),
-            new Coordinate(38, -104),
-            new Coordinate(39, -104),
-            new Coordinate(39, -107)
+            new Coordinate(-107, 39),
+            new Coordinate(-107, 38),
+            new Coordinate(-104, 38),
+            new Coordinate(-104, 39),
+            new Coordinate(-107, 39)
         };
         LinearRing shell = gf.createLinearRing(coordinates);
         Polygon polygon = gf.createPolygon(shell, null);
         FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
         return ff.intersects(ff.property("the_geom"), ff.literal(polygon));
+    }
+
+    @Test
+    @Override
+    public void testDataStoreSupportsPlainBBOXInterface() throws Exception {
+        super.testDataStoreSupportsPlainBBOXInterface();
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/GeoServerOnlineTest.java
@@ -46,17 +46,18 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
                 -1,
                 ff.id(Collections.singleton(ff.featureId("states.1"))),
                 createSpatialFilter(),
-                WFSDataStoreFactory.AXIS_ORDER_EAST_NORTH);
+                WFSDataStoreFactory.AXIS_ORDER_COMPLIANT);
     }
 
     public static Filter createSpatialFilter() {
+        // compliant axis order for WFS 2.0, lat and then lon
         GeometryFactory gf = new GeometryFactory();
         Coordinate[] coordinates = {
-            new Coordinate(-107, 39),
-            new Coordinate(-107, 38),
-            new Coordinate(-104, 38),
-            new Coordinate(-104, 39),
-            new Coordinate(-107, 39)
+            new Coordinate(39, -107),
+            new Coordinate(38, -107),
+            new Coordinate(38, -104),
+            new Coordinate(39, -104),
+            new Coordinate(39, -107)
         };
         LinearRing shell = gf.createLinearRing(coordinates);
         Polygon polygon = gf.createPolygon(shell, null);


### PR DESCRIPTION
[![GEOT-7497](https://badgen.net/badge/JIRA/GEOT-7497/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7497) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport of https://github.com/geotools/geotools/pull/4563

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->