### PR TITLE
Fix url for the user mailing list archives

### DIFF
--- a/docs/user/welcome/userlistguide.rst
+++ b/docs/user/welcome/userlistguide.rst
@@ -58,7 +58,7 @@ Before posting a question, check to see if it is already answered in the followi
 
    - `Tutorials <http://docs.geotools.org/latest/userguide/tutorial/>`_.
 
-   - `User list archives <http://osgeo-org.1560.n6.nabble.com/geotools-gt2-users-f4317834.html>`_.
+   - `User list archives <https://sourceforge.net/p/geotools/mailman/geotools-gt2-users/>`_.
 
 Post enough (but not too much)
 ------------------------------


### PR DESCRIPTION
I tried to find the user mailing list archive and stumbled upon the "GeoTools user list posting guide". Unfortunately the link to "User list archives" was broken. After a little bit of research I found the new user mailinglist archive: https://sourceforge.net/p/geotools/mailman/geotools-gt2-users/
This PR fixes this issue.