### PR TITLE
[Backport 29.x] Remove GDAL from OSX, brew install is not working anymore

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,11 +14,6 @@ jobs:
       with:
         java-version: 11
         distribution: 'temurin'
-    - name: Set up GDAL
-      run: |
-        brew update
-        brew upgrade
-        brew install gdal
     - name: Maven repository caching
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
Backport #4636
 **Authored by:** @aaime