### PR TITLE
[Backport 30.x] Vector mosaic: typename and filter not being loaded when property selection is active

### DIFF
--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicGranule.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicGranule.java
@@ -32,6 +32,10 @@ public class VectorMosaicGranule implements Serializable {
     public static final String GRANULE_FILTER = "filter";
     public static final String GRANULE_ID_FIELD = "id";
 
+    public static final String[] GRANULE_CONFIG_FIELDS = {
+        CONNECTION_PARAMETERS_DELEGATE_FIELD_DEFAULT, GRANULE_FILTER, GRANULE_TYPE_NAME
+    };
+
     /** The feature type name */
     String name;
 

--- a/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFeatureSourceTest.java
+++ b/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFeatureSourceTest.java
@@ -370,8 +370,8 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
                         featureReader.delegateFeature.getType().getDescriptors().stream()
                                 .map(d -> d.getName().getLocalPart())
                                 .collect(Collectors.joining(","));
-                // params is a required element of the delegate feature
-                assertEquals("rank,params", delegateAttributes);
+                // params is a required element of the delegate feature, so is type
+                assertEquals("rank,params,type", delegateAttributes);
             }
         }
     }
@@ -392,8 +392,8 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
                         featureReader.delegateFeature.getType().getDescriptors().stream()
                                 .map(d -> d.getName().getLocalPart())
                                 .collect(Collectors.joining(","));
-                // params is a required element of the delegate feature
-                assertEquals("rank,params", delegateAttributes);
+                // params is a required element of the delegate feature, so is type
+                assertEquals("rank,params,type", delegateAttributes);
                 String granuleAttributes =
                         featureReader.rawGranule.getType().getDescriptors().stream()
                                 .map(d -> d.getName().getLocalPart())

--- a/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsRepositoryFilter.properties
+++ b/modules/unsupported/vector-mosaic/src/test/resources/org.geotools.vectormosaic.data2/RoadSegmentsRepositoryFilter.properties
@@ -1,0 +1,4 @@
+# filter setup so that it matches no features
+_=the_geom:Polygon,params:String,type:String,filter:String,side:String
+RoadSegmentsAll.1=POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))|granulesStore|RoadSegments1|fid=101|left
+RoadSegmentsAll.2=POLYGON((2 0, 3 0, 3 1, 2 3, 2 2))|granulesStore|RoadSegments2|fid=103|right


### PR DESCRIPTION
Backport #4687
 **Authored by:** @aaime