### PR TITLE
[Backport 31.x] [GEOT-7599] Update MySQL CI matrix (drop 5.7, add 8.4)

### DIFF
--- a/.github/workflows/mysql_online.yml
+++ b/.github/workflows/mysql_online.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql: [ '5.7', '8.0', '8.2' ]
+        # 8.0 and 8.4 are LTS versions
+        mysql: [ '8.0', '8.2', '8.4' ]
         java: [ 11 ]
 
     steps:


### PR DESCRIPTION
[![GEOT-7599](https://badgen.net/badge/JIRA/GEOT-7599/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7599) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4816
 **Authored by:** @mprins