### PR TITLE
[GEOT-7589] Fix the JsonArrayDelegation for Postgres to support searching in root level array

### DIFF
--- a/docs/user/library/jdbc/postgis.rst
+++ b/docs/user/library/jdbc/postgis.rst
@@ -64,6 +64,9 @@ Advanced
 |                        | be encoded into their SQL equivalent           |
 +------------------------+------------------------------------------------+
 
+By default JsonArrayContains function will be delegated to @> operator. However for postgres versions >= 12 it will be delegated to jsonPathExists function.
+jsonPathExists is able to search values in the root level array.
+
 Example use::
   
   params.put(PostgisNGDataStoreFactory.LOOSEBBOX, true );

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISDialect.java
@@ -174,6 +174,8 @@ public class PostGISDialect extends BasicSQLDialect {
 
     static final Version PGSQL_V_9_1 = new Version("9.1");
 
+    static final Version PGSQL_V_12_0 = new Version("12.0");
+
     public PostGISDialect(JDBCDataStore dataStore) {
         super(dataStore);
         this.forceLongitudeFirst =
@@ -1407,7 +1409,7 @@ public class PostGISDialect extends BasicSQLDialect {
 
     @Override
     public FilterToSQL createFilterToSQL() {
-        PostgisFilterToSQL sql = new PostgisFilterToSQL(this);
+        PostgisFilterToSQL sql = new PostgisFilterToSQL(this, pgsqlVersion);
         sql.setLooseBBOXEnabled(looseBBOXEnabled);
         sql.setEncodeBBOXFilterAsEnvelope(encodeBBOXFilterAsEnvelope);
         sql.setFunctionEncodingEnabled(functionEncodingEnabled);

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostGISPSDialect.java
@@ -259,7 +259,7 @@ public class PostGISPSDialect extends PreparedStatementSQLDialect {
 
     @Override
     public PreparedFilterToSQL createPreparedFilterToSQL() {
-        PostgisPSFilterToSql fts = new PostgisPSFilterToSql(this);
+        PostgisPSFilterToSql fts = new PostgisPSFilterToSql(this, delegate.pgsqlVersion);
         fts.setFunctionEncodingEnabled(delegate.isFunctionEncodingEnabled());
         fts.setLooseBBOXEnabled(delegate.isLooseBBOXEnabled());
         fts.setEncodeBBOXFilterAsEnvelope(delegate.isEncodeBBOXFilterAsEnvelope());

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
@@ -33,6 +33,7 @@ import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.function.JsonArrayContainsFunction;
 import org.geotools.filter.function.JsonPointerFunction;
 import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.util.Version;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LinearRing;
 
@@ -44,6 +45,11 @@ public class PostgisFilterToSQL extends FilterToSQL {
 
     public PostgisFilterToSQL(PostGISDialect dialect) {
         helper = new FilterToSqlHelper(this);
+        pgDialect = dialect;
+    }
+
+    public PostgisFilterToSQL(PostGISDialect dialect, Version pgVersion) {
+        helper = new FilterToSqlHelper(this, pgVersion);
         pgDialect = dialect;
     }
 

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisPSFilterToSql.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisPSFilterToSql.java
@@ -29,6 +29,7 @@ import org.geotools.api.filter.spatial.BinarySpatialOperator;
 import org.geotools.api.filter.spatial.DistanceBufferOperator;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.jdbc.PreparedFilterToSQL;
+import org.geotools.util.Version;
 
 public class PostgisPSFilterToSql extends PreparedFilterToSQL {
 
@@ -38,6 +39,11 @@ public class PostgisPSFilterToSql extends PreparedFilterToSQL {
     public PostgisPSFilterToSql(PostGISPSDialect dialect) {
         super(dialect);
         helper = new FilterToSqlHelper(this);
+    }
+
+    public PostgisPSFilterToSql(PostGISPSDialect dialect, Version pgVersion) {
+        super(dialect);
+        helper = new FilterToSqlHelper(this, pgVersion);
     }
 
     public boolean isLooseBBOXEnabled() {

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISJsonOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISJsonOnlineTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 import org.geotools.api.data.FeatureReader;
 import org.geotools.api.data.Query;
 import org.geotools.api.feature.Feature;
@@ -40,6 +41,7 @@ import org.geotools.data.FilteringFeatureReader;
 import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
+import org.geotools.feature.simple.SimpleFeatureImpl;
 import org.geotools.jdbc.JDBCFeatureReader;
 import org.geotools.jdbc.JDBCTestSetup;
 import org.geotools.jdbc.JDBCTestSupport;
@@ -443,6 +445,78 @@ public class PostGISJsonOnlineTest extends JDBCTestSupport {
     }
 
     @Test
+    public void testJSONArrayContainsFunctionRootArrayString() throws Exception {
+        if (pgJsonTestSetup.supportJsonPathExists) {
+            ContentFeatureSource fs = dataStore.getFeatureSource(tname("jsontest"));
+            FilterFactory ff = dataStore.getFilterFactory();
+
+            testDelegatedArrayContains(
+                    ff,
+                    fs,
+                    "jsonColumn",
+                    "/type",
+                    "OTHERS",
+                    feature -> assertEquals("jsontest.10", feature.getIdentifier().getID()),
+                    feature ->
+                            assertTrue(
+                                    feature.getAttribute("jsonColumn")
+                                            .toString()
+                                            .contains("\"type\": \"OTHERS\"")));
+
+            if (pgJsonTestSetup.supportJsonB) {
+                testDelegatedArrayContains(
+                        ff,
+                        fs,
+                        "jsonbColumn",
+                        "/type",
+                        "OTHERS",
+                        feature -> assertEquals("jsontest.10", feature.getIdentifier().getID()),
+                        feature ->
+                                assertTrue(
+                                        feature.getAttribute("jsonbColumn")
+                                                .toString()
+                                                .contains("\"type\": \"OTHERS\"")));
+            }
+        }
+    }
+
+    @Test
+    public void testJSONArrayContainsFunctionRootArrayNumber() throws Exception {
+        if (pgJsonTestSetup.supportJsonPathExists) {
+            ContentFeatureSource fs = dataStore.getFeatureSource(tname("jsontest"));
+            FilterFactory ff = dataStore.getFilterFactory();
+
+            testDelegatedArrayContains(
+                    ff,
+                    fs,
+                    "jsonColumn",
+                    "/version",
+                    3,
+                    feature -> assertEquals("jsontest.11", feature.getIdentifier().getID()),
+                    feature ->
+                            assertTrue(
+                                    feature.getAttribute("jsonColumn")
+                                            .toString()
+                                            .contains("\"version\": 3")));
+
+            if (pgJsonTestSetup.supportJsonB) {
+                testDelegatedArrayContains(
+                        ff,
+                        fs,
+                        "jsonbColumn",
+                        "/version",
+                        3,
+                        feature -> assertEquals("jsontest.11", feature.getIdentifier().getID()),
+                        feature ->
+                                assertTrue(
+                                        feature.getAttribute("jsonbColumn")
+                                                .toString()
+                                                .contains("\"version\": 3")));
+            }
+        }
+    }
+
+    @Test
     public void testJSONArrayContainsFunctionNested() throws Exception {
         ContentFeatureSource fs = dataStore.getFeatureSource(tname("jsontest"));
         FilterFactory ff = dataStore.getFilterFactory();
@@ -476,9 +550,7 @@ public class PostGISJsonOnlineTest extends JDBCTestSupport {
                         ff.property(column),
                         ff.literal(pointer),
                         ff.literal(expected));
-        Filter filter = ff.equals(jsonArrayContains, ff.literal(true));
-        Query query = new Query(tname("jsontest"), filter);
-        FeatureCollection collection = fs.getFeatures(query);
+        FeatureCollection collection = fetchQueryResult(fs, ff, jsonArrayContains);
         try (FeatureIterator it = collection.features()) {
             int size = 0;
             while (it.hasNext()) {
@@ -488,5 +560,40 @@ public class PostGISJsonOnlineTest extends JDBCTestSupport {
             }
             assertEquals(result, size);
         }
+    }
+
+    @SafeVarargs
+    private void testDelegatedArrayContains(
+            FilterFactory ff,
+            ContentFeatureSource fs,
+            String column,
+            String path,
+            Object value,
+            Consumer<SimpleFeatureImpl>... assertions)
+            throws IOException {
+        Function jsonArrayContains =
+                ff.function(
+                        "jsonArrayContains",
+                        ff.property(column),
+                        ff.literal(path),
+                        ff.literal(value));
+
+        FeatureCollection collection = fetchQueryResult(fs, ff, jsonArrayContains);
+        try (FeatureIterator features = collection.features()) {
+            assertTrue(features.hasNext());
+
+            SimpleFeatureImpl feature = (SimpleFeatureImpl) features.next();
+            for (Consumer<SimpleFeatureImpl> assertion : assertions) {
+                assertion.accept(feature);
+            }
+        }
+    }
+
+    private FeatureCollection fetchQueryResult(
+            ContentFeatureSource fs, FilterFactory ff, Function jsonArrayContains)
+            throws IOException {
+        Filter filter = ff.equals(jsonArrayContains, ff.literal(true));
+        Query query = new Query(tname("jsontest"), filter);
+        return fs.getFeatures(query);
     }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISJsonTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostGISJsonTestSetup.java
@@ -35,6 +35,8 @@ public class PostGISJsonTestSetup extends JDBCDelegatingTestSetup {
 
     protected boolean supportJsonB = false;
 
+    protected boolean supportJsonPathExists = false;
+
     @Override
     protected void setUpData() throws Exception {
         dropTestJsonTable();
@@ -44,11 +46,15 @@ public class PostGISJsonTestSetup extends JDBCDelegatingTestSetup {
                 ResultSet rs = st.executeQuery("SELECT current_setting('server_version_num')")) {
             if (rs.next()) {
                 try {
+                    int version = Integer.parseInt(rs.getString(1));
                     // JSONB has been introduced with version 9.4
-                    supportJsonB = Integer.parseInt(rs.getString(1)) >= 90004;
+                    supportJsonB = version >= 90004;
+                    // JsonPathExists has been introduced with version 12.0
+                    supportJsonPathExists = version >= 120000;
                 } catch (NumberFormatException nfe) {
                     // unable to determine PostgreSQL version because non-integer returned
                     supportJsonB = false;
+                    supportJsonPathExists = false;
                 }
             }
         } catch (PSQLException pse) {
@@ -126,6 +132,16 @@ public class PostGISJsonTestSetup extends JDBCDelegatingTestSetup {
                         + ");"
                         + "INSERT INTO \"jsontest\" VALUES (9, 'arrayEntryStr', '{\"arrayStrValues\":[\"EL1\",\"EL2\",\"EL3\"]}'"
                         + (supportJsonB ? ", '{\"arrayStrValues\":[\"EL1\",\"EL2\",\"EL3\"]}'" : "")
+                        + ");"
+                        + "INSERT INTO \"jsontest\" VALUES (10, 'arrayEntryStr', '[{\"type\": \"MAIN\", \"version\": 1 }, {\"type\": \"OTHERS\", \"version\": 2 }]'"
+                        + (supportJsonB
+                                ? ", '[{\"type\": \"MAIN\", \"version\": 1 }, {\"type\": \"OTHERS\", \"version\": 2 }]'"
+                                : "")
+                        + ");"
+                        + "INSERT INTO \"jsontest\" VALUES (11, 'arrayEntryStr', '[{\"type\": \"DEFAULT\", \"version\": 3 }, {\"type\": \"UNKNOWN\", \"version\": 4 }]'"
+                        + (supportJsonB
+                                ? ", '[{\"type\": \"DEFAULT\", \"version\": 3 }, {\"type\": \"UNKNOWN\", \"version\": 4 }]'"
+                                : "")
                         + ");";
 
         run(sql);

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJsonPathExistsTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJsonPathExistsTest.java
@@ -1,0 +1,127 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.StringWriter;
+import org.geotools.api.feature.IllegalAttributeException;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.Function;
+import org.geotools.data.jdbc.SQLFilterTestSupport;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.SchemaException;
+import org.geotools.util.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PostgisJsonPathExistsTest extends SQLFilterTestSupport {
+
+    private static FilterFactory ff;
+
+    private PostGISDialect dialect;
+
+    PostgisFilterToSQL filterToSql;
+
+    StringWriter writer;
+
+    @Override
+    @Before
+    public void setUp() throws IllegalAttributeException, SchemaException {
+        ff = CommonFactoryFinder.getFilterFactory();
+        dialect = new PostGISDialect(null);
+        filterToSql = new PostgisFilterToSQL(dialect, new Version("12.0.0"));
+        filterToSql.setFunctionEncodingEnabled(true);
+        writer = new StringWriter();
+        filterToSql.setWriter(writer);
+
+        prepareFeatures();
+    }
+
+    @Test
+    public void testFunctionJsonArrayContainsJsonPathExists() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer =
+                ff.function(
+                        "jsonArrayContains",
+                        ff.property("OPERATIONS"),
+                        ff.literal("/operations"),
+                        ff.literal("OP1"));
+        filterToSql.encode(pointer);
+        String sql = writer.toString().trim();
+        assertEquals("jsonb_path_exists(OPERATIONS::jsonb, '$ ? (@.operations == \"OP1\")')", sql);
+    }
+
+    @Test
+    public void testFunctionJsonArrayContainsNumberJsonPathExists() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer =
+                ff.function(
+                        "jsonArrayContains",
+                        ff.property("OPERATIONS"),
+                        ff.literal("/operations"),
+                        ff.literal(1));
+        filterToSql.encode(pointer);
+        String sql = writer.toString().trim();
+        assertEquals("jsonb_path_exists(OPERATIONS::jsonb, '$ ? (@.operations == 1)')", sql);
+    }
+
+    @Test
+    public void testNestedObjectJsonArrayContainsJsonPathExists() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer =
+                ff.function(
+                        "jsonArrayContains",
+                        ff.property("OPERATIONS"),
+                        ff.literal("/operations/parameters"),
+                        ff.literal("P1"));
+        filterToSql.encode(pointer);
+        String sql = writer.toString().trim();
+        assertEquals(
+                "jsonb_path_exists(OPERATIONS::jsonb, '$.operations ? (@.parameters == \"P1\")')",
+                sql);
+    }
+
+    @Test
+    public void testFunctionJsonArrayContainsEscapingPointerJsonPathExists() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer =
+                ff.function(
+                        "jsonArrayContains",
+                        ff.property("OPERATIONS"),
+                        ff.literal("/\"'FOO"),
+                        ff.literal("OP1"));
+        filterToSql.encode(pointer);
+        String sql = writer.toString().trim();
+        assertEquals("jsonb_path_exists(OPERATIONS::jsonb, '$ ? (@.\\\"''FOO == \"OP1\")')", sql);
+    }
+
+    @Test
+    public void testFunctionJsonArrayContainsEscapingExpectedJsonPathExists() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer =
+                ff.function(
+                        "jsonArrayContains",
+                        ff.property("OPERATIONS"),
+                        ff.literal("/operations"),
+                        ff.literal("\"'FOO"));
+        filterToSql.encode(pointer);
+        String sql = writer.toString().trim();
+        assertEquals(
+                "jsonb_path_exists(OPERATIONS::jsonb, '$ ? (@.operations == \"\"'FOO\")')", sql);
+    }
+}


### PR DESCRIPTION
[![GEOT-7589](https://badgen.net/badge/JIRA/GEOT-7589/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7589) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is aimed to add support for searching root level arrays using postgres implementation of JsonArrayContains.

Current implementation is using the @> operator, however to use it with array at root level the searched object should be wrapped in square brackets. Below is an examples of working queries for array wrapped in object and non wrapped:
```
("jsonColumn"::jsonb @> '{ "arrayStrValues": ["EL2"] }'::jsonb
```
for {"arrayStrValues":["EL1","EL2","EL3"]} and
```
("jsonColumn"::jsonb @> '[{ "arrayStrValues": "EL2" }]'::jsonb
```
for ["EL1","EL2","EL3"]

That is, to properly resolve this we should know if we are targeting root array during building query, which is currently not possible.

The new approach relies on jsonb_path_exists, which does not have this drawback.
```
jsonb_path_exists(jsonColumn::jsonb, '$ ? (@.arrayStrValues == "EL2")')
```

The check "PostGIS online tests / build (pull_request)" is failing because this functionality was added in Postgres 12, and VM that runs the check apparently uses older version, resulting in "ERROR: function jsonb_path_exists(jsonb, unknown) does not exist". ~~Thus this functionality is disabled by default, and can be enabled by using the "org.geotools.data.postgis.useJsonPathExists" property.~~
Code will use new implementation for versions >= 12, and old implementation for previous ones.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->