### PR TITLE
Fix updating immutable AmazonS3 client

### DIFF
--- a/modules/unsupported/s3-geotiff/src/main/java/org/geotools/s3/S3Connector.java
+++ b/modules/unsupported/s3-geotiff/src/main/java/org/geotools/s3/S3Connector.java
@@ -19,10 +19,10 @@ package org.geotools.s3;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.S3ClientOptions;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -116,6 +116,10 @@ public class S3Connector {
 
             Properties prop = readProperties(s3Alias);
 
+            String endpoint = prop.getProperty(s3Alias + ".s3.endpoint");
+            AwsClientBuilder.EndpointConfiguration endpointConfiguration =
+                    new AwsClientBuilder.EndpointConfiguration(endpoint, region.getName());
+
             s3 =
                     AmazonS3ClientBuilder.standard()
                             .withCredentials(
@@ -123,16 +127,9 @@ public class S3Connector {
                                             new BasicAWSCredentials(
                                                     prop.getProperty(s3Alias + ".s3.user"),
                                                     prop.getProperty(s3Alias + ".s3.password"))))
+                            .withEndpointConfiguration(endpointConfiguration)
+                            .withPathStyleAccessEnabled(true)
                             .build();
-
-            final S3ClientOptions clientOptions =
-                    S3ClientOptions.builder().setPathStyleAccess(true).build();
-            s3.setS3ClientOptions(clientOptions);
-            String endpoint = prop.getProperty(s3Alias + ".s3.endpoint");
-            if (!endpoint.endsWith("/")) {
-                endpoint = endpoint + "/";
-            }
-            s3.setEndpoint(endpoint);
 
             // aws cli client
         } else if (useAnon) {

--- a/modules/unsupported/s3-geotiff/src/test/java/org/geotools/s3/S3ConnectorTest.java
+++ b/modules/unsupported/s3-geotiff/src/test/java/org/geotools/s3/S3ConnectorTest.java
@@ -17,11 +17,20 @@
 package org.geotools.s3;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.amazonaws.services.s3.AmazonS3;
+import org.junit.Before;
 import org.junit.Test;
 
 public class S3ConnectorTest {
+
+    @Before
+    public void before() {
+        System.setProperty(
+                S3Connector.S3_GEOTIFF_CONFIG_PATH, "./src/test/resources/s3.properties");
+    }
+
     @Test
     public void testDefaultRegionWithDefaultCredentialChain() {
         S3Connector s3Connector = new S3Connector("s3://bucket/prefix/raster.tif");
@@ -54,5 +63,38 @@ public class S3ConnectorTest {
 
         AmazonS3 s3Client = s3Connector.getS3Client();
         assertEquals("US_East_2", s3Client.getRegion().name());
+    }
+
+    @Test
+    public void testDefaultRegionWithCustomEndpointChain() {
+        S3Connector s3Connector = new S3Connector("other://bucket/prefix/raster.tif");
+
+        AmazonS3 s3Client = s3Connector.getS3Client();
+        assertEquals("US_Standard", s3Client.getRegion().name());
+        assertEquals(
+                "http://your-other-s3-server/bucket/prefix",
+                s3Client.getUrl("bucket", "prefix").toString());
+    }
+
+    @Test
+    public void testRegionOverrideWithCustomEndpointChain() {
+        S3Connector s3Connector =
+                new S3Connector("other://bucket/prefix/raster.tif?awsRegion=US_EAST_2");
+
+        AmazonS3 s3Client = s3Connector.getS3Client();
+        assertEquals("US_East_2", s3Client.getRegion().name());
+        assertEquals(
+                "http://your-other-s3-server/bucket/prefix",
+                s3Client.getUrl("bucket", "prefix").toString());
+    }
+
+    @Test
+    public void throwsWithInvalidCustomEndpoint() {
+        S3Connector s3Connector = new S3Connector("invalid/url/raster.tif");
+
+        assertThrows(
+                "Following this style: s3Alias://bucket/filename",
+                IllegalArgumentException.class,
+                s3Connector::getS3Client);
     }
 }


### PR DESCRIPTION
When using a custom endpoint (for instance using a mock in integration tests), the S3Connector still tried to update the immutable client and throw.

A similar issue was already addressed in 27c6861858fe81979085bf41f2ed7e7a986e8e1d ([PR](https://github.com/geotools/geotools/pull/4355)), however, the chain which is used for custom endpoints was not covered.

I suppose this should be considered to backport to v29 as well?

Thanks for your review.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).
