### PR TITLE
[Backport 31.x] [GEOT-7579] FlatGeobuf handle java.util.Date and iso correctness

### DIFF
--- a/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/FeatureConversions.java
+++ b/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/FeatureConversions.java
@@ -17,6 +17,12 @@
 package org.geotools.data.flatgeobuf;
 
 import static java.nio.charset.CodingErrorAction.REPLACE;
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
 
 import com.google.common.io.LittleEndianDataInputStream;
 import com.google.flatbuffers.FlatBufferBuilder;
@@ -190,21 +196,25 @@ public class FeatureConversions {
             else if (type == ColumnType.DateTime) {
                 String isoDateTime = "";
                 if (value instanceof LocalDateTime) {
-                    isoDateTime = ((LocalDateTime) value).toString();
+                    isoDateTime = ISO_LOCAL_DATE_TIME.format((LocalDateTime) value);
                 } else if (value instanceof LocalDate) {
-                    isoDateTime = ((LocalDate) value).toString();
+                    isoDateTime = ISO_LOCAL_DATE.format((LocalDate) value);
                 } else if (value instanceof LocalTime) {
-                    isoDateTime = ((LocalTime) value).toString();
+                    isoDateTime = ISO_LOCAL_TIME.format((LocalTime) value);
                 } else if (value instanceof OffsetDateTime) {
-                    isoDateTime = ((OffsetDateTime) value).toString();
+                    isoDateTime = ISO_OFFSET_DATE_TIME.format((OffsetDateTime) value);
                 } else if (value instanceof OffsetTime) {
-                    isoDateTime = ((OffsetTime) value).toString();
+                    isoDateTime = ISO_OFFSET_TIME.format((OffsetTime) value);
                 } else if (value instanceof java.sql.Date) {
-                    isoDateTime = ((java.sql.Date) value).toString();
+                    isoDateTime = ISO_LOCAL_DATE.format(((java.sql.Date) value).toLocalDate());
                 } else if (value instanceof java.sql.Time) {
-                    isoDateTime = ((java.sql.Time) value).toString();
+                    isoDateTime = ISO_LOCAL_TIME.format(((java.sql.Time) value).toLocalTime());
                 } else if (value instanceof java.sql.Timestamp) {
-                    isoDateTime = ((java.sql.Timestamp) value).toString();
+                    isoDateTime =
+                            ISO_LOCAL_DATE_TIME.format(
+                                    ((java.sql.Timestamp) value).toLocalDateTime());
+                } else if (value instanceof java.util.Date) {
+                    isoDateTime = ISO_INSTANT.format(((java.util.Date) value).toInstant());
                 } else {
                     throw new RuntimeException(
                             "Cannot handle datetime type " + value.getClass().getName());

--- a/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/AttributeRoundtripTest.java
+++ b/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/AttributeRoundtripTest.java
@@ -15,9 +15,15 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.Date;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.data.geojson.GeoJSONReader;
@@ -87,16 +93,20 @@ public class AttributeRoundtripTest {
         sftb.add("exotic1_6", BigDecimal.class);
         sftb.add("exotic1_7", Byte.class);
         sftb.add("exotic1_8", Short.class);
+        sftb.add("exotic1_9", Date.class);
         SimpleFeatureType ft = sftb.buildFeatureType();
         SimpleFeatureBuilder sfb = new SimpleFeatureBuilder(ft);
-        sfb.set("exotic1_1", Integer.parseInt("99"));
+        sfb.set("exotic1_1", Integer.valueOf("99"));
         sfb.set("exotic1_2", new BigInteger("1111111111111111111"));
-        sfb.set("exotic1_3", LocalDateTime.now());
+        sfb.set("exotic1_3", LocalDateTime.now().withNano(0));
         sfb.set("exotic1_4", LocalDate.now());
-        sfb.set("exotic1_5", LocalTime.now());
+        sfb.set("exotic1_5", LocalTime.now().withNano(0));
         sfb.set("exotic1_6", new BigDecimal("1.1111"));
         sfb.set("exotic1_7", Byte.parseByte("99"));
         sfb.set("exotic1_8", Short.parseShort("9999"));
+        Calendar cal = Calendar.getInstance();
+        cal.set(2020, 1, 1, 0, 0, 0);
+        sfb.set("exotic1_9", cal.getTime());
         SimpleFeature sf = sfb.buildFeature("0");
         MemoryFeatureCollection expected = new MemoryFeatureCollection(ft);
         expected.add(sf);
@@ -135,5 +145,10 @@ public class AttributeRoundtripTest {
         assertEquals(
                 expectedFeature.getAttribute(8).toString(),
                 actualFeature.getAttribute(8).toString());
+        Date date = (Date) expectedFeature.getAttribute(9);
+        Instant instant = date.toInstant();
+        ZonedDateTime zonedDateTime = instant.atZone(ZoneId.of("UTC"));
+        String isoString = zonedDateTime.format(DateTimeFormatter.ISO_INSTANT);
+        assertEquals(isoString, actualFeature.getAttribute(9).toString());
     }
 }


### PR DESCRIPTION
[![GEOT-7579](https://badgen.net/badge/JIRA/GEOT-7579/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7579) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4768
 **Authored by:** @bjornharrtell