### PR TITLE
[GEOT-7561] Proposal: Individual contributor clarification

### DIFF
--- a/docs/developer/procedures/contribution_license.rst
+++ b/docs/developer/procedures/contribution_license.rst
@@ -5,10 +5,10 @@ GeoTools has adopted a formal policy as part of the process of joining the Open 
 
 All new :doc:`contributors </roles/contributor>` will be required to grant copyright to the foundation using a `Contributor Licenses <https://www.osgeo.org/about/licenses/>`_:
 
-* individual_contributor (:download:`txt </artifacts/individual_contributor.txt>` | :download:`pdf </artifacts/individual_contributor.pdf>`)
-* corporate_contributor (:download:`txt </artifacts/corporate_contributor.txt>` | :download:`pdf </artifacts/corporate_contributor.pdf>`)
+* `individual_contributor <https://www.osgeo.org/resources/individual-contributor-license/>`__
+* `corporate_contributor <https://www.osgeo.org/resources/corporate-contributor-license/>`__
 
-These licenses are directly derived from the Apache code contribution licenses (CLA V2.0 and CCLA v r190612).
+GeoTools is grateful that organizations of all shapes and sizes support our project with in-kind participation of their employees. Extending commit access is made to individuals directly based on their expertise demonstrated over time.
 
 #. Contributors must print out a copy of the Contribution License document(s) and either sign it themselves or have their employer sign the document, depending on the circumstances governing when and where the Contributor develops the code. It is up to the Contributor to understand the legal status of the code which the Contributor produces.
 #. Scan the document and email to **info@osgeo.org**. Once we have confirmation the document has

--- a/docs/developer/procedures/contribution_license.rst
+++ b/docs/developer/procedures/contribution_license.rst
@@ -8,6 +8,8 @@ All new :doc:`contributors </roles/contributor>` will be required to grant copyr
 * `individual_contributor <https://www.osgeo.org/resources/individual-contributor-license/>`__
 * `corporate_contributor <https://www.osgeo.org/resources/corporate-contributor-license/>`__
 
+These licenses are directly derived from the Apache code contribution licenses (CLA V2.0 and CCLA v r190612).
+
 GeoTools is grateful that organizations of all shapes and sizes support our project with in-kind participation of their employees. Extending commit access is made to individuals directly based on their expertise demonstrated over time.
 
 #. Contributors must print out a copy of the Contribution License document(s) and either sign it themselves or have their employer sign the document, depending on the circumstances governing when and where the Contributor develops the code. It is up to the Contributor to understand the legal status of the code which the Contributor produces.


### PR DESCRIPTION
[![GEOT-7561](https://badgen.net/badge/JIRA/GEOT-7561/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7561) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Implements https://github.com/geotools/geotools/wiki/Individual-contributor-clarification

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->