### PR TITLE
Update docs on maven shade plugin to 3.5.1

### DIFF
--- a/docs/user/build/faq.rst
+++ b/docs/user/build/faq.rst
@@ -136,7 +136,7 @@ GeoTools modules and their dependencies.
                         </goals>
                         <configuration>
                             <filters>
-						                         	<!-- filter signed jars in the dependencies -->
+	                  	<!-- filter signed jars in the dependencies -->
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
@@ -152,7 +152,7 @@ GeoTools modules and their dependencies.
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.geotools.demo.Quickstart</mainClass>
                                 </transformer>
-	 							                      <!-- merge services (eg referencing plugins) -->
+	 			<!-- merge services (eg referencing plugins) -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                         </configuration>

--- a/docs/user/build/faq.rst
+++ b/docs/user/build/faq.rst
@@ -127,7 +127,7 @@ GeoTools modules and their dependencies.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -135,15 +135,24 @@ GeoTools modules and their dependencies.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+						                         	<!-- filter signed jars in the dependencies -->
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>                    
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
                             <transformers>
-                                <!-- This bit sets the main class for the executable jar as you otherwise -->
-                                <!-- would with the assembly plugin                                       -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <manifestEntries>
-                                        <Main-Class>org.geotools.demo.Quickstart</Main-Class>
-                                    </manifestEntries>
+                                    <mainClass>org.geotools.demo.Quickstart</mainClass>
                                 </transformer>
-                                <!-- This bit merges the various GeoTools META-INF/services files         -->
+	 							                      <!-- merge services (eg referencing plugins) -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                         </configuration>

--- a/docs/user/build/faq.rst
+++ b/docs/user/build/faq.rst
@@ -152,7 +152,7 @@ GeoTools modules and their dependencies.
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.geotools.demo.Quickstart</mainClass>
                                 </transformer>
-	 			<!-- merge services (eg referencing plugins) -->
+	 			<!-- This bit merges the various GeoTools META-INF/services files  (e.g. referencing plugins) -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                         </configuration>


### PR DESCRIPTION
This updates the documentation in the FAQ for creating an executable JAR to the maven 3.5.1 shade plugin, adding likely needed transformers/filters

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->