### PR TITLE
[Backport 30.x] [GEOT-7507] Vector mosaic store: filtering is not working if it uses a property that's not retrieved by the query

### DIFF
--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureReader.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureReader.java
@@ -17,10 +17,10 @@
 package org.geotools.vectormosaic;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.api.data.DataStore;
@@ -29,21 +29,29 @@ import org.geotools.api.data.SimpleFeatureReader;
 import org.geotools.api.feature.Feature;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
-import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.filter.Filter;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.util.logging.Logging;
 
-/** {@link DataStore} for a vector mosaic. */
-public class VectorMosaicFeatureReader implements SimpleFeatureReader {
+/**
+ * Feature reader for vector mosaics, it reads from the delegate and granule stores, merges the
+ * features, applies the required filtering, and retypes the result to match the Query property
+ * selection.
+ */
+class VectorMosaicFeatureReader implements SimpleFeatureReader {
     static final Logger LOGGER = Logging.getLogger(VectorMosaicFeatureReader.class);
     private final SimpleFeatureCollection delegateCollection;
     private final Query query;
     private final VectorMosaicFeatureSource source;
-    private final SimpleFeatureType schema;
+    private final SimpleFeatureType internalSchema;
+    private SimpleFeatureType targetSchema;
+
+    private SimpleFeatureBuilder builder;
+    private SimpleFeatureBuilder retypeBuilder;
     FeatureIterator delegateIterator;
     FeatureIterator granuleIterator;
     DataStore granuleDataStore;
@@ -67,13 +75,23 @@ public class VectorMosaicFeatureReader implements SimpleFeatureReader {
         this.delegateCollection = delegateFeatures;
         this.query = query;
         this.source = vectorMosaicFeatureSource;
-        this.schema = retype(source.getSchema(), query);
+        this.targetSchema = this.internalSchema = retype(source.getSchema(), query);
+        this.builder = new SimpleFeatureBuilder(internalSchema);
+
+        // if the query is not using all attributes, we migth need to retype the result post merge
+        if (query.getPropertyNames() != null) {
+            this.targetSchema =
+                    SimpleFeatureTypeBuilder.retype(internalSchema, query.getPropertyNames());
+            if (!internalSchema.equals(targetSchema))
+                this.retypeBuilder = new SimpleFeatureBuilder(targetSchema);
+        }
+
         this.delegateIterator = delegateCollection.features();
     }
 
     @Override
     public SimpleFeatureType getFeatureType() {
-        return schema;
+        return targetSchema;
     }
 
     @Override
@@ -99,12 +117,8 @@ public class VectorMosaicFeatureReader implements SimpleFeatureReader {
         }
         if (granuleIterator != null && delegateFeature != null) {
             while (granuleIterator.hasNext()) {
-                rawGranule = (SimpleFeature) granuleIterator.next();
-                Feature peek = mergeGranuleAndDelegate(rawGranule, delegateFeature, query);
-                if (query.getFilter().evaluate(peek)) {
-                    nextGranule = peek;
-                    return true;
-                }
+                nextGranule = readNext();
+                if (nextGranule != null) return true;
             }
         }
 
@@ -150,18 +164,27 @@ public class VectorMosaicFeatureReader implements SimpleFeatureReader {
                             .features();
 
             while (granuleIterator.hasNext()) {
-                rawGranule = (SimpleFeature) granuleIterator.next();
-                Feature peek = mergeGranuleAndDelegate(rawGranule, delegateFeature, query);
-                if (query.getFilter().evaluate(peek)) {
-                    nextGranule = peek;
-                    return true;
-                }
+                nextGranule = readNext();
+                if (nextGranule != null) return true;
             }
         }
 
         // no more
         close();
         return false;
+    }
+
+    private SimpleFeature readNext() {
+        rawGranule = (SimpleFeature) granuleIterator.next();
+        SimpleFeature peek = mergeGranuleAndDelegate(rawGranule, delegateFeature, query);
+        if (query.getFilter().evaluate(peek)) {
+            if (retypeBuilder != null) {
+                return SimpleFeatureBuilder.retype(peek, retypeBuilder);
+            } else {
+                return peek;
+            }
+        }
+        return null;
     }
 
     /**
@@ -171,27 +194,21 @@ public class VectorMosaicFeatureReader implements SimpleFeatureReader {
      * @param delegateFeature the delegate feature
      * @return the merged feature
      */
-    private Feature mergeGranuleAndDelegate(
+    private SimpleFeature mergeGranuleAndDelegate(
             SimpleFeature peekGranule, SimpleFeature delegateFeature, Query query) {
-        SimpleFeatureType mergedType = getFeatureType();
-        List<Object> attributes = new ArrayList<>();
+        // collect attributes from the granule and the delegate, making no assumption
+        // on the order, the query might have imposed one that does not match the
+        // normal layout of the mosaic features
         peekGranule.getType().getAttributeDescriptors().stream()
-                .filter(a -> isInRetype(a, query))
-                .forEach(
-                        attributeDescriptor -> {
-                            attributes.add(peekGranule.getAttribute(attributeDescriptor.getName()));
-                        }); // type starts with of all granule attributes
+                .filter(ad1 -> internalSchema.getDescriptor(ad1.getLocalName()) != null)
+                .map(ad1 -> ad1.getLocalName())
+                .forEach(name1 -> builder.set(name1, peekGranule.getAttribute(name1)));
         delegateFeature.getType().getAttributeDescriptors().stream()
                 .filter(source::isNotMandatoryIndexType)
-                .filter(a -> isInRetype(a, query))
-                .forEach(
-                        attributeDescriptor -> {
-                            attributes.add(
-                                    delegateFeature.getAttribute(attributeDescriptor.getName()));
-                        }); // then add all delegate attributes except mandatory index types
-
-        return SimpleFeatureBuilder.build(
-                mergedType, attributes, peekGranule.getIdentifier().getID());
+                .filter(ad -> internalSchema.getDescriptor(ad.getLocalName()) != null)
+                .map(ad -> ad.getLocalName())
+                .forEach(name -> builder.set(name, delegateFeature.getAttribute(name)));
+        return builder.buildFeature(peekGranule.getID());
     }
 
     private SimpleFeatureType retype(SimpleFeatureType mergedType, Query query) {
@@ -204,10 +221,18 @@ public class VectorMosaicFeatureReader implements SimpleFeatureReader {
         typeBuilder.setName(mergedType.getName());
         typeBuilder.setNamespaceURI(mergedType.getName().getNamespaceURI());
 
+        // Collect the required attributes, and the filter attributes
+        Set<String> propertyNames = new HashSet<>(Arrays.asList(query.getPropertyNames()));
+        if (query.getFilter() != null) {
+            FilterAttributeExtractor extractor = new FilterAttributeExtractor();
+            query.getFilter().accept(extractor, null);
+            propertyNames.addAll(extractor.getAttributeNameSet());
+        }
+
         boolean geomAdded = false;
         for (int i = 0; i < mergedType.getAttributeCount(); i++) {
             String attributeName = mergedType.getDescriptor(i).getLocalName();
-            if (contains(query.getPropertyNames(), attributeName)) {
+            if (propertyNames.contains(attributeName)) {
                 typeBuilder.add(mergedType.getDescriptor(i));
                 if (attributeName.equals(mergedType.getGeometryDescriptor().getLocalName())) {
                     geomAdded = true;
@@ -221,23 +246,6 @@ public class VectorMosaicFeatureReader implements SimpleFeatureReader {
 
         // Create the new feature type without the specified attributes
         return typeBuilder.buildFeatureType();
-    }
-
-    private boolean contains(String[] propertyNames, String attributeName) {
-        for (String propertyName : propertyNames) {
-            if (propertyName.equals(attributeName)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isInRetype(AttributeDescriptor a, Query query) {
-        if (query.getPropertyNames() == Query.ALL_NAMES) {
-            return true;
-        }
-        boolean inRetype = Arrays.asList(query.getPropertyNames()).contains(a.getLocalName());
-        return inRetype;
     }
 
     @Override

--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureSource.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureSource.java
@@ -25,6 +25,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -47,7 +48,6 @@ import org.geotools.api.feature.type.GeometryType;
 import org.geotools.api.feature.type.Name;
 import org.geotools.api.filter.Filter;
 import org.geotools.data.DataUtilities;
-import org.geotools.data.FilteringFeatureReader;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.store.ContentEntry;
@@ -58,6 +58,7 @@ import org.geotools.feature.visitor.FeatureAttributeVisitor;
 import org.geotools.feature.visitor.MaxVisitor;
 import org.geotools.feature.visitor.MinVisitor;
 import org.geotools.feature.visitor.UniqueVisitor;
+import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.logging.Logging;
 
@@ -178,7 +179,7 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
     @SuppressWarnings("PMD.CloseResource")
     protected FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(Query query)
             throws IOException {
-        FeatureReader<SimpleFeatureType, SimpleFeature> out = null;
+        FeatureReader<SimpleFeatureType, SimpleFeature> reader = null;
         Name dsname = buildName(delegateStoreName);
         DataStore delegateDataStore = repository.dataStore(dsname);
         Filter splitFilterIndex =
@@ -193,31 +194,28 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
             delegateQuery.setPropertyNames(filteredArray);
         }
         SimpleFeatureCollection features = delegateFeatureSource.getFeatures(delegateQuery);
-        out = new VectorMosaicFeatureReader(features, query, this);
-        if (query.getFilter() != null) {
-            Filter filter = query.getFilter();
-            boolean filterIsAllIndex =
-                    allFilterAttributesAreInType(delegateFeatureSource.getSchema(), filter);
-            SimpleFeatureType granuleType = getGranuleType();
-            boolean filterIsAllGranule = allFilterAttributesAreInType(granuleType, filter);
-            // filter is not all index and not all granule, so wrap in FilteringFeatureReader
-            if (!filterIsAllIndex && !filterIsAllGranule) {
-                out = new FilteringFeatureReader<>(out, filter);
-            }
-        }
-        return out;
+
+        // The reader merges the features from delegate and granule, filters contents, and
+        // retypes to the target feature type
+        reader = new VectorMosaicFeatureReader(features, query, this);
+
+        return reader;
     }
 
-    public static String[] getOnlyTypeMatchingAttributes(
+    static String[] getOnlyTypeMatchingAttributes(
             DataStore typeStore, String typeName, Query query, boolean isDelegate)
             throws IOException {
         SimpleFeatureType featureType = typeStore.getSchema(typeName);
         Set<String> attributeNames =
                 VectorMosaicFeatureSource.getAttributeNamesForType(featureType);
+        Set<String> queryNames = new LinkedHashSet<>(Arrays.asList(query.getPropertyNames()));
+        if (query.getFilter() != null) {
+            FilterAttributeExtractor extractor = new FilterAttributeExtractor(featureType);
+            query.getFilter().accept(extractor, null);
+            queryNames.addAll(Arrays.asList(extractor.getAttributeNames()));
+        }
         String[] filteredArray =
-                Arrays.stream(query.getPropertyNames())
-                        .filter(attributeNames::contains)
-                        .toArray(String[]::new);
+                queryNames.stream().filter(attributeNames::contains).toArray(String[]::new);
         // delegate must have the connection parameters field
         if (isDelegate) {
             if (!containsString(
@@ -231,6 +229,7 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
 
         return filteredArray;
     }
+
     // Method to check if a string is present in an array
     private static boolean containsString(String[] array, String target) {
         return Arrays.asList(array).contains(target);
@@ -383,18 +382,6 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
         return indexAttributeNames.containsAll(Arrays.asList(filterAttributeNames));
     }
 
-    private boolean allFilterAttributesAreInType(SimpleFeatureType featureType, Filter filter)
-            throws IOException {
-        String[] filterAttributeNames = DataUtilities.attributeNames(filter);
-        return typeHasAllAttributeNames(filterAttributeNames, featureType);
-    }
-
-    private boolean typeHasAllAttributeNames(String[] propertyNames, SimpleFeatureType featureType)
-            throws IOException {
-        Set<String> indexAttributeNames = getAttributeNamesForType(featureType);
-        return indexAttributeNames.containsAll(Arrays.asList(propertyNames));
-    }
-
     @Override
     protected boolean handleVisitor(Query query, FeatureVisitor visitor) throws IOException {
         // check if visitor is aggregate visitor
@@ -463,6 +450,7 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
     protected boolean canFilter() {
         return true;
     }
+
     /**
      * Validates and loads the connection string properties into the granule
      *

--- a/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFeatureSourceTest.java
+++ b/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFeatureSourceTest.java
@@ -19,18 +19,22 @@ package org.geotools.vectormosaic;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.geotools.api.data.FeatureSource;
 import org.geotools.api.data.Query;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.feature.Feature;
+import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.data.DataUtilities;
 import org.geotools.data.FilteringFeatureReader;
 import org.geotools.data.store.ContentDataStore;
 import org.geotools.data.store.ContentEntry;
+import org.geotools.data.store.ContentFeatureCollection;
 import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.feature.visitor.MaxVisitor;
@@ -215,7 +219,7 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
     }
 
     @Test
-    public void testMixedQueryFilterUsesFilteringFeatureReader() throws Exception {
+    public void testMixedQueryFilter() throws Exception {
         VectorMosaicFeatureSource featureSource =
                 (VectorMosaicFeatureSource) MOSAIC_STORE.getFeatureSource(MOSAIC_TYPE_NAME);
         Query q = new Query();
@@ -223,9 +227,39 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
         PropertyName p = FF.property("rank");
         // weight is in the granule
         PropertyName p2 = FF.property("weight");
-        Filter f = FF.and(FF.lessOrEqual(p, FF.literal(100)), FF.lessOrEqual(p2, FF.literal(50)));
+        Filter f = FF.and(FF.greaterOrEqual(p, FF.literal(2)), FF.lessOrEqual(p2, FF.literal(7)));
         q.setFilter(f);
-        assertEquals(FilteringFeatureReader.class, featureSource.getReaderInternal(q).getClass());
+        ContentFeatureCollection features = featureSource.getFeatures(q);
+        List<SimpleFeature> list = DataUtilities.list(features);
+        assertEquals(1, list.size());
+        assertEquals("granule2.1", list.get(0).getID());
+    }
+
+    /**
+     * Test filtering on attributes found both in the index and in the granule, but return a third
+     * property
+     */
+    @Test
+    public void testMixedFilterAttributeSelection() throws Exception {
+        VectorMosaicFeatureSource featureSource =
+                (VectorMosaicFeatureSource) MOSAIC_STORE.getFeatureSource(MOSAIC_TYPE_NAME);
+        Query q = new Query();
+        // rank is in the index
+        PropertyName p = FF.property("rank");
+        // weight is in the granule
+        PropertyName p2 = FF.property("weight");
+        Filter f = FF.and(FF.greaterOrEqual(p, FF.literal(2)), FF.lessOrEqual(p2, FF.literal(7)));
+        q.setFilter(f);
+        q.setPropertyNames("tractorid");
+        ContentFeatureCollection features = featureSource.getFeatures(q);
+
+        // expected, just one feature, with only the tractorid attribute
+        List<SimpleFeature> list = DataUtilities.list(features);
+        assertEquals(1, list.size());
+        SimpleFeature feature = list.get(0);
+        assertEquals("granule2.1", feature.getID());
+        assertEquals(1, feature.getType().getAttributeCount());
+        assertEquals("deere2", feature.getAttribute("tractorid"));
     }
 
     @Test
@@ -307,10 +341,10 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
                                 .map(d -> d.getName().getLocalPart())
                                 .collect(Collectors.joining(","));
                 assertEquals("weight", granuleAttributes);
-                // validate that both show in final merged feature
+                // validate that both show in final merged feature, following the query order
                 Feature f1 = featureReader.next();
                 assertEquals(
-                        "weight,rank",
+                        "rank,weight",
                         f1.getType().getDescriptors().stream()
                                 .map(d -> d.getName().getLocalPart())
                                 .collect(Collectors.joining(",")));


### PR DESCRIPTION
[![GEOT-7507](https://badgen.net/badge/JIRA/GEOT-7507/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7507) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4595
 **Authored by:** @aaime