### PR TITLE
[GEOT-7527] StreamingRenderer can ask stores to simplify geometries with a distance of 'zero'

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -1271,25 +1271,30 @@ public class StreamingRenderer implements GTRenderer {
                     }
                 }
 
+                // if there is any trouble during generalization distance calculation, we'll
+                // get [0,0] as the spans. Do not generalize in that case.
                 double distance = spans[0] < spans[1] ? spans[0] : spans[1];
-                if (hasRenderingTransformation) {
-                    // the RT might need valid geometries, we can at most apply a topology
-                    // preserving generalization
-                    if (fsHints.contains(Hints.GEOMETRY_GENERALIZATION)) {
-                        hints.put(Hints.GEOMETRY_GENERALIZATION, distance);
-                        disableInMemoryGeneralization(styleList);
-                    }
-                } else {
-                    // ... if possible we let the datastore do the generalization
-                    if (fsHints.contains(Hints.GEOMETRY_SIMPLIFICATION)) {
-                        // good, we don't need to perform in memory generalization, the datastore
-                        // does it all for us
-                        hints.put(Hints.GEOMETRY_SIMPLIFICATION, distance);
-                        disableInMemoryGeneralization(styleList);
-                    } else if (fsHints.contains(Hints.GEOMETRY_DISTANCE)) {
-                        // in this case the datastore can get us close, but we can still
-                        // perform some in memory generalization
-                        hints.put(Hints.GEOMETRY_DISTANCE, distance);
+                if (distance > 0) {
+                    if (hasRenderingTransformation) {
+                        // the RT might need valid geometries, we can at most apply a topology
+                        // preserving generalization
+                        if (fsHints.contains(Hints.GEOMETRY_GENERALIZATION)) {
+                            hints.put(Hints.GEOMETRY_GENERALIZATION, distance);
+                            disableInMemoryGeneralization(styleList);
+                        }
+                    } else {
+                        // ... if possible we let the datastore do the generalization
+                        if (fsHints.contains(Hints.GEOMETRY_SIMPLIFICATION)) {
+                            // good, we don't need to perform in memory generalization, the
+                            // datastore
+                            // does it all for us
+                            hints.put(Hints.GEOMETRY_SIMPLIFICATION, distance);
+                            disableInMemoryGeneralization(styleList);
+                        } else if (fsHints.contains(Hints.GEOMETRY_DISTANCE)) {
+                            // in this case the datastore can get us close, but we can still
+                            // perform some in memory generalization
+                            hints.put(Hints.GEOMETRY_DISTANCE, distance);
+                        }
                     }
                 }
             }

--- a/modules/library/render/src/test/java/org/geotools/renderer/GeneralizationDistanceTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/GeneralizationDistanceTest.java
@@ -18,6 +18,7 @@ package org.geotools.renderer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.awt.RenderingHints;
 import java.util.Collections;
@@ -136,18 +137,18 @@ public class GeneralizationDistanceTest {
     @Test
     public void testDistanceReprojectionWholeWorld() throws Exception {
         // when APH is disabled the calculation will fail, disabling generalization
-        assertDistanceWholeWorldRendering(Collections.emptyMap(), 0);
+        assertDistanceWholeWorldRendering(Collections.emptyMap(), null);
 
         // before the fix we would have gotten zero with APH enabled too (failure to compute the
         // distance), but no more, it's using a valid distance for a envelope spanning the planet
         assertDistanceWholeWorldRendering(
                 Collections.singletonMap(
                         StreamingRenderer.ADVANCED_PROJECTION_HANDLING_KEY, Boolean.TRUE),
-                160300);
+                160300d);
     }
 
     public void assertDistanceWholeWorldRendering(
-            Map<Object, Object> hints, double expectedDistance) {
+            Map<Object, Object> hints, Double expectedDistance) {
         MapContent mc = new MapContent();
         mc.addLayer(new FeatureLayer(source, style));
         StreamingRenderer sr = new StreamingRenderer();
@@ -160,7 +161,11 @@ public class GeneralizationDistanceTest {
                 null,
                 200,
                 100);
-        assertNotNull(lastDistance);
-        assertEquals(expectedDistance, lastDistance, 1);
+        if (expectedDistance == null) {
+            assertNull(lastDistance);
+        } else {
+            assertNotNull(lastDistance);
+            assertEquals(expectedDistance, lastDistance, 1);
+        }
     }
 }

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/StreamingRendererTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/StreamingRendererTest.java
@@ -24,6 +24,7 @@ import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -31,6 +32,7 @@ import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
@@ -44,9 +46,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.media.jai.Interpolation;
 import javax.media.jai.JAI;
 import org.geotools.api.data.Query;
@@ -97,6 +101,7 @@ import org.geotools.styling.StyleBuilder;
 import org.geotools.styling.StyleFactoryImpl;
 import org.geotools.styling.StyleImpl;
 import org.geotools.test.TestData;
+import org.geotools.util.factory.Hints;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -983,5 +988,64 @@ public class StreamingRendererTest {
 
         Assert.assertEquals(0, errors);
         Assert.assertEquals(inFeatures.size(), features);
+    }
+
+    /**
+     * When a test point for simplfication spans cannot be reprojected back to source, a
+     * simplification distance of "0" is returned. It should not be sent down to the store.
+     */
+    @Test
+    public void testInvalidSimplificationDistance() throws Exception {
+        // TODO: advertise supported hints and cycle through the distance variations
+        Style lineStyle = createLineStyle();
+        testInvalidSimplificationDistance2(Hints.GEOMETRY_DISTANCE, lineStyle);
+        testInvalidSimplificationDistance2(Hints.GEOMETRY_SIMPLIFICATION, lineStyle);
+        testInvalidSimplificationDistance2(Hints.GEOMETRY_GENERALIZATION, lineStyle);
+        Style rtStyle = RendererBaseTest.loadStyle(this, "attributeRename.sld");
+        testInvalidSimplificationDistance2(Hints.GEOMETRY_DISTANCE, rtStyle);
+        testInvalidSimplificationDistance2(Hints.GEOMETRY_SIMPLIFICATION, rtStyle);
+        testInvalidSimplificationDistance2(Hints.GEOMETRY_GENERALIZATION, rtStyle);
+    }
+
+    /**
+     * Tests that the simplification distance is not sent to the store when it is zero. Allows to
+     * check different siplification hints, and vary the style.
+     */
+    void testInvalidSimplificationDistance2(final RenderingHints.Key hint, Style style)
+            throws Exception {
+        AtomicReference<Object> reference = new AtomicReference<>();
+        SimpleFeatureSource testSource =
+                new CollectionFeatureSource(createLineCollection()) {
+                    @Override
+                    public SimpleFeatureCollection getFeatures(Query query) {
+                        reference.set(query.getHints().get(hint));
+                        return super.getFeatures(query);
+                    }
+
+                    @Override
+                    public synchronized Set<RenderingHints.Key> getSupportedHints() {
+                        return Set.of(hint);
+                    }
+                };
+
+        MapContent mc = new MapContent();
+        FeatureLayer layer = new FeatureLayer(testSource, style);
+        mc.addLayer(layer);
+
+        StreamingRenderer sr = new StreamingRenderer();
+        sr.setMapContent(mc);
+
+        ReferencedEnvelope envelope =
+                new ReferencedEnvelope(-1e7, 1e7, -1e7, 1e7, CRS.decode("AUTO:42003,9001,45,0"));
+
+        BufferedImage bi = new BufferedImage(100, 100, BufferedImage.TYPE_3BYTE_BGR);
+        Graphics2D graphics = bi.createGraphics();
+        try {
+            sr.paint(graphics, new Rectangle(5, 5, 7, 7), envelope);
+        } finally {
+            graphics.dispose();
+            mc.dispose();
+        }
+        assertNull("Got a distance simplification reference, unexpected", reference.get());
     }
 }


### PR DESCRIPTION
[![GEOT-7527](https://badgen.net/badge/JIRA/GEOT-7527/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7527) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Details and rationale in the Jira ticket description.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->