### PR TITLE
Java 21 build support

### DIFF
--- a/.github/workflows/linux_jdk21.yml
+++ b/.github/workflows/linux_jdk21.yml
@@ -1,0 +1,46 @@
+name: Linux JDK 21 GitHub CI
+
+on: [pull_request]
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: [ubuntu-20.04]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 21
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: 21
+    - name: Setup python for docs
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+        cache: 'pip' # caching pip dependencies from requirements.txt below
+    - name: Setup python pip requirements for building docs
+      working-directory: docs
+      run: |
+        pip install -r requirements.txt
+    - name: Maven repository caching
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: gt-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          gt-maven-
+    - name: Disable checksum offloading
+      # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
+      run: sudo ethtool -K eth0 tx off rx off
+    - name: Build with Maven
+      run: |
+        mvn -B clean install -Dspotless.apply.skip=true -Dall -T2 -U -Plinux-github-build --file pom.xml
+    - name: Remove SNAPSHOT jars from repository
+      run: |
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/TestUtils.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/TestUtils.java
@@ -350,7 +350,7 @@ public enum TestUtils {
 
     /** Matches a YSLD Tuple with n values */
     @SuppressWarnings("unchecked")
-    public static Matcher<Object> yTuple(int n) {
+    public static Matcher<? extends Object> yTuple(int n) {
         Matcher[] matchers = new Matcher[n];
         Arrays.fill(matchers, anything());
         return Matchers.describedAs("A YSLD Tuple with %0 values", yTuple(matchers), n);

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/CategoryList.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/CategoryList.java
@@ -50,9 +50,22 @@ import org.geotools.util.Utilities;
  * @version $Id$
  * @author Martin Desruisseaux (IRD)
  */
-class CategoryList extends AbstractList<Category> implements Comparator<Category>, Serializable {
+class CategoryList extends AbstractList<Category> implements Serializable {
     /** Serial number for interoperability with different versions. */
     private static final long serialVersionUID = 2647846361059903365L;
+
+    /**
+     * Compares {@link Category} objects according their {@link Category#minimum} value. This is
+     * used for sorting the {@link #categories} array at construction time.
+     */
+    static Comparator<Category> COMPARATOR =
+            new Comparator<Category>() {
+
+                @Override
+                public int compare(Category c1, Category c2) {
+                    return CategoryList.compare(c1.minimum, c2.minimum);
+                }
+            };
 
     /**
      * The range of values in this category list. This is the union of the range of values of every
@@ -153,7 +166,7 @@ class CategoryList extends AbstractList<Category> implements Comparator<Category
     CategoryList(Category[] categories, Unit<?> units, boolean searchNearest)
             throws IllegalArgumentException {
         this.categories = categories = categories.clone();
-        Arrays.sort(categories, this);
+        Arrays.sort(categories, COMPARATOR);
         assert isSorted(categories);
         /*
          * Constructs the array of Category.minimum values. During
@@ -250,15 +263,6 @@ class CategoryList extends AbstractList<Category> implements Comparator<Category
         }
         this.overflowFallback = overflowFallback;
         this.unit = units;
-    }
-
-    /**
-     * Compares {@link Category} objects according their {@link Category#minimum} value. This is
-     * used for sorting the {@link #categories} array at construction time.
-     */
-    @Override
-    public final int compare(final Category o1, final Category o2) {
-        return compare(o1.minimum, o2.minimum);
     }
 
     /**

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/CategoryListTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/CategoryListTest.java
@@ -69,7 +69,7 @@ public final class CategoryListTest {
             for (int i = 0; i < categories.length; i++) {
                 categories[i] = new Category(String.valueOf(i), null, random.nextInt(100));
             }
-            Arrays.sort(categories, new CategoryList(new Category[0], null));
+            Arrays.sort(categories, CategoryList.COMPARATOR);
             assertTrue("isSorted", CategoryList.isSorted(categories));
             for (int i = 0; i < categories.length; i++) {
                 array[i] = categories[i].minimum;

--- a/modules/unsupported/vsi/pom.xml
+++ b/modules/unsupported/vsi/pom.xml
@@ -44,8 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>${mockito.core.version}</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
     <jts.version>1.19.0</jts.version>
     <log4j2.version>2.17.2</log4j2.version>
     <logback.version>1.3.12</logback.version>
-    <mockito.core.version>3.12.4</mockito.core.version>
+    <mockito.core.version>5.6.0</mockito.core.version>
     <mssql-jdbc.version>9.4.0.jre8</mssql-jdbc.version>
     <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
     <netcdf.version>4.6.15</netcdf.version>
@@ -1174,7 +1174,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>4.3</version>
+        <version>5.2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1757,7 +1757,7 @@
             <java.util.logging.SimpleFormatter.format>%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-7s [%3$s] %5$s%6$s%n</java.util.logging.SimpleFormatter.format>
           </systemPropertyVariables>
           <!-- Use systemPropertyVariables @{argLine} late subtitution for jacoco params injection in surefire-->
-          <argLine>@{argLine} -Xmx${test.maxHeapSize} ${jvm.opts} -Dfile.encoding=UTF-8 -Djava.library.path="${java.library.path}" ${test.args} -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+IgnoreUnrecognizedVMOptions -XX:-OmitStackTraceInFastThrow --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED ${test.otherJVMParams}</argLine>
+          <argLine>@{argLine} -Xmx${test.maxHeapSize} ${jvm.opts} -Dfile.encoding=UTF-8 -Djava.library.path="${java.library.path}" ${test.args} -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=240m -XX:+IgnoreUnrecognizedVMOptions -XX:-OmitStackTraceInFastThrow --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED ${test.otherJVMParams}</argLine>
           <!-- Ignores test failure only if we are generating a       -->
           <!-- report for publication on the web site. See the        -->
           <!-- profiles section at the beginning of this pom.xml file. -->


### PR DESCRIPTION
Pairs with https://github.com/geoserver/geoserver/pull/7207

Notes:
- Seems to be just enough to build with Java 21
- One cannot run the QA Profile with Java 21 (but it's not possible with Java 17 either, see notes in the [ErrorProne documentation](https://errorprone.info/docs/installation))
- Add a new Java 21 build (classic way, if the duplication annoys @jodygarnett, further PRs to clean the actions code are welcomed).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->