### PR TITLE
[Backport 29.x] [GEOS-11256] getTWKBDigits should return 7 instead of -7 for 0 distance.

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/GeometryColumnEncoder.java
@@ -154,6 +154,9 @@ public class GeometryColumnEncoder {
      * distance
      */
     private int getTWKBDigits(Double distance) {
+        if (distance.doubleValue() == 0D) {
+            return 7;
+        }
         int result = -(int) Math.floor(Math.log10(distance));
         // Prevent PostGIS ERROR: lwgeom_write_to_buffer: X/Z precision cannot be greater than 7 or
         // less than -7

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisSimplifiedGeometryTest.java
@@ -71,6 +71,13 @@ public class PostgisSimplifiedGeometryTest extends JDBCTestSupport {
     }
 
     @Test
+    public void testPolygon0Distance() throws IOException, ParseException {
+        Geometry geom = getFirstGeometry("simplify_polygon", 0);
+        // do not simplify
+        assertGeometryEquals(geom, "POLYGON ((-120 40, -130 40, -130 50, -130 40, -120 40))");
+    }
+
+    @Test
     public void testCollection() throws IOException, ParseException {
         Geometry geom = getFirstGeometry("simplify_collection", 20);
         // line part simplified, but won't use TWKB


### PR DESCRIPTION
[![GEOS-11256](https://badgen.net/badge/JIRA/GEOS-11256/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11256) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4655
 **Authored by:** @iaunzu