### PR TITLE
[GEOT-7544]:Adding MemoryMappedRandomAccessFile

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/cv/CoordinateVariable.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/cv/CoordinateVariable.java
@@ -81,17 +81,23 @@ public abstract class CoordinateVariable<T> {
         }
 
         @Override
-        public T getMinimum() {
+        public synchronized T getMinimum() {
+            // Made it synchronized since axis1D values retrieval
+            // does cached read on its underlying
             return convertValue(axis1D.getMinValue());
         }
 
         @Override
-        public T getMaximum() {
+        public synchronized T getMaximum() {
+            // Made it synchronized since axis1D values retrieval
+            // does cached read on its underlying
             return convertValue(axis1D.getMaxValue());
         }
 
         @Override
-        public List<T> getAll() {
+        public synchronized List<T> getAll() {
+            // Made it synchronized since axis1D values retrieval
+            // does cached read on its underlying
             return new AbstractList<T>() {
                 @Override
                 public T get(int index) {

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/io/MemoryMappedFileCache.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/io/MemoryMappedFileCache.java
@@ -1,0 +1,873 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 1998-2023, University Corporation for Atmospheric Research/Unidata
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.geotools.io;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.nc2.dataset.DatasetUrl;
+import ucar.nc2.time.CalendarDate;
+import ucar.nc2.time.CalendarDateFormatter;
+import ucar.nc2.util.CancelTask;
+import ucar.nc2.util.cache.FileCacheIF;
+import ucar.nc2.util.cache.FileCacheable;
+import ucar.nc2.util.cache.FileFactory;
+import ucar.unidata.util.StringUtil2;
+
+@SuppressWarnings("unchecked")
+@ThreadSafe
+/**
+ * {@link FileCacheIF} implementation based on {@link ucar.nc2.util.cache.FileCache} from Unidata,
+ * using MemoryMappedRandomAccessFile instead of standard RandomAccessFile. FileCache cannot be
+ * subclassed since some fields are private and are needed by implementation.
+ */
+public class MemoryMappedFileCache implements FileCacheIF {
+    protected static final Logger log = LoggerFactory.getLogger(MemoryMappedFileCache.class);
+    protected static final Logger cacheLog = LoggerFactory.getLogger("MemoryMappedFileCacheLogger");
+    private static Timer timer;
+    private static Object lock = new Object();
+    protected String name;
+    protected final int softLimit;
+    protected final int minElements;
+    protected final int hardLimit;
+    protected final long period;
+    private final AtomicBoolean disabled;
+    protected final AtomicBoolean hasScheduled;
+    protected final ConcurrentHashMap<Object, CacheElement> cache;
+    protected final ConcurrentHashMap<FileCacheable, CacheElement.CacheFile> files;
+    protected final AtomicInteger cleanups;
+    protected final AtomicInteger hits;
+    protected final AtomicInteger miss;
+    protected ConcurrentHashMap<Object, CacheTracking> track;
+    protected boolean trackAll = false;
+
+    public static void shutdown() {
+        synchronized (lock) {
+            if (timer != null) {
+                timer.cancel();
+                cacheLog.info("MemoryMappedFileCache.shutdown called%n");
+            }
+
+            timer = null;
+        }
+    }
+
+    private static void scheduleAtFixedRate(TimerTask task, long delay, long period) {
+        synchronized (lock) {
+            if (timer == null) {
+                timer = new Timer("MemoryMappedFileCache");
+            }
+
+            timer.scheduleAtFixedRate(task, delay, period);
+        }
+    }
+
+    private static void schedule(TimerTask task, long delay) {
+        synchronized (lock) {
+            if (timer == null) {
+                timer = new Timer("MemoryMappedFileCache");
+            }
+
+            timer.schedule(task, delay);
+        }
+    }
+
+    public MemoryMappedFileCache(int minElementsInMemory, int maxElementsInMemory, int period) {
+        this("", minElementsInMemory, maxElementsInMemory, -1, period);
+    }
+
+    public MemoryMappedFileCache(
+            int minElementsInMemory, int softLimit, int hardLimit, int period) {
+        this("", minElementsInMemory, softLimit, hardLimit, period);
+    }
+
+    public MemoryMappedFileCache(
+            String name, int minElementsInMemory, int softLimit, int hardLimit, int period) {
+        this.disabled = new AtomicBoolean(false);
+        this.hasScheduled = new AtomicBoolean(false);
+        this.cleanups = new AtomicInteger();
+        this.hits = new AtomicInteger();
+        this.miss = new AtomicInteger();
+        this.name = name;
+        this.minElements = minElementsInMemory;
+        this.softLimit = softLimit;
+        this.hardLimit = hardLimit;
+        this.period = 1000L * (long) period;
+        this.cache = new ConcurrentHashMap(2 * softLimit, 0.75F, 8);
+        this.files = new ConcurrentHashMap(4 * softLimit, 0.75F, 8);
+        boolean wantsCleanup = period > 0;
+        if (wantsCleanup) {
+            scheduleAtFixedRate(new MemoryMappedFileCache.CleanupTask(), this.period, this.period);
+            if (cacheLog.isDebugEnabled()) {
+                cacheLog.debug(
+                        "MemoryMappedFileCache " + name + " cleanup every " + period + " secs");
+            }
+        }
+
+        if (this.trackAll) {
+            this.track = new ConcurrentHashMap(5000);
+        }
+    }
+
+    protected void addRaf(String uriString, MemoryMappedRandomAccessFile mmraf) {
+        MemoryMappedFileCache.CacheElement elem =
+                cache.putIfAbsent(uriString, new CacheElement(mmraf, uriString));
+
+        if (elem != null) {
+            synchronized (elem) {
+                elem.addFile(mmraf);
+            }
+        }
+    }
+
+    @Override
+    public void disable() {
+        this.disabled.set(true);
+        this.clearCache(true);
+    }
+
+    @Override
+    public void enable() {
+        this.disabled.set(false);
+    }
+
+    @Override
+    public FileCacheable acquire(FileFactory factory, DatasetUrl durl) throws IOException {
+        return this.acquire(factory, durl.getTrueurl(), durl, -1, null, null);
+    }
+
+    @Override
+    public FileCacheable acquire(
+            FileFactory factory,
+            Object hashKey,
+            DatasetUrl location,
+            int buffer_size,
+            CancelTask cancelTask,
+            Object spiObject)
+            throws IOException {
+        if (null == hashKey) {
+            hashKey = location.getTrueurl();
+        }
+
+        if (null == hashKey) {
+            throw new IllegalArgumentException();
+        } else {
+            CacheTracking t = null;
+            if (this.trackAll) {
+                t = new CacheTracking(hashKey);
+                CacheTracking prev = this.track.putIfAbsent(hashKey, t);
+                if (prev != null) {
+                    t = prev;
+                }
+            }
+
+            FileCacheable ncfile = this.acquireCacheOnly(hashKey);
+            if (ncfile != null) {
+                this.hits.incrementAndGet();
+                if (t != null) {
+                    ++t.hit;
+                }
+
+                return ncfile;
+            } else {
+                this.miss.incrementAndGet();
+                if (t != null) {
+                    ++t.miss;
+                }
+
+                String uriString = StringUtil2.replace(location.getTrueurl(), '\\', "/");
+                if (uriString.startsWith("file:")) {
+                    uriString = StringUtil2.unescape(uriString.substring(5));
+                }
+                ncfile = new MemoryMappedRandomAccessFile(uriString, "r");
+                if (cacheLog.isDebugEnabled()) {
+                    cacheLog.debug(
+                            "MemoryMappedFileCache "
+                                    + this.name
+                                    + " acquire "
+                                    + hashKey
+                                    + " "
+                                    + ncfile.getLocation());
+                }
+
+                if (cancelTask != null && cancelTask.isCancel()) {
+                    if (ncfile != null) {
+                        ncfile.close();
+                    }
+
+                    return null;
+                } else if (this.disabled.get()) {
+                    return ncfile;
+                } else {
+                    MemoryMappedFileCache.CacheElement elem =
+                            this.cache.putIfAbsent(hashKey, new CacheElement(ncfile, hashKey));
+
+                    if (elem != null) {
+                        synchronized (elem) {
+                            elem.addFile(ncfile);
+                        }
+                    }
+
+                    boolean needHard = false;
+                    boolean needSoft = false;
+
+                    if (!this.hasScheduled.get()) {
+                        int count = this.files.size();
+                        if (count > this.hardLimit && this.hardLimit > 0) {
+                            needHard = true;
+                            this.hasScheduled.getAndSet(true);
+                        } else if (count > this.softLimit && this.softLimit > 0) {
+                            this.hasScheduled.getAndSet(true);
+                            needSoft = true;
+                        }
+                    }
+
+                    if (needHard) {
+                        this.cleanup(this.hardLimit);
+                    } else if (needSoft) {
+                        schedule(new CleanupTask(), 100L);
+                    }
+
+                    return ncfile;
+                }
+            }
+        }
+    }
+
+    private FileCacheable acquireCacheOnly(Object hashKey) {
+        if (this.disabled.get()) {
+            return null;
+        } else {
+            CacheElement wantCacheElem = this.cache.get(hashKey);
+            if (wantCacheElem == null) {
+                return null;
+            } else {
+                CacheElement.CacheFile want = null;
+                Iterator listIt = wantCacheElem.list.iterator();
+
+                while (listIt.hasNext()) {
+                    CacheElement.CacheFile file = (CacheElement.CacheFile) listIt.next();
+                    if (file.isLocked.compareAndSet(false, true)) {
+                        want = file;
+                        break;
+                    }
+                }
+
+                if (want == null) {
+                    return null;
+                } else {
+                    if (want.ncfile != null) {
+                        long lastModified = want.ncfile.getLastModified();
+                        boolean changed = lastModified != want.lastModified;
+                        if (cacheLog.isDebugEnabled() && changed) {
+                            cacheLog.debug(
+                                    "MemoryMappedFileCache "
+                                            + this.name
+                                            + ": acquire from cache "
+                                            + hashKey
+                                            + " "
+                                            + want.ncfile.getLocation()
+                                            + " was changed; discard");
+                        }
+
+                        if (changed) {
+                            this.remove(want);
+                        }
+                    }
+
+                    if (want.ncfile != null) {
+                        try {
+                            want.ncfile.reacquire();
+                        } catch (IOException ioe) {
+                            if (cacheLog.isDebugEnabled()) {
+                                cacheLog.debug(
+                                        "MemoryMappedFileCache "
+                                                + this.name
+                                                + " acquire from cache "
+                                                + hashKey
+                                                + " "
+                                                + want.ncfile.getLocation()
+                                                + " failed: "
+                                                + ioe.getMessage());
+                            }
+
+                            this.remove(want);
+                        }
+                    }
+
+                    return want.ncfile;
+                }
+            }
+        }
+    }
+
+    private void remove(CacheElement.CacheFile want) {
+        want.remove();
+        this.files.remove(want.ncfile);
+
+        try {
+            want.ncfile.setFileCache(null);
+            want.ncfile.close();
+        } catch (IOException ioe) {
+            log.error("close failed on " + want.ncfile.getLocation(), ioe);
+        }
+
+        want.ncfile = null;
+    }
+
+    @Override
+    public void eject(Object hashKey) {
+        if (!this.disabled.get()) {
+            CacheElement wantCacheElem = this.cache.get(hashKey);
+            if (wantCacheElem != null) {
+                Iterator listIt = wantCacheElem.list.iterator();
+
+                while (true) {
+                    if (!listIt.hasNext()) {
+                        wantCacheElem.list.clear();
+                        break;
+                    }
+
+                    CacheElement.CacheFile want = (CacheElement.CacheFile) listIt.next();
+                    this.files.remove(want.ncfile);
+
+                    try {
+                        want.ncfile.setFileCache(null);
+                        want.ncfile.close();
+                        log.debug("close " + want.ncfile.getLocation());
+                    } catch (IOException ioe) {
+                        log.error("close failed on " + want.ncfile.getLocation(), ioe);
+                    }
+
+                    want.ncfile = null;
+                }
+
+                this.cache.remove(hashKey);
+            }
+        }
+    }
+
+    @Override
+    public boolean release(FileCacheable ncfile) throws IOException {
+        if (ncfile == null) {
+            return false;
+        } else if (this.disabled.get()) {
+            ncfile.setFileCache(null);
+            ncfile.close();
+            return false;
+        } else {
+            CacheElement.CacheFile file = this.files.get(ncfile);
+            if (file != null) {
+                if (!file.isLocked.get()) {
+                    cacheLog.warn(
+                            "MemoryMappedFileCache "
+                                    + this.name
+                                    + " release "
+                                    + ncfile.getLocation()
+                                    + " not locked; hash= "
+                                    + ncfile.hashCode());
+                }
+
+                file.lastAccessed = System.currentTimeMillis();
+                ++file.countAccessed;
+
+                try {
+                    file.ncfile.release();
+                    file.isLocked.set(false);
+                } catch (IOException ioe) {
+                    cacheLog.error(
+                            "MemoryMappedFileCache {} release failed on {} - will try to remove from cache. Failure due to:",
+                            new Object[] {this.name, file.getCacheName(), ioe});
+                    this.remove(file);
+                }
+
+                if (cacheLog.isDebugEnabled()) {
+                    cacheLog.debug(
+                            "MemoryMappedFileCache "
+                                    + this.name
+                                    + " release "
+                                    + ncfile.getLocation()
+                                    + "; hash= "
+                                    + ncfile.hashCode());
+                }
+
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    @Override
+    public synchronized void clearCache(boolean force) {
+        List<CacheElement.CacheFile> deleteList = new ArrayList(2 * this.cache.size());
+        Iterator iter;
+        CacheElement.CacheFile file;
+        if (force) {
+            this.cache.clear();
+            deleteList.addAll(this.files.values());
+            this.files.clear();
+        } else {
+            iter = this.files.values().iterator();
+
+            while (iter.hasNext()) {
+                file = (CacheElement.CacheFile) iter.next();
+                if (file.isLocked.compareAndSet(false, true)) {
+                    file.remove();
+                    deleteList.add(file);
+                    iter.remove();
+                }
+            }
+
+            Iterator<CacheElement> iterator = this.cache.values().iterator();
+            while (iterator.hasNext()) {
+                CacheElement elem = iterator.next();
+                synchronized (elem) {
+                    if (elem.list.isEmpty()) {
+                        iterator.remove();
+                    }
+                }
+            }
+        }
+
+        iter = deleteList.iterator();
+
+        while (iter.hasNext()) {
+            file = (CacheElement.CacheFile) iter.next();
+            if (force && file.isLocked.get()) {
+                cacheLog.warn(
+                        "MemoryMappedFileCache " + this.name + " force close locked file= " + file);
+            }
+
+            try {
+                if (file != null && file.ncfile != null) {
+                    file.ncfile.setFileCache(null);
+                    file.ncfile.close();
+                } else {
+                    log.error(
+                            String.format(
+                                    "MemoryMappedFileCache %s: null file or null ncfile",
+                                    this.name));
+                }
+
+                if (file != null) {
+                    file.ncfile = null;
+                }
+            } catch (IOException ioe) {
+                log.error("MemoryMappedFileCache " + this.name + " close failed on " + file);
+            }
+        }
+
+        if (cacheLog.isDebugEnabled()) {
+            cacheLog.debug(
+                    "*MemoryMappedFileCache "
+                            + this.name
+                            + " clearCache force= "
+                            + force
+                            + " deleted= "
+                            + deleteList.size()
+                            + " left="
+                            + this.files.size());
+        }
+    }
+
+    @Override
+    public void showCache(Formatter format) {
+        ArrayList<CacheElement.CacheFile> allFiles = new ArrayList(this.files.size());
+        Iterator it = this.cache.values().iterator();
+
+        while (it.hasNext()) {
+            CacheElement elem = (CacheElement) it.next();
+            synchronized (elem) {
+                allFiles.addAll(elem.list);
+            }
+        }
+
+        Collections.sort(allFiles);
+        format.format(
+                "%nFileCache %s (min=%d softLimit=%d hardLimit=%d scour=%d secs):%n",
+                this.name, this.minElements, this.softLimit, this.hardLimit, this.period / 1000L);
+        format.format(" isLocked  accesses lastAccess                   location %n");
+        it = allFiles.iterator();
+
+        while (it.hasNext()) {
+            CacheElement.CacheFile file = (CacheElement.CacheFile) it.next();
+            String loc = file.ncfile != null ? file.ncfile.getLocation() : "null";
+            format.format(
+                    "%8s %9d %s == %s %n",
+                    file.isLocked,
+                    file.countAccessed,
+                    CalendarDateFormatter.toDateTimeStringISO(file.lastAccessed),
+                    loc);
+        }
+
+        this.showStats(format);
+    }
+
+    @Override
+    public List<String> showCache() {
+        List<CacheElement.CacheFile> allFiles = new ArrayList(this.files.size());
+        Iterator valIt = this.cache.values().iterator();
+
+        while (valIt.hasNext()) {
+            CacheElement elem = (CacheElement) valIt.next();
+            synchronized (elem) {
+                allFiles.addAll(elem.list);
+            }
+        }
+
+        Collections.sort(allFiles);
+        List<String> result = new ArrayList(allFiles.size());
+        Iterator fileIt = allFiles.iterator();
+
+        while (fileIt.hasNext()) {
+            CacheElement.CacheFile file = (CacheElement.CacheFile) fileIt.next();
+            result.add(file.toString());
+        }
+
+        return result;
+    }
+
+    @Override
+    public void showStats(Formatter format) {
+        format.format(
+                "  hits= %d miss= %d nfiles= %d elems= %d%n",
+                this.hits.get(), this.miss.get(), this.files.size(), this.cache.values().size());
+    }
+
+    @Override
+    public void showTracking(Formatter format) {
+        if (this.track != null) {
+            List<CacheTracking> all = new ArrayList(this.track.size());
+            all.addAll(this.track.values());
+            Collections.sort(all);
+            int seq = 0;
+            int countAll = 0;
+            int countHits = 0;
+            int countMiss = 0;
+            format.format("%nTracking All files in cache %s%n", this.name);
+            format.format("    #    accum       hit    miss  file%n");
+            Iterator allIt = all.iterator();
+
+            while (allIt.hasNext()) {
+                CacheTracking t = (CacheTracking) allIt.next();
+                ++seq;
+                countAll += t.hit + t.miss;
+                countHits += t.hit;
+                countMiss += t.miss;
+                format.format("%6d  %7d : %6d %6d %s%n", seq, countAll, t.hit, t.miss, t.key);
+            }
+
+            float r = countAll == 0 ? 0.0F : (float) countHits / (float) countAll;
+            format.format(
+                    "  total=%7d : %6d %6d hit ratio=%f%n", countAll, countHits, countMiss, r);
+        }
+    }
+
+    @Override
+    public void resetTracking() {
+        this.track = new ConcurrentHashMap(5000);
+        this.trackAll = true;
+    }
+
+    synchronized void cleanup(int maxElements) {
+        try {
+            int size = this.files.size();
+            if (size > this.minElements) {
+                if (cacheLog.isDebugEnabled()) {
+                    cacheLog.debug(
+                            "MemoryMappedFileCache {} cleanup started at {} for maxElements={}",
+                            new Object[] {this.name, CalendarDate.present(), maxElements});
+                }
+
+                this.cleanups.incrementAndGet();
+                ArrayList<CacheFileSorter> unlockedFiles = new ArrayList();
+                Iterator filesIt = this.files.values().iterator();
+
+                while (filesIt.hasNext()) {
+                    CacheElement.CacheFile file = (CacheElement.CacheFile) filesIt.next();
+                    if (!file.isLocked.get()) {
+                        unlockedFiles.add(new CacheFileSorter(file));
+                    }
+                }
+
+                Collections.sort(unlockedFiles);
+                int need2delete = size - this.minElements;
+                int minDelete = size - maxElements;
+                List<CacheElement.CacheFile> deleteList = new ArrayList(need2delete);
+                int count = 0;
+                Iterator iter = unlockedFiles.iterator();
+
+                while (iter.hasNext() && count < need2delete) {
+                    CacheElement.CacheFile file = ((CacheFileSorter) iter.next()).cacheFile;
+                    if (file.isLocked.compareAndSet(false, true)) {
+                        file.remove();
+                        deleteList.add(file);
+                        ++count;
+                    }
+                }
+
+                if (count < minDelete) {
+                    cacheLog.warn(
+                            "MemoryMappedFileCache "
+                                    + this.name
+                                    + " cleanup couldnt remove enough to keep under the maximum= "
+                                    + maxElements
+                                    + " due to locked files; currently at = "
+                                    + (size - count));
+                }
+
+                Iterator<CacheElement> iterator = this.cache.values().iterator();
+                while (iterator.hasNext()) {
+                    CacheElement elem = iterator.next();
+                    synchronized (elem) {
+                        if (elem.list.isEmpty()) {
+                            iterator.remove();
+                        }
+                    }
+                }
+                long start = System.currentTimeMillis();
+                Iterator deleteIt = deleteList.iterator();
+
+                while (deleteIt.hasNext()) {
+                    CacheElement.CacheFile file = (CacheElement.CacheFile) deleteIt.next();
+                    if (null == this.files.remove(file.ncfile) && cacheLog.isDebugEnabled()) {
+                        cacheLog.debug(
+                                " MemoryMappedFileCache {} cleanup failed to remove {}%n",
+                                this.name, file.ncfile.getLocation());
+                    }
+
+                    try {
+                        file.ncfile.setFileCache(null);
+                        file.ncfile.close();
+                        file.ncfile = null;
+                    } catch (IOException ioe) {
+                        log.error(
+                                "MemoryMappedFileCache "
+                                        + this.name
+                                        + " close failed on "
+                                        + file.getCacheName());
+                    }
+                }
+
+                long took = System.currentTimeMillis() - start;
+                if (cacheLog.isDebugEnabled()) {
+                    cacheLog.debug(
+                            " MemoryMappedFileCache {} cleanup had={} removed={} took={} msecs%n",
+                            new Object[] {this.name, size, deleteList.size(), took});
+                }
+
+                return;
+            }
+        } finally {
+            this.hasScheduled.set(false);
+        }
+    }
+
+    private class CleanupTask extends TimerTask {
+        private CleanupTask() {}
+
+        @Override
+        public void run() {
+            if (!MemoryMappedFileCache.this.disabled.get()) {
+                MemoryMappedFileCache.this.cleanup(MemoryMappedFileCache.this.softLimit);
+            }
+        }
+    }
+
+    private class CacheFileSorter implements Comparable<CacheFileSorter> {
+        private final CacheElement.CacheFile cacheFile;
+        private final long lastAccessed;
+
+        CacheFileSorter(CacheElement.CacheFile cacheFile) {
+            this.cacheFile = cacheFile;
+            this.lastAccessed = cacheFile.lastAccessed;
+        }
+
+        @Override
+        public int compareTo(CacheFileSorter o) {
+            return Long.compare(this.lastAccessed, o.lastAccessed);
+        }
+    }
+
+    class CacheElement {
+        final ConcurrentLinkedDeque<CacheFile> list = new ConcurrentLinkedDeque<>();
+
+        final Object key;
+
+        CacheElement(FileCacheable ncfile, Object key) {
+            this.key = key;
+            CacheElement.CacheFile file = new CacheElement.CacheFile(ncfile);
+            this.list.add(file);
+            MemoryMappedFileCache.this.files.put(ncfile, file);
+            if (cacheLog.isDebugEnabled()) {
+                cacheLog.debug(
+                        "CacheElement add to cache " + key + " " + MemoryMappedFileCache.this.name);
+            }
+        }
+
+        CacheElement.CacheFile addFile(FileCacheable ncfile) {
+            CacheElement.CacheFile file = new CacheElement.CacheFile(ncfile);
+            this.list.add(file);
+
+            MemoryMappedFileCache.this.files.put(ncfile, file);
+            return file;
+        }
+
+        @Override
+        public String toString() {
+            return this.key + " count=" + this.list.size();
+        }
+
+        class CacheFile implements Comparable<CacheElement.CacheFile> {
+            FileCacheable ncfile;
+            final AtomicBoolean isLocked;
+            int countAccessed;
+            long lastModified;
+            long lastAccessed;
+
+            private CacheFile(FileCacheable ncfile) {
+                this.isLocked = new AtomicBoolean(true);
+                this.ncfile = ncfile;
+                this.lastModified = ncfile.getLastModified();
+                this.lastAccessed = System.currentTimeMillis();
+                ncfile.setFileCache(MemoryMappedFileCache.this);
+                if (cacheLog.isDebugEnabled()) {
+                    cacheLog.debug(
+                            "MemoryMappedFileCache "
+                                    + MemoryMappedFileCache.this.name
+                                    + " add to cache "
+                                    + CacheElement.this.key);
+                }
+            }
+
+            String getCacheName() {
+                return this.ncfile.getLocation();
+            }
+
+            void remove() {
+                if (!CacheElement.this.list.remove(this)) {
+                    cacheLog.warn(
+                            "MemoryMappedFileCache "
+                                    + MemoryMappedFileCache.this.name
+                                    + " could not remove "
+                                    + this.ncfile.getLocation());
+                }
+
+                if (cacheLog.isDebugEnabled()) {
+                    cacheLog.debug(
+                            "MemoryMappedFileCache "
+                                    + MemoryMappedFileCache.this.name
+                                    + " remove "
+                                    + this.ncfile.getLocation());
+                }
+            }
+
+            @Override
+            public String toString() {
+                String name = this.ncfile == null ? "ncfile is null" : this.ncfile.getLocation();
+                return this.isLocked
+                        + " "
+                        + this.countAccessed
+                        + " "
+                        + CalendarDateFormatter.toDateTimeStringISO(this.lastAccessed)
+                        + "   "
+                        + name;
+            }
+
+            @Override
+            public int compareTo(CacheElement.CacheFile o) {
+                return Long.compare(this.lastAccessed, o.lastAccessed);
+            }
+        }
+    }
+
+    private static class CacheTracking implements Comparable<CacheTracking> {
+        Object key;
+        int hit;
+        int miss;
+
+        private CacheTracking(Object key) {
+            this.key = key;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            } else if (o != null && this.getClass() == o.getClass()) {
+                CacheTracking tracker = (CacheTracking) o;
+                return this.key.equals(tracker.key);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return this.key.hashCode();
+        }
+
+        @Override
+        public int compareTo(CacheTracking o) {
+            return Integer.compare(this.hit + this.miss, o.hit + o.miss);
+        }
+    }
+}

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/io/MemoryMappedRandomAccessFile.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/io/MemoryMappedRandomAccessFile.java
@@ -1,0 +1,303 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.io;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import org.geotools.util.NIOUtilities;
+import ucar.nc2.util.cache.FileCacheIF;
+import ucar.unidata.io.KMPMatch;
+import ucar.unidata.io.RandomAccessFile;
+import ucar.unidata.util.StringUtil2;
+
+/**
+ * A ReadOnly MemoryMapped RandomAccessFile. It will map the file in memory, using a
+ * MappedByteBuffer.
+ *
+ * <p>Writing capability is not supported at the moment.
+ */
+public class MemoryMappedRandomAccessFile extends RandomAccessFile {
+
+    enum CacheUsage {
+        NOT_IN_CACHE,
+        IN_USE,
+        NOT_IN_USE
+    }
+
+    private static final int BUFFER_MEMORY_LIMIT;
+
+    private static final int MAX_SEARCH_BUFFER_LIMIT;
+
+    private static final int DEFAULT_BUFFER_SIZE = 1;
+
+    static {
+        long limit = Integer.MAX_VALUE;
+        String memoryMappingLimit =
+                System.getProperty("org.geotools.coverage.io.netcdf.memorymaplimit");
+        if (memoryMappingLimit != null && !memoryMappingLimit.isEmpty()) {
+            limit = Long.parseLong(memoryMappingLimit);
+            // The mapped byte buffer cannot be bigger than 2GB.
+            if (limit < 0 || limit > Integer.MAX_VALUE) {
+                limit = Integer.MAX_VALUE;
+            }
+        }
+        BUFFER_MEMORY_LIMIT = (int) limit;
+        MAX_SEARCH_BUFFER_LIMIT = Math.min(16384, BUFFER_MEMORY_LIMIT);
+    }
+
+    private MappedByteBuffer mappedByteBuffer;
+
+    private FileChannel channel;
+
+    private CacheUsage cacheUsage = CacheUsage.NOT_IN_USE;
+
+    private long currentOffset = 0;
+
+    private FileChannel.MapMode mapMode;
+
+    public MemoryMappedRandomAccessFile(String location, String mode) throws IOException {
+        super(MemoryMappedRandomAccessFile.getUriString(location), mode, DEFAULT_BUFFER_SIZE);
+        if (!readonly) reportReadOnly();
+        initDataBuffer();
+        cacheUsage = CacheUsage.IN_USE;
+    }
+
+    private void initDataBuffer() throws IOException {
+        channel = file.getChannel();
+        mapMode = FileChannel.MapMode.READ_ONLY;
+        long channelSize = channel.size();
+        dataSize = (int) channelSize;
+        dataEnd = channelSize;
+
+        long initialMapSize =
+                (channelSize - channel.position()) < (long) BUFFER_MEMORY_LIMIT
+                        ? channelSize
+                        : BUFFER_MEMORY_LIMIT;
+        mappedByteBuffer = channel.map(mapMode, 0, initialMapSize);
+        mappedByteBuffer.position((int) channel.position());
+        bufferStart = 0;
+        filePosition = 0;
+        endOfFile = false;
+    }
+
+    @Override
+    public void seek(long pos) throws IOException {
+        filePosition = pos;
+        if (filePosition < 0) throw new IOException("Negative seek offset");
+        if (filePosition < dataEnd) {
+            if (filePosition >= currentOffset + BUFFER_MEMORY_LIMIT
+                    || filePosition < currentOffset) {
+                // If going outside of the currently mapped portion we need to remap the buffer
+                bufferCheck(-1);
+            } else {
+                mappedByteBuffer.position((int) (filePosition - currentOffset));
+            }
+            endOfFile = false;
+        } else {
+            endOfFile = true;
+        }
+    }
+
+    @SuppressWarnings("deprecation") // we need to use it to mark the internal cacheState
+    @Override
+    public void release() {
+        cacheUsage = CacheUsage.NOT_IN_USE;
+        super.release();
+    }
+
+    @SuppressWarnings("deprecation") // we need to use it to mark the internal cacheState
+    @Override
+    public void reacquire() {
+        cacheUsage = CacheUsage.IN_USE;
+        super.reacquire();
+    }
+
+    @SuppressWarnings("deprecation") // we need to use it to mark the internal cacheState
+    @Override
+    public synchronized void setFileCache(FileCacheIF fileCache) {
+        super.setFileCache(fileCache);
+        if (fileCache == null) {
+            cacheUsage = CacheUsage.NOT_IN_CACHE;
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        bufferCheck(1);
+        if (filePosition < 0)
+            throw new IOException(format("Negative file position %d for %s", filePosition, this));
+        if (filePosition < dataEnd) {
+            filePosition++;
+            return mappedByteBuffer.get() & 0xff;
+        } else {
+            return -1;
+        }
+    }
+
+    private void bufferCheck(long readSize) throws IOException {
+        if (mappedByteBuffer.remaining() < readSize || readSize < 0) {
+            long fcPosition = filePosition;
+            if (dataEnd > fcPosition + BUFFER_MEMORY_LIMIT) {
+                currentOffset = fcPosition;
+            } else {
+                currentOffset = dataEnd - BUFFER_MEMORY_LIMIT;
+                // Can't go before the beginning of the file
+                if (currentOffset < 0) {
+                    currentOffset = 0;
+                }
+            }
+            NIOUtilities.clean(mappedByteBuffer);
+            mappedByteBuffer = channel.map(mapMode, currentOffset, BUFFER_MEMORY_LIMIT);
+            // make sure to properly re-align the position
+            mappedByteBuffer.position((int) (fcPosition - currentOffset));
+        }
+    }
+
+    @Override
+    public int readBytes(byte[] dst, int offset, int length) throws IOException {
+        if (endOfFile) return -1;
+        length = (int) Math.min(length, dataEnd - filePosition);
+        if (length > 0) {
+            if (filePosition < 0)
+                throw new IOException(
+                        format("Negative file position %d for %s", filePosition, this));
+            bufferCheck(length);
+            mappedByteBuffer.get(dst, offset, length);
+            filePosition += length;
+            if (filePosition == dataEnd) {
+                endOfFile = true;
+            }
+        }
+        return length;
+    }
+
+    @Override
+    public void write(int b) {
+        reportReadOnly();
+    }
+
+    @Override
+    public void writeBytes(byte[] dst, int offset, int length) {
+        reportReadOnly();
+    }
+
+    private void reportReadOnly() {
+        throw new UnsupportedOperationException("Read Only MemoryMappedRandomAccessFile");
+    }
+
+    @Override
+    public long length() {
+        return dataEnd;
+    }
+
+    @SuppressWarnings("PMD.SystemPrintln") // low level leaks debug as done in the RAF class
+    @Override
+    public synchronized void close() throws IOException {
+        FileCacheIF cache = getGlobalFileCache();
+        if (cache != null && cacheUsage != CacheUsage.NOT_IN_CACHE) {
+            if (cacheUsage != CacheUsage.IN_USE) {
+                return;
+            }
+
+            cacheUsage = CacheUsage.NOT_IN_USE;
+            if (cache.release(this)) {
+                return;
+            }
+            this.cacheUsage = CacheUsage.NOT_IN_CACHE;
+        }
+
+        if (debugLeaks) {
+            openFiles.remove(this.location);
+            if (showOpen) {
+                System.out.println("  close " + this.location);
+            }
+        }
+
+        if (this.file != null) {
+            this.flush();
+            this.file.close();
+            this.file = null;
+        }
+        if (channel != null && channel.isOpen()) {
+            channel.close();
+        }
+        if (mappedByteBuffer != null) {
+            NIOUtilities.clean(mappedByteBuffer, true);
+        }
+
+        mappedByteBuffer = null;
+        channel = null;
+    }
+
+    public static String getUriString(String uriString) {
+        StringUtil2.replace(uriString, '\\', "/");
+        if (uriString.startsWith("file:")) {
+            uriString = StringUtil2.unescape(uriString.substring(5));
+        }
+        return uriString;
+    }
+
+    @Override
+    public boolean searchForward(KMPMatch match, int maxBytes) throws IOException {
+        long start = this.getFilePointer();
+        long last = maxBytes < 0 ? this.length() : Math.min(this.length(), start + (long) maxBytes);
+        long needToScan = last - start;
+        int bytesAvailable = (int) (this.dataEnd - this.filePosition);
+        if (bytesAvailable < 1) {
+            this.seek(this.filePosition);
+            bytesAvailable = (int) (this.dataEnd - this.filePosition);
+        }
+        int scanBytes =
+                (int) Math.min(Math.min(bytesAvailable, needToScan), MAX_SEARCH_BUFFER_LIMIT);
+        byte[] tempBuffer = new byte[scanBytes];
+        long startPosition = mappedByteBuffer.position() % BUFFER_MEMORY_LIMIT;
+        readBytes(tempBuffer, 0, scanBytes);
+        int pos = match.indexOf(tempBuffer, 0, scanBytes);
+        long seekPos = last;
+        if (pos >= 0) {
+            seekPos = this.currentOffset + startPosition + (long) pos;
+            this.seek(seekPos);
+            return true;
+        } else {
+            int matchLen = match.getMatchLength();
+
+            for (needToScan -= scanBytes; needToScan > (long) matchLen; needToScan -= scanBytes) {
+                scanBytes =
+                        (int)
+                                Math.min(
+                                        maxBytes > 0 ? maxBytes : MAX_SEARCH_BUFFER_LIMIT,
+                                        needToScan);
+                readBytes(tempBuffer, 0, scanBytes);
+                pos = match.indexOf(tempBuffer, 0, scanBytes);
+                if (pos > 0) {
+                    seekPos =
+                            this.currentOffset
+                                    + (long) pos
+                                    + (endOfFile ? BUFFER_MEMORY_LIMIT - scanBytes : 0);
+                    this.seek(seekPos);
+                    return true;
+                }
+            }
+
+            this.seek(seekPos);
+            return false;
+        }
+    }
+}

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/CoordinateVariableTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/CoordinateVariableTest.java
@@ -18,7 +18,8 @@ package org.geotools.coverage.io.netcdf;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -35,6 +36,7 @@ import org.geotools.imageio.netcdf.cv.CoordinateHandlerFinder;
 import org.geotools.imageio.netcdf.cv.CoordinateHandlerSpi.CoordinateHandler;
 import org.geotools.imageio.netcdf.cv.CoordinateVariable;
 import org.geotools.imageio.netcdf.utilities.NetCDFTimeUtilities;
+import org.geotools.imageio.netcdf.utilities.NetCDFUtilities;
 import org.geotools.test.TestData;
 import org.junit.AfterClass;
 import org.junit.Ignore;
@@ -72,8 +74,9 @@ public class CoordinateVariableTest extends NetCDFBaseTest {
 
     @Test
     public void timeUnitsTest() throws Exception {
-        try (NetcdfDataset dataset =
-                NetcdfDatasets.openDataset(TestData.url(this, "O3-NO2.nc").toExternalForm())) {
+        String url = TestData.url(this, "O3-NO2.nc").toExternalForm();
+        URI uri = new URI(url);
+        try (NetcdfDataset dataset = NetCDFUtilities.acquireDataset(uri)) {
             Dimension dim = dataset.findDimension("time");
 
             // check type
@@ -206,9 +209,9 @@ public class CoordinateVariableTest extends NetCDFBaseTest {
     @Test
     public void polyphemus() throws Exception {
 
-        // acquire dataset
-        try (NetcdfDataset dataset =
-                NetcdfDatasets.openDataset(TestData.url(this, "O3-NO2.nc").toExternalForm())) {
+        String url = TestData.url(this, "O3-NO2.nc").toExternalForm();
+        URI uri = new URI(url);
+        try (NetcdfDataset dataset = NetCDFUtilities.acquireDataset(uri)) {
             assertNotNull(dataset);
             final List<CoordinateAxis> cvs = dataset.getCoordinateAxes();
             assertNotNull(cvs);
@@ -403,7 +406,7 @@ public class CoordinateVariableTest extends NetCDFBaseTest {
     }
 
     @Test
-    public void testClimatologicalTimeVariable() throws MalformedURLException, IOException {
+    public void testClimatologicalTimeVariable() throws IOException, URISyntaxException {
         // Selection of the input file
         final File workDir = new File(TestData.file(this, "."), "climatologicalaxis");
         if (!workDir.mkdir()) {
@@ -414,11 +417,9 @@ public class CoordinateVariableTest extends NetCDFBaseTest {
         FileUtils.copyFile(
                 TestData.file(this, "climatological.zip"), new File(workDir, "climatological.zip"));
         TestData.unzipFile(this, "climatologicalaxis/climatological.zip");
-
-        try (NetcdfDataset dataset =
-                NetcdfDatasets.openDataset(
-                        TestData.url(this, "climatologicalaxis/climatological.nc")
-                                .toExternalForm())) {
+        String url = TestData.url(this, "climatologicalaxis/climatological.nc").toExternalForm();
+        URI uri = new URI(url);
+        try (NetcdfDataset dataset = NetCDFUtilities.acquireDataset(uri)) {
             Dimension dim = dataset.findDimension("time");
             CoordinateAxis1D coordinateAxis =
                     (CoordinateAxis1D) dataset.findCoordinateAxis(dim.getShortName());
@@ -451,7 +452,7 @@ public class CoordinateVariableTest extends NetCDFBaseTest {
                     timeVariable.read(Collections.singletonMap("time", 2)).getTime());
 
         } finally {
-            FileUtils.deleteDirectory(TestData.file(this, "climatologicalaxis"));
+            cleanupData(TestData.file(this, "climatologicalaxis"), false);
         }
     }
 }

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFBaseTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFBaseTest.java
@@ -16,6 +16,10 @@
  */
 package org.geotools.coverage.io.netcdf;
 
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.geotools.imageio.netcdf.utilities.NetCDFUtilities;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
@@ -25,5 +29,31 @@ public class NetCDFBaseTest extends Assert {
     public static void init() {
         System.setProperty("user.timezone", "GMT");
         System.setProperty("netcdf.coordinates.enablePlugins", "true");
+        System.setProperty("org.geotools.coverage.io.netcdf.cachefile", "true");
+        System.setProperty("org.geotools.coverage.io.netcdf.memorymap", "true");
+        // We are hard limiting the mapped byte buffer to validate that it's
+        // capable of reading files bigger than the max size of the memory
+        // mapped byte buffer
+        System.setProperty("org.geotools.coverage.io.netcdf.memorymaplimit", "32768");
+        // Cache is statically initialized. However, Let's keep it disabled by default
+        // so it won't affect testing where not needed
+        NetCDFUtilities.disableNetCDFFileCaches();
+    }
+
+    public void cleanCache() {
+        if (NetCDFUtilities.useCache()) {
+            cleanNetCDFCache();
+        }
+    }
+
+    public static void cleanNetCDFCache() {
+        NetCDFUtilities.clearCaches();
+    }
+
+    public void cleanupData(File file, boolean cleanCache) throws IOException {
+        if (cleanCache) {
+            cleanCache();
+        }
+        FileUtils.deleteDirectory(file);
     }
 }

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFBasicTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFBasicTest.java
@@ -68,7 +68,7 @@ import ucar.nc2.dataset.NetcdfDatasets;
  *
  * @author Simone Giannecchini, GeoSolutions SAS
  */
-public final class NetCDFBasicTest extends Assert {
+public final class NetCDFBasicTest extends NetCDFBaseTest {
 
     private static final Logger LOGGER = Logger.getLogger(NetCDFBasicTest.class.toString());
 
@@ -772,7 +772,7 @@ public final class NetCDFBasicTest extends Assert {
     }
 
     @Test
-    public void testNetCDFWithDifferentTimeDimensions() throws MalformedURLException, IOException {
+    public void testNetCDFWithDifferentTimeDimensions() throws IOException {
         // Selection of the input file
         final File workDir = new File(TestData.file(this, "."), "times");
         if (!workDir.mkdir()) {

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMemoryMappedRandomAccessFileTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMemoryMappedRandomAccessFileTest.java
@@ -1,0 +1,195 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.coverage.io.netcdf;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.TimeZone;
+import org.geotools.api.geometry.Position;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.api.parameter.ParameterValue;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.gce.imagemosaic.ImageMosaicFormat;
+import org.geotools.geometry.Position2D;
+import org.geotools.imageio.netcdf.utilities.NetCDFUtilities;
+import org.geotools.io.MemoryMappedRandomAccessFile;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.test.TestData;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.iosp.AbstractIOServiceProvider;
+import ucar.nc2.util.cache.FileCacheIF;
+import ucar.unidata.io.RandomAccessFile;
+
+public class NetCDFMemoryMappedRandomAccessFileTest extends NetCDFBaseTest {
+
+    @Before
+    public void cleanup() {
+        cleanCache();
+    }
+
+    @BeforeClass
+    public static void enableCache() {
+        NetCDFBaseTest.init();
+        NetCDFUtilities.enableNetCDFFileCaches();
+    }
+
+    @Test
+    public void testMemoryMappedRandomAccessFileIsBeingUsed()
+            throws IOException, NoSuchFieldException, IllegalAccessException {
+
+        File file = TestData.file(this, "O3-NO2.nc");
+        try (NetcdfDataset netcdfDataset = NetCDFUtilities.acquireDataset(file.toURI())) {
+
+            // Let's use reflection to verify if the underlying machinery
+            // is actually using the MemoryMappedRandomAccessFile
+
+            // First: Access the orgFile field from the dataset object
+            Field orgFileField = NetcdfDataset.class.getDeclaredField("orgFile");
+            orgFileField.setAccessible(true); // Make the field accessible
+
+            // Second: Access the iosp field from the orgFile object
+            Object orgFile = orgFileField.get(netcdfDataset);
+            Field iospField = orgFile.getClass().getDeclaredField("iosp");
+            iospField.setAccessible(true); // Make the field accessible
+
+            // Third: Access the raf field from the iosp object
+            Object iosp = iospField.get(orgFile);
+            Field rafField = AbstractIOServiceProvider.class.getDeclaredField("raf");
+            rafField.setAccessible(true);
+
+            // Finally, get the RandomAccessFile object
+            @SuppressWarnings("PMD.CloseResource")
+            RandomAccessFile raf = (RandomAccessFile) rafField.get(iosp);
+            assertTrue(raf instanceof MemoryMappedRandomAccessFile);
+            assertTrue(raf.getLocation().endsWith("O3-NO2.nc"));
+        }
+    }
+
+    @Test
+    /**
+     * This test is going to access a file that won't fit entirely in the memory mapped buffer and
+     * that will involve some seek back and forth. (File is 122Kb whilst configured buffer limit is
+     * 32k)
+     */
+    public void testMemoryMappingPartialBuffering() throws IOException, ParseException {
+        final File testURL = TestData.file(this, "O3-NO2.nc");
+        final NetCDFReader reader = new NetCDFReader(testURL, null);
+        assertNotNull(reader);
+        final String t1 = "2012-04-01T00:00:00.000Z";
+        final String t2 = "2012-04-01T01:00:00.000Z";
+        final ParameterValue<List> time = ImageMosaicFormat.TIME.createValue();
+        final ParameterValue<List> elevation = ImageMosaicFormat.ELEVATION.createValue();
+        final SimpleDateFormat formatD = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        formatD.setTimeZone(TimeZone.getTimeZone("GMT"));
+        final double elevation1 = 10d;
+        final double elevation2 = 450d;
+
+        try {
+            String[] names = reader.getGridCoverageNames();
+            assertNotNull(names);
+            assertEquals(2, names.length);
+            time.setValue(List.of(formatD.parse(t1)));
+            elevation.setValue(List.of(elevation1));
+
+            GeneralParameterValue[] values = {time, elevation};
+            GridCoverage2D grid = reader.read("NO2", values);
+            assertFalse(grid.getSampleDimension(0).getDescription().toString().endsWith(":sd"));
+            assertNotNull(grid);
+            float[] value =
+                    grid.evaluate(
+                            (Position) new Position2D(DefaultGeographicCRS.WGS84, 5, 45),
+                            new float[1]);
+            assertEquals(6.15991f, value[0], 0.00001);
+
+            time.setValue(List.of(formatD.parse(t2)));
+            elevation.setValue(List.of(elevation2));
+            grid = reader.read("O3", values);
+            assertFalse(grid.getSampleDimension(0).getDescription().toString().endsWith(":sd"));
+            assertNotNull(grid);
+            value =
+                    grid.evaluate(
+                            (Position) new Position2D(DefaultGeographicCRS.WGS84, 5, 45),
+                            new float[1]);
+            assertEquals(56.946774f, value[0], 0.00001);
+
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.dispose();
+                } catch (Throwable t) {
+                    // Does nothing
+                }
+            }
+        }
+    }
+
+    @Test
+    /**
+     * This tests memoryMapping for a file that can be fully mapped, also making sure that the file
+     * get cached
+     */
+    public void testMemoryMapping() throws IOException {
+        final File file = TestData.file(this, "sst.nc");
+
+        String cachedRaf1 = testReadingData(file);
+        assertTrue(cachedRaf1.startsWith("true 0")); // it's locked and no hits yet
+        // Read it again. It should use the same cached randomaccessfile
+        String cachedRaf2 = testReadingData(file);
+
+        assertTrue(cachedRaf2.startsWith("true 1")); // it's still locked and 1 hit
+    }
+
+    private String testReadingData(File file) throws IOException {
+        NetCDFReader reader = new NetCDFReader(file, null);
+        assertNotNull(reader);
+        try {
+            String[] names = reader.getGridCoverageNames();
+            GridCoverage2D grid = reader.read(names[0], null);
+            assertFalse(grid.getSampleDimension(0).getDescription().toString().endsWith(":sd"));
+            assertNotNull(grid);
+            float[] value =
+                    grid.evaluate(
+                            (Position) new Position2D(DefaultGeographicCRS.WGS84, -84, 26),
+                            new float[1]);
+            assertEquals(24.0f, value[0], 0.00001);
+            FileCacheIF fileCache = NetCDFUtilities.getRafFileCache();
+            List<String> cached = fileCache.showCache();
+            return cached.get(0);
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.dispose();
+                } catch (Throwable t) {
+                    // Does nothing
+                }
+            }
+        }
+    }
+
+    @AfterClass
+    public static void disableCache() {
+        NetCDFUtilities.disableNetCDFFileCaches();
+    }
+}

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -1709,7 +1709,6 @@ public class NetCDFMosaicReaderTest {
 
             // remove granule
             GranuleStore store = (GranuleStore) reader.getGranules("NO2", false);
-
             int removed =
                     store.removeGranules(FF.like(FF.property("location"), "*20130101*"), hints);
             assertEquals(1, removed);

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFPolyphemusTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFPolyphemusTest.java
@@ -54,11 +54,10 @@ import org.geotools.util.DateRange;
 import org.geotools.util.NumberRange;
 import org.geotools.util.logging.Logging;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public final class NetCDFPolyphemusTest extends Assert {
+public final class NetCDFPolyphemusTest extends NetCDFBaseTest {
 
     private static final Logger LOGGER = Logging.getLogger(NetCDFPolyphemusTest.class);
     private File testDirectory;

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFStationsTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFStationsTest.java
@@ -69,7 +69,6 @@ public final class NetCDFStationsTest {
 
     @Test
     public void readMultipleBandsDimensionSelectingOnlyOneBand() throws Exception {
-
         // we should have only band a single band
         ParameterValue<int[]> selectedBands = AbstractGridFormat.BANDS.createValue();
         selectedBands.setValue(new int[] {1});
@@ -80,7 +79,6 @@ public final class NetCDFStationsTest {
 
     @Test
     public void readMultipleBandsDimensionWithDifferentOrderBandsSelection() throws Exception {
-
         // we should have three bands with values indexes ordered as 2, 0, 1
         ParameterValue<int[]> selectedBands = AbstractGridFormat.BANDS.createValue();
         selectedBands.setValue(new int[] {2, 0, 1});


### PR DESCRIPTION
[![GEOT-7544](https://badgen.net/badge/JIRA/GEOT-7544/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7544) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Replaces https://github.com/geotools/geotools/pull/4706

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->