### PR TITLE
[Backport 30.x] Bump com.jayway.jsonpath:json-path from 2.7.0 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1209,7 +1209,7 @@
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
-        <version>2.7.0</version>
+        <version>2.9.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Backport #4628
 **Authored by:** @dependabot[bot]