### PR TITLE
[Backport 29.x] Bump org.postgresql:postgresql from 42.6.0 to 42.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
     <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
     <netcdf.version>4.6.15</netcdf.version>
     <ojdbc8.version>19.18.0.0</ojdbc8.version>
-    <postgresql.jdbc.version>42.6.0</postgresql.jdbc.version>
+    <postgresql.jdbc.version>42.7.2</postgresql.jdbc.version>
     <reload4j.version>1.2.19</reload4j.version>
     <sl4j.version>1.7.32</sl4j.version>
     <solrj.version>8.9.0</solrj.version>


### PR DESCRIPTION
Backport #4663
 **Authored by:** @dependabot[bot]