### PR TITLE
[Backport 29.x] [GEOT-7508] Optimize execution of NearestVisitor in Vector Mosaic store

### DIFF
--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureSource.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureSource.java
@@ -50,6 +50,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.feature.visitor.FeatureAttributeVisitor;
 import org.geotools.feature.visitor.MaxVisitor;
 import org.geotools.feature.visitor.MinVisitor;
+import org.geotools.feature.visitor.NearestVisitor;
 import org.geotools.feature.visitor.UniqueVisitor;
 import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -387,7 +388,8 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
         // check if visitor is aggregate visitor
         if (visitor instanceof MaxVisitor
                 || visitor instanceof MinVisitor
-                || visitor instanceof UniqueVisitor) {
+                || visitor instanceof UniqueVisitor
+                || visitor instanceof NearestVisitor) {
             Set<String> indexAttributeNames =
                     getAttributeNamesForType(delegateStoreName, delegateStoreTypeName);
             // check if all filter attributes are in index/delegate


### PR DESCRIPTION
[![GEOT-7508](https://badgen.net/badge/JIRA/GEOT-7508/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7508) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4597
 **Authored by:** @aaime