### PR TITLE
[Backport 31.x] [GEOT-7615] Update Jackson 2 libs from 2.17.1 to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
     <elasticsearch.version>7.14.0</elasticsearch.version>
     <imageio.ext.version>1.4.12</imageio.ext.version>
     <informix.jdbc.version>4.50.7.1</informix.jdbc.version>
-    <jackson2.version>2.17.1</jackson2.version>
+    <jackson2.version>2.17.2</jackson2.version>
     <jackson2.databind.version>${jackson2.version}</jackson2.databind.version>
     <jaiext.version>1.1.25</jaiext.version>
     <javax.activation-api.version>1.2.0</javax.activation-api.version>


### PR DESCRIPTION
[![GEOT-7615](https://badgen.net/badge/JIRA/GEOT-7615/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7615) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4836
 **Authored by:** @mprins