### PR TITLE
[Backport 29.x] Bump com.jayway.jsonpath:json-path from 2.7.0 to 2.9.0

### DIFF
--- a/.github/workflows/linux_jdk11.yml
+++ b/.github/workflows/linux_jdk11.yml
@@ -26,14 +26,12 @@ jobs:
         key: gt-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           gt-maven-
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: BSFishy/pip-action@v1
-      with:
-        packages: |
-          sphinx==4.5.0
-          requests
+    - name: Setup python packages for building docs
+      run: |
+        pip install -U sphinx
     - name: Disable checksum offloading
       # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
       run: sudo ethtool -K eth0 tx off rx off

--- a/.github/workflows/linux_jdk17.yml
+++ b/.github/workflows/linux_jdk17.yml
@@ -26,14 +26,12 @@ jobs:
         key: gt-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           gt-maven-
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: BSFishy/pip-action@v1
-      with:
-        packages: |
-          sphinx==4.5.0
-          requests
+    - name: Setup python packages for building docs
+      run: |
+        pip install -U sphinx
     - name: Disable checksum offloading
       # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
       run: sudo ethtool -K eth0 tx off rx off

--- a/pom.xml
+++ b/pom.xml
@@ -1209,7 +1209,7 @@
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
-        <version>2.7.0</version>
+        <version>2.9.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Backport #4628
 **Authored by:** @dependabot[bot]