### PR TITLE
[Backport 31.x] [GEOT-7540] Added `startIndex` parameter handling for WFS feature reqs

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
@@ -255,7 +255,7 @@ class WFSFeatureSource extends ContentFeatureSource {
             request.setMaxFeatures(maxFeatures);
         }
         Integer startIndex = query.getStartIndex();
-        if (startIndex != null && Integer.MAX_VALUE > startIndex && canOffset(query)) {
+        if (startIndex != null && canOffset(query)) {
             request.setStartIndex(startIndex);
         }
         // let the request decide request.setOutputFormat(outputFormat);

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
@@ -92,7 +92,7 @@ class WFSFeatureSource extends ContentFeatureSource {
 
     @Override
     protected boolean canOffset(Query query) {
-        return false; // TODO: check with the WFS client
+        return true; // TODO: check with the WFS client
     }
 
     /**
@@ -253,6 +253,10 @@ class WFSFeatureSource extends ContentFeatureSource {
         int maxFeatures = query.getMaxFeatures();
         if (Integer.MAX_VALUE > maxFeatures && canLimit(query)) {
             request.setMaxFeatures(maxFeatures);
+        }
+        Integer startIndex = query.getStartIndex();
+        if (startIndex != null && Integer.MAX_VALUE > startIndex && canOffset(query)) {
+            request.setStartIndex(startIndex);
         }
         // let the request decide request.setOutputFormat(outputFormat);
         request.setPropertyNames(query.getPropertyNames());

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
@@ -92,7 +92,7 @@ class WFSFeatureSource extends ContentFeatureSource {
 
     @Override
     protected boolean canOffset(Query query) {
-        return true; // TODO: check with the WFS client
+        return client.canOffset();
     }
 
     /**

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
@@ -341,7 +341,7 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
             map.put("MAXFEATURES", String.valueOf(request.getMaxFeatures()));
         }
 
-        if (request.getStartIndex() != null) {
+        if (request.getStartIndex() != null && this.canOffset()) {
             map.put("STARTINDEX", String.valueOf(request.getStartIndex()));
         }
 

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/AbstractWFSStrategy.java
@@ -108,7 +108,7 @@ import org.geotools.xsd.Encoder;
  *   <li>{@link #createTransactionRequest}
  * </ul>
  *
- * <p>Additionaly, specific strategy objects may override any other method to work around specific
+ * <p>Additionally, specific strategy objects may override any other method to work around specific
  * service implementation oddities. To that end, the following methods might be of special interest:
  *
  * <ul>
@@ -339,6 +339,10 @@ public abstract class AbstractWFSStrategy extends WFSStrategy {
 
         if (request.getMaxFeatures() != null) {
             map.put("MAXFEATURES", String.valueOf(request.getMaxFeatures()));
+        }
+
+        if (request.getStartIndex() != null) {
+            map.put("STARTINDEX", String.valueOf(request.getStartIndex()));
         }
 
         if (request.getPropertyNames() != null && request.getPropertyNames().length > 0) {

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetFeatureRequest.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetFeatureRequest.java
@@ -41,6 +41,8 @@ public class GetFeatureRequest extends WFSRequest {
 
     private Integer maxFeatures;
 
+    private Integer startIndex;
+
     private ResultType resultType;
 
     private SortBy[] sortBy;
@@ -90,6 +92,10 @@ public class GetFeatureRequest extends WFSRequest {
         return maxFeatures;
     }
 
+    public Integer getStartIndex() {
+        return startIndex;
+    }
+
     public ResultType getResultType() {
         return resultType;
     }
@@ -116,6 +122,11 @@ public class GetFeatureRequest extends WFSRequest {
     /** @param maxFeatures the maxFeatures to set */
     public void setMaxFeatures(Integer maxFeatures) {
         this.maxFeatures = maxFeatures;
+    }
+
+    /** @param startIndex the startIndex to set */
+    public void setStartIndex(Integer startIndex) {
+        this.startIndex = startIndex;
     }
 
     /** @param resultType the resultType to set */

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSClient.java
@@ -261,6 +261,10 @@ public class WFSClient extends AbstractOpenWebService<WFSGetCapabilities, QName>
         return getStrategy().canLimit();
     }
 
+    public boolean canOffset() {
+        return getStrategy().canOffset();
+    }
+
     public boolean canFilter() {
         return true;
     }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSStrategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/WFSStrategy.java
@@ -215,4 +215,14 @@ public abstract class WFSStrategy extends Specification {
     public boolean canLimit() {
         return true;
     }
+
+    /**
+     * Indicates whether the server supports adjusting the starting position of the result set.
+     * Defaults to false, as not all servers provide support for paging.
+     *
+     * @return true if the server supports setting an offset for the results, otherwise false
+     */
+    public boolean canOffset() {
+        return false;
+    }
 }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -765,4 +765,9 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
 
         return delete;
     }
+
+    @Override
+    public boolean canOffset() {
+        return true;
+    }
 }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v2_0/StrictWFS_2_0_Strategy.java
@@ -307,7 +307,7 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
 
     @Override
     @SuppressWarnings("CollectionIncompatibleType")
-    protected EObject createGetFeatureRequestPost(GetFeatureRequest query) throws IOException {
+    protected EObject createGetFeatureRequestPost(GetFeatureRequest query) {
         final QName typeName = query.getTypeName();
         final FeatureTypeInfoImpl featureTypeInfo =
                 (FeatureTypeInfoImpl) getFeatureTypeInfo(typeName);
@@ -325,7 +325,11 @@ public class StrictWFS_2_0_Strategy extends AbstractWFSStrategy {
 
         Integer maxFeatures = query.getMaxFeatures();
         if (maxFeatures != null) {
-            getFeature.setCount(BigInteger.valueOf(maxFeatures.intValue()));
+            getFeature.setCount(BigInteger.valueOf(maxFeatures));
+        }
+        Integer startIndex = query.getStartIndex();
+        if (startIndex != null) {
+            getFeature.setStartIndex(BigInteger.valueOf(startIndex));
         }
 
         ResultType resultType = query.getResultType();

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/AbstractWFSStrategyTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/AbstractWFSStrategyTest.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import javax.xml.namespace.QName;
 import org.geotools.api.filter.Filter;
 import org.geotools.data.wfs.TestHttpResponse;
+import org.geotools.data.wfs.internal.v1_x.StrictWFS_1_x_Strategy;
 import org.geotools.data.wfs.internal.v2_0.StrictWFS_2_0_Strategy;
 import org.geotools.filter.LikeFilterImpl;
 import org.geotools.filter.LiteralExpressionImpl;
@@ -67,5 +68,61 @@ public class AbstractWFSStrategyTest {
         Assert.assertNotNull(filters);
         Assert.assertEquals(2, filters.length);
         Assert.assertTrue(filters[0].evaluate(filter));
+    }
+
+    /**
+     * Test method for {@link
+     * org.geotools.data.wfs.internal.AbstractWFSStrategy#buildUrlGET(WFSRequest)}, to check if it
+     * produces the STARTINDEX query parameter for a WFS 1.1.0 request.
+     */
+    @Test
+    public void testWfs1UrlBuildingWithStartIndexParameter() throws IOException, ServiceException {
+        HTTPResponse httpResponse =
+                new TestHttpResponse(
+                        "text/xml", "UTF-8", url("GeoServer_1.7.x/1.1.0/GetCapabilities.xml"));
+
+        WFSStrategy strategy = new StrictWFS_1_x_Strategy();
+
+        WFSGetCapabilities capabilities =
+                new GetCapabilitiesResponse(httpResponse, null).getCapabilities();
+        strategy.setCapabilities(capabilities);
+
+        GetFeatureRequest request = new GetFeatureRequest(new WFSConfig(), strategy);
+
+        request.setTypeName(new QName("example"));
+        request.setFilter(Filter.INCLUDE);
+        request.setStartIndex(100);
+
+        URL url = strategy.buildUrlGET(request);
+
+        Assert.assertTrue(url.getQuery().contains("STARTINDEX=100"));
+    }
+
+    /**
+     * Test method for {@link
+     * org.geotools.data.wfs.internal.AbstractWFSStrategy#buildUrlGET(WFSRequest)}, to check if it
+     * produces the STARTINDEX query parameter for a WFS 2.0.0 request.
+     */
+    @Test
+    public void testWfs2UrlBuildingWithStartIndexParameter() throws IOException, ServiceException {
+        HTTPResponse httpResponse =
+                new TestHttpResponse(
+                        "text/xml", "UTF-8", url("GeoServer_2.2.x/2.0.0/GetCapabilities.xml"));
+
+        WFSStrategy strategy = new StrictWFS_2_0_Strategy();
+
+        WFSGetCapabilities capabilities =
+                new GetCapabilitiesResponse(httpResponse, null).getCapabilities();
+        strategy.setCapabilities(capabilities);
+
+        GetFeatureRequest request = new GetFeatureRequest(new WFSConfig(), strategy);
+
+        request.setTypeName(new QName("example"));
+        request.setFilter(Filter.INCLUDE);
+        request.setStartIndex(100);
+
+        URL url = strategy.buildUrlGET(request);
+
+        Assert.assertTrue(url.getQuery().contains("STARTINDEX=100"));
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/AbstractWFSStrategyTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/AbstractWFSStrategyTest.java
@@ -154,11 +154,11 @@ public class AbstractWFSStrategyTest {
         request.setStartIndex(100);
         request.setMaxFeatures(222222);
 
-        InputStream postContents = strategy.getPostContents(request);
-
-        String postContentsString =
-                String.join("\n", IOUtils.readLines(new InputStreamReader(postContents)));
-        Assert.assertFalse(postContentsString.contains("startIndex"));
+        try (InputStream postContents = strategy.getPostContents(request)) {
+            String postContentsString =
+                    String.join("\n", IOUtils.readLines(new InputStreamReader(postContents)));
+            Assert.assertFalse(postContentsString.contains("startIndex"));
+        }
     }
 
     /**
@@ -185,10 +185,10 @@ public class AbstractWFSStrategyTest {
         request.setStartIndex(100);
         request.setMaxFeatures(222222);
 
-        InputStream postContents = strategy.getPostContents(request);
-
-        String postContentsString =
-                String.join("\n", IOUtils.readLines(new InputStreamReader(postContents)));
-        Assert.assertTrue(postContentsString.contains("startIndex=\"100\""));
+        try (InputStream postContents = strategy.getPostContents(request)) {
+            String postContentsString =
+                    String.join("\n", IOUtils.readLines(new InputStreamReader(postContents)));
+            Assert.assertTrue(postContentsString.contains("startIndex=\"100\""));
+        }
     }
 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/AbstractWFSStrategyTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/AbstractWFSStrategyTest.java
@@ -98,7 +98,7 @@ public class AbstractWFSStrategyTest {
 
         URL url = strategy.buildUrlGET(request);
 
-        Assert.assertTrue(url.getQuery().contains("STARTINDEX=100"));
+        Assert.assertFalse(url.getQuery().contains("STARTINDEX"));
     }
 
     /**


### PR DESCRIPTION
[![GEOT-7540](https://badgen.net/badge/JIRA/GEOT-7540/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7540) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4686
 **Authored by:** @axl8713