### PR TITLE
Add Nullable annotation to GeometryClipper

### DIFF
--- a/modules/library/main/pom.xml
+++ b/modules/library/main/pom.xml
@@ -267,6 +267,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+      <version>3.0.0</version>
     </dependency>
   </dependencies>
 

--- a/modules/library/main/pom.xml
+++ b/modules/library/main/pom.xml
@@ -267,7 +267,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.2</version>
     </dependency>
   </dependencies>
 

--- a/modules/library/main/pom.xml
+++ b/modules/library/main/pom.xml
@@ -264,6 +264,10 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
   </dependencies>
 
   <!-- =========================================================== -->

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometryClipper.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometryClipper.java
@@ -35,6 +35,7 @@ import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.precision.GeometryPrecisionReducer;
+import javax.annotation.Nullable;
 
 /**
  * A stateful geometry clipper, can clip linestring on a specified rectangle. Trivial benchmarks
@@ -94,6 +95,7 @@ public class GeometryClipper {
      * @param scale Scale used to snap geometry to precision model, 0 to disable
      * @return a clipped geometry, which may be empty, or null
      */
+    @Nullable
     public Geometry clipSafe(Geometry g, boolean ensureValid, double scale) {
         try {
             return clip(g, ensureValid);
@@ -142,6 +144,7 @@ public class GeometryClipper {
      * @param ensureValid If false there is no guarantee the polygons returned will be valid
      *     according to JTS rules (but should still be good enough to be used for pure rendering)
      */
+    @Nullable
     public Geometry clip(Geometry g, boolean ensureValid) {
         // basic pre-flight checks
         if (g == null) {

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometryClipper.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/GeometryClipper.java
@@ -19,6 +19,7 @@ package org.geotools.geometry.jts;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
 import org.locationtech.jts.geom.Envelope;
@@ -35,7 +36,6 @@ import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.precision.GeometryPrecisionReducer;
-import javax.annotation.Nullable;
 
 /**
  * A stateful geometry clipper, can clip linestring on a specified rectangle. Trivial benchmarks


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
Hi all, I'm proposing a change to add a `@Nullable` annotation to the `GeometryClipper#clip` and `Geometry#clipSafe` functions. This would help prevent NPEs by callers of this library method. Would appreciate any input, thank you!

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->