### PR TITLE
Update jaxb module -> 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -482,8 +482,8 @@
     <jackson2.databind.version>${jackson2.version}</jackson2.databind.version>
     <jaiext.version>1.1.25</jaiext.version>
     <javax.activation-api.version>1.2.0</javax.activation-api.version>
-    <jaxb.api.version>2.4.0-b180830.0359</jaxb.api.version>
-    <jaxb.runtime.version>2.4.0-b180830.0438</jaxb.runtime.version>
+    <jaxb.api.version>4.0.3</jaxb.api.version>
+    <jaxb.runtime.version>4.0.3</jaxb.runtime.version>
     <jt.version>1.6.0</jt.version>
     <jtds.jdbc.version>1.3.1</jtds.jdbc.version>
     <jts.version>1.19.0</jts.version>


### PR DESCRIPTION
Hibernate is using the latest version of jaxb, this means that it breaks when we implementing these 2 libraries. Especially, GeotiffWriter 

```
java.lang.NullPointerException: Cannot invoke "javax.xml.bind.JAXBContext.createUnmarshaller()" because "it.geosolutions.imageioimpl.plugins.tiff.gdal.GDALMetadataParser.CONTEXT" is null

And that CONTEXT is null because of this:
javax.xml.bind.JAXBException: Implementation of JAXB-API has not been found on module path or classpath.
- with linked exception:
[java.lang.ClassNotFoundException: com.sun.xml.bind.v2.ContextFactory]
```