### PR TITLE
[Backport 30.x] [GEOT-7568] ExternalGraphic isn't drawn when defined in LegendGraphic

### DIFF
--- a/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/GraphicLegendBuilder.java
+++ b/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/GraphicLegendBuilder.java
@@ -139,17 +139,16 @@ public class GraphicLegendBuilder extends AbstractStyleBuilder<GraphicLegend> {
         displacement.reset(graphic.getDisplacement());
         symbols.clear();
         for (GraphicalSymbol symbol : graphic.graphicalSymbols()) {
-            Builder<? extends Symbol> builder =
-                    ((symbol instanceof Mark)
-                            ? new MarkBuilder(this).reset((Mark) symbol)
-                            : (symbol instanceof ExternalGraphic)
-                                    ? new ExternalGraphicBuilder(this)
-                                            .reset((ExternalGraphic) symbol)
-                                    : null);
-            if (builder == null) {
+            final Builder<? extends Symbol> builder;
+            if ((symbol instanceof Mark)) {
+                builder = new MarkBuilder(this).reset((Mark) symbol);
+            } else if ((symbol instanceof ExternalGraphic)) {
+                builder = new ExternalGraphicBuilder(this).reset((ExternalGraphic) symbol);
+            } else {
                 throw new IllegalArgumentException(
                         "Unrecognized symbol type: " + symbol.getClass());
             }
+
             symbols.add(builder);
         }
         unset = false;

--- a/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/GraphicLegendBuilder.java
+++ b/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/GraphicLegendBuilder.java
@@ -16,13 +16,17 @@
  */
 package org.geotools.brewer.styling.builder;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.geotools.api.filter.expression.Expression;
+import org.geotools.api.style.ExternalGraphic;
 import org.geotools.api.style.GraphicLegend;
 import org.geotools.api.style.GraphicalSymbol;
+import org.geotools.api.style.Mark;
+import org.geotools.api.style.Symbol;
 
 public class GraphicLegendBuilder extends AbstractStyleBuilder<GraphicLegend> {
-    private List<GraphicalSymbol> symbols;
+    private List<Builder<? extends Symbol>> symbols = new ArrayList<>();
 
     private Expression opacity;
 
@@ -48,14 +52,17 @@ public class GraphicLegendBuilder extends AbstractStyleBuilder<GraphicLegend> {
         if (unset) {
             return null;
         }
+
+        if (symbols.isEmpty()) {
+            symbols.add(new MarkBuilder(this));
+        }
+        List<GraphicalSymbol> list = new ArrayList<>();
+        for (Builder<? extends Symbol> symbol : symbols) {
+            list.add(symbol.build());
+        }
         GraphicLegend graphic =
                 sf.graphicLegend(
-                        symbols,
-                        opacity,
-                        size,
-                        rotation,
-                        anchorPoint.build(),
-                        displacement.build());
+                        list, opacity, size, rotation, anchorPoint.build(), displacement.build());
         return graphic;
     }
 
@@ -115,12 +122,13 @@ public class GraphicLegendBuilder extends AbstractStyleBuilder<GraphicLegend> {
         rotation = literal(0);
         anchorPoint.reset();
         displacement.reset();
+        symbols.clear();
         unset = false;
         return this;
     }
 
     @Override
-    public GraphicLegendBuilder reset(org.geotools.api.style.GraphicLegend graphic) {
+    public GraphicLegendBuilder reset(GraphicLegend graphic) {
         if (graphic == null) {
             return unset();
         }
@@ -129,6 +137,21 @@ public class GraphicLegendBuilder extends AbstractStyleBuilder<GraphicLegend> {
         rotation = graphic.getRotation();
         anchorPoint.reset(graphic.getAnchorPoint());
         displacement.reset(graphic.getDisplacement());
+        symbols.clear();
+        for (GraphicalSymbol symbol : graphic.graphicalSymbols()) {
+            Builder<? extends Symbol> builder =
+                    ((symbol instanceof Mark)
+                            ? new MarkBuilder(this).reset((Mark) symbol)
+                            : (symbol instanceof ExternalGraphic)
+                                    ? new ExternalGraphicBuilder(this)
+                                            .reset((ExternalGraphic) symbol)
+                                    : null);
+            if (builder == null) {
+                throw new IllegalArgumentException(
+                        "Unrecognized symbol type: " + symbol.getClass());
+            }
+            symbols.add(builder);
+        }
         unset = false;
         return this;
     }

--- a/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/MarkBuilder.java
+++ b/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/MarkBuilder.java
@@ -29,10 +29,16 @@ public class MarkBuilder extends AbstractStyleBuilder<Mark> {
     Expression wellKnownName;
 
     public MarkBuilder() {
-        this(null);
+        super(null);
+        reset();
     }
 
     MarkBuilder(GraphicBuilder parent) {
+        super(parent);
+        reset();
+    }
+
+    MarkBuilder(GraphicLegendBuilder parent) {
         super(parent);
         reset();
     }

--- a/modules/library/main/src/test/java/org/geotools/styling/ExternalGraphicImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/styling/ExternalGraphicImplTest.java
@@ -1,0 +1,59 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.styling;
+
+import java.net.URL;
+import org.geotools.api.style.ExternalGraphic;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExternalGraphicImplTest {
+
+    private static final String TEST_URL = "http://test.io/graphic.png";
+
+    private static final String TEST_FORMAT = "image/png";
+
+    /**
+     * The Url of OnlineResource could be set by three independent set'ers. Test that they all ends
+     * up in the location field of onlineResource
+     */
+    @Test
+    public void testOnlineResourceConsistency() throws Exception {
+        CheckOnlineResource testObject = new CheckOnlineResource();
+
+        ExternalGraphic external = new ExternalGraphicImpl();
+        external.setLocation(new URL(TEST_URL));
+
+        external.accept(testObject);
+
+        external.setURI(TEST_URL);
+        external.accept(testObject);
+
+        StyleFactoryImpl fact = new StyleFactoryImpl();
+        external = fact.createExternalGraphic(TEST_URL, TEST_FORMAT);
+        external.accept(testObject);
+    }
+
+    private static class CheckOnlineResource extends AbstractStyleVisitor {
+
+        @Override
+        public void visit(ExternalGraphic exgr) {
+            Assert.assertNotNull(exgr.getOnlineResource());
+            Assert.assertEquals(TEST_URL, exgr.getOnlineResource().getLinkage().toString());
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-7568](https://badgen.net/badge/JIRA/GEOT-7568/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7568) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4745
 **Authored by:** @roarbra