### PR TITLE
[GEOT-7514] PropertyIsEqualTo fails to compare true and Boolean.TRUE, when both are literals

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/IsEqualsToImpl.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/IsEqualsToImpl.java
@@ -20,10 +20,15 @@ import org.geotools.api.filter.FilterVisitor;
 import org.geotools.api.filter.PropertyIsEqualTo;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.filter.expression.Literal;
+import org.geotools.util.ConverterFactory;
 import org.geotools.util.Converters;
+import org.geotools.util.factory.Hints;
 
 /** @author jdeolive TODO: rename this class to IsEqualToImpl */
 public class IsEqualsToImpl extends MultiCompareFilterImpl implements PropertyIsEqualTo {
+
+    public static final Hints SAFE_CONVERSION_HINTS =
+            new Hints(ConverterFactory.SAFE_CONVERSION, true);
 
     protected IsEqualsToImpl(Expression expression1, Expression expression2) {
         this(expression1, expression2, true);
@@ -86,6 +91,15 @@ public class IsEqualsToImpl extends MultiCompareFilterImpl implements PropertyIs
             if (v1 != null && v1.equals(value2)) return true;
         } else if (expression2 instanceof Literal && !(expression1 instanceof Literal)) {
             Object v2 = Converters.convert(value2, value1.getClass());
+            if (v2 != null && v2.equals(value1)) return true;
+        }
+
+        // if one side is string and the other is not, try to convert the string to non-string
+        if (value1 instanceof String && !(value2 instanceof String)) {
+            Object v1 = Converters.convert(value1, value2.getClass(), SAFE_CONVERSION_HINTS);
+            if (v1 != null && v1.equals(value2)) return true;
+        } else if (value2 instanceof String && !(value1 instanceof String)) {
+            Object v2 = Converters.convert(value2, value1.getClass(), SAFE_CONVERSION_HINTS);
             if (v2 != null && v2.equals(value1)) return true;
         }
 

--- a/modules/library/main/src/test/java/org/geotools/filter/IsEqualsToImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/IsEqualsToImplTest.java
@@ -16,11 +16,13 @@
  */
 package org.geotools.filter;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.math.BigDecimal;
 import org.geotools.api.filter.PropertyIsEqualTo;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.factory.CommonFactoryFinder;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class IsEqualsToImplTest {
@@ -34,7 +36,7 @@ public class IsEqualsToImplTest {
         Expression e2 = filterFactory.literal(1);
 
         PropertyIsEqualTo equal = filterFactory.equals(e1, e2);
-        Assert.assertTrue(equal.evaluate(null));
+        assertTrue(equal.evaluate(null));
     }
 
     @Test
@@ -46,13 +48,13 @@ public class IsEqualsToImplTest {
         Expression literalFloat42 = filterFactory.literal((float) 42);
         Expression literalBig42 = filterFactory.literal(new BigDecimal(42));
 
-        Assert.assertTrue(filterFactory.equals(literalShort42, literalShort42).evaluate(null));
-        Assert.assertTrue(filterFactory.equals(literalShort42, literalString42).evaluate(null));
-        Assert.assertTrue(filterFactory.equals(literalShort42, literalDouble42).evaluate(null));
-        Assert.assertTrue(filterFactory.equals(literalShort42, literalLong42).evaluate(null));
-        Assert.assertTrue(filterFactory.equals(literalShort42, literalFloat42).evaluate(null));
-        Assert.assertTrue(filterFactory.equals(literalShort42, literalBig42).evaluate(null));
-        Assert.assertTrue(filterFactory.equals(literalShort42, literalDouble42).evaluate(null));
+        assertTrue(filterFactory.equals(literalShort42, literalShort42).evaluate(null));
+        assertTrue(filterFactory.equals(literalShort42, literalString42).evaluate(null));
+        assertTrue(filterFactory.equals(literalShort42, literalDouble42).evaluate(null));
+        assertTrue(filterFactory.equals(literalShort42, literalLong42).evaluate(null));
+        assertTrue(filterFactory.equals(literalShort42, literalFloat42).evaluate(null));
+        assertTrue(filterFactory.equals(literalShort42, literalBig42).evaluate(null));
+        assertTrue(filterFactory.equals(literalShort42, literalDouble42).evaluate(null));
     }
 
     @Test
@@ -61,7 +63,7 @@ public class IsEqualsToImplTest {
         Expression e2 = filterFactory.literal("1");
 
         PropertyIsEqualTo equal = filterFactory.equals(e1, e2);
-        Assert.assertTrue(equal.evaluate(null));
+        assertTrue(equal.evaluate(null));
     }
 
     @Test
@@ -70,7 +72,7 @@ public class IsEqualsToImplTest {
         Expression e2 = filterFactory.literal("1.2");
 
         PropertyIsEqualTo equal = filterFactory.equals(e1, e2);
-        Assert.assertFalse(equal.evaluate(null));
+        assertFalse(equal.evaluate(null));
     }
 
     @Test
@@ -79,7 +81,7 @@ public class IsEqualsToImplTest {
         Expression e2 = filterFactory.literal(1l);
 
         PropertyIsEqualTo equal = filterFactory.equals(e1, e2);
-        Assert.assertTrue(equal.evaluate(null));
+        assertTrue(equal.evaluate(null));
     }
 
     @Test
@@ -88,7 +90,7 @@ public class IsEqualsToImplTest {
         Expression e2 = filterFactory.literal(1);
 
         PropertyIsEqualTo equal = filterFactory.equals(e1, e2);
-        Assert.assertTrue(equal.evaluate(null));
+        assertTrue(equal.evaluate(null));
     }
 
     @Test
@@ -97,7 +99,7 @@ public class IsEqualsToImplTest {
         Expression e2 = filterFactory.literal(1l);
 
         PropertyIsEqualTo equal = filterFactory.equals(e1, e2);
-        Assert.assertTrue(equal.evaluate(null));
+        assertTrue(equal.evaluate(null));
     }
 
     @Test
@@ -106,7 +108,7 @@ public class IsEqualsToImplTest {
         Expression e2 = filterFactory.literal(Long.MAX_VALUE);
 
         PropertyIsEqualTo equal = filterFactory.equals(e1, e2);
-        Assert.assertFalse(equal.evaluate(null));
+        assertFalse(equal.evaluate(null));
     }
 
     @Test
@@ -115,9 +117,21 @@ public class IsEqualsToImplTest {
         Expression e2 = filterFactory.literal("FoO");
 
         PropertyIsEqualTo caseSensitive = filterFactory.equal(e1, e2, true);
-        Assert.assertFalse(caseSensitive.evaluate(null));
+        assertFalse(caseSensitive.evaluate(null));
 
         PropertyIsEqualTo caseInsensitive = filterFactory.equal(e1, e2, false);
-        Assert.assertTrue(caseInsensitive.evaluate(null));
+        assertTrue(caseInsensitive.evaluate(null));
+    }
+
+    @Test
+    public void testLiteralConversion() {
+        Expression e1 = filterFactory.literal("true");
+        Expression e2 = filterFactory.literal(Boolean.TRUE);
+
+        PropertyIsEqualTo caseSensitive = filterFactory.equal(e1, e2, true);
+        assertTrue(caseSensitive.evaluate(null));
+
+        PropertyIsEqualTo caseInsensitive = filterFactory.equal(e1, e2, false);
+        assertTrue(caseInsensitive.evaluate(null));
     }
 }


### PR DESCRIPTION
[![GEOT-7514](https://badgen.net/badge/JIRA/GEOT-7514/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7514) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->