### PR TITLE
[GEOT-7590] Fix ampersand handling in Like filters

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/LikeToRegexConverter.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/LikeToRegexConverter.java
@@ -149,8 +149,7 @@ public class LikeToRegexConverter {
                 || (chr == '(')
                 || (chr == ')')
                 || (chr == '|')
-                || (chr == '\\')
-                || (chr == '&'));
+                || (chr == '\\'));
     }
 
     /**

--- a/modules/library/main/src/test/java/org/geotools/filter/LikeFilterImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/LikeFilterImplTest.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.filter;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.geotools.api.filter.FilterFactory;
@@ -84,5 +85,18 @@ public class LikeFilterImplTest {
         } catch (IllegalArgumentException e) {
             // as expected, no OOM anylonger
         }
+    }
+
+    /** Verifies patterns containing ampersand are working as expected */
+    @Test
+    public void testAmpersandHandling() {
+        String input = "this is foo & bar geospatial";
+        String pattern = "*foo & bar*";
+        PropertyIsLike pil = ff.like(ff.literal(input), pattern);
+        String msg = String.format("Expecting '%s' to match '%s'.", pattern, input);
+        assertTrue(msg, pil.evaluate(null));
+
+        pil = ff.like(ff.literal(input), pattern, "*", "?", "!");
+        assertTrue(msg, pil.evaluate(null));
     }
 }


### PR DESCRIPTION
[![GEOT-7590](https://badgen.net/badge/JIRA/GEOT-7590/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7590) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Small fix for supporting ampersand usage in "Like" filters. 
See https://osgeo-org.atlassian.net/browse/GEOT-7590
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

Thank you for taking care!