### PR TITLE
[Backport 30.x] [GEOT-7555] Use dateFormatter of GeoJSONWriter instead of the default one

### DIFF
--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/GeoJSONWriter.java
@@ -262,7 +262,7 @@ public class GeoJSONWriter implements AutoCloseable {
         } else if (binding == Boolean.class) {
             g.writeBoolean((boolean) value);
         } else if (Date.class.isAssignableFrom(binding)) {
-            g.writeString(DEFAULT_DATE_FORMATTER.format(value));
+            g.writeString(this.dateFormatter.format(value));
         } else if (Object.class.isAssignableFrom(binding) && value instanceof JsonNode) {
             ((JsonNode) value)
                     .serialize(

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.geotools.TestData;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
@@ -273,6 +274,30 @@ public class GeoJSONWriteTest {
                 "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})\\.(\\d{3})Z";
         String date = root.get("properties").get("date").textValue();
         assertTrue(date + " does not match ISO date", date.matches(isoDatePattern));
+    }
+
+    @Test
+    public void testDateFormat() throws Exception {
+        Date testDate = new Date();
+        // test feature
+        SimpleFeatureType type =
+                DataUtilities.createType("test", "the_geom:Point:srid=4326,date:java.util.Date");
+        SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
+        builder.add(new GeometryFactory().createPoint(new Coordinate(1, 2)));
+        builder.add(testDate);
+        SimpleFeature feature = builder.buildFeature(null);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GeoJSONWriter writer = new GeoJSONWriter(out)) {
+            writer.setSingleFeature(true);
+            writer.setDatePattern(DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.getPattern());
+            writer.write(feature);
+        }
+
+        String json = out.toString(StandardCharsets.UTF_8);
+        JsonNode root = new ObjectMapper().readTree(json);
+        String date = root.get("properties").get("date").textValue();
+        assertEquals(DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.format(testDate), date);
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7555](https://badgen.net/badge/JIRA/GEOT-7555/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7555) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4721
 **Authored by:** @initialdmg