### PR TITLE
[GEOT-7555] Use dateFormatter of GeoJSONWriter instead of the default one

### DIFF
--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
@@ -262,7 +262,7 @@ public class GeoJSONWriter implements AutoCloseable {
         } else if (binding == Boolean.class) {
             g.writeBoolean((boolean) value);
         } else if (Date.class.isAssignableFrom(binding)) {
-            g.writeString(DEFAULT_DATE_FORMATTER.format(value));
+            g.writeString(this.dateFormatter.format(value));
         } else if (Object.class.isAssignableFrom(binding) && value instanceof JsonNode) {
             ((JsonNode) value)
                     .serialize(

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.geotools.TestData;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
@@ -273,6 +274,30 @@ public class GeoJSONWriteTest {
                 "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})\\.(\\d{3})Z";
         String date = root.get("properties").get("date").textValue();
         assertTrue(date + " does not match ISO date", date.matches(isoDatePattern));
+    }
+
+    @Test
+    public void testDateFormat() throws Exception {
+        Date testDate = new Date();
+        // test feature
+        SimpleFeatureType type =
+                DataUtilities.createType("test", "the_geom:Point:srid=4326,date:java.util.Date");
+        SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
+        builder.add(new GeometryFactory().createPoint(new Coordinate(1, 2)));
+        builder.add(testDate);
+        SimpleFeature feature = builder.buildFeature(null);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GeoJSONWriter writer = new GeoJSONWriter(out)) {
+            writer.setSingleFeature(true);
+            writer.setDatePattern(DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.getPattern());
+            writer.write(feature);
+        }
+
+        String json = out.toString(StandardCharsets.UTF_8);
+        JsonNode root = new ObjectMapper().readTree(json);
+        String date = root.get("properties").get("date").textValue();
+        assertEquals(DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.format(testDate), date);
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7555](https://badgen.net/badge/JIRA/GEOT-7555/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7555) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

Module: `gt-geojson-core`.

[[GEOT-7555](https://osgeo-org.atlassian.net/browse/GEOT-7555)] This is a small fix to `GeoJSONWriter`, to format `Date` using private member variable date formatter.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->