### PR TITLE
[GEOT-7601] Transform FeatureCollection Query handling of reprojection

### DIFF
--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/filter/expression/ToLineStringFunction.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/filter/expression/ToLineStringFunction.java
@@ -27,6 +27,7 @@ import org.geotools.api.filter.expression.Literal;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.filter.capability.FunctionNameImpl;
+import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultVerticalCRS;
 import org.geotools.referencing.cs.DefaultVerticalCS;
@@ -151,7 +152,7 @@ public class ToLineStringFunction implements Function {
             points[1] = new Coordinate(dblTwo, Coordinate.NULL_ORDINATE, Coordinate.NULL_ORDINATE);
 
             linestring = geomFactory.createLineString(points);
-            linestring.setUserData(crs);
+            JTS.setCRS(linestring, crs);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException(
                     "Error converting the parameters for toLineString function: "

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/filter/expression/ToPointFunction.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/appschema/filter/expression/ToPointFunction.java
@@ -32,6 +32,7 @@ import org.geotools.api.referencing.NoSuchAuthorityCodeException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.capability.FunctionNameImpl;
+import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -184,13 +185,13 @@ public class ToPointFunction implements Function {
      * @param gmlId gml:id value
      */
     private void setUserData(Point point, CoordinateReferenceSystem crs, String gmlId) {
-        Map<Object, Object> userData = new HashMap<>();
         if (gmlId != null) {
+            Map<Object, Object> userData = new HashMap<>();
             userData.put("gml:id", gmlId);
+            point.setUserData(userData);
         }
         if (crs != null) {
-            userData.put(CoordinateReferenceSystem.class, crs);
+            JTS.setCRS(point, crs);
         }
-        point.setUserData(userData);
     }
 }

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/appschema/filter/GeometryFunctionsTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/appschema/filter/GeometryFunctionsTest.java
@@ -43,6 +43,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeImpl;
 import org.geotools.feature.type.AttributeDescriptorImpl;
+import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.gml3.GMLSchema;
 import org.geotools.referencing.CRS;
@@ -297,7 +298,7 @@ public class GeometryFunctionsTest extends AppSchemaTestSupport {
         LineString linestring = (LineString) value;
         assertEquals(linestring.getDimension(), 1);
         // 1D SRS should be created
-        CoordinateReferenceSystem crs = (CoordinateReferenceSystem) linestring.getUserData();
+        CoordinateReferenceSystem crs = JTS.getCRS(linestring);
         assertEquals(1, crs.getCoordinateSystem().getDimension());
         assertEquals("EPSG:9902", crs.getName().getCode());
         assertEquals(linestring.getCoordinateN(0).x, 5.0, 0);
@@ -318,7 +319,7 @@ public class GeometryFunctionsTest extends AppSchemaTestSupport {
         LineString linestring = (LineString) value;
         assertEquals(linestring.getDimension(), 1);
         // 1D SRS should be created
-        CoordinateReferenceSystem crs = (CoordinateReferenceSystem) linestring.getUserData();
+        CoordinateReferenceSystem crs = JTS.getCRS(linestring);
         assertEquals(1, crs.getCoordinateSystem().getDimension());
         assertEquals(customSRS, crs.getName().getCode());
         assertEquals(linestring.getCoordinateN(0).x, 5.0, 0);

--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/CRSEvaluator.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/CRSEvaluator.java
@@ -30,7 +30,7 @@ import org.geotools.api.filter.expression.NilExpression;
 import org.geotools.api.filter.expression.PropertyName;
 import org.geotools.api.filter.expression.Subtract;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.referencing.CRS;
+import org.geotools.geometry.jts.JTS;
 import org.locationtech.jts.geom.Geometry;
 
 /**
@@ -51,17 +51,9 @@ class CRSEvaluator implements ExpressionVisitor {
         Object value = expression.getValue();
         if (value instanceof Geometry) {
             Geometry g = (Geometry) value;
-            if (g.getUserData() instanceof CoordinateReferenceSystem) {
-                return g.getUserData();
-            } else if (g.getSRID() > 0) {
-                try {
-                    return CRS.decode("EPSG:" + g.getSRID());
-                } catch (Exception e) {
-                    return null;
-                }
-            }
+            CoordinateReferenceSystem crs = JTS.getCRS(g);
+            return crs;
         }
-
         return null;
     }
 

--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureCollection.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureCollection.java
@@ -44,6 +44,7 @@ import org.geotools.feature.visitor.MaxVisitor;
 import org.geotools.feature.visitor.MinVisitor;
 import org.geotools.feature.visitor.UniqueVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -69,12 +70,19 @@ class TransformFeatureCollection extends AbstractFeatureCollection {
         this.query = query;
     }
 
-    /** Creates a sub-schema with only the selected attributes */
+    /**
+     * Creates a sub-schema with only the selected attributes.
+     *
+     * <p>Transformer is going to trust that the source can handle any reprojection.
+     */
     static SimpleFeatureType retypeSchema(SimpleFeatureType schema, Query query) {
-        if (query.getPropertyNames() == Query.ALL_NAMES) {
+        if (query.getPropertyNames() == Query.ALL_NAMES
+                && CRS.equalsIgnoreMetadata(
+                        schema.getCoordinateReferenceSystem(),
+                        query.getCoordinateSystemReproject())) {
             return schema;
         } else {
-            return SimpleFeatureTypeBuilder.retype(schema, query.getPropertyNames());
+            return SimpleFeatureTypeBuilder.retype(schema, query);
         }
     }
 
@@ -123,7 +131,7 @@ class TransformFeatureCollection extends AbstractFeatureCollection {
 
             result = new SimpleFeatureIteratorIterator(transformed);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Transform failure: " + e.getMessage(), e);
         } finally {
             // if result is null, an exception has occurred, close the wrapped iterator
             if (result == null) {

--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/Transformer.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/Transformer.java
@@ -255,6 +255,11 @@ class Transformer {
         txQuery.setSortBy(getTransformedSortBy(query));
         txQuery.setFilter(txFilter);
 
+        // Right now source is responsible for handling reprojection
+        // (we may change this in the future, to provide geometry for functions such as buffer)
+        txQuery.setCoordinateSystem(query.getCoordinateSystem());
+        txQuery.setCoordinateSystemReproject(query.getCoordinateSystemReproject());
+
         // can we support the required sorting?
         QueryCapabilities caps = source.getQueryCapabilities();
         if (query.getSortBy() != null && !caps.supportsSorting(txQuery.getSortBy())) {

--- a/modules/library/main/src/main/java/org/geotools/api/data/Query.java
+++ b/modules/library/main/src/main/java/org/geotools/api/data/Query.java
@@ -31,6 +31,7 @@ import org.geotools.api.filter.identity.Version;
 import org.geotools.api.filter.sort.SortBy;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.referencing.CRS;
 import org.geotools.util.factory.Hints;
 
 /**
@@ -955,6 +956,18 @@ public class Query {
                 if (i < (properties.size() - 1)) {
                     returnString.append(", ");
                 }
+            }
+
+            returnString.append("]");
+        }
+        if (coordinateSystem != null || coordinateSystemReproject != null) {
+            returnString.append("\n   [");
+            if (coordinateSystem != null) {
+                returnString.append(CRS.toSRS(coordinateSystem));
+            }
+            if (coordinateSystemReproject != null) {
+                returnString.append(" --> ");
+                returnString.append(CRS.toSRS(coordinateSystemReproject));
             }
 
             returnString.append("]");

--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureBuilder.java
@@ -361,6 +361,12 @@ public class SimpleFeatureBuilder extends FeatureBuilder<FeatureType, Feature> {
      * @param id FeatureID for the generated feature, use null to allow one to be supplied for you
      */
     public static SimpleFeature build(SimpleFeatureType type, List<Object> values, String id) {
+        if (type.getAttributeCount() != values.size()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s attributes %d count does not match %d values provided",
+                            type.getTypeName(), type.getAttributeCount(), values.size()));
+        }
         return build(type, values.toArray(), id);
     }
 

--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
@@ -1080,21 +1080,21 @@ public class SimpleFeatureTypeBuilder {
         // initialize the builder
         b.init(original);
 
-        List<String> properties;
+        List<String> attributeNames;
         if (attributes == Query.ALL_NAMES) {
-            properties =
+            attributeNames =
                     original.getAttributeDescriptors().stream()
                             .map(AttributeDescriptor::getLocalName)
                             .collect(Collectors.toList());
         } else {
-            properties = Arrays.asList(attributes);
+            attributeNames = Arrays.asList(attributes);
         }
 
         // clear the attributes
         b.attributes().clear();
 
         // add attributes in order requested
-        for (String localName : properties) {
+        for (String localName : attributeNames) {
             AttributeDescriptor descriptor = original.getDescriptor(localName);
             if (descriptor instanceof GeometryDescriptor) {
                 GeometryDescriptor geometryDescriptor =
@@ -1109,7 +1109,7 @@ public class SimpleFeatureTypeBuilder {
         GeometryDescriptor defaultGeometry = original.getGeometryDescriptor();
         String defaultGeometryName =
                 defaultGeometry != null ? defaultGeometry.getLocalName() : null;
-        if (defaultGeometryName != null && properties.contains(defaultGeometryName)) {
+        if (defaultGeometryName != null && attributeNames.contains(defaultGeometryName)) {
             b.setDefaultGeometry(defaultGeometryName);
         } else {
             b.setDefaultGeometry(null);

--- a/modules/library/main/src/main/java/org/geotools/feature/type/Types.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/type/Types.java
@@ -27,6 +27,7 @@ import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import org.geotools.api.feature.Attribute;
 import org.geotools.api.feature.ComplexAttribute;
+import org.geotools.api.feature.Feature;
 import org.geotools.api.feature.IllegalAttributeException;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.AttributeDescriptor;
@@ -63,7 +64,7 @@ public class Types {
      * Ensures an attribute value is withing the restrictions of the AttributeDescriptor and
      * AttributeType.
      *
-     * @return true if the attribute value is valid
+     * @return true if the attribute value is valid.
      */
     public static boolean isValid(Attribute attribute) {
 
@@ -74,8 +75,11 @@ public class Types {
             return false;
         }
     }
+
     /**
      * Validates content against an attribute.
+     *
+     * <p>Same result as calling: {@code validate(attribute.getType(), attribute, attributeContent)}
      *
      * @param attribute The attribute.
      * @param attributeContent Content of attribute (often attribute.getValue()
@@ -84,10 +88,12 @@ public class Types {
      */
     public static void validate(Attribute attribute, Object attributeContent)
             throws IllegalAttributeException {
-
         validate(attribute.getType(), attribute, attributeContent, false);
     }
+
     /**
+     * Validates content against attribute (using the supplied attribute type).
+     *
      * @param type AttributeType (often attribute.getType() )
      * @param attribute Attribute being tested
      * @param attributeContent Content of the attribute (often attribute.getValue() )
@@ -99,6 +105,8 @@ public class Types {
     }
 
     /**
+     * Validates content against attribute (using the supplied attribute type).
+     *
      * @param type AttributeType (often attribute.getType() )
      * @param attribute Attribute being tested
      * @param attributeContent Content of the attribute (often attribute.getValue() )
@@ -124,13 +132,11 @@ public class Types {
         }
 
         if (!isSuper) {
-
-            // JD: This is an issue with how the xml simpel type hierarchy
-            // maps to our current Java Type hiearchy, the two are inconsitent.
+            // JD: This is an issue with how the xml simple type hierarchy
+            // maps to our current Java Type hierarchy, the two are inconsistent.
             // For instance, xs:integer, and xs:int, the later extend the
             // former, but their associated java bindings, (BigDecimal, and
-            // Integer)
-            // dont.
+            // Integer) do not.
             Class<?> clazz = attributeContent.getClass();
             Class<?> binding = type.getBinding();
             if (binding != null && binding != clazz && !binding.isAssignableFrom(clazz)) {
@@ -140,6 +146,19 @@ public class Types {
                                 + type.getName()
                                 + " as it is not assignable from "
                                 + binding);
+            }
+        }
+
+        if (type instanceof ComplexType
+                && attribute instanceof ComplexAttribute
+                && attributeContent instanceof Collection) {
+            if (!isSuper || attribute instanceof Feature) {
+                // JG: If we are going to check super, only validate once for ComplexAttribute
+                // (not subclasses like Feature and SimpleFeature)
+
+                @SuppressWarnings("unchecked")
+                Collection<Attribute> attributeList = (Collection<Attribute>) attributeContent;
+                validateAll((ComplexType) type, (ComplexAttribute) attribute, attributeList);
             }
         }
 
@@ -644,30 +663,51 @@ public class Types {
     }
 
     /**
-     * Validates anattribute. <br>
+     * Validates attribute. <br>
      *
-     * <p>Same result as calling:
-     *
-     * <pre>
-     *  &lt;code&gt;
-     * validate(attribute.type(), attribute)
-     * &lt;/code&gt;
-     * </pre>
+     * <p>Same result as calling: {@code validate(attribute, attribute.getValue())}
      *
      * @param attribute The attribute.
      * @throws IllegalAttributeException In the event that content violates any restrictions
      *     specified by the attribute.
      */
     public static void validate(Attribute attribute) throws IllegalAttributeException {
-
         validate(attribute, attribute.getValue());
     }
 
-    public static void validate(ComplexAttribute attribute) throws IllegalArgumentException {}
+    /**
+     * Validate complex attribute, including all properties.
+     *
+     * <p>Same result as calling: {@code validate(attribute,attribute.getProperties())}
+     *
+     * @param attribute
+     * @throws IllegalArgumentException
+     */
+    public static void validate(ComplexAttribute attribute) throws IllegalArgumentException {
+        validate(attribute, attribute.getProperties());
+    }
 
-    public static void validate(ComplexAttribute attribute, Collection content)
-            throws IllegalArgumentException {}
+    /**
+     * Validate content using complex attribute restrictions.
+     *
+     * <p>Same result as calling: {@code validate(attribute.type(), attribute)}
+     *
+     * @param attribute
+     * @throws IllegalArgumentException
+     */
+    public static void validate(ComplexAttribute attribute, Collection<Attribute> content)
+            throws IllegalArgumentException {
+        validate(attribute.getType(), attribute, content);
+    }
 
+    /**
+     * Validate content using complex attribute and type restrictions.
+     *
+     * @param type
+     * @param attribute
+     * @param content
+     * @throws IllegalAttributeException
+     */
     protected static void validate(
             ComplexType type, ComplexAttribute attribute, Collection<Attribute> content)
             throws IllegalAttributeException {
@@ -735,38 +775,62 @@ public class Types {
         }
     }
 
+    /**
+     * Validate attribute content values, and check also that attributes follow min / max occurs
+     * restrictions.
+     *
+     * @param type ComplexType being validated, may be a super type or abstract
+     * @param att ComplexAttribute
+     * @param content Attributes in order provided for validation
+     * @throws IllegalAttributeException
+     */
     private static void validateAll(
             ComplexType type, ComplexAttribute att, Collection<Attribute> content)
             throws IllegalAttributeException {
-        processAll(type.getDescriptors(), content);
+
+        // JG: validate each attribute individually
+        for (Attribute attribute : content) {
+            validate(attribute);
+        }
+        if (!type.isAbstract()) {
+            // Check content follows min / max occurs restrictions
+            processAll(descriptors(type), content);
+        }
     }
 
+    /**
+     * Check the content follows the property min / max occurs restrictions.
+     *
+     * @param all Descriptors providing min / max occurs restrictions
+     * @param content attribute content in supplied in order
+     * @throws IllegalAttributeException
+     */
     private static void processAll(
             Collection<PropertyDescriptor> all, Collection<Attribute> content)
             throws IllegalAttributeException {
 
-        // TODO: JD: this can be definitley be optimzed, as written its O(n^2)
+        // TODO: JD: this can be definitely be optimized, as written its O(n^2)
 
-        // for each descriptor, count occurences of each matching attribute
+        // for each descriptor, count occurrences of each matching attribute
         ArrayList<Attribute> remaining = new ArrayList<>(content);
         for (PropertyDescriptor ad : all) {
             int min = ad.getMinOccurs();
             int max = ad.getMaxOccurs();
-            int occurences = 0;
+            int occurrences = 0;
 
             for (Iterator citr = remaining.iterator(); citr.hasNext(); ) {
                 Attribute a = (Attribute) citr.next();
                 if (a.getName().equals(ad.getName())) {
-                    occurences++;
+                    occurrences++;
                     citr.remove();
                 }
             }
 
-            if (occurences < ad.getMinOccurs() || occurences > ad.getMaxOccurs()) {
+            if (occurrences < ad.getMinOccurs() || occurrences > ad.getMaxOccurs()) {
                 throw new IllegalAttributeException(
                         (AttributeDescriptor) ad,
                         "Found "
-                                + occurences
+                                + occurrences
                                 + " of "
                                 + ad.getName()
                                 + " when type"
@@ -778,9 +842,10 @@ public class Types {
         }
 
         if (!remaining.isEmpty()) {
+            Attribute next = remaining.iterator().next();
             throw new IllegalAttributeException(
-                    (AttributeDescriptor) remaining.iterator().next(),
-                    "Extra content found beyond the specified in the schema: " + remaining);
+                    next.getDescriptor(),
+                    "Extra content found beyond that specified in the schema: " + remaining);
         }
     }
 

--- a/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleFeatureBuilderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleFeatureBuilderTest.java
@@ -19,13 +19,17 @@ package org.geotools.feature.simple;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.geotools.api.feature.Attribute;
+import org.geotools.api.feature.IllegalAttributeException;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.PropertyIsEqualTo;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.AttributeTypeBuilder;
+import org.geotools.feature.type.Types;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,9 +46,19 @@ public class SimpleFeatureBuilderTest {
     @Before
     public void setUp() throws Exception {
         SimpleFeatureTypeBuilder typeBuilder = new SimpleFeatureTypeBuilder();
+        AttributeTypeBuilder attributeBuilder = new AttributeTypeBuilder();
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+
         typeBuilder.setName("test");
         typeBuilder.add("point", Point.class, (CoordinateReferenceSystem) null);
-        typeBuilder.add("integer", Integer.class);
+
+        // integer value is required, and must be non-negative
+        Filter nonNegative = ff.greaterOrEqual(ff.property("."), ff.literal(0));
+        attributeBuilder.setBinding(Integer.class);
+        attributeBuilder.setNillable(false);
+        attributeBuilder.addRestriction(nonNegative);
+        typeBuilder.add(attributeBuilder.buildDescriptor("integer"));
+
         typeBuilder.add("float", Float.class);
 
         featureType = typeBuilder.buildFeatureType();
@@ -71,14 +85,57 @@ public class SimpleFeatureBuilderTest {
     }
 
     @Test
-    public void testTooFewAttributes() throws Exception {
+    public void testValidation() {
+        GeometryFactory gf = new GeometryFactory();
+        Point point = gf.createPoint(new Coordinate(0, 0));
+
+        builder.setValidating(false);
+        builder.add(point);
+        builder.add(-1);
+        builder.add(0.0f);
+        SimpleFeature invalidFeature = builder.buildFeature("invalid");
+
+        Assert.assertTrue("valid", Types.isValid((Attribute) invalidFeature.getProperty("point")));
+        Assert.assertFalse(
+                "valid", Types.isValid((Attribute) invalidFeature.getProperty("integer")));
+        Assert.assertTrue("valid", Types.isValid((Attribute) invalidFeature.getProperty("float")));
+        Assert.assertFalse("invalid", Types.isValid(invalidFeature));
+
+        builder.setValidating(true);
+        builder.add(point);
+        try {
+            builder.add(-1);
+            Assert.fail(
+                    "Builder with validation enabled should not be able to add an invalid value");
+        } catch (IllegalAttributeException huh) {
+            // expected error
+        }
+
+        builder.reset();
+        builder.setValidating(false);
+        builder.add(point);
+        builder.add(-1);
+        builder.add(0.0f);
+
+        builder.setValidating(true);
+        try {
+            SimpleFeature brokenFeature = builder.buildFeature("broken");
+            Assert.assertNotNull(brokenFeature);
+            Assert.fail("Builder with validation should not produce invalid feature");
+        } catch (IllegalAttributeException huh) {
+            // expected error
+        }
+    }
+
+    @Test
+    public void testBeRelaxedAboutNumberOfAttributes() throws Exception {
         GeometryFactory gf = new GeometryFactory();
         Point point = gf.createPoint(new Coordinate(0, 0));
         builder.add(point);
         builder.add(Integer.valueOf(1));
 
-        // build feature uses default values for anything missing
-        SimpleFeature feature = builder.buildFeature("fid");
+        // be forgiving if too few values provided (use default values for anything missing)
+        SimpleFeature feature = builder.buildFeature("fid.1");
         Assert.assertNotNull(feature);
 
         Assert.assertEquals(3, feature.getAttributeCount());
@@ -90,13 +147,20 @@ public class SimpleFeatureBuilderTest {
         List<Object> tooFew = new ArrayList<>();
         tooFew.add(point);
 
-        // static build method requires values in the order specified
-        try {
-            SimpleFeature feature2 = SimpleFeatureBuilder.build(featureType, tooFew, "fid");
-            Assert.assertNotNull(feature2);
-        } catch (IllegalArgumentException expected) {
-            Assert.assertTrue(expected.getMessage().contains("count does not match"));
-        }
+        SimpleFeature feature2 = SimpleFeatureBuilder.build(featureType, tooFew, "fid.2");
+        Assert.assertNotNull(feature2);
+
+        Assert.assertSame("provided point", point, feature.getAttribute(0));
+        Assert.assertNotNull("default count", feature.getAttribute(1));
+
+        // be forgiving if too many values provided
+        List<Object> tooMany = new ArrayList<>();
+        tooMany.add(point);
+        tooMany.add(1);
+        tooMany.add(3.0f);
+        tooMany.add("Sasquatch");
+        SimpleFeature feature3 = SimpleFeatureBuilder.build(featureType, tooMany, "fid.3");
+        Assert.assertNotNull(feature3);
     }
 
     @Test

--- a/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleTypeBuilderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleTypeBuilderTest.java
@@ -17,14 +17,17 @@
 package org.geotools.feature.simple;
 
 import java.util.Collections;
+import org.geotools.api.data.Query;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.AttributeType;
 import org.geotools.api.feature.type.GeometryType;
 import org.geotools.api.feature.type.Schema;
+import org.geotools.api.filter.Filter;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.feature.NameImpl;
 import org.geotools.feature.type.FeatureTypeFactoryImpl;
 import org.geotools.feature.type.SchemaImpl;
+import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Assert;
 import org.junit.Before;
@@ -138,6 +141,29 @@ public class SimpleTypeBuilderTest {
         // the default geometry, that had a special meaning in the original source
         SimpleFeatureType retyped = SimpleFeatureTypeBuilder.retype(type, "geo2", "geo1");
         Assert.assertEquals("geo1", retyped.getGeometryDescriptor().getLocalName());
+    }
+
+    @Test
+    public void testRetypeQuery() throws Exception {
+        builder.setName("Location");
+        builder.add("geom", Point.class, DefaultGeographicCRS.WGS84);
+        builder.add("name", String.class);
+        builder.add("number", Integer.class);
+        builder.setDefaultGeometry("geom");
+        SimpleFeatureType type = builder.buildFeatureType();
+
+        CoordinateReferenceSystem ballWorld = CRS.decode("EPSG:3857");
+        // Changing projection should work when reducing number of attributes
+        Query query = new Query("Location", Filter.INCLUDE, "geom", "name");
+        query.setCoordinateSystem(ballWorld);
+
+        SimpleFeatureType retyped = SimpleFeatureTypeBuilder.retype(type, query);
+        Assert.assertSame("crs", ballWorld, retyped.getCoordinateReferenceSystem());
+        Assert.assertEquals("geom", retyped.getGeometryDescriptor().getLocalName());
+        Assert.assertSame(
+                "geom crs",
+                ballWorld,
+                retyped.getGeometryDescriptor().getCoordinateReferenceSystem());
     }
 
     @Test

--- a/modules/library/main/src/test/java/org/geotools/feature/type/TypesTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/type/TypesTest.java
@@ -85,13 +85,17 @@ public class TypesTest {
 
         SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder(); // $NON-NLS-1$
         builder.setName("test");
-        builder.restriction(filter).add(attributeName, String.class);
+        builder.restriction(filter).minOccurs(1).nillable(false).add(attributeName, String.class);
         SimpleFeatureType featureType = builder.buildFeatureType();
 
         SimpleFeature feature =
                 SimpleFeatureBuilder.build(featureType, new Object[] {"Value"}, null);
 
         Assert.assertNotNull(feature);
+        Assert.assertTrue("valid", Types.isValid(feature));
+
+        feature.setAttribute("string", null);
+        Assert.assertFalse("invalid", Types.isValid(feature));
     }
 
     @Test

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/JTSTest.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/JTSTest.java
@@ -444,6 +444,8 @@ public class JTSTest extends JTSTestBase {
         Point world = (Point) JTS.toGeographic(point, gda94);
         assertEquals(point.getX(), world.getY(), 0.00000005);
         assertEquals(point.getY(), world.getX(), 0.00000005);
+
+        assertEquals(gda94, JTS.getCRS(world));
     }
 
     @Test

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/data/geojson/GeoJSONWriteTest.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import org.apache.commons.lang3.time.DateFormatUtils;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.geotools.TestData;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
@@ -279,6 +280,7 @@ public class GeoJSONWriteTest {
     @Test
     public void testDateFormat() throws Exception {
         Date testDate = new Date();
+
         // test feature
         SimpleFeatureType type =
                 DataUtilities.createType("test", "the_geom:Point:srid=4326,date:java.util.Date");
@@ -297,7 +299,12 @@ public class GeoJSONWriteTest {
         String json = out.toString(StandardCharsets.UTF_8);
         JsonNode root = new ObjectMapper().readTree(json);
         String date = root.get("properties").get("date").textValue();
-        assertEquals(DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.format(testDate), date);
+
+        FastDateFormat utm =
+                FastDateFormat.getInstance(
+                        DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.getPattern(),
+                        GeoJSONWriter.DEFAULT_TIME_ZONE);
+        assertEquals(utm.format(testDate), date);
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7601](https://badgen.net/badge/JIRA/GEOT-7601/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7601) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Transform FeatureCollection handling of a query that both limits attributes and changes CRS.

During this PR several other issues came up as I ran into missing or inconsistent functionality. 

* [GEOT-7612](https://osgeo-org.atlassian.net/browse/GEOT-7612) Types.validate(Attribute) does not check ComplexAttribute values individually
* [GEOT-7601](https://osgeo-org.atlassian.net/browse/GEOT-7601) Transform FeatureCollection Query handling of reproduction
* [GEOT-7602](https://osgeo-org.atlassian.net/browse/GEOT-7602) Implement SimpleFeatureTypeBuilder.retype(schema,query) for properyNames and crs together
* [GEOT-7603](https://osgeo-org.atlassian.net/browse/GEOT-7603) Use of JTS setCRS / getCRS methods for use of geometry user data
* [GEOT-7604](https://osgeo-org.atlassian.net/browse/GEOT-7604) GeoJSON test case was timezone senstive

The approach used is to pass the query crs and retrojectCRS onto to the source and trust it to handle reproduction and the schema change.

aside: An improvement would be handle reproduction and crs change as part of the transform, so that any expressions such as `geom=buffer(geom,0.1)` could be respected (as they would always be executed in the source crs).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->