### PR TITLE
[Backport 30.x] Bump org.springframework.security:spring-security-core from 5.7.10 to 5.7.12 in /modules/unsupported/elasticsearch

### DIFF
--- a/modules/unsupported/elasticsearch/pom.xml
+++ b/modules/unsupported/elasticsearch/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>5.7.10</version>
+      <version>5.7.12</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Backport #4697
 **Authored by:** @dependabot[bot]