### PR TITLE
[GEOT-7576] Use HttpClient in SchemaCache

### DIFF
--- a/modules/library/xml/pom.xml
+++ b/modules/library/xml/pom.xml
@@ -126,6 +126,24 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-http</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-http-commons</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheMockHttpClientFactory.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheMockHttpClientFactory.java
@@ -1,0 +1,61 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+
+package org.geotools.xml.resolver;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import org.geotools.http.AbstractHTTPClientFactory;
+import org.geotools.http.HTTPBehavior;
+import org.geotools.http.HTTPClient;
+import org.geotools.http.MockHttpClient;
+import org.geotools.http.MockHttpResponse;
+
+/**
+ * Factory for mock http client.
+ *
+ * <p>Registered in META-INF/services, when used make sure to set Hints.HTTP_CLIENT_FACTORY.
+ *
+ * @author Cécile Vuilleumier (camptocamp)
+ */
+public class SchemaCacheMockHttpClientFactory extends AbstractHTTPClientFactory {
+
+    @Override
+    public List<Class<?>> clientClasses() {
+        return Collections.singletonList(SchemaCacheMockHttpClient.class);
+    }
+
+    @Override
+    public HTTPClient createClient(List<Class<? extends HTTPBehavior>> behaviors) {
+        return new SchemaCacheMockHttpClient();
+    }
+
+    private static class SchemaCacheMockHttpClient extends MockHttpClient {
+
+        public SchemaCacheMockHttpClient() {
+            try {
+                final MockHttpResponse response =
+                        new MockHttpResponse(
+                                SchemaCacheTest.MOCK_HTTP_RESPONSE_BODY, "application/xml");
+                expectGet(new URL(SchemaCacheTest.MOCK_SCHEMA_LOCATION), response);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheOnlineTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheOnlineTest.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import org.geotools.test.OnlineTestSupport;
 import org.geotools.util.URLs;
@@ -170,26 +169,22 @@ public class SchemaCacheOnlineTest extends OnlineTestSupport {
         }
     }
 
+    /** Test that redirection is followed. */
     @Test
     public void downloadWithRedirect() throws IOException {
-        URL url = new URL("http://inspire.ec.europa.eu/schemas/common/1.0");
+        URL url = new URL("http://wms.geo.admin.ch");
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         // this url has the header with a redirect
         Assert.assertNotNull(conn.getHeaderField("Location"));
-        byte[] responseBody =
-                SchemaCache.download("http://inspire.ec.europa.eu/schemas/common/1.0");
+        byte[] responseBody = SchemaCache.download("http://wms.geo.admin.ch");
         Assert.assertNotNull(responseBody);
         Assert.assertTrue(responseBody.length > 0);
     }
 
+    /** Test that a failed download does not throw an exception. */
     @Test
-    public void testMaxRedirectionLimit() throws IOException, URISyntaxException {
-        URL url = new URL("http://inspire.ec.europa.eu/schemas/common/1.0");
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        // this url has the header with a redirect
-        Assert.assertNotNull(conn.getHeaderField("Location"));
-        URI uri = new URI("http://inspire.ec.europa.eu/schemas/common/1.0");
-        byte[] responseBody = SchemaCache.download(uri, 4096, 16);
+    public void downloadFails() {
+        byte[] responseBody = SchemaCache.download("https://www.google.com/404");
         Assert.assertNull(responseBody);
     }
 }

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
@@ -17,12 +17,20 @@
 
 package org.geotools.xml.resolver;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.Assert.assertTrue;
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.File;
 import java.io.PrintWriter;
 import java.net.URI;
+import org.geotools.http.commons.MultithreadedHttpClientFactory;
 import org.geotools.util.URLs;
+import org.geotools.util.factory.Hints;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +42,10 @@ import org.junit.rules.TemporaryFolder;
  * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
  */
 public class SchemaCacheTest {
+
+    public static final String MOCK_SCHEMA_LOCATION = "http://schemacache";
+
+    public static final String MOCK_HTTP_RESPONSE_BODY = "<schemaCacheMockHttpClientResponse>";
 
     @Rule public TemporaryFolder folder = new TemporaryFolder();
 
@@ -92,4 +104,38 @@ public class SchemaCacheTest {
         defaultXmlFile.createNewFile();
         assertTrue(SchemaCache.isSuitableDirectoryToContainCache(dataFolder));
     }
+
+    /** Test download with the HTTP client specified in the GeoTools hints */
+    @Test
+    public void downloadWithHttpClient() {
+        Hints.putSystemDefault(Hints.HTTP_CLIENT_FACTORY, SchemaCacheMockHttpClientFactory.class);
+        byte[] responseBody = SchemaCache.download(MOCK_SCHEMA_LOCATION);
+        Assert.assertArrayEquals(MOCK_HTTP_RESPONSE_BODY.getBytes(), responseBody);
+        Hints.removeSystemDefault(Hints.HTTP_CLIENT_FACTORY);
+    }
+
+    /**
+     * Test that a circular redirect is not followed indefinitely when using the multithreaded HTTP
+     * client
+     */
+    @Test
+    public void circularRedirectMultithreadedHttpClient() {
+        Hints.putSystemDefault(Hints.HTTP_CLIENT_FACTORY, MultithreadedHttpClientFactory.class);
+        String redirectUrl = "http://localhost:" + wireMockRule.port() + "/test";
+        wireMockRule.addStubMapping(
+                stubFor(
+                        get(urlEqualTo("/test"))
+                                .willReturn(
+                                        aResponse()
+                                                .withStatus(301)
+                                                .withHeader("Location", redirectUrl))));
+        byte[] responseBody = SchemaCache.download(redirectUrl);
+        Assert.assertNull(responseBody);
+        Hints.removeSystemDefault(Hints.HTTP_CLIENT_FACTORY);
+    }
+
+    // use a dynamic http port to avoid conflicts
+    @Rule
+    public WireMockRule wireMockRule =
+            new WireMockRule(WireMockConfiguration.options().dynamicPort());
 }

--- a/modules/library/xml/src/test/resources/META-INF/services/org.geotools.http.HTTPClientFactory
+++ b/modules/library/xml/src/test/resources/META-INF/services/org.geotools.http.HTTPClientFactory
@@ -1,0 +1,1 @@
+org.geotools.xml.resolver.SchemaCacheMockHttpClientFactory


### PR DESCRIPTION
[![GEOT-7576](https://badgen.net/badge/JIRA/GEOT-7576/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7576) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently the XML SchemaCache makes direct HTTP calls for downloading XML schemas.
The goal of this PR is for the SchemaCache to use the geotools HttpClient instead. This ensures that if a specific HttpClient is set (see https://github.com/geotools/geotools/blob/main/docs/user/library/http/index.rst) it will be used for all outgoing HTTP calls.

Since there was a bit of logic for following redirections in SchemaCache, I have moved it to the SimpleHttpClient so that the default behavior is preserved. This won't be the case for applications already using another specific HttpClient. Note that after testing it appeared that `java.net.HttpURLConnection` already follows redirections if the protocol is the same (i.e. HTTP or HTTPS) so this bit of code seems to be needed only for HTTP to HTTPS redirection.

Also changed a URL in the online tests which was causing a SSL error.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->