### PR TITLE
[Backport 30.x] [GEOT-7521] Use style_body to define CSS style for a layer

### DIFF
--- a/docs/user/unsupported/css.rst
+++ b/docs/user/unsupported/css.rst
@@ -72,4 +72,5 @@ Here is the SLD representation of the generated style:
       </sld:NamedLayer>
     </sld:StyledLayerDescriptor>
 
+.. note:: You can use the ``@styleName '<style name>'`` directive to set the name of the style, otherwise ``"Default Styler"`` will be used
 

--- a/docs/user/unsupported/css.rst
+++ b/docs/user/unsupported/css.rst
@@ -72,5 +72,4 @@ Here is the SLD representation of the generated style:
       </sld:NamedLayer>
     </sld:StyledLayerDescriptor>
 
-.. note:: You can use the ``@styleName '<style name>'`` directive to set the name of the style, otherwise ``"Default Styler"`` will be used
 

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssTranslator.java
@@ -139,6 +139,8 @@ public class CssTranslator {
 
     static final String DIRECTIVE_TRANSLATION_MODE = "mode";
 
+    static final String DIRECTIVE_STYLE_NAME = "styleName";
+
     static final String DIRECTIVE_STYLE_TITLE = "styleTitle";
 
     static final String DIRECTIVE_STYLE_ABSTRACT = "styleAbstract";
@@ -278,7 +280,11 @@ public class CssTranslator {
 
         // prepare the full SLD builder
         StyleBuilder styleBuilder = new StyleBuilder();
-        styleBuilder.name("Default Styler");
+
+        String styleName =
+                Objects.requireNonNullElse(
+                        stylesheet.getDirectiveValue(DIRECTIVE_STYLE_NAME), "Default Styler");
+        styleBuilder.name(styleName);
         styleBuilder.title(stylesheet.getDirectiveValue(DIRECTIVE_STYLE_TITLE));
         styleBuilder.styleAbstract(stylesheet.getDirectiveValue(DIRECTIVE_STYLE_ABSTRACT));
 

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
@@ -1850,4 +1850,11 @@ public class TranslatorSyntheticTest extends CssBaseTest {
         assertEquals(0.5, g.getAnchorPoint().getAnchorPointX().evaluate(null, Double.class), 0d);
         assertEquals(1, g.getAnchorPoint().getAnchorPointY().evaluate(null, Double.class), 0d);
     }
+
+    @Test
+    public void testStylenameDirective() {
+        String css = "@styleName 'testStyle'; * { fill: orange; }";
+        Style style = translate(css);
+        assertEquals("testStyle", style.getName());
+    }
 }


### PR DESCRIPTION
[![GEOT-7521](https://badgen.net/badge/JIRA/GEOT-7521/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7521) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4631
 **Authored by:** @mirco-romagnoli