### PR TITLE
GEOT-7564 Allow to skip check on staleness of index files on IndexManager

### DIFF
--- a/docs/user/library/data/shape.rst
+++ b/docs/user/library/data/shape.rst
@@ -51,7 +51,10 @@ The following connection parameters are available:
 |                          | used even if available (and won't be created if   |
 |                          | missing.                                          |
 +--------------------------+---------------------------------------------------+
-
+|``ignore index staleness``| Optional: if true, skips the check on index       |
+|                          | staleness (avoids recreation of indexes if .shp   |
+|                          | is newer than .qix/.fix)                          |
++--------------------------+---------------------------------------------------+
 
 
 This information is also in the `javadocs <http://docs.geotools.org/latest/javadocs/org/geotools/data/shapefile/ShapefileDataStoreFactory.html>`_ .

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/IndexManager.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/IndexManager.java
@@ -237,7 +237,7 @@ class IndexManager {
 
             File indexFile = URLs.urlToFile(indexURL);
             File shpFile = URLs.urlToFile(shpURL);
-            
+
             if (store.ignoreIndexStaleness) return !indexFile.exists();
 
             long indexLastModified = indexFile.lastModified();

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/IndexManager.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/IndexManager.java
@@ -237,6 +237,9 @@ class IndexManager {
 
             File indexFile = URLs.urlToFile(indexURL);
             File shpFile = URLs.urlToFile(shpURL);
+            
+            if (store.ignoreIndexStaleness) return !indexFile.exists();
+
             long indexLastModified = indexFile.lastModified();
             long shpLastModified = shpFile.lastModified();
             boolean shpChangedMoreRecently = indexLastModified < shpLastModified;

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStore.java
@@ -109,6 +109,8 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
 
     boolean fidIndexed = true;
 
+    boolean ignoreIndexStaleness = false;
+
     IndexManager indexManager;
 
     ShapefileSetManager shpManager;
@@ -203,6 +205,18 @@ public class ShapefileDataStore extends ContentDataStore implements FileDataStor
      */
     public void setIndexed(boolean indexed) {
         this.indexed = indexed;
+    }
+
+    public boolean isIgnoringIndexStaleness() {
+        return ignoreIndexStaleness;
+    }
+
+    /**
+     * When set to true, will force IndexManager to avoid the check on the index staleness (so it
+     * doesn't
+     */
+    public void setIgnoreIndexStaleness(boolean ignore) {
+        ignoreIndexStaleness = ignore;
     }
 
     /** The current max shapefile size */

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStoreFactory.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/ShapefileDataStoreFactory.java
@@ -198,6 +198,19 @@ public class ShapefileDataStoreFactory implements FileDataStoreFactorySpi {
                     true,
                     new KVP(Param.LEVEL, "advanced"));
 
+    /**
+     * Optional - if true, skips the check on index staleness (avoids recreation of indexes if .shp
+     * is newer than .qix/.fix)
+     */
+    public static final Param IGNORE_STALENESS =
+            new Param(
+                    "ignore index staleness",
+                    Boolean.class,
+                    "If true, skips the check on index staleness (avoids recreation of indexes if .shp is newer than .qix/.fix)",
+                    false,
+                    false,
+                    new KVP(Param.LEVEL, "advanced"));
+
     @Override
     public String getDisplayName() {
         return "Shapefile";
@@ -221,7 +234,8 @@ public class ShapefileDataStoreFactory implements FileDataStoreFactorySpi {
             CACHE_MEMORY_MAPS,
             FILE_TYPE,
             FSTYPE,
-            SKIP_SCAN
+            SKIP_SCAN,
+            IGNORE_STALENESS
         };
     }
 
@@ -245,6 +259,7 @@ public class ShapefileDataStoreFactory implements FileDataStoreFactorySpi {
         TimeZone dbfTimeZone = lookup(DBFTIMEZONE, params, TimeZone.class);
         Boolean isCreateSpatialIndex = lookup(CREATE_SPATIAL_INDEX, params, Boolean.class);
         Boolean skipScan = lookup(SKIP_SCAN, params, Boolean.class);
+        Boolean ignoreStaleness = lookup(IGNORE_STALENESS, params, Boolean.class);
         Boolean isEnableSpatialIndex = (Boolean) ENABLE_SPATIAL_INDEX.lookUp(params);
         if (isEnableSpatialIndex == null) {
             // should not be needed as default is TRUE
@@ -280,6 +295,7 @@ public class ShapefileDataStoreFactory implements FileDataStoreFactorySpi {
             store.setTimeZone(dbfTimeZone);
             store.setIndexed(enableIndex);
             store.setIndexCreationEnabled(createIndex);
+            store.setIgnoreIndexStaleness(ignoreStaleness);
             return store;
         }
     }

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileDataStoreTest.java
@@ -2097,22 +2097,21 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
 
         assertFalse(ds.indexManager.isIndexStale(fix)); // indexes are no longer considered stale
 
-        try(SimpleFeatureIterator sfi = fs.getFeatures(Query.ALL).features()){};
+        try (SimpleFeatureIterator sfi = fs.getFeatures(Query.ALL).features()) {}
         assertEquals(fixModified, fixFile.lastModified());
 
         ds.setIgnoreIndexStaleness(false);
         assertTrue(ds.indexManager.isIndexStale(fix));
 
-        try(SimpleFeatureIterator sfi = fs.getFeatures(Query.ALL).features()){};
+        try (SimpleFeatureIterator sfi = fs.getFeatures(Query.ALL).features()) {}
         assertTrue(fixModified < fixFile.lastModified());
 
         ds.dispose();
     }
 
-
     @Test
     public void testIgnoreIndexStalenessFactoryParam() throws Exception {
-        for(boolean mustIgnore : new boolean[]{true, false}) {
+        for (boolean mustIgnore : new boolean[] {true, false}) {
             ShapefileDataStoreFactory factory = new ShapefileDataStoreFactory();
 
             Map<String, Serializable> map = new HashMap<>();
@@ -2124,5 +2123,4 @@ public class ShapefileDataStoreTest extends TestCaseSupport {
             store.dispose();
         }
     }
-
 }


### PR DESCRIPTION
[![GEOT-7564](https://badgen.net/badge/JIRA/GEOT-7564/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7564) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When loading a shapefile, a check is made to ensure that the index files (.qif/.fix) are not "stale". This is done by comparing lastModified times of .shp and indexes files, if the latter are <= that .shp's lastModified the indexes are recreated.
The problem is that when files are copied, they will be considered stale and geotools will waste time recreating them.

I propose a new property to skip this check.

The changes are the following:
- ShapefileDataStore now has an attribute (ignoreIndexStaleness), with its getter and setter methods
- IndexManager now checks index staleness only if ShapefileDataStore's ignoreIndexStaleness is False
- ShapefileDataStoreFactory has a new Param "IGNORE_STALENESS"
- shape.rst was updated with the new parameter
- unit tests were made to check the new code

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).
- [x] Bug fixes and small new features are presented as a single commit.
