### PR TITLE
WIP Support meters in dwithin filter

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/data/util/DistanceBufferUtil.java
+++ b/modules/library/main/src/main/java/org/geotools/data/util/DistanceBufferUtil.java
@@ -111,8 +111,18 @@ public class DistanceBufferUtil {
      * units distance
      */
     public static double getDistanceInMeters(DistanceBufferOperator operator) {
-        double distance = operator.getDistance();
-        String units = operator.getDistanceUnits();
+        return getDistanceInMeters(operator.getDistance(), operator.getDistanceUnits());
+    }
+
+    /**
+     * Converts the distance of the operator in meters, or returns the current value if there is no
+     * units distance
+     *
+     * @param distance distance
+     * @param units distance units
+     * @return distance in meters, or original distance if units are not specified
+     */
+    public static double getDistanceInMeters(double distance, String units) {
         // no units or no SRID, no party, return value as-is
         if (units == null || UNITS_MAP.get(units.toLowerCase()) == null) {
             return distance;

--- a/modules/library/main/src/main/java/org/geotools/filter/spatial/DWithinImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/spatial/DWithinImpl.java
@@ -16,13 +16,33 @@
  */
 package org.geotools.filter.spatial;
 
+import java.util.logging.Logger;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.geotools.api.filter.FilterVisitor;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.filter.spatial.DWithin;
+import org.geotools.api.geometry.Position;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.data.util.DistanceBufferUtil;
 import org.geotools.filter.CartesianDistanceFilter;
+import org.geotools.geometry.Position2D;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.GeodeticCalculator;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.operation.distance.DistanceOp;
 
 public class DWithinImpl extends CartesianDistanceFilter implements DWithin {
+
+    private static final Logger LOGGER =
+            org.geotools.util.logging.Logging.getLogger(DWithinImpl.class);
+
+    private static final ThreadLocal<Pair<Integer, GeodeticCalculator>> CALCULATORS =
+            new ThreadLocal<>();
+
+    private double distanceInMeters;
 
     public DWithinImpl(Expression e1, Expression e2) {
         super(e1, e2);
@@ -33,12 +53,88 @@ public class DWithinImpl extends CartesianDistanceFilter implements DWithin {
     }
 
     @Override
+    public void setDistance(double distance) {
+        super.setDistance(distance);
+        setDistanceInMeters();
+    }
+
+    @Override
+    public void setUnits(String units) {
+        super.setUnits(units);
+        setDistanceInMeters();
+    }
+
+    private void setDistanceInMeters() {
+        distanceInMeters = DistanceBufferUtil.getDistanceInMeters(this);
+    }
+
+    @Override
     public boolean evaluateInternal(Geometry left, Geometry right) {
+        if (left.getSRID() != 0 && left.getSRID() == right.getSRID()) {
+            try {
+                DistanceOp op = new DistanceOp(left, right);
+                Coordinate[] points = op.nearestPoints();
+                GeodeticCalculator calculator = getCalculator(left);
+                // we need to use positions to ensure that any CRS transform gets applied
+                calculator.setStartingPosition(new Position2D(points[0].getX(), points[0].getY()));
+                calculator.setDestinationPosition(
+                        new Position2D(points[1].getX(), points[1].getY()));
+                return calculator.getOrthodromicDistance() <= distanceInMeters;
+            } catch (Exception e) {
+                LOGGER.warning(
+                        "Error calculating distance in meters, falling back to native units: " + e);
+            }
+        }
+
         return left.isWithinDistance(right, getDistance());
     }
 
     @Override
     public Object accept(FilterVisitor visitor, Object extraData) {
         return visitor.visit(this, extraData);
+    }
+
+    public static Envelope buffer(Geometry geom, double distance, String units) {
+        Envelope env = geom.getEnvelopeInternal();
+        if (geom.getSRID() == 0) {
+            env.expandBy(distance);
+        } else {
+            try {
+                double distanceInMeters = DistanceBufferUtil.getDistanceInMeters(distance, units);
+                double deltaX = 0, deltaY = 0;
+                GeodeticCalculator calculator = getCalculator(geom);
+                calculator.setStartingPosition(new Position2D(env.getMaxX(), env.getMaxY()));
+                calculator.setDirection(0, distanceInMeters);
+                Position north = calculator.getDestinationPosition();
+                deltaX += (env.getMaxX() - north.getOrdinate(0));
+                deltaY += (env.getMaxY() - north.getOrdinate(1));
+                calculator.setDirection(90, distanceInMeters);
+                Position east = calculator.getDestinationPosition();
+                deltaX += (env.getMaxX() - east.getOrdinate(0));
+                deltaY += (env.getMaxY() - east.getOrdinate(1));
+                env.expandBy(deltaX, deltaY);
+            } catch (Exception e) {
+                LOGGER.warning(
+                        "Error calculating distance in meters, falling back to native units: " + e);
+                env.expandBy(distance);
+            }
+        }
+        return env;
+    }
+
+    private static GeodeticCalculator getCalculator(Geometry geom) throws FactoryException {
+        Pair<Integer, GeodeticCalculator> cached = CALCULATORS.get();
+        if (cached == null || cached.getLeft() != geom.getSRID()) {
+            GeodeticCalculator calc;
+            if (geom.getSRID() == 4326) {
+                calc = new GeodeticCalculator();
+            } else {
+                // using this constructor causes a transform step from native CRS into 4326
+                calc = new GeodeticCalculator(CRS.decode("EPSG:" + geom.getSRID()));
+            }
+            cached = new ImmutablePair<>(geom.getSRID(), calc);
+            CALCULATORS.set(cached);
+        }
+        return cached.getRight();
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/visitor/ExtractBoundsFilterVisitor.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/visitor/ExtractBoundsFilterVisitor.java
@@ -68,6 +68,7 @@ import org.geotools.api.filter.temporal.TContains;
 import org.geotools.api.filter.temporal.TEquals;
 import org.geotools.api.filter.temporal.TOverlaps;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.filter.spatial.DWithinImpl;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -293,8 +294,7 @@ public class ExtractBoundsFilterVisitor extends NullFilterVisitor {
             return infinity();
         }
 
-        Envelope env = geom.getEnvelopeInternal();
-        env.expandBy(filter.getDistance());
+        Envelope env = DWithinImpl.buffer(geom, filter.getDistance(), filter.getDistanceUnits());
 
         if (bbox != null) {
             bbox.expandToInclude(env);

--- a/modules/library/main/src/test/java/org/geotools/filter/DWithinTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/DWithinTest.java
@@ -1,0 +1,100 @@
+package org.geotools.filter;
+
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.api.filter.spatial.DWithin;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.collection.ListFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.SchemaException;
+import org.geotools.util.logging.Logging;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+
+public class DWithinTest {
+
+    // a point far away from all others (100+ km)
+
+    static final Point REFERENCE_POINT = new GeometryFactory().createPoint(new Coordinate(3, 3));
+
+    static final SimpleFeatureCollection FEATURES;
+
+    static final Logger LOGGER = Logging.getLogger(DWithinTest.class);
+
+    static {
+        SimpleFeatureType ft1;
+        try {
+            ft1 = DataUtilities.createType("ft1", "*geometry:Point:srid=4326,intProperty:Integer,doubleProperty:Double,stringProperty:String");
+        } catch (SchemaException e) {
+            LOGGER.severe("Could not create feature type: " + e);
+            throw new RuntimeException("Could not create feature type", e);
+        }
+        List<SimpleFeature> features = new ArrayList<>();
+        features.add(DataUtilities.createFeature(ft1, "0=POINT(0 0)|0|0.0|zero"));
+        features.add(DataUtilities.createFeature(ft1, "1=POINT(1 1)|1|1.1|one"));
+        features.add(DataUtilities.createFeature(ft1, "2=POINT(2 2)|2|2.2|two"));
+        FEATURES = new ListFeatureCollection(ft1, features);
+    }
+
+    @Test
+    public void testDWithinGeographicKm() throws IOException {
+        double pointDistance = 111d * Math.sqrt(2); // ft1 points are in diagonal
+        assertDWithinFilter(0, pointDistance * 0.1, "km");
+        assertDWithinFilter(0, pointDistance * 0.9, "km");
+        assertDWithinFilter(1, pointDistance * 1.1, "km");
+        assertDWithinFilter(2, pointDistance * 2.1, "km");
+        assertDWithinFilter(3, pointDistance * 3.1, "km");
+    }
+
+    @Test
+    public void testDWithinGeographicMeter() throws IOException {
+        double pointDistance = 111000 * Math.sqrt(2); // ft1 points are in diagonal
+        assertDWithinFilter(0, pointDistance * 0.1, "m");
+        assertDWithinFilter(0, pointDistance * 0.9, "m");
+        assertDWithinFilter(1, pointDistance * 1.1, "m");
+        assertDWithinFilter(2, pointDistance * 2.1, "m");
+        assertDWithinFilter(3, pointDistance * 3.1, "m");
+    }
+
+    @Test
+    public void testDWithinGeographicMile() throws IOException {
+        double pointDistance = 69 * Math.sqrt(2); // ft1 points are in diagonal
+        assertDWithinFilter(0, pointDistance * 0.1, "mi");
+        assertDWithinFilter(0, pointDistance * 0.9, "mi");
+        assertDWithinFilter(1, pointDistance * 1.1, "mi");
+        assertDWithinFilter(2, pointDistance * 2.1, "mi");
+        assertDWithinFilter(3, pointDistance * 3.1, "mi");
+    }
+
+    @Test
+    public void testDWithinGeographicFeet() throws IOException {
+        double pointDistance = 5280 * 69 * Math.sqrt(2); // ft1 points are in diagonal
+        assertDWithinFilter(0, pointDistance * 0.1, "ft");
+        assertDWithinFilter(0, pointDistance * 0.9, "ft");
+        assertDWithinFilter(1, pointDistance * 1.1, "ft");
+        assertDWithinFilter(2, pointDistance * 2.1, "ft");
+        assertDWithinFilter(3, pointDistance * 3.1, "ft");
+    }
+
+    private void assertDWithinFilter(int expectedMatches, double distance, String unit)
+          throws IOException {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        final PropertyName geomProperty = ff.property("geometry");
+        // too short distance
+        DWithin filter = ff.dwithin(geomProperty, ff.literal(REFERENCE_POINT), distance, unit);
+        SimpleFeatureCollection fc = FEATURES.subCollection(filter);
+        assertEquals(expectedMatches, fc.size());
+    }
+}


### PR DESCRIPTION
This PR attempts to get DWITHIN filters working correctly in meters, vs in the native cartesian units. It's currently just a draft for gathering comments.

Based on the geoserver mailing list thread [here](https://sourceforge.net/p/geoserver/mailman/geoserver-users/thread/CALHQADUEnqdJdW2-yEQ5fn4Tk6GHsJEcnTqh-pMdxfo5Zc5T%3DA%40mail.gmail.com/#msg58713421).
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->