### PR TITLE
[Backport 30.x] [GEOT-7539] The latest tutorials link is broken in https://docs.geotools.org/

### DIFF
--- a/docs/index/index.rst
+++ b/docs/index/index.rst
@@ -30,7 +30,7 @@ The GeoTools User Guide is available online:
     The user guide is available for `download <https://sourceforge.net/projects/geotools/files/>`__
     as a zip file.
        
-`Tutorials <https://docs.geotools.org/latest/tutorial/https://docs.geotools.org/stable/userguide/>`__ ( `stable <https://docs.geotools.org/stable/userguide/tutorial/>`__ | `maintenance <https://docs.geotools.org/maintenance/userguide/tutorial/>`__ )
+`Tutorials <https://docs.geotools.org/latest/userguide/tutorial/>`__ ( `stable <https://docs.geotools.org/stable/userguide/tutorial/>`__ | `maintenance <https://docs.geotools.org/maintenance/userguide/tutorial/>`__ )
     Step by step tutorials introducing both GeoTools and geospatial concepts for Java developers.
 
 `FAQ <https://docs.geotools.org/stable/userguide/faq.html>`__ ( `stable <https://docs.geotools.org/stable/userguide/faq.html>`__ | `maintenance <https://docs.geotools.org/maintenance/userguide/faq.html>`__ )


### PR DESCRIPTION
[![GEOT-7539](https://badgen.net/badge/JIRA/GEOT-7539/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7539) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4679
 **Authored by:** @DevDengChao