### PR TITLE
GEOT-7626: refine compatible CRS check that fallback on CRS's identity transformation check

### DIFF
--- a/docs/user/library/referencing/compare.rst
+++ b/docs/user/library/referencing/compare.rst
@@ -76,3 +76,14 @@ The name is usually ignored, with only 2 exceptions:
   We have be unable to define an alias for "x" and "y" up to date, because "x" (for
   example) can means too many different things: "Easting" in a map projection,
   "Geocentric X" in a ``GeocentricCRS``, "Column" in an ``ImageCRS``, etc...
+
+
+Compare Equivalent
+^^^^^^^^^^^^^^^^^^
+You can check if two CRSs are equivalent, while ignoring the metadata as above, and eventually checking if a Transformation is required between the two.::
+  
+  if( CRS.isEquivalent(crs1, crs2)){
+      
+  }
+
+This method will first determine if the two objects are equal by ignoring metadata, using the previously mentioned equalsIgnoreMetadata method as the initial step. If the objects are not equal, it will then check for the existence of a transformation between them. If no transformation is required, meaning the transformation is the identity and does not alter any points, the objects can be considered equivalent.

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -341,7 +341,7 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
         if (crs != null) {
             final CoordinateReferenceSystem other = bbox.getCoordinateReferenceSystem();
             if (other != null) {
-                if (!CRS.equalsIgnoreMetadata(crs, other)) {
+                if (!CRS.isEquivalent(crs, other)) {
                     throw new MismatchedReferenceSystemException(
                             ErrorKeys.MISMATCHED_COORDINATE_REFERENCE_SYSTEM);
                 }
@@ -358,7 +358,7 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
         if (crs != null) {
             final CoordinateReferenceSystem other = location.getCoordinateReferenceSystem();
             if (other != null) {
-                if (!CRS.equalsIgnoreMetadata(crs, other)) {
+                if (!CRS.isEquivalent(crs, other)) {
                     throw new MismatchedReferenceSystemException(
                             ErrorKeys.MISMATCHED_COORDINATE_REFERENCE_SYSTEM);
                 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
@@ -961,6 +961,32 @@ public final class CRS {
     }
 
     /**
+     * This method is checking if the 2 CRSs are equivalent by first using the equalsIgnoreMetadata
+     * approach and then looking for an identity transformation between the 2 CRSs if the first
+     * check fails.
+     *
+     * @param source The source {@link CoordinateReferenceSystem}
+     * @param target the target {@link CoordinateReferenceSystem}
+     */
+    public static boolean isEquivalent(
+            CoordinateReferenceSystem source, CoordinateReferenceSystem target) {
+        boolean equivalentCRS = equalsIgnoreMetadata(source, target);
+        if (!equivalentCRS) {
+
+            try {
+                equivalentCRS = !isTransformationRequired(source, target);
+            } catch (FactoryException e) {
+                // That was an attempt looking for an identity transform.
+                // Let's ignore the exception and return the previous result
+                LOGGER.log(
+                        Level.FINE,
+                        "Unable to find MathTransform between source and target CRS",
+                        e);
+            }
+        }
+        return equivalentCRS;
+    }
+    /**
      * Returns the <cite>Spatial Reference System</cite> identifier, or {@code null} if none. OGC
      * Web Services have the concept of a Spatial Reference System identifier used to communicate
      * CRS information between systems.

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageReaderHelper.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageReaderHelper.java
@@ -125,7 +125,7 @@ public class GridCoverageReaderHelper {
         // we are going to read
 
         sameCRS =
-                GridCoverageRendererUtilities.isEquivalentCRS(
+                CRS.isEquivalent(
                         mapExtent.getCoordinateReferenceSystem(),
                         reader.getCoordinateReferenceSystem());
         paddingRequired =

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRenderer.java
@@ -796,7 +796,7 @@ public final class GridCoverageRenderer {
                 }
             }
         } else if (!coverages.isEmpty()
-                && !GridCoverageRendererUtilities.isEquivalentCRS(
+                && !CRS.isEquivalent(
                         coverages.get(0).getCoordinateReferenceSystem2D(), destinationCRS)) {
             // do the affine step to allow warp/affine merging, in order to best preserve rotations
             // in the warp in case of oversampling

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRendererUtilities.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GridCoverageRendererUtilities.java
@@ -155,7 +155,7 @@ public final class GridCoverageRendererUtilities {
                 continue;
             }
             final CoordinateReferenceSystem coverageCRS = coverage.getCoordinateReferenceSystem();
-            if (!isEquivalentCRS(coverageCRS, destinationCRS)) {
+            if (!CRS.isEquivalent(coverageCRS, destinationCRS)) {
                 GridCoverage2D reprojected =
                         reproject(
                                 coverage,
@@ -516,7 +516,7 @@ public final class GridCoverageRendererUtilities {
                 continue;
             }
             final CoordinateReferenceSystem coverageCRS = coverage.getCoordinateReferenceSystem();
-            if (!isEquivalentCRS(coverageCRS, targetCRS)) {
+            if (!CRS.isEquivalent(coverageCRS, targetCRS)) {
                 reprojectionNeeded = true;
                 break;
             }
@@ -543,33 +543,6 @@ public final class GridCoverageRendererUtilities {
             coverages = cropped;
         }
         return coverages;
-    }
-
-    /**
-     * This method is checking if the 2 CRSs are equivalent by first using the equalsIgnoreMetadata
-     * approach and then looking for an identity transformation between the 2 CRSs if the first
-     * check fails.
-     *
-     * @param source The source {@link CoordinateReferenceSystem}
-     * @param target the target {@link CoordinateReferenceSystem}
-     */
-    public static boolean isEquivalentCRS(
-            CoordinateReferenceSystem source, CoordinateReferenceSystem target) {
-        boolean equivalentCRS = CRS.equalsIgnoreMetadata(source, target);
-        if (!equivalentCRS) {
-
-            try {
-                equivalentCRS = !CRS.isTransformationRequired(source, target);
-            } catch (FactoryException e) {
-                // That was an attempt looking for an identity transform.
-                // Let's ignore the exception and return the previous result
-                LOGGER.log(
-                        Level.FINE,
-                        "Unable to find MathTransform between source and target CRS",
-                        e);
-            }
-        }
-        return equivalentCRS;
     }
 
     /** Crop a coverage on a specified destination Envelope */


### PR DESCRIPTION
[![GEOT-7626](https://badgen.net/badge/JIRA/GEOT-7626/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7626) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This fix allows the CRSs compatibility check required by Rendering and ReferencedEnvelope to fallback on the identity transformation check. It may be the case that 2 CRSs are equivalent (no transformation required from source to target CRS) although the initial CRS.equalsIgnoreMetdata returns false.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->