### PR TITLE
[Backport 29.x] Bump org.eclipse.platform:org.eclipse.core.runtime from 3.23.0 to 3.29.0 in /modules/unsupported/swt

### DIFF
--- a/modules/unsupported/swt/pom.xml
+++ b/modules/unsupported/swt/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.core.runtime</artifactId>
-      <version>3.23.0</version>
+      <version>3.29.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
Backport #4678
 **Authored by:** @dependabot[bot]