### PR TITLE
[GEOT-7565] Upgrade ImageIO-Ext to 1.4.10

### DIFF
--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/NetCDFImageReader.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/NetCDFImageReader.java
@@ -1182,7 +1182,8 @@ public class NetCDFImageReader extends GeoSpatialImageReader implements FileSetM
 
         double[] noData = getNoData(wrapper);
         if (noData != null) {
-            metadata.setNoData(noData);
+            Double[] noDataValues = Arrays.stream(noData).boxed().toArray(n -> new Double[n]);
+            metadata.setNoDataValues(noDataValues);
         }
 
         return metadata;

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -129,6 +130,7 @@ public class GranuleDescriptor {
             return pathType.resolvePath(parentLocation, granuleLocation);
         }
     }
+
     /** Logger. */
     private static final Logger LOGGER =
             org.geotools.util.logging.Logging.getLogger(GranuleDescriptor.class);
@@ -603,11 +605,14 @@ public class GranuleDescriptor {
             if (metadata instanceof CoreCommonImageMetadata) {
                 CoreCommonImageMetadata ccm = (CoreCommonImageMetadata) metadata;
 
-                double[] noData = ccm.getNoData();
-                if (noData != null) {
-                    this.noData = new NoDataContainer(noData);
+                double[] noDataArray = null;
+                if (ccm.getNoDataValues() != null) {
+                    noDataArray =
+                            Arrays.stream(ccm.getNoDataValues())
+                                    .mapToDouble(d -> d == null ? Double.NaN : d)
+                                    .toArray();
+                    this.noData = new NoDataContainer(noDataArray);
                 }
-
                 this.scales = ccm.getScales();
                 this.offsets = ccm.getOffsets();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -476,7 +476,7 @@
     <db2.jdbc.version>11.5.9.0</db2.jdbc.version>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>
     <elasticsearch.version>7.14.0</elasticsearch.version>
-    <imageio.ext.version>1.4.9</imageio.ext.version>
+    <imageio.ext.version>1.4.10</imageio.ext.version>
     <informix.jdbc.version>4.50.7.1</informix.jdbc.version>
     <jackson2.databind.version>2.15.2</jackson2.databind.version>
     <jackson2.version>2.15.2</jackson2.version>


### PR DESCRIPTION
[![GEOT-7565](https://badgen.net/badge/JIRA/GEOT-7565/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7565) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Follows up with imageio-ext deprecation of a redundant property

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->