### PR TITLE
[Backport 31.x] Pinning MSSQL 2022 tag to avoid changes in tools directories. 

### DIFF
--- a/.github/workflows/mssql_online.yml
+++ b/.github/workflows/mssql_online.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        mssql: [2019-latest, 2022-latest]
+        mssql: [2019-latest, 2022-CU13-ubuntu-22.04]
         java: [11]
 
     steps:


### PR DESCRIPTION
Backport #4848
 **Authored by:** @aaime