### PR TITLE
[GEOT-7580] Fix missing builder clear writing FlatGeobuf data

### DIFF
--- a/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/FlatGeobufWriter.java
+++ b/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/FlatGeobufWriter.java
@@ -38,11 +38,13 @@ public class FlatGeobufWriter {
 
     public void writeFeature(SimpleFeature feature) throws IOException {
         FeatureConversions.serialize(feature, this.headerMeta, this.outputStream, this.builder);
+        builder.clear();
     }
 
     public void writeFeatureType(SimpleFeatureType featureType) throws IOException {
         outputStream.write(Constants.MAGIC_BYTES);
         headerMeta = HeaderMetaUtil.fromFeatureType(featureType, 0);
         HeaderMeta.write(headerMeta, outputStream, builder);
+        builder.clear();
     }
 }

--- a/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/FlatGeobufDataStoreTest.java
+++ b/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/FlatGeobufDataStoreTest.java
@@ -133,6 +133,8 @@ public class FlatGeobufDataStoreTest {
         SimpleFeatureCollection collection = DataUtilities.collection(feature1, feature2);
         featureStore.addFeatures(collection);
 
+        assertEquals(408, file.length());
+
         // Read
         SimpleFeatureCollection featureCollection = featureStore.getFeatures();
         assertEquals(2, featureCollection.size());


### PR DESCRIPTION
[![GEOT-7569](https://badgen.net/badge/JIRA/GEOT-7569/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7569) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Without this fix FlatGeobuf output will become much larger than expected. It appears the output will still work, which is why it went under the radar for quite some time, likely due to that redundant data is appended in buffers that is not read. If possible it would be good if this fix could be backported.

Originally noted in https://osgeo-org.atlassian.net/browse/GEOT-7569.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->