### PR TITLE
[Geot 7522] NetCDFMosaicReaderTest faillure

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -1928,6 +1928,7 @@ public class NetCDFMosaicReaderTest {
                 nc1 = it.next();
                 nc2 = it.next();
             }
+						
             assertEquals("2017-02-06 00:00:00.0", nc1.getAttribute("time").toString());
             assertEquals("2017-02-06 12:00:00.0", nc2.getAttribute("time").toString());
         } finally {

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -1929,7 +1929,6 @@ public class NetCDFMosaicReaderTest {
                 nc2 = it.next();
             }
 
-            // TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
             assertEquals("2017-02-06 00:00:00.0", nc1.getAttribute("time").toString());
             assertEquals("2017-02-06 12:00:00.0", nc2.getAttribute("time").toString());
         } finally {

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -149,6 +149,19 @@ public class NetCDFMosaicReaderTest {
         return new JUnit4TestAdapter(NetCDFMosaicReaderTest.class);
     }
 
+    private static TimeZone DEFAULT;
+
+    @BeforeClass
+    public static void setupTimeZone() {
+        DEFAULT = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    @AfterClass
+    public static void resetTimeZone() {
+        TimeZone.setDefault(DEFAULT);
+    }
+
     @Test
     public void testHarvestAddTime() throws IOException {
         // prepare a "mosaic" with just one NetCDF
@@ -1916,7 +1929,7 @@ public class NetCDFMosaicReaderTest {
                 nc2 = it.next();
             }
 
-            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+            // TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
             assertEquals("2017-02-06 00:00:00.0", nc1.getAttribute("time").toString());
             assertEquals("2017-02-06 12:00:00.0", nc2.getAttribute("time").toString());
         } finally {

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -1928,7 +1928,6 @@ public class NetCDFMosaicReaderTest {
                 nc1 = it.next();
                 nc2 = it.next();
             }
-
             assertEquals("2017-02-06 00:00:00.0", nc1.getAttribute("time").toString());
             assertEquals("2017-02-06 12:00:00.0", nc2.getAttribute("time").toString());
         } finally {

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -1916,6 +1916,7 @@ public class NetCDFMosaicReaderTest {
                 nc2 = it.next();
             }
 
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
             assertEquals("2017-02-06 00:00:00.0", nc1.getAttribute("time").toString());
             assertEquals("2017-02-06 12:00:00.0", nc2.getAttribute("time").toString());
         } finally {


### PR DESCRIPTION
[![GEOT-7522](https://badgen.net/badge/JIRA/GEOT-7522/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7522) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

Modification of the test NetCDFMosaicReaderTest.testGranuleSourceFileView() by the addition of a line of code to set the Timezone of the JVM before running two assertEquals using a timestamp. Without this change, the test uses the computer's Timezone  when running "mvn install". The Timezone is set to "UTC" for UTC+0:00.



  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [X] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
