### PR TITLE
[GEOT-7628] Regression in JDBC optimization of unique visitor with sorting

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCDataStore.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.apache.commons.lang3.ArrayUtils;
 import org.geotools.api.data.DataStore;
@@ -1462,12 +1463,21 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
 
         // In the SQL standard distinct and order by can work only if all order by attributes also
         // show up in the select
-        // Given the Unique visitor makes no promise regarding sorting, it's easier to just remove
-        // the sort
         if (visitor instanceof UniqueVisitor
                 && query.getSortBy() != null
                 && query.getSortBy().length > 0) {
-            query.setSortBy();
+            UniqueVisitor unique = (UniqueVisitor) visitor;
+            if (!unique.isPreserveOrder()) {
+                // not order preserving, easy peasy, just remove the sort
+                query.setSortBy();
+            } else {
+                // need to preserve the sorting, can we abide to SQL rules though?
+                if (!isSortAttributesPartOfUnique((UniqueVisitor) visitor, query)) {
+                    // cannot execute this one on a database, but the visitor requires order
+                    // preservation, so, fall back on in-memory execution.
+                    return null;
+                }
+            }
         }
 
         // if the visitor is limiting the result to a given start - max, we will
@@ -1555,6 +1565,16 @@ public final class JDBCDataStore extends ContentDataStore implements GmlObjectSt
         } catch (SQLException e) {
             throw (IOException) new IOException().initCause(e);
         }
+    }
+
+    private static boolean isSortAttributesPartOfUnique(UniqueVisitor visitor, Query query) {
+        Set<String> uniqueAttributes = new HashSet<>(visitor.getAttrNames());
+        Set<String> sortAttributes =
+                Arrays.stream(query.getSortBy())
+                        .map(sb -> sb.getPropertyName().getPropertyName())
+                        .collect(Collectors.toSet());
+        boolean sortAttributesPartOfUnique = uniqueAttributes.containsAll(sortAttributes);
+        return sortAttributesPartOfUnique;
     }
 
     /**


### PR DESCRIPTION
[![GEOT-7628](https://badgen.net/badge/JIRA/GEOT-7628/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7628) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->