### PR TITLE
Updated FeatureJSON to (optionally) use Geometry as the geometry type…

### DIFF
--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureJSON.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureJSON.java
@@ -492,12 +492,56 @@ public class FeatureJSON {
      * @param nullValuesEncoded if the input has null values encoded. If this flag is set to true
      *     and the GeoJSON doesn't actually encode null values, only the first feature attributes
      *     will be discovered.
+     * @param checkAllGeometryTypes if we should check the geometry type of each feature, and not
+     *     just the first. If this flag is set to true and the GeoJSON contains a mix of geometry
+     *     types, the type will be set to {@link Geometry}. If this flag is set to false the
+     *     geometry type of the first feature will be used.
+     * @return The feature collection schema
+     * @throws IOException In the event of a parsing error or if the input json is invalid.
+     */
+    public SimpleFeatureType readFeatureCollectionSchema(
+            Object input, boolean nullValuesEncoded, boolean checkAllGeometryTypes)
+            throws IOException {
+        return GeoJSONUtil.parse(
+                new FeatureTypeHandler(nullValuesEncoded, checkAllGeometryTypes), input, false);
+    }
+
+    /**
+     * Reads the {@link SimpleFeatureType} of a GeoJSON feature collection. In the worst case, it
+     * will parse all features searching for attributes not present in previous features.
+     *
+     * @param input The input. See {@link GeoJSONUtil#toReader(Object)} for details.
+     * @param nullValuesEncoded if the input has null values encoded. If this flag is set to true
+     *     and the GeoJSON doesn't actually encode null values, only the first feature attributes
+     *     will be discovered.
      * @return The feature collection schema
      * @throws IOException In the event of a parsing error or if the input json is invalid.
      */
     public SimpleFeatureType readFeatureCollectionSchema(Object input, boolean nullValuesEncoded)
             throws IOException {
-        return GeoJSONUtil.parse(new FeatureTypeHandler(nullValuesEncoded), input, false);
+        return readFeatureCollectionSchema(input, nullValuesEncoded, false);
+    }
+
+    /**
+     * Reads the {@link SimpleFeatureType} of a GeoJSON feature collection. In the worst case, it
+     * will parse all features searching for attributes not present in previous features.
+     *
+     * @param input The input. See {@link GeoJSONUtil#toReader(Object)} for details.
+     * @param nullValuesEncoded if the input has null values encoded. If this flag is set to true
+     *     and the GeoJSON doesn't actually encode null values, only the first feature attributes
+     *     will be discovered.
+     * @param checkAllGeometryTypes if we should check the geometry type of each feature, and not
+     *     just the first. If this flag is set to true and the GeoJSON contains a mix of geometry
+     *     types, the type will be set to {@link Geometry}. If this flag is set to false the
+     *     geometry type of the first feature will be used.
+     * @return The feature collection schema
+     * @throws IOException In the event of a parsing error or if the input json is invalid.
+     */
+    public SimpleFeatureType readFeatureCollectionSchema(
+            InputStream input, boolean nullValuesEncoded, boolean checkAllGeometryTypes)
+            throws IOException {
+        return readFeatureCollectionSchema(
+                (Object) input, nullValuesEncoded, checkAllGeometryTypes);
     }
 
     /**
@@ -513,7 +557,7 @@ public class FeatureJSON {
      */
     public SimpleFeatureType readFeatureCollectionSchema(
             InputStream input, boolean nullValuesEncoded) throws IOException {
-        return readFeatureCollectionSchema((Object) input, false);
+        return readFeatureCollectionSchema((Object) input, nullValuesEncoded, false);
     }
 
     /**


### PR DESCRIPTION
… if mixed geometries are present in a feature collection.

I ran into an issue recently where I was trying to read a feature collection containing features with a mix of geometry types (point, linestring, and polygon).  Using the `readFeatureCollectionSchema` method in FeatureJSON to extract the schema as a simple feature type, the simple feature type returned specifies `Point` as the geometry type.  This causes the GeoJSON geometries to be incorrectly read as `Point` instead of their original Geometry type.  

For my application I was able to create a new SimpleFeatureType from the returned SimpleFeatureType and update the geometry type to be `Geometry`.  Doing that, all of the original geometry types are preserved.  It would be nice if I didn't have to do that though, which is why I created this PR.  

The unit tests I added showcase the issue with the original logic, and the fixed output from the proposed PR.

Sent my license agreement in, and tried creating an issue in jira, but I don't have sufficient permissions at the moment.  Happy to do that if that's resolved.

Thanks!