### PR TITLE
Fix ShapefileDataStore feature ordering not respected with offset

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/sort/AlphanumComparator.java
+++ b/modules/library/main/src/main/java/org/geotools/data/sort/AlphanumComparator.java
@@ -1,0 +1,116 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.sort;
+
+/*
+ * Copyright © 2021 Dave Koelle www.davekoelle.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+class AlphanumComparator {
+    private static boolean isDigit(char ch) {
+        return ((ch >= 48) && (ch <= 57));
+    }
+
+    /** Length of string is passed in for improved efficiency (only need to calculate it once) */
+    private static String getChunk(String s, int slength, int marker) {
+        StringBuilder chunk = new StringBuilder();
+        char c = s.charAt(marker);
+        chunk.append(c);
+        marker++;
+        if (isDigit(c)) {
+            while (marker < slength) {
+                c = s.charAt(marker);
+                if (!isDigit(c)) {
+                    break;
+                }
+                chunk.append(c);
+                marker++;
+            }
+        } else {
+            while (marker < slength) {
+                c = s.charAt(marker);
+                if (isDigit(c)) {
+                    break;
+                }
+                chunk.append(c);
+                marker++;
+            }
+        }
+        return chunk.toString();
+    }
+
+    public static int compare(String s1, String s2) {
+        if ((s1 == null) || (s2 == null)) {
+            return 0;
+        }
+
+        int thisMarker = 0;
+        int thatMarker = 0;
+        int s1Length = s1.length();
+        int s2Length = s2.length();
+
+        while (thisMarker < s1Length && thatMarker < s2Length) {
+            String thisChunk = getChunk(s1, s1Length, thisMarker);
+            thisMarker += thisChunk.length();
+
+            String thatChunk = getChunk(s2, s2Length, thatMarker);
+            thatMarker += thatChunk.length();
+
+            // If both chunks contain numeric characters, sort them numerically
+            int result = 0;
+            if (isDigit(thisChunk.charAt(0)) && isDigit(thatChunk.charAt(0))) {
+                // Simple chunk comparison by length.
+                int thisChunkLength = thisChunk.length();
+                result = thisChunkLength - thatChunk.length();
+                // If equal, the first different number counts
+                if (result == 0) {
+                    for (int i = 0; i < thisChunkLength; i++) {
+                        result = thisChunk.charAt(i) - thatChunk.charAt(i);
+                        if (result != 0) {
+                            return result;
+                        }
+                    }
+                }
+            } else {
+                result = thisChunk.compareTo(thatChunk);
+            }
+
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        return s1Length - s2Length;
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/data/sort/FidComparator.java
+++ b/modules/library/main/src/main/java/org/geotools/data/sort/FidComparator.java
@@ -60,7 +60,7 @@ class FidComparator implements Comparator<SimpleFeature> {
         } else if (id2 == null) {
             return 1;
         } else {
-            return id1.compareTo(id2);
+            return AlphanumComparator.compare(id1, id2);
         }
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/data/sort/SortedReaderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/sort/SortedReaderTest.java
@@ -193,7 +193,7 @@ public class SortedReaderTest {
                 SimpleFeature f = sr.next();
                 String id = f.getID();
                 if (prev != null) {
-                    assertTrue(id.compareTo(prev) >= 0);
+                    assertTrue(AlphanumComparator.compare(id, prev) >= 0);
                 }
                 prev = id;
             }
@@ -213,7 +213,7 @@ public class SortedReaderTest {
                 SimpleFeature f = sr.next();
                 String id = f.getID();
                 if (prev != null) {
-                    assertTrue(id.compareTo(prev) >= 0);
+                    assertTrue(AlphanumComparator.compare(id, prev) >= 0);
                 }
                 prev = id;
                 count++;

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
@@ -1476,6 +1476,27 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
         store.dispose();
     }
 
+    @Test
+    public void testOffset() throws Exception {
+        URL url = TestData.url(STATE_POP);
+        ShapefileDataStore store = new ShapefileDataStore(url);
+        SimpleFeatureSource featureSource = store.getFeatureSource();
+        Query q1 = new Query(Query.ALL);
+        String idIterate;
+        String idOffset;
+        try (SimpleFeatureIterator it = featureSource.getFeatures(q1).features()) {
+            it.next();
+            idIterate = it.next().getID();
+        }
+        Query q2 = new Query(Query.ALL);
+        q2.setStartIndex(1);
+        try (SimpleFeatureIterator it = featureSource.getFeatures(q2).features()) {
+            idOffset = it.next().getID();
+        }
+        assertEquals(idIterate, idOffset);
+        store.dispose();
+    }
+
     /** Checks if feature reading optimizations still allow to execute the queries or not */
     @Test
     public void testGetReaderOptimizations() throws Exception {


### PR DESCRIPTION
This PR currently only demonstrates unexpected behaviour that ordering is not the same if using an offset to get features in ShapefileDataStore. AFAIK this is due to sorting happening using alphabetic sort on the stringified typename + numeric id.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->