### PR TITLE
Vector mosaic: support granule filtering and picking granules from a repository

### DIFF
--- a/modules/unsupported/vector-mosaic/pom.xml
+++ b/modules/unsupported/vector-mosaic/pom.xml
@@ -21,6 +21,11 @@
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
+      <artifactId>gt-cql</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
       <artifactId>gt-shapefile</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureSource.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicFeatureSource.java
@@ -335,6 +335,8 @@ public class VectorMosaicFeatureSource extends ContentFeatureSource {
     protected boolean isNotMandatoryIndexType(AttributeDescriptor descriptor) {
         String name = descriptor.getLocalName();
         return (!VectorMosaicGranule.CONNECTION_PARAMETERS_DELEGATE_FIELD_DEFAULT.equals(name)
+                && !VectorMosaicGranule.GRANULE_TYPE_NAME.equals(name)
+                && !VectorMosaicGranule.GRANULE_FILTER.equals(name)
                 && !(descriptor.getType() instanceof GeometryType)
                 && (!name.equals(VectorMosaicGranule.GRANULE_ID_FIELD)));
     }

--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicGranule.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicGranule.java
@@ -39,6 +39,8 @@ public class VectorMosaicGranule implements Serializable {
     String params;
     Properties connProperties;
 
+    String storeName;
+
     Filter filter;
 
     public static VectorMosaicGranule fromDelegateFeature(SimpleFeature delegateFeature) {
@@ -97,5 +99,13 @@ public class VectorMosaicGranule implements Serializable {
 
     public void setFilter(Filter filter) {
         this.filter = filter;
+    }
+
+    public String getStoreName() {
+        return storeName;
+    }
+
+    public void setStoreName(String storeName) {
+        this.storeName = storeName;
     }
 }

--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicGranule.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicGranule.java
@@ -19,12 +19,17 @@ package org.geotools.vectormosaic;
 import java.io.Serializable;
 import java.util.Properties;
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.filter.Filter;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.filter.text.ecql.ECQL;
 
 /** Configuration for a vector mosaic. */
 public class VectorMosaicGranule implements Serializable {
 
     public static final String CONNECTION_PARAMETERS_DELEGATE_FIELD_DEFAULT = "params";
     public static final String GRANULE_TYPE_NAME = "type";
+
+    public static final String GRANULE_FILTER = "filter";
     public static final String GRANULE_ID_FIELD = "id";
 
     /** The feature type name */
@@ -34,12 +39,22 @@ public class VectorMosaicGranule implements Serializable {
     String params;
     Properties connProperties;
 
+    Filter filter;
+
     public static VectorMosaicGranule fromDelegateFeature(SimpleFeature delegateFeature) {
         VectorMosaicGranule config = new VectorMosaicGranule();
         config.params =
                 (String) delegateFeature.getAttribute(CONNECTION_PARAMETERS_DELEGATE_FIELD_DEFAULT);
         if (delegateFeature.getAttribute(GRANULE_TYPE_NAME) != null) {
             config.granuleTypeName = (String) delegateFeature.getAttribute(GRANULE_TYPE_NAME);
+        }
+        String filterAttribute = (String) delegateFeature.getAttribute(GRANULE_FILTER);
+        if (filterAttribute != null && !filterAttribute.isEmpty()) {
+            try {
+                config.filter = ECQL.toFilter(filterAttribute);
+            } catch (CQLException e) {
+                throw new IllegalArgumentException("Failed to parse filter: " + filterAttribute);
+            }
         }
         return config;
     }
@@ -74,5 +89,13 @@ public class VectorMosaicGranule implements Serializable {
 
     public void setConnProperties(Properties connProperties) {
         this.connProperties = connProperties;
+    }
+
+    public Filter getFilter() {
+        return filter;
+    }
+
+    public void setFilter(Filter filter) {
+        this.filter = filter;
     }
 }

--- a/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFilterTest.java
+++ b/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFilterTest.java
@@ -1,0 +1,141 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2022, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.vectormosaic;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.Query;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.PropertyIsEqualTo;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.DefaultRepository;
+import org.geotools.data.property.PropertyDataStore;
+import org.geotools.data.property.PropertyDataStoreFactory;
+import org.geotools.factory.CommonFactoryFinder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.locationtech.jts.geom.LineString;
+
+public class VectorMosaicFilterTest {
+    protected static DataStore MOSAIC_STORE;
+
+    protected static FilterFactory FF = CommonFactoryFinder.getFilterFactory();
+
+    @BeforeClass
+    public static void initialize() throws IOException {
+        DefaultRepository repository = new DefaultRepository();
+        File delegate = new File("src/test/resources/org.geotools.vectormosaic.data2");
+
+        PropertyDataStore ds = new PropertyDataStore(delegate);
+        repository.register("delegate", ds);
+        VectorMosaicStoreFactory factory = new VectorMosaicStoreFactory();
+        Map<String, Object> params = new HashMap<>();
+        params.put(VectorMosaicStoreFactory.DELEGATE_STORE_NAME.getName(), "delegate");
+        params.put(VectorMosaicStoreFactory.NAMESPACE.getName(), "topp");
+        params.put(VectorMosaicStoreFactory.REPOSITORY_PARAM.getName(), repository);
+        params.put(
+                VectorMosaicStoreFactory.PREFERRED_DATASTORE_SPI.getName(),
+                PropertyDataStoreFactory.class.getName());
+        MOSAIC_STORE = factory.createDataStore(params);
+    }
+
+    @Test
+    public void testTypeNames() throws Exception {
+        List<String> typeNames = Arrays.asList(MOSAIC_STORE.getTypeNames());
+        // Lakes is not included, not valid
+        assertEquals(3, typeNames.size());
+        assertThat(
+                typeNames,
+                hasItems(
+                        "RoadSegmentsAll_mosaic",
+                        "RoadSegmentsFilter_mosaic",
+                        "RoadSegmentsNone_mosaic"));
+    }
+
+    @Test
+    public void testAll() throws Exception {
+        String typeName = "RoadSegmentsAll_mosaic";
+        checkRoadSegmentsSchema(typeName);
+
+        Set<Object> fids = collectFids(typeName, Query.ALL);
+        assertThat(fids, hasItems(101, 102, 103, 104));
+    }
+
+    @Test
+    public void testFilter() throws Exception {
+        String typeName = "RoadSegmentsFilter_mosaic";
+        checkRoadSegmentsSchema(typeName);
+
+        // grab all
+        assertThat(collectFids(typeName, Query.ALL), hasItems(101, 103));
+
+        // mix in a user filter
+        PropertyIsEqualTo left = FF.equal(FF.property("side"), FF.literal("left"), true);
+        Query queryLeft = new Query(typeName, left);
+        assertThat(collectFids(typeName, queryLeft), hasItems(101));
+
+        // mix in a user filter
+        PropertyIsEqualTo right = FF.equal(FF.property("side"), FF.literal("right"), true);
+        Query queryRight = new Query(typeName, right);
+        assertThat(collectFids(typeName, queryRight), hasItems(103));
+    }
+
+    @Test
+    public void testNone() throws Exception {
+        String typeName = "RoadSegmentsNone_mosaic";
+        checkRoadSegmentsSchema(typeName);
+
+        Set<Object> fids = collectFids(typeName, Query.ALL);
+        assertThat(fids, empty());
+    }
+
+    private static Set<Object> collectFids(String typeName, Query query) throws IOException {
+        List<SimpleFeature> features =
+                DataUtilities.list(MOSAIC_STORE.getFeatureSource(typeName).getFeatures(query));
+        Set<Object> fids =
+                features.stream().map(f -> f.getAttribute("fid")).collect(Collectors.toSet());
+        return fids;
+    }
+
+    private static void checkRoadSegmentsSchema(String typeName) throws IOException {
+        // check the schema skips both the "type" and "filter" attributes
+        SimpleFeatureType schema = MOSAIC_STORE.getSchema(typeName);
+        assertArrayEquals(
+                new String[] {"geom", "fid", "name", "side"},
+                schema.getAttributeDescriptors().stream()
+                        .map(d -> d.getLocalName())
+                        .toArray(String[]::new));
+        assertEquals(LineString.class, schema.getDescriptor("geom").getType().getBinding());
+        assertEquals(Integer.class, schema.getDescriptor("fid").getType().getBinding());
+        assertEquals(String.class, schema.getDescriptor("side").getType().getBinding());
+    }
+}

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/Lakes.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/Lakes.properties
@@ -1,0 +1,3 @@
+# This is here just to make sure the mosaic won't try to use this as an index, it lacks the required fields
+_=the_geom:MultiPolygon,FID:String,NAME:String
+Lakes.1107531835962=MULTIPOLYGON (((0.0006 -0.0018, 0.001 -0.0006, 0.0024 -0.0001, 0.0031 -0.0015, 0.0006 -0.0018), (0.0017 -0.0011, 0.0025 -0.0011, 0.0025 -0.0006, 0.0017 -0.0006, 0.0017 -0.0011)))|101|Blue Lake

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsAll.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsAll.properties
@@ -1,0 +1,4 @@
+# filter missing or matching all features
+_=the_geom:Polygon,params:String,type:String,filter:String,side:String
+RoadSegmentsAll.1=POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))|directory=./src/test/resources/org.geotools.vectormosaic.data2/granules|RoadSegments1||left
+RoadSegmentsAll.2=POLYGON((2 0, 3 0, 3 1, 2 3, 2 2))|directory=./src/test/resources/org.geotools.vectormosaic.data2/granules|RoadSegments2|fid > 0|right

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsFilter.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsFilter.properties
@@ -1,0 +1,4 @@
+# filter matching one feature
+_=the_geom:Polygon,params:String,type:String,filter:String,side:String
+RoadSegmentsAll.1=POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))|directory=./src/test/resources/org.geotools.vectormosaic.data2/granules|RoadSegments1|fid=101|left
+RoadSegmentsAll.2=POLYGON((2 0, 3 0, 3 1, 2 3, 2 2))|directory=./src/test/resources/org.geotools.vectormosaic.data2/granules|RoadSegments2|fid=103|right

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsNone.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsNone.properties
@@ -1,0 +1,4 @@
+# filter setup so that it matches no features
+_=the_geom:Polygon,params:String,type:String,filter:String,side:String
+RoadSegmentsAll.1=POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))|directory=./src/test/resources/org.geotools.vectormosaic.data2/granules|RoadSegments1|fid=-1|left
+RoadSegmentsAll.2=POLYGON((2 0, 3 0, 3 1, 2 3, 2 2))|directory=./src/test/resources/org.geotools.vectormosaic.data2/granules|RoadSegments2|fid=-2|right

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsRepository.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsRepository.properties
@@ -1,0 +1,4 @@
+# filter setup so that it matches no features
+_=the_geom:Polygon,params:String,type:String,filter:String,side:String
+RoadSegmentsAll.1=POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))|granulesStore|RoadSegments1||left
+RoadSegmentsAll.2=POLYGON((2 0, 3 0, 3 1, 2 3, 2 2))|granulesStore|RoadSegments2||right

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/granules/RoadSegments1.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/granules/RoadSegments1.properties
@@ -1,0 +1,3 @@
+_=geom:LineString,fid:int,name:String
+RoadSegments.1=LINESTRING(0 0, 1 0)|101|Route 1
+RoadSegments.2=LINESTRING(0 0, 0 1)|102|Route 2

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/granules/RoadSegments2.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/granules/RoadSegments2.properties
@@ -1,0 +1,3 @@
+_=geom:LineString,fid:int,name:String
+RoadSegments.3=LINESTRING(2 0, 3 0)|103|Route 3
+RoadSegments.4=LINESTRING(2 0, 2 1)|104|Route 4


### PR DESCRIPTION
Extend the vector mosaic store to support filtering granule stores, and picking them from a repository

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->