### PR TITLE
[Backport 31.x] [GEOT-7534] fix geojsonreader stops reading features if it encounters one with geometry=null

### DIFF
--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -358,9 +358,12 @@ public class GeoJSONReader implements AutoCloseable {
                 }
                 while (parser.nextToken() == JsonToken.START_OBJECT) {
                     ObjectNode node = mapper.readTree(parser);
-
-                    SimpleFeature feature = getNextFeature(node);
-                    features.add(feature);
+                    try {
+                        SimpleFeature feature = getNextFeature(node);
+                        features.add(feature);
+                    } catch (IOException e) {
+                        LOGGER.log(Level.WARNING, e.getMessage(), e);
+                    }
                 }
             }
             // support paged feature collections, OGC API style
@@ -446,7 +449,7 @@ public class GeoJSONReader implements AutoCloseable {
 
         // the geometry might have been selected away by a property selection
         Geometry g = null;
-        if (geom != null) g = GEOM_PARSER.geometryFromJson(geom);
+        if (geom != null && !geom.isNull()) g = GEOM_PARSER.geometryFromJson(geom);
 
         JsonNode props = node.get("properties");
         // accommodate for STAC servers that remove the properties object altogether, when

--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONReader.java
@@ -358,12 +358,8 @@ public class GeoJSONReader implements AutoCloseable {
                 }
                 while (parser.nextToken() == JsonToken.START_OBJECT) {
                     ObjectNode node = mapper.readTree(parser);
-                    try {
-                        SimpleFeature feature = getNextFeature(node);
-                        features.add(feature);
-                    } catch (IOException e) {
-                        LOGGER.log(Level.WARNING, e.getMessage(), e);
-                    }
+                    SimpleFeature feature = getNextFeature(node);
+                    features.add(feature);
                 }
             }
             // support paged feature collections, OGC API style

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
@@ -691,6 +691,15 @@ public class GeoJSONReaderTest {
     }
 
     @Test
+    public void testGeometrynull() throws Exception {
+        URL url = TestData.url(GeoJSONReaderTest.class, "geometrynull.json");
+        try (GeoJSONReader reader = new GeoJSONReader(url)) {
+            SimpleFeatureCollection features = reader.getFeatures();
+            assertEquals(3, features.size());
+        }
+    }
+
+    @Test
     public void testEmpty() throws Exception {
         URL url = TestData.url(GeoJSONReaderTest.class, "empty.json");
         try (GeoJSONReader reader = new GeoJSONReader(url)) {

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONReaderTest.java
@@ -691,7 +691,7 @@ public class GeoJSONReaderTest {
     }
 
     @Test
-    public void testGeometrynull() throws Exception {
+    public void testGeometryNull() throws Exception {
         URL url = TestData.url(GeoJSONReaderTest.class, "geometrynull.json");
         try (GeoJSONReader reader = new GeoJSONReader(url)) {
             SimpleFeatureCollection features = reader.getFeatures();

--- a/modules/unsupported/geojson-core/src/test/resources/org/geotools/data/geojson/test-data/geometrynull.json
+++ b/modules/unsupported/geojson-core/src/test/resources/org/geotools/data/geojson/test-data/geometrynull.json
@@ -1,0 +1,10 @@
+{
+    "type": "FeatureCollection",
+    "name": "null-geometry",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "features": [
+    { "type": "Feature", "properties": { }, "geometry": { "type": "Point", "coordinates": [ 38.0094, 48.4292 ] } },
+    { "type": "Feature", "properties": { }, "geometry": null },
+    { "type": "Feature", "properties": { }, "geometry": { "type": "Point", "coordinates": [ 37.8014, 48.015 ] } }
+    ]
+}


### PR DESCRIPTION
[![GEOT-7534](https://badgen.net/badge/JIRA/GEOT-7534/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7534) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4668
 **Authored by:** @oberhamsi