### PR TITLE
[GEOT-7532] GDALTestCase superfluous reports on missing test.zip

### DIFF
--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/GDALTestCase.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/GDALTestCase.java
@@ -83,10 +83,11 @@ public class GDALTestCase {
         Assume.assumeTrue(testingEnabled());
 
         try {
-            final File file = TestData.file(this, "test.zip");
-            if (file != null && file.exists() && file.canRead())
+            final File file = new File(TestData.file(this, null), "test.zip");
+            if (file.exists()) {
                 // unzip it
                 TestData.unzipFile(this, "test.zip");
+            }
         } catch (FileNotFoundException e) {
             LOGGER.log(Level.SEVERE, "can not locate test-data for \"test.zip\"");
         } catch (Exception e1) {


### PR DESCRIPTION
[![GEOT-7532](https://badgen.net/badge/JIRA/GEOT-7532/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7532) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

As the javadocs says, the function TestData.file will throw exception on missing file. Therefore I use an alternative approach to check if the file test.zip exists.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->