### PR TITLE
Make this job remind devs to update the GWC/GS downstream branches when not running on the main branch  (31.x test, should fail)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,8 +15,11 @@ jobs:
       - name: Verify branch
         if: ${{ github.base_ref != 'main' }}
         uses: actions/github-script@v7
-        script: |
-          core.setFailed("This workflow can only run as-is on the main branch. Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). Current branch is ${GITHUB_BASE_REF}")
+        with:
+          script: |
+            core.setFailed(
+              "This workflow can only run as-is on the main branch. Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). Current branch is ${GITHUB_BASE_REF}"
+            )
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
           script: |
             core.setFailed(`This workflow can only run as-is on the main branch. 
               Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). 
-              Current branch is ${JSON.stringify(context.payload)}`)
+              Current target branch is ${context.payload.pull_request.base.ref}`)
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
           script: |
             core.setFailed(`This workflow can only run as-is on the main branch. 
               Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). 
-              Current branch is ${context.payload.base_ref}`)
+              Current branch is ${context}`)
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Verify branch
+        if: ${{ github.base_ref != 'main' }}
+        run: |
+          echo "This workflow can only run as-is on the main branch. Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). Current branch is ${GITHUB_BASE_REF}"
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
           script: |
             core.setFailed(`This workflow can only run as-is on the main branch. 
               Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). 
-              Current branch is ${context}`)
+              Current branch is ${context.toString()}`)
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
           script: |
             core.setFailed(`This workflow can only run as-is on the main branch. 
               Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). 
-              Current branch is ${github.base_ref}`)
+              Current branch is ${context.payload.base_ref}`)
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.setFailed(
-              "This workflow can only run as-is on the main branch. Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). Current branch is ${GITHUB_BASE_REF}"
-            )
+            core.setFailed(`This workflow can only run as-is on the main branch. 
+              Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). 
+              Current branch is ${github.base_ref}`)
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
           script: |
             core.setFailed(`This workflow can only run as-is on the main branch. 
               Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). 
-              Current branch is ${JSON.stringify(context)}`)
+              Current branch is ${JSON.stringify(context.payload)}`)
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
           script: |
             core.setFailed(`This workflow can only run as-is on the main branch. 
               Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). 
-              Current branch is ${context.toString()}`)
+              Current branch is ${JSON.stringify(context)}`)
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,8 +14,9 @@ jobs:
     steps:
       - name: Verify branch
         if: ${{ github.base_ref != 'main' }}
-        run: |
-          echo "This workflow can only run as-is on the main branch. Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). Current branch is ${GITHUB_BASE_REF}"
+        uses: actions/github-script@v7
+        script: |
+          core.setFailed("This workflow can only run as-is on the main branch. Please remove this conditional check and make sure GWC and GS are checked out on the right branches for this GeoTools series (see the --branch hints below). Current branch is ${GITHUB_BASE_REF}")
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->