### PR TITLE
Run downstream integration builds for the 31.x too

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,6 @@
 name: Downstream integration build (GeoWebCache and GeoServer)
 
-on:
-  # trigger on PR, but only on main branch, the checkouts of the downstream projects are also targeting main (default branch)
-  pull_request:
-    branches:
-      - main
+on: [pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -43,10 +39,10 @@ jobs:
           mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
           echo "Checking out GeoWebCache"
           mkdir geowebcache
-          git clone https://github.com/GeoWebCache/geowebcache.git geowebcache
+          git clone https://github.com/GeoWebCache/geowebcache.git geowebcache --branch 1.25.x
           echo "Checking out GeoServer"
           mkdir geoserver
-          git clone https://github.com/geoserver/geoserver.git geoserver
+          git clone https://github.com/geoserver/geoserver.git geoserver --branch 2.25.x
           echo "Checking out mapfish-print-v2"
           mkdir mapfish-print-v2
           git clone https://github.com/mapfish/mapfish-print-v2.git mapfish-print-v2


### PR DESCRIPTION
The integration downstream build is using the main branch of each project, which is fine for the main branch of GeoTools, but useless in stable/maintenance ones.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->