### PR TITLE
[GEOT-7559] App-Schema throws an error when mappings have duplicate names, even when they come from includes

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/AppSchemaDataAccessFactory.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/AppSchemaDataAccessFactory.java
@@ -74,6 +74,9 @@ public class AppSchemaDataAccessFactory implements DataAccessFactory {
                     "URL to an application schema datastore XML configuration file",
                     true);
 
+    // marks whether data store is based on an XML include, need to handle duplicates
+    public static final String IS_INCLUDE = "isInclude";
+
     public AppSchemaDataAccessFactory() {}
 
     @Override
@@ -110,6 +113,8 @@ public class AppSchemaDataAccessFactory implements DataAccessFactory {
         List<String> includes = config.getIncludes();
         Map<String, Object> extendedParams = new HashMap<>(params);
         for (String include : includes) {
+            // mark this as an include, so that the DataAccess can handle it properly
+            extendedParams.put(IS_INCLUDE, true);
             extendedParams.put("url", buildIncludeUrl(configFileUrl, include));
             // this will register the related data access, to enable feature chaining;
             // sourceDataStoreMap is passed on to keep track of the already created source data
@@ -125,8 +130,11 @@ public class AppSchemaDataAccessFactory implements DataAccessFactory {
                     parentUrl == null ? configFileUrl : parentUrl);
         }
 
+        boolean isInclude = Boolean.TRUE.equals(params.get(IS_INCLUDE));
+
         Set<FeatureTypeMapping> mappings =
-                AppSchemaDataAccessConfigurator.buildMappings(config, sourceDataStoreMap);
+                AppSchemaDataAccessConfigurator.buildMappings(
+                        config, sourceDataStoreMap, isInclude);
 
         AppSchemaDataAccess dataStore = new AppSchemaDataAccess(mappings, hidden);
         dataStore.url = configFileUrl;

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/FeatureTypeMapping.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/FeatureTypeMapping.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.xml.namespace.QName;
 import org.geotools.api.data.FeatureSource;
@@ -80,6 +81,9 @@ public class FeatureTypeMapping {
     private Expression featureFidMapping;
 
     private boolean isDenormalised;
+
+    // whether the mapping came from an XML include
+    private boolean isInclude;
 
     /**
      * User-provided XPath expression specifying a property to be used as default geometry for the
@@ -389,6 +393,37 @@ public class FeatureTypeMapping {
         return clientPropertyExpressions;
     }
 
+    @Override
+    // null check is needed to see if we should use target feature name or mapping name
+    @SuppressWarnings("PMD.UnusedNullCheckInEquals")
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FeatureTypeMapping that = (FeatureTypeMapping) o;
+        return Objects.equals(attributeMappings, that.attributeMappings)
+                && Objects.equals(sourceDatastoreId, that.sourceDatastoreId)
+                && isDenormalised == that.isDenormalised
+                && ((mappingName != null && Objects.equals(mappingName, that.mappingName))
+                        || Objects.equals(
+                                getTargetFeature().getName(), that.getTargetFeature().getName()));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                source,
+                sourceDatastoreId,
+                indexSource,
+                target,
+                attributeMappings,
+                namespaces,
+                mappingName,
+                featureFidMapping,
+                isDenormalised,
+                isInclude,
+                defaultGeometryXPath);
+    }
+
     /** Extracts the source Expressions from a list of {@link AttributeMapping}s */
     private List<Expression> getExpressions(
             List<AttributeMapping> attributeMappings, boolean includeNestedMappings) {
@@ -422,6 +457,14 @@ public class FeatureTypeMapping {
 
     public void setDenormalised(boolean isDenormalised) {
         this.isDenormalised = isDenormalised;
+    }
+
+    public boolean isInclude() {
+        return isInclude;
+    }
+
+    public void setInclude(boolean isInclude) {
+        this.isInclude = isInclude;
     }
 
     /**


### PR DESCRIPTION
[![GEOT-7559](https://badgen.net/badge/JIRA/GEOT-7559/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7559) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

deep equality trimmed down

fixed equality compare and started on test

Cleanup

more cleanup

moved equal to local

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->