### PR TITLE
[GEOT-7500] New function fixing a rotation angle to account for local north direction: northFix

### DIFF
--- a/docs/user/artifacts/function_list
+++ b/docs/user/artifacts/function_list
@@ -1227,6 +1227,17 @@ Contains 203 functions.
 
 * ``result`` (``Color``)
 
+``northFix(targetCRS, point, angle, sourceCRS)``: returns ``result``
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+* ``targetCRS`` (``CoordinateRefereneSystem``) required. Rendering CRS.
+
+* ``point`` (``Point``) required. Point where the north direction is computed.
+
+* ``angle`` (``Double``) optional. Angle to be north-fixed. Default is 0.
+
+* ``sourceCRS`` (``CoordinateRefereneSystem``) optional. CRS of the source point. If missing, automatically looked up from the geometry user data, the feature type description, or the point SRID.
+
 ``modulo(dividend, divisor)``: returns ``modulo``
 '''''''''''''''''''''''''''''''''''''''''''''''''
 

--- a/modules/library/api/src/main/java/org/geotools/api/filter/expression/SimplifiableFunction.java
+++ b/modules/library/api/src/main/java/org/geotools/api/filter/expression/SimplifiableFunction.java
@@ -1,0 +1,38 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.api.filter.expression;
+
+import org.geotools.api.feature.type.FeatureType;
+import org.geotools.api.filter.FilterFactory;
+
+/**
+ * Implemented by functions that can turn themselves into a simpler, more efficient expression, when
+ * certain conditions are met. Called by the SimplifyingfilterVisitor when the arguments of the
+ * function are not all literals (in which case, a one time simplification is performed instead).
+ */
+public interface SimplifiableFunction {
+
+    /**
+     * Returns a simplified version of the function, or the function itself it cannot be be
+     * simplified
+     *
+     * @param ff The filter factory to use for creating new expressions (mandatory, non null)
+     * @param featureType The target feature type, if available, <code>null</code> otherwise
+     * @return The simplified expression
+     */
+    Expression simplify(FilterFactory ff, FeatureType featureType);
+}

--- a/modules/library/main/src/main/java/org/geotools/filter/function/NorthFix.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/NorthFix.java
@@ -1,0 +1,283 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import static java.lang.Math.atan2;
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geotools.api.data.Parameter;
+import org.geotools.api.feature.Feature;
+import org.geotools.api.feature.type.FeatureType;
+import org.geotools.api.feature.type.GeometryDescriptor;
+import org.geotools.api.feature.type.PropertyDescriptor;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.capability.FunctionName;
+import org.geotools.api.filter.expression.Expression;
+import org.geotools.api.filter.expression.Literal;
+import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.api.filter.expression.SimplifiableFunction;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CompoundCRS;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.crs.EngineeringCRS;
+import org.geotools.api.referencing.crs.GeographicCRS;
+import org.geotools.api.referencing.crs.ProjectedCRS;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.referencing.operation.projection.CylindricalEqualArea;
+import org.geotools.referencing.operation.projection.EquidistantCylindrical;
+import org.geotools.referencing.operation.projection.Mercator;
+import org.geotools.util.SimpleInternationalString;
+import org.geotools.util.logging.Logging;
+import org.locationtech.jts.algorithm.Angle;
+import org.locationtech.jts.geom.Point;
+
+/**
+ * Function that allows correcting a heading angle based on the north direction in the point and CRS
+ * provided. Useful to perform mapping with vectors (wind, currents) on CRSs that do not typically
+ * have the north up (e.g. Polar Stereographic).
+ */
+public class NorthFix extends FunctionExpressionImpl implements SimplifiableFunction {
+
+    static final Logger LOGGER = Logging.getLogger(NorthFix.class);
+
+    public static final String FUNCTION_NAME = "northFix";
+
+    public static final org.geotools.api.parameter.Parameter<Double> RESULT =
+            parameter(
+                    "angle",
+                    Double.class,
+                    "North fix",
+                    "Returns the fixed angle, given the current CRS and position (in case the angle is missing, the result is the offset that needs to be added to the angle.");
+
+    public static final org.geotools.api.parameter.Parameter<CoordinateReferenceSystem> TARGET_CRS =
+            parameter(
+                    "targetCRS",
+                    CoordinateReferenceSystem.class,
+                    "Target coordinate reference system",
+                    "The target coordinate reference system used to paint the map");
+
+    public static final org.geotools.api.parameter.Parameter<Point> POINT =
+            parameter(
+                    "point", Point.class, "point", "The point at which to perform the calculation");
+    public static final Parameter<Double> ANGLE =
+            new Parameter<>(
+                    "angle",
+                    Double.class,
+                    new SimpleInternationalString("angle"),
+                    new SimpleInternationalString(
+                            "The angle to be fixed (optional, defaults to 0)"),
+                    false,
+                    0,
+                    1,
+                    null,
+                    null);
+
+    public static final org.geotools.api.parameter.Parameter<CoordinateReferenceSystem> SOURCE_CRS =
+            new Parameter<>(
+                    "sourceCRS",
+                    CoordinateReferenceSystem.class,
+                    new SimpleInternationalString("Source Coordinate Reference System"),
+                    new SimpleInternationalString(
+                            "The CRS of the provided point. Optional, the function will look up the CRS of the point, and if the source is a simple feature, use its CRS instead. If none of the above is available, then the target and source CRS are assumed to be the same"),
+                    false,
+                    0,
+                    1,
+                    null,
+                    null);
+    public static final int FULL_CIRCLE = 360;
+
+    public static FunctionName NAME =
+            new FunctionNameImpl(FUNCTION_NAME, RESULT, TARGET_CRS, POINT, ANGLE, SOURCE_CRS);
+
+    public NorthFix() {
+        super(NAME);
+    }
+
+    @Override
+    public Object evaluate(Object feature) {
+        // hopefully the input is already a CRS
+        CoordinateReferenceSystem targetCRS =
+                getExpression(0).evaluate(feature, CoordinateReferenceSystem.class);
+        // check if any fix is required, otherwise return the angle as is
+        double angle = 0d;
+        if (getParameters().size() >= 3) {
+            // optional, defaults to zero
+            angle = getExpression(2).evaluate(feature, Double.class);
+        }
+        if (!fixRequired(targetCRS)) return angle;
+
+        // compute the correction angle
+        Point point = getExpression(1).evaluate(feature, Point.class);
+        if (point == null) return angle;
+        CoordinateReferenceSystem sourceCRS = getSourceCRS(feature, point);
+        try {
+            double x = point.getX();
+            double y = point.getY();
+            double[] pt = {x, y};
+            // we have a point in source CRS, move it to target CRS
+            if (sourceCRS != null && !CRS.equalsIgnoreMetadata(sourceCRS, targetCRS)) {
+                // go to target CRS
+                MathTransform step1 = CRS.findMathTransform(sourceCRS, targetCRS, true);
+                step1.transform(pt, 0, pt, 0, 1);
+                // x and y updated in the target CRS
+                x = pt[0];
+                y = pt[1];
+            }
+            // go to WGS84, safe way to compute a second point north of the original one
+            MathTransform step2 =
+                    CRS.findMathTransform(targetCRS, DefaultGeographicCRS.WGS84, true);
+            step2.transform(pt, 0, pt, 0, 1);
+            // move north and then back to target CRS
+            pt[1] += 1e-2;
+            // go back to target CRS
+            step2.inverse().transform(pt, 0, pt, 0, 1);
+
+            // atan2 used to compute the angle between the two points, taking one as the origin
+            // see
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2
+            double northDirection = Angle.toDegrees(atan2(pt[1] - y, pt[0] - x));
+            // compute correction angle considering north is normally at 90°, and normalize
+            return normalizeAngle(angle - northDirection + 90);
+        } catch (TransformException | FactoryException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Normalize an angle to be between 0 and 360 */
+    private double normalizeAngle(double angle) {
+        return (angle % FULL_CIRCLE + FULL_CIRCLE) % FULL_CIRCLE;
+    }
+
+    private CoordinateReferenceSystem getSourceCRS(Object feature, Point point) {
+        CoordinateReferenceSystem sorceCRS = null;
+        if (getParameters().size() == 4) {
+            // optional, defaults to zero
+            sorceCRS = getExpression(3).evaluate(feature, CoordinateReferenceSystem.class);
+        }
+        if (sorceCRS == null && point.getUserData() instanceof CoordinateReferenceSystem) {
+            sorceCRS = (CoordinateReferenceSystem) point.getUserData();
+        }
+        // Heuristic here... the feature CRS is more likely to be correct than the geometry srid,
+        // which cannot carry an authority to begin with
+        if (feature instanceof Feature) {
+            sorceCRS = ((Feature) feature).getType().getCoordinateReferenceSystem();
+        }
+        if (sorceCRS == null && point.getSRID() > 0) {
+            try {
+                // assume it's an EPSG code (not always true, but we have no way to know the
+                // authority)
+                sorceCRS = CRS.decode("EPSG:" + point.getSRID(), true);
+            } catch (FactoryException e) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, "Could not decode EPSG:" + point.getSRID(), e);
+                }
+            }
+        }
+        return sorceCRS;
+    }
+
+    static boolean fixRequired(CoordinateReferenceSystem crs) {
+        // try to go for quick exit cases
+        if (crs == null) {
+            return false;
+        }
+        // flatten if necessary, we only care about the horizontal part
+        if (crs instanceof CompoundCRS) {
+            crs = org.geotools.referencing.CRS.getHorizontalCRS(crs);
+        }
+        // geographic and engineering CRSs are always north up
+        if ((crs instanceof GeographicCRS) || (crs instanceof EngineeringCRS)) {
+            return false;
+        }
+
+        if (crs instanceof ProjectedCRS) {
+            ProjectedCRS projected = (ProjectedCRS) crs;
+            MathTransform mt = projected.getConversionFromBase().getMathTransform();
+            if (isNorthUpProjection(mt)) return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks for the known north up projections implemented by GeoTools, see also a visual
+     * reference at <a href="https://en.wikipedia.org/wiki/List_of_map_projections">Wikipedia</a>.
+     * If a north-up projection is not listed here, that will result in a slower execution, but the
+     * result will be the same.
+     */
+    private static boolean isNorthUpProjection(MathTransform mt) {
+        return mt instanceof Mercator
+                || mt instanceof CylindricalEqualArea
+                || mt instanceof EquidistantCylindrical;
+    }
+
+    @Override
+    public Expression simplify(FilterFactory ff, FeatureType featureType) {
+        List<Expression> parameters = new ArrayList<>(getParameters());
+
+        // if target CRS is a literal it's possible to do useful optimizations
+        if (parameters.get(0) instanceof Literal) {
+            CoordinateReferenceSystem crs =
+                    parameters.get(0).evaluate(null, CoordinateReferenceSystem.class);
+
+            if (!fixRequired(crs)) {
+                // no fix required, remove the function, just return the angle as-is
+                if (parameters.size() >= 3) return parameters.get(2);
+                else return ff.literal(0d);
+            } else {
+                // otherwise, at least make sure the CRS needs no more conversions
+                parameters.set(0, ff.literal(crs));
+            }
+        }
+
+        // if the source CRS is a literal, we can try to pre-convert
+        if (parameters.size() == 4) {
+            if (parameters.get(3) instanceof Literal) {
+                CoordinateReferenceSystem crs =
+                        parameters.get(3).evaluate(null, CoordinateReferenceSystem.class);
+                if (crs != null) {
+                    parameters.set(3, ff.literal(crs));
+                }
+            }
+        } else if (featureType != null && parameters.get(2) instanceof PropertyName) {
+            // otherwise, see if we can lookup the source CRS by looking up a geometry descriptor
+            PropertyDescriptor pd =
+                    parameters.get(1).evaluate(featureType, PropertyDescriptor.class);
+            if (pd instanceof GeometryDescriptor) {
+                GeometryDescriptor gd = (GeometryDescriptor) pd;
+                CoordinateReferenceSystem crs = gd.getCoordinateReferenceSystem();
+                // found it, force it to be an explicit literal to avoid further lookups
+                if (crs != null) {
+                    parameters.add(3, ff.literal(crs));
+                }
+            }
+        }
+
+        NorthFix simplified = new NorthFix();
+        simplified.setParameters(parameters);
+        return simplified;
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/SimplifyingFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/SimplifyingFilterVisitor.java
@@ -50,6 +50,7 @@ import org.geotools.api.filter.expression.Literal;
 import org.geotools.api.filter.expression.Multiply;
 import org.geotools.api.filter.expression.NilExpression;
 import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.api.filter.expression.SimplifiableFunction;
 import org.geotools.api.filter.expression.Subtract;
 import org.geotools.api.filter.expression.VolatileFunction;
 import org.geotools.api.filter.identity.FeatureId;
@@ -482,9 +483,17 @@ public class SimplifyingFilterVisitor extends DuplicatingFilterVisitor {
         if (attributeExtractor.isConstantExpression()) {
             Object result = function.evaluate(null);
             return ff.literal(result);
-        } else {
-            return super.visit(function, extraData);
         }
+
+        // perform simplifying copy, the arguments will be simplified if possible
+        Object result = super.visit(function, extraData);
+
+        // past that, we can try to ask the function to simplify itself
+        if (result instanceof SimplifiableFunction) {
+            return ((SimplifiableFunction) result).simplify(ff, featureType);
+        }
+
+        return result;
     }
 
     /**

--- a/modules/library/main/src/main/resources/META-INF/services/org.geotools.api.filter.expression.Function
+++ b/modules/library/main/src/main/resources/META-INF/services/org.geotools.api.filter.expression.Function
@@ -142,6 +142,7 @@ org.geotools.filter.function.GeometryFunction
 org.geotools.filter.function.IDFunction
 org.geotools.filter.function.InterpolateFunction
 org.geotools.filter.function.MapGetFunction
+org.geotools.filter.function.NorthFix
 org.geotools.filter.function.RecodeFunction
 org.geotools.filter.function.math.FilterFunction_IEEEremainder
 org.geotools.filter.function.math.FilterFunction_abs

--- a/modules/library/main/src/test/java/org/geotools/filter/function/NorthFixTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/NorthFixTest.java
@@ -1,0 +1,273 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2023, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import static org.geotools.referencing.crs.DefaultEngineeringCRS.CARTESIAN_2D;
+import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.Expression;
+import org.geotools.api.filter.expression.Function;
+import org.geotools.api.filter.expression.Literal;
+import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.IdentifiedObject;
+import org.geotools.api.referencing.crs.CRSFactory;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.data.DataUtilities;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.metadata.iso.citation.Citations;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.NamedIdentifier;
+import org.geotools.referencing.ReferencingFactoryFinder;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+
+public class NorthFixTest {
+
+    static final FilterFactory FF = CommonFactoryFinder.getFilterFactory();
+    public static final Literal ANGLE_LT = FF.literal(10);
+    public static final Literal WGS84_LT = FF.literal(WGS84);
+    static final GeometryFactory GF = new GeometryFactory();
+    static final Point POINT = GF.createPoint();
+    public static final Literal POINT_LT = FF.literal(POINT);
+    public static final String NORTH_FIX = NorthFix.FUNCTION_NAME;
+
+    /**
+     * The tolerance for comparing angles reported by NorthFix. There is a balance here between
+     * accurancy and the distance that NorthFix can use to determine the angle.
+     */
+    private static final double EPS = 1;
+
+    /** Test the SPI registration is working */
+    @Test
+    public void testLookup() throws Exception {
+
+        Function function = FF.function(NORTH_FIX, WGS84_LT, POINT_LT);
+        assertThat(function, instanceOf(NorthFix.class));
+    }
+
+    @Test
+    public void testGeographic() throws Exception {
+        Function function = FF.function(NORTH_FIX, WGS84_LT, POINT_LT);
+        assertThat((Double) function.evaluate(null), equalTo(0d));
+        assertFalse(NorthFix.fixRequired(WGS84));
+    }
+
+    @Test
+    public void testGeographicAngle() throws Exception {
+        Function function = FF.function(NORTH_FIX, WGS84_LT, POINT_LT, ANGLE_LT);
+        assertThat((Double) function.evaluate(null), equalTo(10d));
+        assertFalse(NorthFix.fixRequired(WGS84));
+    }
+
+    @Test
+    public void testCompound() throws Exception {
+        // build a compound programmatically (future proofing)
+        CoordinateReferenceSystem compoundCRS = getCompoundCRS();
+
+        Function function = FF.function(NORTH_FIX, FF.literal(compoundCRS), POINT_LT);
+        assertThat((Double) function.evaluate(null), equalTo(0d));
+        assertFalse(NorthFix.fixRequired(compoundCRS));
+    }
+
+    private static CoordinateReferenceSystem getCompoundCRS() throws FactoryException {
+        CRSFactory crsFactory = ReferencingFactoryFinder.getCRSFactory(null);
+        CoordinateReferenceSystem sourceHorizontalCRS = CRS.decode("EPSG:4326");
+        CoordinateReferenceSystem sourceVerticalCRS = CRS.decode("EPSG:5783");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(
+                IdentifiedObject.NAME_KEY,
+                new NamedIdentifier(Citations.fromName("TEST"), "Compound 4326+5783"));
+        CoordinateReferenceSystem[] elements = {sourceHorizontalCRS, sourceVerticalCRS};
+        CoordinateReferenceSystem compoundCRS = crsFactory.createCompoundCRS(properties, elements);
+        return compoundCRS;
+    }
+
+    @Test
+    public void testEngineering() throws Exception {
+        Function function = FF.function(NORTH_FIX, FF.literal(CARTESIAN_2D), POINT_LT);
+        assertThat((Double) function.evaluate(null), equalTo(0d));
+        assertFalse(NorthFix.fixRequired(CARTESIAN_2D));
+    }
+
+    @Test
+    public void testPolar() throws Exception {
+        CoordinateReferenceSystem polarCRS = CRS.decode("EPSG:3976");
+        assertTrue(NorthFix.fixRequired(polarCRS));
+
+        // a test point on the greenwich meridian, no correction needed
+        assertEquals(0, getNorthFix(polarCRS, getPoint(0, 10000)), EPS);
+        // a test point at 90 longitude
+        assertEquals(90, getNorthFix(polarCRS, getPoint(10000, 0)), EPS);
+        // a test point at 180 longitude (dateline)
+        assertEquals(180, getNorthFix(polarCRS, getPoint(0, -10000)), EPS);
+        // a test point at -90 longitude
+        assertEquals(270, getNorthFix(polarCRS, getPoint(-10000, 0)), EPS);
+        // now going around at diagonal angles instead
+        assertEquals(45, getNorthFix(polarCRS, getPoint(10000, 10000)), EPS);
+        assertEquals(135, getNorthFix(polarCRS, getPoint(10000, -10000)), EPS);
+        assertEquals(225, getNorthFix(polarCRS, getPoint(-10000, -10000)), EPS);
+        assertEquals(315, getNorthFix(polarCRS, getPoint(-10000, 10000)), EPS);
+    }
+
+    /**
+     * Real world use case, with source and target CRS, visually tested. Source CRS provided as a
+     * direct function parameter.
+     */
+    @Test
+    public void testPolarExplicitSourceCRS() throws Exception {
+        CoordinateReferenceSystem polarCRS = CRS.decode("EPSG:3976");
+
+        Point pt = getPoint(-102, -73);
+        Function function =
+                FF.function(
+                        NORTH_FIX, FF.literal(polarCRS), FF.literal(pt), FF.literal(195), WGS84_LT);
+        assertEquals(93, function.evaluate(null, Double.class), EPS);
+    }
+
+    /**
+     * Real world use case, with source and target CRS, visually tested. Source CRS coming from the
+     * geometry user data.
+     */
+    @Test
+    public void testPolarMetadataSourceCRS() throws Exception {
+        CoordinateReferenceSystem polarCRS = CRS.decode("EPSG:3976");
+
+        Point pt = getPoint(-102, -73);
+        pt.setUserData(WGS84);
+        Function function =
+                FF.function(NORTH_FIX, FF.literal(polarCRS), FF.literal(pt), FF.literal(195));
+        assertEquals(93, function.evaluate(null, Double.class), EPS);
+    }
+
+    /**
+     * Real world use case, with source and target CRS, visually tested. Source CRS coming from the
+     * geometry user data.
+     */
+    @Test
+    public void testPolarSridCRS() throws Exception {
+        CoordinateReferenceSystem polarCRS = CRS.decode("EPSG:3976");
+
+        Point pt = getPoint(-102, -73);
+        pt.setSRID(4326);
+        Function function =
+                FF.function(NORTH_FIX, FF.literal(polarCRS), FF.literal(pt), FF.literal(195));
+        assertEquals(93, function.evaluate(null, Double.class), EPS);
+    }
+
+    /**
+     * Real world use case, with source and target CRS, visually tested. Source CRS coming from the
+     * feature schema.
+     */
+    @Test
+    public void testPolarFeatureCRS() throws Exception {
+        CoordinateReferenceSystem polarCRS = CRS.decode("EPSG:3976");
+
+        SimpleFeature feature = buildWGS84Feature();
+
+        Function function =
+                FF.function(NORTH_FIX, FF.literal(polarCRS), FF.property("geom"), FF.literal(195));
+        assertEquals(93, function.evaluate(feature, Double.class), EPS);
+    }
+
+    private static SimpleFeature buildWGS84Feature() {
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.add("geom", Point.class, WGS84);
+        tb.setName("points");
+        SimpleFeatureType ft = tb.buildFeatureType();
+        SimpleFeature feature = DataUtilities.createFeature(ft, "POINT(-102 -73)");
+        return feature;
+    }
+
+    private static Point getPoint(double x, double y) {
+        return GF.createPoint(new Coordinate(x, y));
+    }
+
+    private static Double getNorthFix(CoordinateReferenceSystem crs, Point point) {
+        Function function = FF.function(NORTH_FIX, FF.literal(crs), FF.literal(point));
+        return (Double) function.evaluate(null);
+    }
+
+    @Test
+    public void testSimplifyNoConversion() throws Exception {
+        // no conversion needed, just use the angle directly
+        PropertyName angle = FF.property("myAngle");
+        NorthFix function = (NorthFix) FF.function(NORTH_FIX, WGS84_LT, POINT_LT, angle);
+        Expression simplified = function.simplify(FF, null);
+        assertSame(angle, simplified);
+    }
+
+    @Test
+    public void testSimplifyNoAngle() throws Exception {
+        // no conversion needed, no angle either -> new static literal
+        NorthFix function = (NorthFix) FF.function(NORTH_FIX, WGS84_LT, POINT_LT);
+        Expression simplified = function.simplify(FF, null);
+        assertEquals(FF.literal(0d), simplified);
+    }
+
+    @Test
+    public void testSimplifyCRSConversions() throws Exception {
+        // function that could use conversion to static CRS objects (rather than strings)
+        NorthFix function =
+                (NorthFix)
+                        FF.function(
+                                NORTH_FIX,
+                                FF.literal("EPSG:3976"),
+                                POINT_LT,
+                                ANGLE_LT,
+                                FF.literal("CRS:84"));
+        NorthFix simplified = (NorthFix) function.simplify(FF, null);
+
+        Expression targetCRSParameter = simplified.getParameters().get(0);
+        assertThat(targetCRSParameter, instanceOf(Literal.class));
+        assertEquals(CRS.decode("EPSG:3976"), ((Literal) targetCRSParameter).getValue());
+
+        Expression sourceCRSParameter = simplified.getParameters().get(3);
+        assertThat(sourceCRSParameter, instanceOf(Literal.class));
+        assertEquals(CRS.decode("CRS:84"), ((Literal) sourceCRSParameter).getValue());
+    }
+
+    @Test
+    public void testSimplifyFromFeatureType() throws Exception {
+        SimpleFeature feature = buildWGS84Feature();
+        PropertyName angle = FF.property("myAngle");
+        // the source CRS can be looked up dynamically from the feature type, the simplification
+        // should make that lookup static
+        NorthFix function =
+                (NorthFix)
+                        FF.function(NORTH_FIX, FF.literal("EPSG:3976"), FF.property("geom"), angle);
+        assertEquals(3, function.getParameters().size());
+        NorthFix simplified = (NorthFix) function.simplify(FF, feature.getFeatureType());
+        assertEquals(4, simplified.getParameters().size());
+        assertEquals(WGS84_LT, simplified.getParameters().get(3));
+    }
+}

--- a/modules/library/main/src/test/java/org/geotools/filter/visitor/SimplifyingFilterVisitorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/visitor/SimplifyingFilterVisitorTest.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.filter.visitor;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -23,6 +26,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.filter.And;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
@@ -32,12 +36,15 @@ import org.geotools.api.filter.Or;
 import org.geotools.api.filter.PropertyIsEqualTo;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.filter.expression.Function;
+import org.geotools.api.filter.expression.InternalFunction;
 import org.geotools.api.filter.expression.Literal;
 import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.api.filter.expression.SimplifiableFunction;
 import org.geotools.api.filter.identity.Identifier;
 import org.geotools.data.DataUtilities;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.filter.FunctionExpressionImpl;
 import org.geotools.filter.function.EnvFunction;
 import org.geotools.filter.function.math.FilterFunction_random;
 import org.geotools.filter.visitor.SimplifyingFilterVisitor.FIDValidator;
@@ -766,5 +773,85 @@ public class SimplifyingFilterVisitorTest {
         Expression e = ff.divide(ff.function("env", ff.literal("var")), ff.literal(10));
         Expression result = (Expression) e.accept(simpleVisitor, null);
         assertEquals(ff.literal(12.3), result);
+    }
+
+    /**
+     * Simple mock function to test function simplification. Implements also internal function so
+     * that this mock does not need to be registered. Creating the same behavior with EasyMock is
+     * actually more complicated.
+     */
+    private class MockSimplifiableFunction extends FunctionExpressionImpl
+            implements InternalFunction, SimplifiableFunction {
+
+        protected MockSimplifiableFunction() {
+            super("MockFunction");
+        }
+
+        @Override
+        public InternalFunction duplicate(Expression... parameters) {
+            MockSimplifiableFunction clone = new MockSimplifiableFunction();
+            if (parameters != null) clone.setParameters(Arrays.asList(parameters));
+            return clone;
+        }
+
+        @Override
+        public Expression simplify(FilterFactory ff, FeatureType featureType) {
+            // Odd conditions to allow testing different branches of simplification code
+
+            // if there is a feature type, return its name
+            if (featureType != null) return ff.literal(featureType.getName().getLocalPart());
+            // if there is a single argument, return a static string
+            else if (getParameters().size() == 1) return ff.literal("simplified");
+            // otherwise return the function itself (which is used to test argument simplification)
+            return this;
+        }
+
+        @Override
+        public Object evaluate(Object object) {
+            // this should never be called during the existing tests
+            throw new UnsupportedOperationException("Unexpected");
+        }
+    }
+
+    @Test
+    public void testSimplifiableFunction() throws Exception {
+        MockSimplifiableFunction function = new MockSimplifiableFunction();
+        function.setParameters(Arrays.asList(ff.property("a")));
+        Expression simplified = (Expression) function.accept(simpleVisitor, null);
+        assertEquals("simplified", simplified.evaluate(null, String.class));
+    }
+
+    /**
+     * Check basic simplification works (the simplifiable arguments, are simplified)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSimplifiableFunctionRecurse() throws Exception {
+        MockSimplifiableFunction function = new MockSimplifiableFunction();
+        function.setParameters(
+                Arrays.asList(ff.property("a"), ff.add(ff.literal(1), ff.literal(2))));
+        Expression simplified = (Expression) function.accept(simpleVisitor, null);
+        assertThat(simplified, instanceOf(MockSimplifiableFunction.class));
+        MockSimplifiableFunction sf = (MockSimplifiableFunction) simplified;
+        assertThat(sf.getParameters().get(0), instanceOf(PropertyName.class));
+        Expression p1 = sf.getParameters().get(1);
+        assertThat(p1, instanceOf(Literal.class));
+        assertThat(p1.evaluate(null), equalTo(3d));
+    }
+
+    /**
+     * Test it can do something else when a schema is provided
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSimplifiableFunctionWithSchema() throws Exception {
+        SimpleFeatureType schema = DataUtilities.createType("typeName", "a:String");
+        simpleVisitor.setFeatureType(schema);
+        MockSimplifiableFunction function = new MockSimplifiableFunction();
+        function.setParameters(Arrays.asList(ff.property("a")));
+        Expression simplified = (Expression) function.accept(simpleVisitor, null);
+        assertEquals("typeName", simplified.evaluate(null, String.class));
     }
 }

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/SimplifyingStyleVisitor.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/SimplifyingStyleVisitor.java
@@ -19,6 +19,7 @@ package org.geotools.renderer.lite;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.style.FeatureTypeStyle;
 import org.geotools.api.style.Rule;
 import org.geotools.factory.CommonFactoryFinder;
@@ -43,6 +44,19 @@ class SimplifyingStyleVisitor extends DuplicatingStyleVisitor {
                 CommonFactoryFinder.getStyleFactory(null),
                 CommonFactoryFinder.getFilterFactory(null),
                 new SimplifyingFilterVisitor());
+    }
+
+    SimplifyingStyleVisitor(FeatureType schema) {
+        super(
+                CommonFactoryFinder.getStyleFactory(null),
+                CommonFactoryFinder.getFilterFactory(null),
+                getFilterSimplifier(schema));
+    }
+
+    private static SimplifyingFilterVisitor getFilterSimplifier(FeatureType schema) {
+        SimplifyingFilterVisitor filterSimplifier = new SimplifyingFilterVisitor();
+        filterSimplifier.setFeatureType(schema);
+        return filterSimplifier;
     }
 
     @Override

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -2002,10 +2002,11 @@ public class StreamingRenderer implements GTRenderer {
         layer.getStyle().accept(selectorStyleVisitor);
         Style style = (Style) selectorStyleVisitor.getCopy();
 
+        FeatureType schema = layer.getFeatureSource().getSchema();
         for (FeatureTypeStyle fts : style.featureTypeStyles()) {
-            if (isFeatureTypeStyleActive(layer.getFeatureSource().getSchema(), fts)) {
+            if (isFeatureTypeStyleActive(schema, fts)) {
 
-                SimplifyingStyleVisitor simplifier = new SimplifyingStyleVisitor();
+                SimplifyingStyleVisitor simplifier = new SimplifyingStyleVisitor(schema);
                 fts.accept(simplifier);
                 fts = (FeatureTypeStyle) simplifier.getCopy();
 
@@ -2070,7 +2071,7 @@ public class StreamingRenderer implements GTRenderer {
 
         if (!result.isEmpty()) {
             // make sure all spatial filters in the feature source native SRS
-            reprojectSpatialFilters(result, layer.getFeatureSource().getSchema());
+            reprojectSpatialFilters(result, schema);
 
             // apply the uom and dpi rescale
             applyUnitRescale(result);


### PR DESCRIPTION
[![GEOT-7500](https://badgen.net/badge/JIRA/GEOT-7500/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7500) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details, and discussion on the devel list about use case and automatic simplification.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->