### PR TITLE
Vector mosaic: typename and filter not being loaded when property selection is active

### DIFF
--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicGranule.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicGranule.java
@@ -32,6 +32,10 @@ public class VectorMosaicGranule implements Serializable {
     public static final String GRANULE_FILTER = "filter";
     public static final String GRANULE_ID_FIELD = "id";
 
+    public static final String[] GRANULE_CONFIG_FIELDS = {
+        CONNECTION_PARAMETERS_DELEGATE_FIELD_DEFAULT, GRANULE_FILTER, GRANULE_TYPE_NAME
+    };
+
     /** The feature type name */
     String name;
 

--- a/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFeatureSourceTest.java
+++ b/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFeatureSourceTest.java
@@ -370,8 +370,8 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
                         featureReader.delegateFeature.getType().getDescriptors().stream()
                                 .map(d -> d.getName().getLocalPart())
                                 .collect(Collectors.joining(","));
-                // params is a required element of the delegate feature
-                assertEquals("rank,params", delegateAttributes);
+                // params is a required element of the delegate feature, so is type
+                assertEquals("rank,params,type", delegateAttributes);
             }
         }
     }
@@ -392,8 +392,8 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
                         featureReader.delegateFeature.getType().getDescriptors().stream()
                                 .map(d -> d.getName().getLocalPart())
                                 .collect(Collectors.joining(","));
-                // params is a required element of the delegate feature
-                assertEquals("rank,params", delegateAttributes);
+                // params is a required element of the delegate feature, so is type
+                assertEquals("rank,params,type", delegateAttributes);
                 String granuleAttributes =
                         featureReader.rawGranule.getType().getDescriptors().stream()
                                 .map(d -> d.getName().getLocalPart())

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsRepositoryFilter.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsRepositoryFilter.properties
@@ -1,0 +1,4 @@
+# filter setup so that it matches no features
+_=the_geom:Polygon,params:String,type:String,filter:String,side:String
+RoadSegmentsAll.1=POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))|granulesStore|RoadSegments1|fid=101|left
+RoadSegmentsAll.2=POLYGON((2 0, 3 0, 3 1, 2 3, 2 2))|granulesStore|RoadSegments2|fid=103|right


### PR DESCRIPTION
What the title says. The result is that the granule store typename and filter options are ignored.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->