### PR TITLE
Test Eclipse suggested fix

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/RangeSet.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/RangeSet.java
@@ -784,7 +784,8 @@ public class RangeSet<T extends Comparable<? super T>> extends AbstractSet<Range
         final Range<T> range = (Range<T>) object;
         if (elementClass.equals(range.elementClass)) {
             if (range.isMinIncluded() && range.isMaxIncluded()) {
-                final int index = binarySearch(toArrayElement((Comparable<T>) range.getMinValue()));
+                final int index =
+                        binarySearch(toArrayElement((Comparable<? super T>) range.getMinValue()));
                 if (index >= 0 && (index & 1) == 0) {
                     final int c = get(index + 1).compareTo(range.getMaxValue());
                     return c == 0;


### PR DESCRIPTION
The current GeoTools main branch shows a build error in Eclipse 2023-06 IDE with Java 11, and this is the recommended fix for it.

According to ChatGPT:

> In this line:
> 
> (Comparable<? super T>) is a bounded wildcard. It means that range.getMinValue() should be cast to something that is a superclass of T and is also comparable to that superclass.
> This ensures that you're casting range.getMinValue() to a type that is comparable to T or its superclasses. This can be important when T is not itself comparable, but its superclass is.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->