### PR TITLE
[GEOT-7518, GEOT-7519] Fix i18n in legend rules

### DIFF
--- a/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/RuleBuilder.java
+++ b/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/RuleBuilder.java
@@ -25,6 +25,8 @@ import org.geotools.api.filter.Filter;
 import org.geotools.api.style.GraphicLegend;
 import org.geotools.api.style.Rule;
 import org.geotools.api.style.Symbolizer;
+import org.geotools.api.util.InternationalString;
+import org.geotools.util.SimpleInternationalString;
 
 public class RuleBuilder extends AbstractStyleBuilder<Rule> {
     List<Symbolizer> symbolizers = new ArrayList<>();
@@ -33,7 +35,7 @@ public class RuleBuilder extends AbstractStyleBuilder<Rule> {
 
     String name;
 
-    String ruleAbstract;
+    InternationalString ruleAbstract;
 
     double minScaleDenominator;
 
@@ -43,7 +45,7 @@ public class RuleBuilder extends AbstractStyleBuilder<Rule> {
 
     boolean elseFilter;
 
-    String title;
+    InternationalString title;
 
     protected Map<String, String> options = new LinkedHashMap<>();
 
@@ -64,15 +66,27 @@ public class RuleBuilder extends AbstractStyleBuilder<Rule> {
         return this;
     }
 
-    public RuleBuilder title(String title) {
+    public RuleBuilder title(InternationalString title) {
         unset = false;
         this.title = title;
         return this;
     }
 
-    public RuleBuilder ruleAbstract(String ruleAbstract) {
+    public RuleBuilder title(String title) {
+        unset = false;
+        this.title = new SimpleInternationalString(title);
+        return this;
+    }
+
+    public RuleBuilder ruleAbstract(InternationalString ruleAbstract) {
         unset = false;
         this.ruleAbstract = ruleAbstract;
+        return this;
+    }
+
+    public RuleBuilder ruleAbstract(String ruleAbstract) {
+        unset = false;
+        this.ruleAbstract = new SimpleInternationalString(ruleAbstract);
         return this;
     }
 
@@ -222,16 +236,9 @@ public class RuleBuilder extends AbstractStyleBuilder<Rule> {
             return unset();
         }
         name = rule.getName();
-        title =
-                Optional.ofNullable(rule.getDescription())
-                        .map(d -> d.getTitle())
-                        .map(t -> t.toString())
-                        .orElse(null);
+        title = Optional.ofNullable(rule.getDescription()).map(d -> d.getTitle()).orElse(null);
         ruleAbstract =
-                Optional.ofNullable(rule.getDescription())
-                        .map(d -> d.getAbstract())
-                        .map(t -> t.toString())
-                        .orElse(null);
+                Optional.ofNullable(rule.getDescription()).map(d -> d.getAbstract()).orElse(null);
         minScaleDenominator = rule.getMinScaleDenominator();
         maxScaleDenominator = rule.getMaxScaleDenominator();
         filter = rule.getFilter();

--- a/modules/extension/brewer/src/test/java/org/geotools/brewer/styling/builder/StyleBuilderTest.java
+++ b/modules/extension/brewer/src/test/java/org/geotools/brewer/styling/builder/StyleBuilderTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNull;
 
 import java.awt.Color;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
@@ -28,6 +29,7 @@ import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.api.style.UserLayer;
 import org.geotools.brewer.styling.filter.expression.ExpressionBuilder;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.util.GrowableInternationalString;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -60,6 +62,80 @@ public class StyleBuilderTest {
         layer.userStyles().add(style);
 
         sld.layers().add(layer);
+    }
+
+    @Test
+    public void testRuleResetTitle() {
+        StyleFactory sf = CommonFactoryFinder.getStyleFactory(null);
+        Rule rule = sf.createRule();
+        String ruleName = "Rule name";
+        rule.setName(ruleName);
+        String title = "Rule title";
+        rule.getDescription().setTitle(title);
+
+        Style resetStyle = new RuleBuilder().reset(rule).name(ruleName).buildStyle();
+        Rule resetRule = resetStyle.featureTypeStyles().get(0).rules().get(0);
+
+        assertEquals(resetRule.getDescription().getTitle().toString(), title);
+    }
+
+    @Test
+    public void testRuleResetI18nTitle() {
+        StyleFactory sf = CommonFactoryFinder.getStyleFactory(null);
+        Rule rule = sf.createRule();
+        String ruleName = "Rule name";
+        rule.setName(ruleName);
+        GrowableInternationalString title = new GrowableInternationalString();
+        title.add(Locale.ENGLISH, "Title in English");
+        title.add(Locale.FRENCH, "Titre en français");
+        rule.getDescription().setTitle(title);
+
+        Style resetStyle = new RuleBuilder().reset(rule).name(ruleName).buildStyle();
+        Rule resetRule = resetStyle.featureTypeStyles().get(0).rules().get(0);
+
+        assertEquals(
+                rule.getDescription().getTitle().toString(Locale.ENGLISH),
+                resetRule.getDescription().getTitle().toString(Locale.ENGLISH));
+        assertEquals(
+                rule.getDescription().getTitle().toString(Locale.FRENCH),
+                resetRule.getDescription().getTitle().toString(Locale.FRENCH));
+    }
+
+    @Test
+    public void testRuleResetAbstract() {
+        StyleFactory sf = CommonFactoryFinder.getStyleFactory(null);
+        Rule rule = sf.createRule();
+        String ruleName = "Rule name";
+        rule.setName(ruleName);
+        String ruleAbstract = "Rule abstract";
+        rule.getDescription().setAbstract(ruleAbstract);
+
+        Style resetStyle = new RuleBuilder().reset(rule).name(ruleName).buildStyle();
+        Rule resetRule = resetStyle.featureTypeStyles().get(0).rules().get(0);
+
+        assertEquals(resetRule.getDescription().getAbstract().toString(), ruleAbstract);
+    }
+
+    @Test
+    public void testRuleResetI18nAbstract() {
+        StyleFactory sf = CommonFactoryFinder.getStyleFactory(null);
+        Rule rule = sf.createRule();
+        String ruleName = "Rule name";
+        rule.setName(ruleName);
+        GrowableInternationalString ruleAbstract = new GrowableInternationalString();
+        ruleAbstract.add(Locale.ENGLISH, "Abstract");
+        ruleAbstract.add(Locale.FRENCH, "Résumé");
+        rule.getDescription().setAbstract(ruleAbstract);
+
+        Style resetStyle = new RuleBuilder().reset(rule).name(ruleName).buildStyle();
+        Rule resetRule = resetStyle.featureTypeStyles().get(0).rules().get(0);
+
+        assertEquals(
+                rule.getDescription().getAbstract().toString(Locale.ENGLISH),
+                resetRule.getDescription().getAbstract().toString(Locale.ENGLISH));
+        assertEquals(
+                rule.getDescription().getAbstract().toString(Locale.FRENCH),
+                resetRule.getDescription().getAbstract().toString(Locale.FRENCH));
     }
 
     @Test

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -1014,7 +1014,7 @@ public class SLDParser {
                     LOGGER.finest("about to parse " + child.getLocalName());
                 }
                 Element element = (Element) child;
-                if (element.getTagName().equalsIgnoreCase("localized")) {
+                if (element.getLocalName().equalsIgnoreCase("localized")) {
                     String lang = element.getAttribute("lang");
                     String translation = getFirstChildValue(element);
 

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -75,6 +75,27 @@ public class SLDParserTest {
                     + " </NamedLayer>"
                     + "</StyledLayerDescriptor>";
 
+    public static String SLDWithNamespace =
+            "<sld:StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" "
+                    + "version=\"1.0.0\">"
+                    + "  <sld:NamedLayer>"
+                    + "    <sld:Name>layer</sld:Name>"
+                    + "    <sld:UserStyle>"
+                    + "      <sld:Name>style</sld:Name>"
+                    + "      <sld:FeatureTypeStyle>"
+                    + "        <sld:Name>name</sld:Name>"
+                    + "        <sld:Rule>"
+                    + "          <sld:PolygonSymbolizer>"
+                    + "            <sld:Fill>"
+                    + "              <sld:CssParameter name=\"fill\">#FF0000</sld:CssParameter>"
+                    + "            </sld:Fill>"
+                    + "          </sld:PolygonSymbolizer>"
+                    + "        </sld:Rule>"
+                    + "      </sld:FeatureTypeStyle>"
+                    + "    </sld:UserStyle>"
+                    + "  </sld:NamedLayer>"
+                    + "</sld:StyledLayerDescriptor>";
+
     public static String LocalizedSLD =
             "<StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" version=\"1.0.0\">"
                     + " <NamedLayer>"
@@ -104,6 +125,31 @@ public class SLDParserTest {
                     + "  </UserStyle>"
                     + " </NamedLayer>"
                     + "</StyledLayerDescriptor>";
+
+    public static String LocalizedSLDWithNamespace =
+            "<sld:StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" "
+                    + "version=\"1.0.0\">"
+                    + "  <sld:NamedLayer>"
+                    + "    <sld:Name>style</sld:Name>"
+                    + "    <sld:UserStyle>"
+                    + "      <sld:Name>style</sld:Name>"
+                    + "      <sld:FeatureTypeStyle>"
+                    + "        <sld:Name>name</sld:Name>"
+                    + "        <sld:Rule>"
+                    + "          <sld:Title>sldtitle"
+                    + "            <sld:Localized lang=\"en\">english</sld:Localized>"
+                    + "          </sld:Title>"
+                    + "          <sld:Abstract>sld abstract</sld:Abstract>"
+                    + "          <sld:PolygonSymbolizer>"
+                    + "            <sld:Fill>"
+                    + "              <sld:CssParameter name=\"fill\">#FF0000</sld:CssParameter>"
+                    + "            </sld:Fill>"
+                    + "          </sld:PolygonSymbolizer>"
+                    + "        </sld:Rule>"
+                    + "      </sld:FeatureTypeStyle>"
+                    + "    </sld:UserStyle>"
+                    + "  </sld:NamedLayer>"
+                    + "</sld:StyledLayerDescriptor>";
 
     public static String EmptyTitleSLD =
             "<StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" version=\"1.0.0\">"
@@ -440,6 +486,13 @@ public class SLDParserTest {
     }
 
     @Test
+    public void testWithNamespace() throws Exception {
+        SLDParser parser = new SLDParser(styleFactory, input(SLDWithNamespace));
+        Style[] styles = parser.readXML();
+        assertStyles(styles);
+    }
+
+    @Test
     public void testLocalizedRuleTitle() throws Exception {
         SLDParser parser = new SLDParser(styleFactory, input(LocalizedSLD));
         Style[] styles = parser.readXML();
@@ -574,6 +627,22 @@ public class SLDParserTest {
                         .getAbstract()
                         .toString(Locale.CANADA_FRENCH));
         assertStyles(styles);
+    }
+
+    @Test
+    public void testLocalizedWithNamespace() throws Exception {
+        SLDParser parser = new SLDParser(styleFactory, input(LocalizedSLDWithNamespace));
+        Style[] styles = parser.readXML();
+        assertEquals(
+                "english",
+                styles[0]
+                        .featureTypeStyles()
+                        .get(0)
+                        .rules()
+                        .get(0)
+                        .getDescription()
+                        .getTitle()
+                        .toString(Locale.ENGLISH));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11249](https://badgen.net/badge/JIRA/GEOS-11249/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11249) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR aims at resolving two issues with the i18n of legend titles (and abstracts) in SLD:

### [GEOT-7519](https://osgeo-org.atlassian.net/browse/GEOT-7519)
The i18n does not work anymore since the org.opengis refactor as GeoServer now uses the StyleBuilder (https://github.com/geoserver/geoserver/blob/c2f437acb46d5fd4a487be8c6a44a76cc9428934/src/main/src/main/java/org/geoserver/catalog/ResourcePool.java#L2216). I thought it made sense to use InternationalString for rule title and abstract in the RuleBuilder (as elsewhere)
### [GEOT-7518](https://osgeo-org.atlassian.net/browse/GEOT-7518)
This is an old issue and the author proposed a patch but it seems it was not merged in the end. We encountered the same problem: when posting a SLD to GeoServer REST API, the namespace `sld:` is added everywhere, as a result the i18n of legends is lost when using the REST API.

Thanks in advance for your review / comments

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->