### PR TITLE
[GEOS-11256] getTWKBDigits should return 7 instead of -7 for 0 distance.

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
@@ -154,6 +154,9 @@ public class GeometryColumnEncoder {
      * distance
      */
     private int getTWKBDigits(Double distance) {
+        if (distance.doubleValue() == 0D) {
+            return 7;
+        }
         int result = -(int) Math.floor(Math.log10(distance));
         // Prevent PostGIS ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or
         // less than -7

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryTest.java
@@ -71,6 +71,13 @@ public class PostgisSimplifiedGeometryTest extends JDBCTestSupport {
     }
 
     @Test
+    public void testPolygon0Distance() throws IOException, ParseException {
+        Geometry geom = getFirstGeometry("simplify_polygon", 0);
+        // do not simplify
+        assertGeometryEquals(geom, "POLYGON ((-120 40, -130 40, -130 50, -130 40, -120 40))");
+    }
+
+    @Test
     public void testCollection() throws IOException, ParseException {
         Geometry geom = getFirstGeometry("simplify_collection", 20);
         // line part simplified, but won't use TWKB


### PR DESCRIPTION
[![GEOS-11256](https://badgen.net/badge/JIRA/GEOS-11256/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11256) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is a PR for [GEOT-7526](https://osgeo-org.atlassian.net/browse/GEOT-7526)

When the method ``org.geotools.data.postgis.GeometryColumnEncoder.getTWKBDigits`` is called with 0.0 as distance, a weird case appears: ``-Integer.MIN_VALUE`` is computed but the result is still ``Integer.MIN_VALUE``. Therefore, the returned value is -7 instead of +7.

This change addresses that case.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [X] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [X] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).