### PR TITLE
[Backport 30.x] [GEOT-7553] Vector mosaic store does not optimize filters using the default geometry name

### DIFF
--- a/modules/extension/complex/src/main/java/org/geotools/data/complex/expression/FeaturePropertyAccessorFactory.java
+++ b/modules/extension/complex/src/main/java/org/geotools/data/complex/expression/FeaturePropertyAccessorFactory.java
@@ -17,6 +17,8 @@
 
 package org.geotools.data.complex.expression;
 
+import static org.geotools.filter.expression.SimpleFeaturePropertyAccessorFactory.DEFAULT_GEOMETRY_NAME;
+
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -95,9 +97,7 @@ public class FeaturePropertyAccessorFactory implements PropertyAccessorFactory {
         if (!ComplexAttribute.class.isAssignableFrom(type)
                 && !ComplexType.class.isAssignableFrom(type)
                 && !AttributeDescriptor.class.isAssignableFrom(type)) return null;
-        if ("".equals(xpath))
-            // if ("".equals(xpath) && target == Geometry.class)
-            return DEFAULT_GEOMETRY_ACCESS;
+        if (DEFAULT_GEOMETRY_NAME.equals(xpath)) return DEFAULT_GEOMETRY_ACCESS;
 
         // check for fid access
         if (FID_PATTERN.matcher(xpath).matches()) return FID_ACCESS;
@@ -151,7 +151,7 @@ public class FeaturePropertyAccessorFactory implements PropertyAccessorFactory {
 
         @Override
         public boolean canHandle(Object object, String xpath, Class target) {
-            if (!"".equals(xpath)) return false;
+            if (!DEFAULT_GEOMETRY_NAME.equals(xpath)) return false;
 
             // if (target != Geometry.class || target != GeometryAttribute.class)
             //    return false;

--- a/modules/library/main/src/main/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorFactory.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorFactory.java
@@ -17,6 +17,7 @@
 package org.geotools.filter.expression;
 
 import java.util.regex.Pattern;
+import org.geotools.api.feature.Feature;
 import org.geotools.api.feature.IllegalAttributeException;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
@@ -45,6 +46,14 @@ public class SimpleFeaturePropertyAccessorFactory implements PropertyAccessorFac
     public static final PropertyAccessor DEFAULT_GEOMETRY_ACCESS =
             new DefaultGeometrySimpleFeaturePropertyAccessor();
     public static final PropertyAccessor FID_ACCESS = new FidSimpleFeaturePropertyAccessor();
+
+    /**
+     * Conventional property name used to indicate the "efault gedometry" of a feature, that is, the
+     * one returned by {@link Feature#getDefaultGeometryProperty()} or {@link
+     * SimpleFeature.getDefaultGeometry()}.
+     */
+    public static final String DEFAULT_GEOMETRY_NAME = "";
+
     static Pattern idPattern = Pattern.compile("@(\\w+:)?id");
 
     private static final String NAME_START_CHAR =
@@ -89,8 +98,7 @@ public class SimpleFeaturePropertyAccessorFactory implements PropertyAccessorFac
                 && !SimpleFeatureType.class.isAssignableFrom(type))
             return null; // we only work with simple feature
 
-        // if ("".equals(xpath) && target == Geometry.class)
-        if ("".equals(xpath)) return DEFAULT_GEOMETRY_ACCESS;
+        if (DEFAULT_GEOMETRY_NAME.equals(xpath)) return DEFAULT_GEOMETRY_ACCESS;
 
         // check for fid access
         if (idPattern.matcher(xpath).matches()) return FID_ACCESS;
@@ -155,7 +163,7 @@ public class SimpleFeaturePropertyAccessorFactory implements PropertyAccessorFac
 
         @Override
         public boolean canHandle(Object object, String xpath, Class target) {
-            if (!"".equals(xpath)) return false;
+            if (!DEFAULT_GEOMETRY_NAME.equals(xpath)) return false;
 
             //        	if ( target != Geometry.class )
             //        		return false;

--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicPostPreFilterSplitter.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicPostPreFilterSplitter.java
@@ -49,6 +49,8 @@ public class VectorMosaicPostPreFilterSplitter extends PostPreProcessFilterSplit
         indexAttributeDescriptors.stream()
                 .map(AttributeDescriptor::getLocalName)
                 .forEach(this.attributeNames::add);
+        // add the "default geometry" attribute
+        this.attributeNames.add("");
     }
 
     /**

--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicPostPreFilterSplitter.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/VectorMosaicPostPreFilterSplitter.java
@@ -33,6 +33,7 @@ import org.geotools.api.filter.spatial.BBOX;
 import org.geotools.api.filter.spatial.BinarySpatialOperator;
 import org.geotools.api.filter.temporal.BinaryTemporalOperator;
 import org.geotools.filter.FilterAttributeExtractor;
+import org.geotools.filter.expression.SimpleFeaturePropertyAccessorFactory;
 import org.geotools.filter.visitor.PostPreProcessFilterSplittingVisitor;
 
 public class VectorMosaicPostPreFilterSplitter extends PostPreProcessFilterSplittingVisitor {
@@ -49,8 +50,8 @@ public class VectorMosaicPostPreFilterSplitter extends PostPreProcessFilterSplit
         indexAttributeDescriptors.stream()
                 .map(AttributeDescriptor::getLocalName)
                 .forEach(this.attributeNames::add);
-        // add the "default geometry" attribute
-        this.attributeNames.add("");
+        // add the "default geometry" attribute (conventional property name)
+        this.attributeNames.add(SimpleFeaturePropertyAccessorFactory.DEFAULT_GEOMETRY_NAME);
     }
 
     /**

--- a/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicReaderTest.java
+++ b/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicReaderTest.java
@@ -276,4 +276,21 @@ public class VectorMosaicReaderTest extends VectorMosaicTest {
         // once, when running along with other tests, schema has been computed already)
         verify(spy, Mockito.atMost(1)).getFeatureType(any(), any());
     }
+
+    @Test
+    public void testBBOXFilter() throws Exception {
+        SimpleFeatureSource featureSource = MOSAIC_STORE.getFeatureSource(MOSAIC_TYPE_NAME);
+        GranuleTracker tracker = new GranuleTracker();
+        GranuleStoreFinder finder = ((VectorMosaicFeatureSource) featureSource).finder;
+        finder.granuleTracker = tracker;
+
+        Query q = new Query();
+        Filter bbox = FF.bbox("", -88, -76, 33, 39, "EPSG:4326");
+        q.setFilter(bbox);
+        assertEquals(3, featureSource.getCount(q));
+        FilterTracker filterTracker = ((VectorMosaicFeatureSource) featureSource).filterTracker;
+        // the bbox filter actually applies to both
+        assertEquals(bbox, filterTracker.getDelegateFilter());
+        assertEquals(bbox, filterTracker.getGranuleFilter());
+    }
 }


### PR DESCRIPTION
[![GEOT-7553](https://badgen.net/badge/JIRA/GEOT-7553/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7553) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4714
 **Authored by:** @aaime