### PR TITLE
[GEOT-7614] support for postgres reWriteBatchedInserts

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJNDIDataSourceOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJNDIDataSourceOnlineTest.java
@@ -52,6 +52,7 @@ public class PostgisJNDIDataSourceOnlineTest extends JDBCJNDIDataSourceOnlineTes
         standardParams.remove(PostgisNGDataStoreFactory.CREATE_DB_IF_MISSING.key);
         standardParams.remove(PostgisNGDataStoreFactory.CREATE_PARAMS.key);
         standardParams.remove(PostgisNGDataStoreFactory.SSL_MODE.key);
+        standardParams.remove(PostgisNGDataStoreFactory.REWRITE_BATCHED_INSERTS.key);
         standardParams.removeAll(baseParams);
         List<String> baseJndiParams = getBaseJNDIParams();
         List<String> jndiParams = getParamKeys(getJNDIStoreFactory());

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisNGDataStoreFactoryTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisNGDataStoreFactoryTest.java
@@ -160,4 +160,16 @@ public class PostgisNGDataStoreFactoryTest {
         verify(this.st2, withQuery ? times(1) : never()).close();
         verify(this.rs2, withQuery ? times(1) : never()).close();
     }
+
+    @Test
+    public void testGetJDBCUrl() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put(PostgisNGDataStoreFactory.HOST.key, "localhost");
+        params.put(PostgisNGDataStoreFactory.PORT.key, 5432);
+        params.put(PostgisNGDataStoreFactory.DATABASE.key, "template1");
+        params.put(PostgisNGDataStoreFactory.REWRITE_BATCHED_INSERTS.key, Boolean.TRUE);
+        assertEquals(
+                "jdbc:postgresql://localhost:5432/template1?reWriteBatchedInserts=true",
+                new PostgisNGDataStoreFactory().getJDBCUrl(params));
+    }
 }

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisReWriteBatchedInsertsFeatureStoreOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/ps/PostgisReWriteBatchedInsertsFeatureStoreOnlineTest.java
@@ -1,0 +1,31 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2009, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.postgis.ps;
+
+import java.util.Map;
+import org.geotools.data.postgis.PostgisNGDataStoreFactory;
+
+public class PostgisReWriteBatchedInsertsFeatureStoreOnlineTest
+        extends PostgisFeatureStoreOnlineTest {
+
+    @Override
+    protected Map<String, Object> createDataStoreFactoryParams() throws Exception {
+        Map<String, Object> params = super.createDataStoreFactoryParams();
+        params.put(PostgisNGDataStoreFactory.REWRITE_BATCHED_INSERTS.key, Boolean.TRUE);
+        return params;
+    }
+}


### PR DESCRIPTION
[![GEOT-7614](https://badgen.net/badge/JIRA/GEOT-7614/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7614) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

adds support for setting `reWriteBatchedInserts` as a jdbc property for postgis

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).