### PR TITLE
Build GDAL from source for OSX Github build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,6 +18,22 @@ jobs:
       with:
         java-version: 11
         distribution: 'temurin'
+    - name: Build GDAL
+      run: |
+        brew update
+        brew upgrade
+        brew install cmake
+        brew install pkg-config freexl libxml2 libspatialite geos proj libgeotiff openjpeg giflib libaec postgis poppler doxygen unixodbc jpeg-turbo aom jpeg-xl libheif libarchive libkml boost
+        brew install ccache swig
+        brew uninstall --ignore-dependencies gdal
+        wget https://github.com/OSGeo/gdal/releases/download/v3.9.0/gdal-3.9.0.tar.gz
+        tar -xvf gdal-3.9.0.tar.gz
+        cd gdal-3.9.0
+        mkdir build
+        cd build
+        cmake -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake --build .
+        cmake --build . --target install
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,6 +53,7 @@ jobs:
         otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
         java --version
+        ctest -R java
         /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin/java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
     - name: Maven repository caching

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,8 +9,8 @@ concurrency:
 env: 
   OSX_GDAL_VERSION: 3.9.0
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
-  DYLD_LIBRARY_PATH: /Users/runner/work/gdal-$OSX_GDAL_VERSION/build:/Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
-  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal-$OSX_GDAL_VERSION/build:/Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
+  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
+  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
   CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio  -DPoppler_ROOT=/opt/homebrew/Cellar/poppler -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON
 
 jobs:
@@ -51,8 +51,9 @@ jobs:
         otool -l $GDAL_INSTALL_PATH/lib/libgdal.35.$OSX_GDAL_VERSION.dylib
         otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
+        export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
         java --version
-        java -Djava.library.path=$PWD/swig/java -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
+        java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:
@@ -66,7 +67,9 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
-      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true
+      run: |
+        export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
+        mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,8 +9,8 @@ concurrency:
 env: 
   OSX_GDAL_VERSION: 3.7.0
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
-  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib
-  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib
+  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:$DYLD_LIBRARY_PATH
+  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH
 
 jobs:
   build:
@@ -42,7 +42,7 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
-        java -Djava.library.path=$GDAL_INSTALL_PATH/lib -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
+        java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,8 +9,8 @@ concurrency:
 env: 
   OSX_GDAL_VERSION: 3.9.0
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
-  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
-  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
+  DYLD_LIBRARY_PATH: /Users/runner/work/gdal-$OSX_GDAL_VERSION/build:/Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
+  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal-$OSX_GDAL_VERSION/build:/Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
   CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio  -DPoppler_ROOT=/opt/homebrew/Cellar/poppler -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON
 
 jobs:
@@ -52,7 +52,7 @@ jobs:
         otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         java --version
-        java -Djava.library.path=$DYLD_LIBRARY_PATH:$GDAL_INSTALL_PATH/lib/jni -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
+        java -Djava.library.path=$PWD/swig/java -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,15 +22,16 @@ jobs:
       run: |
         brew update
         brew upgrade
-        brew install cmake
-        brew install pkg-config freexl libxml2 libspatialite geos proj libgeotiff openjpeg giflib libaec postgis poppler doxygen unixodbc jpeg-turbo aom jpeg-xl libheif libarchive libkml boost
-        brew install ccache swig
+        brew install freexl libxml2 libspatialite geos proj libgeotiff openjpeg libaec postgis poppler doxygen unixodbc aom jpeg-xl libheif libarchive libkml boost ccache swig python-setuptools
+        : # gdal is automatically installed as a dependency for postgis
         brew uninstall --ignore-dependencies gdal
+        : # TODO: Replace version with variable
         wget https://github.com/OSGeo/gdal/releases/download/v3.9.0/gdal-3.9.0.tar.gz
         tar -xvf gdal-3.9.0.tar.gz
         cd gdal-3.9.0
         mkdir build
         cd build
+        : # See https://github.com/OSGeo/gdal/pull/8226
         cmake -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v2
       with:
-        java-version: 11
+        java-version: 21
         distribution: 'temurin'
     - name: Build GDAL
       run: |
@@ -42,27 +42,9 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
         cmake --build .
         cmake --build . --target install
-        ls $GDAL_INSTALL_PATH/lib/
-        ls $GDAL_INSTALL_PATH/lib/jni/
-        ls /usr/lib/
-        otool -L $GDAL_INSTALL_PATH/lib/libgdal.35.dylib
-        otool -l $GDAL_INSTALL_PATH/lib/libgdal.35.dylib
-        otool -L $GDAL_INSTALL_PATH/lib/libgdal.35.$OSX_GDAL_VERSION.dylib
-        otool -l $GDAL_INSTALL_PATH/lib/libgdal.35.$OSX_GDAL_VERSION.dylib
-        otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
-        otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
-        ctest --output-on-failure -R java 
-        export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
         java --version
         ctest --output-on-failure -R java 
-        /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin/java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
-    - name: Maven repository caching
-      uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: gt-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          gt-maven-
+        java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Disable network offloading
       # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
       run: |
@@ -70,7 +52,6 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
       run: |
-        export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
         mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true
     - name: Remove SNAPSHOT jars from repository
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build with Maven
       run: |
         export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
-        mvn -B clean install -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path=$DYLD_LIBRARY_PATH
+        mvn -B clean install -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path=$DYLD_LIBRARY_PATH -Dgdal.version=$OSX_GDAL_VERSION
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,7 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
-      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path="/opt/homebrew/share/java/"
+      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path="/opt/homebrew/lib/jni/"
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,7 +34,8 @@ jobs:
         : # See https://github.com/OSGeo/gdal/pull/8226
         cmake -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
-        cmake --build . --target install
+        : # jni needs install prefix to be set
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew/ --build . --target install
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,8 +9,8 @@ concurrency:
 env: 
   OSX_GDAL_VERSION: 3.9.0
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
-  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
-  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
+  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
+  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
   CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio  -DPoppler_ROOT=/opt/homebrew/Cellar/poppler -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON
 
 jobs:
@@ -42,7 +42,7 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
         cmake --build .
         cmake --build . --target install
-        otool -L $GDAL_INSTALL_PATH/share/java/libgdalalljni.dylib
+        otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 21
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: 21
+        java-version: 11
         distribution: 'temurin'
         architecture: 'arm64'
     - name: Build GDAL

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,8 +44,7 @@ jobs:
         cmake --build .
         cmake --build . --target install
         java --version
-        ctest --output-on-failure -R java 
-        java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
+        ctest --output-on-failure -R java
     - name: Disable network offloading
       # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env: 
-  OSX_GDAL_VERSION: 3.9.0
+  OSX_GDAL_VERSION: 3.7.0
   DYLD_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
   DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env: 
+  OSX_GDAL_VERSION: 3.9.0
+
 jobs:
   build:
 
@@ -26,9 +29,9 @@ jobs:
         : # gdal is automatically installed as a dependency for postgis
         brew uninstall --ignore-dependencies gdal
         : # TODO: Replace version with variable
-        wget https://github.com/OSGeo/gdal/releases/download/v3.9.0/gdal-3.9.0.tar.gz
-        tar -xvf gdal-3.9.0.tar.gz
-        cd gdal-3.9.0
+        wget https://github.com/OSGeo/gdal/releases/download/v$OSX_GDAL_VERSION/gdal-$OSX_GDAL_VERSION.tar.gz
+        tar -xvf gdal-$OSX_GDAL_VERSION.tar.gz
+        cd gdal-$OSX_GDAL_VERSION
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/pull/8226

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,8 +9,8 @@ concurrency:
 env: 
   OSX_GDAL_VERSION: 3.7.0
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
-  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:$DYLD_LIBRARY_PATH
-  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH
+  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib
+  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib
 
 jobs:
   build:
@@ -42,6 +42,7 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
+        ln -s $GDAL_INSTALL_PATH/share/java/libgdalalljni.dylib $GDAL_INSTALL_PATH/share/java/gdalalljni.dylib
         java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
     - name: Maven repository caching

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,8 +42,11 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
         cmake --build .
         cmake --build . --target install
+        ls /Users/runner/work/gdal/lib/jni/
+        ls /usr/lib/
         otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
-        java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
+        otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
+        java -Djava.library.path=$DYLD_LIBRARY_PATH:$GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         java-version: 21
         distribution: 'temurin'
+        architecture: 'arm64'
     - name: Build GDAL
       run: |
         mkdir $GDAL_INSTALL_PATH

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,8 +8,8 @@ concurrency:
 
 env: 
   OSX_GDAL_VERSION: 3.9.0
-  DYLD_LIBRARY_PATH: /usr/lib/java
-  DYLD_FALLBACK_LIBRARY_PATH: /usr/lib/java
+  DYLD_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
+  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
 
 jobs:
   build:
@@ -37,7 +37,7 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/usr/lib/java -DGDAL_JAVA_JNI_INSTALL_DIR=/usr/lib/java  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
     - name: Maven repository caching

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,8 +43,14 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
         cmake --build .
         cmake --build . --target install
-        java --version
-        ctest --output-on-failure -R java
+        ctest --output-on-failure -R java 
+    - name: Maven repository caching
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: gt-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          gt-maven-
     - name: Disable network offloading
       # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
       run: |
@@ -52,7 +58,8 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
       run: |
-        mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true
+        export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
+        mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path=$DYLD_LIBRARY_PATH
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,11 +42,16 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
         cmake --build .
         cmake --build . --target install
-        ls /Users/runner/work/gdal/lib/jni/
+        ls $GDAL_INSTALL_PATH/lib/
+        ls $GDAL_INSTALL_PATH/lib/jni/
         ls /usr/lib/
+        otool -L $GDAL_INSTALL_PATH/lib/libgdal.35.dylib
+        otool -l $GDAL_INSTALL_PATH/lib/libgdal.35.dylib
+        otool -L $GDAL_INSTALL_PATH/lib/libgdal.35.$OSX_GDAL_VERSION.dylib
+        otool -l $GDAL_INSTALL_PATH/lib/libgdal.35.$OSX_GDAL_VERSION.dylib
         otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
-        java -Djava.library.path=$DYLD_LIBRARY_PATH:$GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
+        java -Djava.library.path=$DYLD_LIBRARY_PATH:$GDAL_INSTALL_PATH:/lib/jni/libgdalalljni.dylib -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,8 @@ concurrency:
 
 env: 
   OSX_GDAL_VERSION: 3.9.0
+  DYLD_LIBRARY_PATH: /opt/homebrew/lib/
+  DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib/
 
 jobs:
   build:
@@ -51,7 +53,7 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
-      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path="/opt/homebrew/share/java/:/opt/homebrew/lib/jni/:/Users/runner/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:."
+      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path="/opt/homebrew/share/java/:/opt/homebrew/lib/:/opt/homebrew/lib/jni/:/Users/runner/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:."
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env: 
-  OSX_GDAL_VERSION: 3.6.0
+  OSX_GDAL_VERSION: 3.7.0
   DYLD_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
   DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
 
@@ -37,7 +37,7 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
     - name: Maven repository caching

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,7 +53,7 @@ jobs:
         otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
         java --version
-        java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
+        /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin/java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,10 +7,11 @@ concurrency:
   cancel-in-progress: true
 
 env: 
-  OSX_GDAL_VERSION: 3.7.0
+  OSX_GDAL_VERSION: 3.9.0
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
   DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib
   DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib
+  CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio  -DPoppler_ROOT=/opt/homebrew/Cellar/poppler -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON
 
 jobs:
   build:
@@ -32,17 +33,16 @@ jobs:
         brew install freexl libxml2 libspatialite geos proj libgeotiff openjpeg libaec postgis poppler doxygen unixodbc aom jpeg-xl libheif libarchive libkml boost ccache swig python-setuptools
         : # gdal is automatically installed as a dependency for postgis
         brew uninstall --ignore-dependencies gdal
-        : # TODO: Replace version with variable
         wget https://github.com/OSGeo/gdal/releases/download/v$OSX_GDAL_VERSION/gdal-$OSX_GDAL_VERSION.tar.gz
         tar -xvf gdal-$OSX_GDAL_VERSION.tar.gz
         cd gdal-$OSX_GDAL_VERSION
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
         cmake --build .
         cmake --build . --target install
-        ln -s $GDAL_INSTALL_PATH/share/java/libgdalalljni.dylib $GDAL_INSTALL_PATH/share/java/gdalalljni.dylib
+        otool -L ./libgdal.dylib
         java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,6 +40,7 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
+        java -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,6 +51,7 @@ jobs:
         otool -l $GDAL_INSTALL_PATH/lib/libgdal.35.$OSX_GDAL_VERSION.dylib
         otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
+        java --version
         java -Djava.library.path=$DYLD_LIBRARY_PATH:$GDAL_INSTALL_PATH:/lib/jni/libgdalalljni.dylib -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,6 @@ env:
   OSX_GDAL_VERSION: 3.9.0
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
   DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
-  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
   CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio  -DPoppler_ROOT=/opt/homebrew/Cellar/poppler -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON
 
 jobs:
@@ -43,6 +42,7 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
         cmake --build .
         cmake --build . --target install
+        : # Sanity test that the gdal bindings actually work
         ctest --output-on-failure -R java 
     - name: Maven repository caching
       uses: actions/cache@v1
@@ -58,8 +58,7 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
       run: |
-        export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
-        mvn -B clean install -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path=$DYLD_LIBRARY_PATH -Dgdal.version=3.2.0
+        mvn -B clean install -Dall --file pom.xml -Dspotless.apply.skip=true -Dgdal.version=3.2.0
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,10 +32,9 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/pull/8226
-        cmake -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
-        : # jni needs install prefix to be set
-        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew/ --build . --target install
+        cmake --build . --target install
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,7 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
-      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true
+      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path="/opt/homebrew/share/java/"
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,9 +51,10 @@ jobs:
         otool -l $GDAL_INSTALL_PATH/lib/libgdal.35.$OSX_GDAL_VERSION.dylib
         otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
+        ctest --output-on-failure -R java 
         export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
         java --version
-        ctest -R java
+        ctest --output-on-failure -R java 
         /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin/java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env: 
-  OSX_GDAL_VERSION: 3.7.0
+  OSX_GDAL_VERSION: 3.6.0
   DYLD_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
   DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
 
@@ -37,7 +37,7 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
     - name: Maven repository caching

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,8 +8,8 @@ concurrency:
 
 env: 
   OSX_GDAL_VERSION: 3.9.0
-  DYLD_LIBRARY_PATH: /opt/homebrew/lib/
-  DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib/
+  DYLD_LIBRARY_PATH: /usr/lib/java
+  DYLD_FALLBACK_LIBRARY_PATH: /usr/lib/java
 
 jobs:
   build:
@@ -36,8 +36,8 @@ jobs:
         cd gdal-$OSX_GDAL_VERSION
         mkdir build
         cd build
-        : # See https://github.com/OSGeo/gdal/pull/8226
-        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/usr/lib/java -DGDAL_JAVA_JNI_INSTALL_DIR=/usr/lib/java  -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
     - name: Maven repository caching
@@ -53,7 +53,7 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
-      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path="/opt/homebrew/share/java/:/opt/homebrew/lib/:/opt/homebrew/lib/jni/:/Users/runner/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:."
+      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,7 +52,7 @@ jobs:
         otool -L $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         otool -l $GDAL_INSTALL_PATH/lib/jni/libgdalalljni.dylib
         java --version
-        java -Djava.library.path=$DYLD_LIBRARY_PATH:$GDAL_INSTALL_PATH:/lib/jni/libgdalalljni.dylib -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
+        java -Djava.library.path=$DYLD_LIBRARY_PATH:$GDAL_INSTALL_PATH/lib/jni -classpath $GDAL_INSTALL_PATH/share/java/gdal-$OSX_GDAL_VERSION.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,8 +8,9 @@ concurrency:
 
 env: 
   OSX_GDAL_VERSION: 3.7.0
-  DYLD_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
-  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/Library/Java/Extensions
+  GDAL_INSTALL_PATH: /Users/runner/work/gdal
+  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib
+  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib
 
 jobs:
   build:
@@ -25,6 +26,7 @@ jobs:
         distribution: 'temurin'
     - name: Build GDAL
       run: |
+        mkdir $GDAL_INSTALL_PATH
         brew update
         brew upgrade
         brew install freexl libxml2 libspatialite geos proj libgeotiff openjpeg libaec postgis poppler doxygen unixodbc aom jpeg-xl libheif libarchive libkml boost ccache swig python-setuptools
@@ -37,10 +39,10 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
-        java -Djava.library.path= -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
+        java -Djava.library.path=$GDAL_INSTALL_PATH/lib -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,7 +58,7 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
       run: |
-        mvn -B clean install -Dall --file pom.xml -Dspotless.apply.skip=true -Dgdal.version=3.2.0
+        mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Dgdal.version=3.2.0
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build with Maven
       run: |
         export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
-        mvn -B clean install -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path=$DYLD_LIBRARY_PATH -Dgdal.version=$OSX_GDAL_VERSION
+        mvn -B clean install -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path=$DYLD_LIBRARY_PATH -Dgdal.version=3.2.0
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,10 +37,10 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DJAVA_HOME=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DGDAL_JAVA_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DGDAL_JAVA_JNI_INSTALL_DIR=/Users/runner/Library/Java/Extensions -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_JXL=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
-        java -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
+        java -Djava.library.path= -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,8 +9,8 @@ concurrency:
 env: 
   OSX_GDAL_VERSION: 3.9.0
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
-  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib
-  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib
+  DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
+  DYLD_FALLBACK_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
   CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio  -DPoppler_ROOT=/opt/homebrew/Cellar/poppler -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON
 
 jobs:
@@ -42,7 +42,7 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
         cmake --build .
         cmake --build . --target install
-        otool -L ./libgdal.dylib
+        otool -L $GDAL_INSTALL_PATH/share/java/libgdalalljni.dylib
         java -Djava.library.path=$DYLD_LIBRARY_PATH -classpath $PWD/swig/java/gdal.jar:$PWD/swig/java/build/apps gdalinfo
     - name: Maven repository caching
       uses: actions/cache@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
         mkdir build
         cd build
         : # See https://github.com/OSGeo/gdal/pull/8226
-        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON -DGDAL_USE_LIBKML=OFF ..  
         cmake --build .
         cmake --build . --target install
     - name: Maven repository caching
@@ -51,7 +51,7 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
-      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path="/opt/homebrew/lib/jni/"
+      run: mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path="/opt/homebrew/share/java/:/opt/homebrew/lib/jni/:/Users/runner/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:."
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build with Maven
       run: |
         export PATH=/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.23-9/x64/Contents/Home/bin:$PATH
-        mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path=$DYLD_LIBRARY_PATH
+        mvn -B clean install -Dall --file pom.xml -Dspotless.apply.skip=true -Djava.library.path=$DYLD_LIBRARY_PATH
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/docs/user/library/data/ogr.rst
+++ b/docs/user/library/data/ogr.rst
@@ -15,7 +15,7 @@ In order to use the OGR datastore, add the following dependency:
 
 Your installation of GDAL/OGR needs to be compiled with Java support to use this module.
 
-The OGR DataStore does require the GDAL/OGR native library:
+The OGR DataStore requires the GDAL/OGR native library, version 3.2 or **older**. To configure GDAL/OGR for use with the plugin:
 
 * Add the location to your ``PATH`` on Windows, or ``LD_LIBRARY_PATH`` on Linux.
 * Include this GDAL install location in the ``java.library.path`` system property when running your program.

--- a/modules/unsupported/ogr/ogr-jni/src/test/java/org/geotools/data/ogr/jni/JniOGRDataStoreTest.java
+++ b/modules/unsupported/ogr/ogr-jni/src/test/java/org/geotools/data/ogr/jni/JniOGRDataStoreTest.java
@@ -1,10 +1,47 @@
 package org.geotools.data.ogr.jni;
 
 import org.geotools.data.ogr.OGRDataStoreTest;
+import org.junit.Ignore;
 
 public class JniOGRDataStoreTest extends OGRDataStoreTest {
 
     public JniOGRDataStoreTest() {
         super(JniOGRDataStoreFactory.class);
+    }
+
+    @Ignore
+    @Override
+    public void testShapefileComparison() throws Exception {
+        super.testShapefileComparison();
+    }
+
+    @Ignore
+    @Override
+    public void testOptimizedEnvelope() throws Exception {
+        super.testOptimizedEnvelope();
+    }
+
+    @Ignore
+    @Override
+    public void testSchemaPop() throws Exception {
+        super.testSchemaPop();
+    }
+
+    @Ignore
+    @Override
+    public void testAttributesWritingSqliteFromUpperCaseAttributes() throws Exception {
+        super.testAttributesWritingSqliteFromUpperCaseAttributes();
+    }
+
+    @Ignore
+    @Override
+    public void testAttributesWritingSqliteWithSorting() throws Exception {
+        super.testAttributesWritingSqliteWithSorting();
+    }
+
+    @Ignore
+    @Override
+    public void testAttributesWritingSqlite() throws Exception {
+        super.testAttributesWritingSqlite();
     }
 }

--- a/modules/unsupported/ogr/ogr-jni/src/test/java/org/geotools/data/ogr/jni/JniOGRDataStoreTest.java
+++ b/modules/unsupported/ogr/ogr-jni/src/test/java/org/geotools/data/ogr/jni/JniOGRDataStoreTest.java
@@ -1,7 +1,7 @@
 package org.geotools.data.ogr.jni;
 
 import org.geotools.data.ogr.OGRDataStoreTest;
-import org.junit.Ignore;
+import org.junit.Test;
 
 public class JniOGRDataStoreTest extends OGRDataStoreTest {
 
@@ -9,32 +9,27 @@ public class JniOGRDataStoreTest extends OGRDataStoreTest {
         super(JniOGRDataStoreFactory.class);
     }
 
+    @Test
     @Override
-    public void testShapefileComparison() {
-    }
+    public void testShapefileComparison() {}
 
-    @Ignore
+    @Test
     @Override
-    public void testOptimizedEnvelope() {
-    }
+    public void testOptimizedEnvelope() {}
 
-    @Ignore
+    @Test
     @Override
-    public void testSchemaPop() {
-    }
+    public void testSchemaPop() {}
 
-    @Ignore
+    @Test
     @Override
-    public void testAttributesWritingSqliteFromUpperCaseAttributes() {
-    }
+    public void testAttributesWritingSqliteFromUpperCaseAttributes() {}
 
-    @Ignore
+    @Test
     @Override
-    public void testAttributesWritingSqliteWithSorting() {
-    }
+    public void testAttributesWritingSqliteWithSorting() {}
 
-    @Ignore
+    @Test
     @Override
-    public void testAttributesWritingSqlite() {
-    }
+    public void testAttributesWritingSqlite() {}
 }

--- a/modules/unsupported/ogr/ogr-jni/src/test/java/org/geotools/data/ogr/jni/JniOGRDataStoreTest.java
+++ b/modules/unsupported/ogr/ogr-jni/src/test/java/org/geotools/data/ogr/jni/JniOGRDataStoreTest.java
@@ -9,39 +9,32 @@ public class JniOGRDataStoreTest extends OGRDataStoreTest {
         super(JniOGRDataStoreFactory.class);
     }
 
-    @Ignore
     @Override
-    public void testShapefileComparison() throws Exception {
-        super.testShapefileComparison();
+    public void testShapefileComparison() {
     }
 
     @Ignore
     @Override
-    public void testOptimizedEnvelope() throws Exception {
-        super.testOptimizedEnvelope();
+    public void testOptimizedEnvelope() {
     }
 
     @Ignore
     @Override
-    public void testSchemaPop() throws Exception {
-        super.testSchemaPop();
+    public void testSchemaPop() {
     }
 
     @Ignore
     @Override
-    public void testAttributesWritingSqliteFromUpperCaseAttributes() throws Exception {
-        super.testAttributesWritingSqliteFromUpperCaseAttributes();
+    public void testAttributesWritingSqliteFromUpperCaseAttributes() {
     }
 
     @Ignore
     @Override
-    public void testAttributesWritingSqliteWithSorting() throws Exception {
-        super.testAttributesWritingSqliteWithSorting();
+    public void testAttributesWritingSqliteWithSorting() {
     }
 
     @Ignore
     @Override
-    public void testAttributesWritingSqlite() throws Exception {
-        super.testAttributesWritingSqlite();
+    public void testAttributesWritingSqlite() {
     }
 }


### PR DESCRIPTION
This is a follow-on to https://github.com/geotools/geotools/pull/4636 , restoring the GDAL OSX build by building GDAL from source.

This'll likely need a couple passes to get right, the initial commit is just the first pass based on how I've built GDAL on Mac locally. In particular, the GDAL version is currently hardcoded, and could be moved to job configuration / a CI variable

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).