### PR TITLE
[Backport 31.x] Bump org.eclipse.platform:org.eclipse.jface from 3.23.0 to 3.31.0 in /modules/unsupported/swt

### DIFF
--- a/modules/unsupported/swt/pom.xml
+++ b/modules/unsupported/swt/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.jface</artifactId>
-      <version>3.23.0</version>
+      <version>3.31.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
Backport #4677
 **Authored by:** @dependabot[bot]