### PR TITLE
[Backport 28.x]  WFS 2.0 client ignoring max features (along with a fix encoding between filters)

### DIFF
--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/FESConfiguration.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/FESConfiguration.java
@@ -55,6 +55,7 @@ import org.geotools.filter.v2_0.bindings.GeometryOperandsType_GeometryOperandBin
 import org.geotools.filter.v2_0.bindings.Id_CapabilitiesTypeBinding;
 import org.geotools.filter.v2_0.bindings.IntersectsBinding;
 import org.geotools.filter.v2_0.bindings.LiteralBinding;
+import org.geotools.filter.v2_0.bindings.LowerBoundaryTypeBinding;
 import org.geotools.filter.v2_0.bindings.MatchActionBinding;
 import org.geotools.filter.v2_0.bindings.MeasureTypeBinding;
 import org.geotools.filter.v2_0.bindings.MeetsBinding;
@@ -84,6 +85,7 @@ import org.geotools.filter.v2_0.bindings.TContainsBinding;
 import org.geotools.filter.v2_0.bindings.TEqualsBinding;
 import org.geotools.filter.v2_0.bindings.TOverlapsBinding;
 import org.geotools.filter.v2_0.bindings.TouchesBinding;
+import org.geotools.filter.v2_0.bindings.UpperBoundaryTypeBinding;
 import org.geotools.filter.v2_0.bindings.ValueReferenceBinding;
 import org.geotools.filter.v2_0.bindings.VersionTypeBinding;
 import org.geotools.filter.v2_0.bindings.WithinBinding;
@@ -178,7 +180,8 @@ public class FESConfiguration extends Configuration {
         //
         // container.registerComponentImplementation(FES.LogicOpsType,LogicOpsTypeBinding.class);
         //
-        // container.registerComponentImplementation(FES.LowerBoundaryType,LowerBoundaryTypeBinding.class);
+        container.registerComponentImplementation(
+                FES.LowerBoundaryType, LowerBoundaryTypeBinding.class);
         //
         // container.registerComponentImplementation(FES.MatchActionType,MatchActionTypeBinding.class);
 
@@ -225,7 +228,8 @@ public class FESConfiguration extends Configuration {
         //
         // container.registerComponentImplementation(FES.UnaryLogicOpType,UnaryLogicOpTypeBinding.class);
         //
-        // container.registerComponentImplementation(FES.UpperBoundaryType,UpperBoundaryTypeBinding.class);
+        container.registerComponentImplementation(
+                FES.UpperBoundaryType, UpperBoundaryTypeBinding.class);
         //
         // container.registerComponentImplementation(FES.VersionActionTokens,VersionActionTokensBinding.class);
         container.registerComponentImplementation(FES.VersionType, VersionTypeBinding.class);

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/LowerBoundaryTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/LowerBoundaryTypeBinding.java
@@ -1,0 +1,67 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.v2_0.bindings;
+
+import javax.xml.namespace.QName;
+import org.geotools.filter.v2_0.FES;
+import org.geotools.xsd.AbstractComplexBinding;
+import org.geotools.xsd.ElementInstance;
+import org.geotools.xsd.Node;
+import org.opengis.filter.expression.Expression;
+
+/** Binding object for the lower boundary of a property is between filter */
+public class LowerBoundaryTypeBinding extends AbstractComplexBinding {
+    /** @generated */
+    @Override
+    public QName getTarget() {
+        return FES.LowerBoundaryType;
+    }
+
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    @Override
+    public Class getType() {
+        return Expression.class;
+    }
+
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    @Override
+    public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
+        return node.getChildValue(Expression.class);
+    }
+
+    @Override
+    public Object getProperty(Object object, QName name) throws Exception {
+        // &lt;xsd:element ref="ogc:expression"/&gt;
+        if (FES.expression.equals(name)) {
+            return object;
+        }
+
+        return null;
+    }
+}

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/PropertyIsBetweenTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/PropertyIsBetweenTypeBinding.java
@@ -20,6 +20,7 @@ import javax.xml.namespace.QName;
 import org.geotools.filter.v1_0.OGCPropertyIsBetweenTypeBinding;
 import org.geotools.filter.v2_0.FES;
 import org.opengis.filter.FilterFactory;
+import org.opengis.filter.PropertyIsBetween;
 
 /**
  * Binding object for the type http://www.opengis.net/fes/2.0:PropertyIsBetweenType.
@@ -54,5 +55,15 @@ public class PropertyIsBetweenTypeBinding extends OGCPropertyIsBetweenTypeBindin
     @Override
     public QName getTarget() {
         return FES.PropertyIsBetweenType;
+    }
+
+    @Override
+    public Object getProperty(Object object, QName name) throws Exception {
+        if (FES.expression.equals(name)) {
+            PropertyIsBetween between = (PropertyIsBetween) object;
+            return between.getExpression();
+        }
+
+        return super.getProperty(object, name);
     }
 }

--- a/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/UpperBoundaryTypeBinding.java
+++ b/modules/extension/xsd/xsd-fes/src/main/java/org/geotools/filter/v2_0/bindings/UpperBoundaryTypeBinding.java
@@ -1,0 +1,67 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.v2_0.bindings;
+
+import javax.xml.namespace.QName;
+import org.geotools.filter.v2_0.FES;
+import org.geotools.xsd.AbstractComplexBinding;
+import org.geotools.xsd.ElementInstance;
+import org.geotools.xsd.Node;
+import org.opengis.filter.expression.Expression;
+
+/** Binding object for the upper boundary of a property is between filter. */
+public class UpperBoundaryTypeBinding extends AbstractComplexBinding {
+    /** @generated */
+    @Override
+    public QName getTarget() {
+        return FES.UpperBoundaryType;
+    }
+
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    @Override
+    public Class getType() {
+        return Expression.class;
+    }
+
+    /**
+     *
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @generated modifiable
+     */
+    @Override
+    public Object parse(ElementInstance instance, Node node, Object value) throws Exception {
+        return node.getChildValue(Expression.class);
+    }
+
+    @Override
+    public Object getProperty(Object object, QName name) throws Exception {
+        // &lt;xsd:element ref="ogc:expression"/&gt;
+        if (FES.expression.equals(name)) {
+            return object;
+        }
+
+        return null;
+    }
+}

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/PropertyIsBetweenBindingTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/PropertyIsBetweenBindingTest.java
@@ -1,0 +1,57 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.v2_0.bindings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.geotools.filter.v1_1.FilterMockData;
+import org.geotools.filter.v2_0.FES;
+import org.geotools.filter.v2_0.FESTestSupport;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class PropertyIsBetweenBindingTest extends FESTestSupport {
+
+    @Test
+    public void testEncode() throws Exception {
+        Document doc = encode(FilterMockData.propertyIsBetween(), FES.Filter);
+        assertEquals("fes:Filter", doc.getDocumentElement().getNodeName());
+        print(doc);
+
+        Element between = getElementByQName(doc, FES.PropertyIsBetween);
+        assertNotNull(between);
+        NodeList children = between.getChildNodes();
+        assertEquals(3, children.getLength());
+        Node valueReference = children.item(0);
+        assertEquals("fes:ValueReference", valueReference.getNodeName());
+        assertEquals("foo", valueReference.getTextContent());
+
+        assertEquals("fes:LowerBoundary", children.item(1).getNodeName());
+        Node lowerLiteral = children.item(1).getFirstChild();
+        assertEquals("fes:Literal", lowerLiteral.getNodeName());
+        assertEquals("10", lowerLiteral.getTextContent());
+
+        assertEquals("fes:UpperBoundary", children.item(2).getNodeName());
+        Node upperLiteral = children.item(2).getFirstChild();
+        assertEquals("fes:Literal", upperLiteral.getNodeName());
+        assertEquals("20", upperLiteral.getTextContent());
+    }
+}

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/FilterMockData.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/FilterMockData.java
@@ -31,6 +31,7 @@ import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.Id;
 import org.opengis.filter.Not;
 import org.opengis.filter.Or;
+import org.opengis.filter.PropertyIsBetween;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.PropertyIsGreaterThan;
 import org.opengis.filter.PropertyIsGreaterThanOrEqualTo;
@@ -205,6 +206,10 @@ public class FilterMockData {
 
     public static PropertyIsGreaterThanOrEqualTo propertyIsGreaterThanOrEqualTo() {
         return f.greaterOrEqual(propertyName(), literal());
+    }
+
+    public static PropertyIsBetween propertyIsBetween() {
+        return f.between(propertyName(), literal(10), literal(20));
     }
 
     public static Element binaryComparisonOp(Document document, Node parent, QName name) {

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
@@ -28,6 +28,7 @@ import org.geotools.data.EmptyFeatureReader;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.FilteringFeatureReader;
+import org.geotools.data.MaxFeatureReader;
 import org.geotools.data.Query;
 import org.geotools.data.ReTypeFeatureReader;
 import org.geotools.data.ResourceInfo;
@@ -277,12 +278,17 @@ class WFSFeatureSource extends ContentFeatureSource {
 
         GetFeatureRequest request = createGetFeature(localQuery, ResultType.RESULTS);
 
-        final SimpleFeatureType destType = getQueryType(localQuery, getSchema());
+        // the read type migth contain extra properties to run the unsupported filter
+        CoordinateReferenceSystem crs = localQuery.getCoordinateSystemReproject();
+        final SimpleFeatureType destType =
+                getQueryType(crs, localQuery.getPropertyNames(), getSchema());
         final SimpleFeatureType contentType =
-                getQueryType(localQuery, (SimpleFeatureType) request.getFullType());
+                getQueryType(
+                        crs, request.getPropertyNames(), (SimpleFeatureType) request.getFullType());
         request.setQueryType(contentType);
-
+        LOGGER.fine(() -> "request = " + request);
         GetFeatureResponse response = client.issueRequest(request);
+        LOGGER.fine(() -> "response = " + response);
 
         GeometryFactory geometryFactory = findGeometryFactory(localQuery.getHints());
         GetParser<SimpleFeature> features = response.getSimpleFeatures(geometryFactory);
@@ -290,9 +296,14 @@ class WFSFeatureSource extends ContentFeatureSource {
         FeatureReader<SimpleFeatureType, SimpleFeature> reader =
                 new WFSFeatureReader(features, response);
 
-        if (request.getUnsupportedFilter() != null
-                && request.getUnsupportedFilter() != Filter.INCLUDE) {
-            reader = new FilteringFeatureReader<>(reader, request.getUnsupportedFilter());
+        Filter unsupportedFilter = request.getUnsupportedFilter();
+        if (unsupportedFilter != null && unsupportedFilter != Filter.INCLUDE) {
+            reader = new FilteringFeatureReader<>(reader, unsupportedFilter);
+            // in case of unsupported filters, the max features has not been sent to the server,
+            // needs to be applied locally
+            if (localQuery.getMaxFeatures() < Integer.MAX_VALUE) {
+                reader = new MaxFeatureReader<>(reader, localQuery.getMaxFeatures());
+            }
         }
 
         if (!reader.hasNext()) {
@@ -416,13 +427,9 @@ class WFSFeatureSource extends ContentFeatureSource {
      * original feature type for the request's type name in terms of the query CRS and requested
      * attributes.
      */
-    SimpleFeatureType getQueryType(final Query query, SimpleFeatureType featureType)
+    SimpleFeatureType getQueryType(
+            CoordinateReferenceSystem crs, String[] propertyNames, SimpleFeatureType featureType)
             throws IOException {
-
-        final CoordinateReferenceSystem coordinateSystemReproject =
-                query.getCoordinateSystemReproject();
-
-        String[] propertyNames = query.getPropertyNames();
 
         SimpleFeatureType queryType = featureType;
         if (propertyNames != null && propertyNames.length > 0) {
@@ -435,11 +442,9 @@ class WFSFeatureSource extends ContentFeatureSource {
             propertyNames = DataUtilities.attributeNames(featureType);
         }
 
-        if (coordinateSystemReproject != null) {
+        if (crs != null) {
             try {
-                queryType =
-                        DataUtilities.createSubType(
-                                queryType, propertyNames, coordinateSystemReproject);
+                queryType = DataUtilities.createSubType(queryType, propertyNames, crs);
             } catch (SchemaException e) {
                 throw new DataSourceException(e);
             }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
@@ -222,7 +222,9 @@ public class WFSClient extends AbstractOpenWebService<WFSGetCapabilities, QName>
             } else if (uri.toLowerCase().contains("/arcgis/services/")
                     && Versions.v2_0_0.equals(capsVersion)) {
                 strategy = new ArcGisStrategy_2_0();
-            } else if (uri.contains("mapserver") || uri.contains("map=")) {
+            } else if ((uri.contains("mapserver") || uri.contains("map="))
+                    && !Versions.v2_0_0.equals(capsVersion)) {
+                // v 1.x strategy, won't work with WFS 2.0
                 strategy = new MapServerWFSStrategy(capabilitiesDoc);
             }
         }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v1_x/StrictWFS_1_x_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v1_x/StrictWFS_1_x_Strategy.java
@@ -181,8 +181,10 @@ public class StrictWFS_1_x_Strategy extends AbstractWFSStrategy {
         }
 
         query.setUnsupportedFilter(unsupportedFilter);
+        updatePropertyNames(query, unsupportedFilter);
 
         if (!Filter.INCLUDE.equals(supportedFilter)) {
+            // the unsupported filter must be able to run in memory afterwards
             wfsQuery.setFilter(supportedFilter);
         }
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -185,15 +185,6 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
     }
 
     @Override
-    /**
-     * Currently the wfs-ng client is unable to handle max features and filters. Setting canLimit to
-     * false is inefficient but gives correct results.
-     */
-    public boolean canLimit() {
-        return false;
-    }
-
-    @Override
     public Version getServiceVersion() {
         return Versions.v2_0_0;
     }
@@ -242,6 +233,7 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
             Filter originalFilter = query.getFilter();
 
             query.setUnsupportedFilter(originalFilter);
+            updatePropertyNames(query, originalFilter);
 
             Map<String, String> viewParams = null;
             if (query.getRequestHints() != null) {
@@ -350,6 +342,7 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
 
             // The query filter must be processed locally in full
             query.setUnsupportedFilter(query.getFilter());
+            updatePropertyNames(query, query.getFilter());
 
             Map<String, String> viewParams = null;
             StoredQueryConfiguration config = null;
@@ -386,6 +379,7 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
             }
 
             query.setUnsupportedFilter(unsupportedFilter);
+            updatePropertyNames(query, unsupportedFilter);
 
             if (!Filter.INCLUDE.equals(supportedFilter)) {
                 wfsQuery.setFilter(supportedFilter);

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/MapServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/MapServerOnlineTest.java
@@ -17,8 +17,10 @@
  */
 package org.geotools.data.wfs.online;
 
+import static java.util.logging.Level.SEVERE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -26,6 +28,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.logging.Logger;
 import org.geotools.data.DataStore;
 import org.geotools.data.Query;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -37,6 +40,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.util.factory.GeoTools;
+import org.geotools.util.logging.Logging;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,9 +49,12 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 public class MapServerOnlineTest {
+
+    static final Logger LOGGER = Logging.getLogger(MapServerOnlineTest.class);
 
     public static final String SERVER_URL_100 =
             "http://demo.mapserver.org/cgi-bin/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities";
@@ -77,36 +84,43 @@ public class MapServerOnlineTest {
         url_100 = new URL(SERVER_URL_100);
         url_110 = new URL(SERVER_URL_110);
         url_200 = new URL(SERVER_URL_200);
-        if (url_100 != null) {
-            try {
-                Map<String, Serializable> params = new HashMap<>();
-                params.put(WFSDataStoreFactory.URL.key, url_100);
-                params.put(WFSDataStoreFactory.WFS_STRATEGY.key, "mapserver");
-                params.put(WFSDataStoreFactory.GML_COMPATIBLE_TYPENAMES.key, Boolean.TRUE);
-                wfs100 = new WFSDataStoreFactory().createDataStore(params);
+        try {
+            Map<String, Serializable> params = new HashMap<>();
+            params.put(WFSDataStoreFactory.URL.key, url_100);
+            params.put(WFSDataStoreFactory.WFS_STRATEGY.key, "mapserver");
+            params.put(WFSDataStoreFactory.GML_COMPATIBLE_TYPENAMES.key, Boolean.TRUE);
+            wfs100 = new WFSDataStoreFactory().createDataStore(params);
 
-                params = new HashMap<>();
-                params.put(WFSDataStoreFactory.URL.key, url_110);
-                params.put(WFSDataStoreFactory.WFS_STRATEGY.key, "mapserver");
-                params.put(WFSDataStoreFactory.GML_COMPATIBLE_TYPENAMES.key, Boolean.TRUE);
-                wfs110 = new WFSDataStoreFactory().createDataStore(params);
+            params = new HashMap<>();
+            params.put(WFSDataStoreFactory.URL.key, url_110);
+            params.put(WFSDataStoreFactory.WFS_STRATEGY.key, "mapserver");
+            params.put(WFSDataStoreFactory.GML_COMPATIBLE_TYPENAMES.key, Boolean.TRUE);
+            wfs110 = new WFSDataStoreFactory().createDataStore(params);
 
-                params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
-                wfs110_with_get = new WFSDataStoreFactory().createDataStore(params);
+            params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
+            wfs110_with_get = new WFSDataStoreFactory().createDataStore(params);
 
-                params = new HashMap<>();
-                params.put(WFSDataStoreFactory.URL.key, url_200);
-                params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
-                wfs200 = new WFSDataStoreFactory().createDataStore(params);
+            assertEquals("1.0.0", wfs100.getInfo().getVersion());
+            assertEquals("1.1.0", wfs110.getInfo().getVersion());
+            assertEquals("1.1.0", wfs110_with_get.getInfo().getVersion());
+        } catch (Exception e) {
+            LOGGER.log(
+                    SEVERE, "WFS 1.0 and 1.1 tests disabled, server not available: " + url_100, e);
+            url_100 = null;
+            url_110 = null;
+        }
 
-                assertEquals("1.0.0", wfs100.getInfo().getVersion());
-                assertEquals("1.1.0", wfs110.getInfo().getVersion());
-                assertEquals("1.1.0", wfs110_with_get.getInfo().getVersion());
-                assertEquals("2.0.0", wfs200.getInfo().getVersion());
-            } catch (Exception e) {
-                // System.err.println("Server is not available. test disabled ");
-                url_100 = null;
-            }
+        try {
+            Map<String, Serializable> params = new HashMap<>();
+            params = new HashMap<>();
+            params.put(WFSDataStoreFactory.URL.key, url_200);
+            params.put(WFSDataStoreFactory.PROTOCOL.key, Boolean.FALSE);
+            wfs200 = new WFSDataStoreFactory().createDataStore(params);
+
+            assertEquals("2.0.0", wfs200.getInfo().getVersion());
+        } catch (Exception e) {
+            LOGGER.log(SEVERE, "WFS 2.0 tests disabled, server not available: " + url_200, e);
+            url_200 = null;
         }
     }
 
@@ -115,6 +129,9 @@ public class MapServerOnlineTest {
         if (url_100 != null) {
             wfs100.dispose();
             wfs110.dispose();
+        }
+        if (url_200 != null) {
+            wfs200.dispose();
         }
     }
 
@@ -183,13 +200,11 @@ public class MapServerOnlineTest {
     }
 
     private void testSingleType2(DataStore wfs) throws IOException, NoSuchElementException {
-        if (url_100 == null) return;
+        if (url_200 == null) return;
 
         String typeName = "ms:rt_cartoteca.ctr10k.dxf";
 
         SimpleFeatureType type = wfs.getSchema(typeName);
-        type.getTypeName();
-        type.getName().getNamespaceURI();
         assertEquals(typeName, type.getName().getLocalPart());
 
         SimpleFeatureSource source = wfs.getFeatureSource(typeName);
@@ -212,18 +227,44 @@ public class MapServerOnlineTest {
         query.setTypeName(typeName);
         query.setFilter(filter);
         // test property names
-        query.setPropertyNames("codice", "nome");
+        query.setPropertyNames("idrt", "origine");
+        query.setMaxFeatures(10);
 
         features = source.getFeatures(query);
 
         int size = features.size();
-        assertEquals(308, size);
+        assertTrue("Got more features than expected: " + size, size <= 10);
+        SimpleFeatureType schema = features.getSchema();
+        assertEquals(2, schema.getAttributeCount());
+        assertEquals("idrt", schema.getDescriptor(0).getLocalName());
+        assertEquals("origine", schema.getDescriptor(1).getLocalName());
 
         try (SimpleFeatureIterator iterator = features.features()) {
             while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();
                 assertNotNull(feature.getID());
+                assertNotNull(feature.getAttribute("idrt"));
+                assertNotNull(feature.getAttribute("origine"));
             }
         }
+
+        // test un-encodable filter
+        PropertyIsEqualTo functionFilter =
+                ff.equal(
+                        ff.function(
+                                "strSubstring",
+                                ff.property("nome_fog"), // property not in selection
+                                ff.literal(0),
+                                ff.literal(5)),
+                        ff.literal("ISOLA"),
+                        true);
+        query.setFilter(ff.and(filter, functionFilter));
+        query.setMaxFeatures(5); // there are 7 matching at the time of writing
+        features = source.getFeatures(query);
+        assertEquals(5, features.size()); // but only 7 returned
+        schema = features.getSchema();
+        assertEquals(2, schema.getAttributeCount());
+        assertEquals("idrt", schema.getDescriptor(0).getLocalName());
+        assertEquals("origine", schema.getDescriptor(1).getLocalName());
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v1_0/GeoServerOnlineTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.online.AbstractWfsDataStoreOnlineTest;
 import org.geotools.factory.CommonFactoryFinder;
+import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LinearRing;
@@ -51,15 +52,21 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
     public static Filter createSpatialFilter() {
         GeometryFactory gf = new GeometryFactory();
         Coordinate[] coordinates = {
-            new Coordinate(39, -107),
-            new Coordinate(38, -107),
-            new Coordinate(38, -104),
-            new Coordinate(39, -104),
-            new Coordinate(39, -107)
+            new Coordinate(-107, 39),
+            new Coordinate(-107, 38),
+            new Coordinate(-104, 38),
+            new Coordinate(-104, 39),
+            new Coordinate(-107, 39)
         };
         LinearRing shell = gf.createLinearRing(coordinates);
         Polygon polygon = gf.createPolygon(shell, null);
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2(null);
         return ff.intersects(ff.property("the_geom"), ff.literal(polygon));
+    }
+
+    @Test
+    @Override
+    public void testDataStoreSupportsPlainBBOXInterface() throws Exception {
+        super.testDataStoreSupportsPlainBBOXInterface();
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/GeoServerOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/GeoServerOnlineTest.java
@@ -46,17 +46,18 @@ public class GeoServerOnlineTest extends AbstractWfsDataStoreOnlineTest {
                 -1,
                 ff.id(Collections.singleton(ff.featureId("states.1"))),
                 createSpatialFilter(),
-                WFSDataStoreFactory.AXIS_ORDER_EAST_NORTH);
+                WFSDataStoreFactory.AXIS_ORDER_COMPLIANT);
     }
 
     public static Filter createSpatialFilter() {
+        // compliant axis order for WFS 2.0, lat and then lon
         GeometryFactory gf = new GeometryFactory();
         Coordinate[] coordinates = {
-            new Coordinate(-107, 39),
-            new Coordinate(-107, 38),
-            new Coordinate(-104, 38),
-            new Coordinate(-104, 39),
-            new Coordinate(-107, 39)
+            new Coordinate(39, -107),
+            new Coordinate(38, -107),
+            new Coordinate(38, -104),
+            new Coordinate(39, -104),
+            new Coordinate(39, -107)
         };
         LinearRing shell = gf.createLinearRing(coordinates);
         Polygon polygon = gf.createPolygon(shell, null);


### PR DESCRIPTION
Backport of https://github.com/geotools/geotools/pull/4563 

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->