### PR TITLE
[GEOT-7629] Add validation when deserializing objects

### DIFF
--- a/modules/extension/graph/pom.xml
+++ b/modules/extension/graph/pom.xml
@@ -85,6 +85,10 @@
       <artifactId>gt-main</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/modules/extension/graph/src/main/java/org/geotools/graph/io/standard/SerializedReaderWriter.java
+++ b/modules/extension/graph/src/main/java/org/geotools/graph/io/standard/SerializedReaderWriter.java
@@ -21,8 +21,8 @@ import java.io.BufferedOutputStream;
 import java.io.EOFException;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.geotools.graph.build.GraphBuilder;
 import org.geotools.graph.io.GraphReaderWriter;
 import org.geotools.graph.structure.Edge;
@@ -56,10 +56,12 @@ public class SerializedReaderWriter extends AbstractReaderWriter implements File
         GraphBuilder builder = (GraphBuilder) getProperty(BUILDER);
 
         // create file input stream
-        try (ObjectInputStream objin =
-                new ObjectInputStream(
+        try (ValidatingObjectInputStream objin =
+                new ValidatingObjectInputStream(
                         new BufferedInputStream(
                                 new FileInputStream((String) getProperty(FILENAME))))) {
+            // only allow graph objects and arrays of graph objects
+            objin.accept("org.geotools.graph.structure.*", "[Lorg.geotools.graph.structure.*");
 
             // read header
             objin.readInt(); // nnodes, not used

--- a/modules/extension/graph/src/test/java/org/geotools/graph/io/standard/BasicGraphSerializerTest.java
+++ b/modules/extension/graph/src/test/java/org/geotools/graph/io/standard/BasicGraphSerializerTest.java
@@ -16,9 +16,15 @@
  */
 package org.geotools.graph.io.standard;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.StringTokenizer;
 import org.geotools.graph.GraphTestUtil;
@@ -251,6 +257,19 @@ public class BasicGraphSerializerTest {
             java.util.logging.Logger.getGlobal().log(java.util.logging.Level.INFO, "", e);
             Assert.fail();
         }
+    }
+
+    @Test
+    public void testDeserializationValidation() throws Exception {
+        File victim = File.createTempFile("graph", null);
+        victim.deleteOnExit();
+        m_serializer.setProperty(SerializedReaderWriter.FILENAME, victim.getAbsolutePath());
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(victim))) {
+            out.writeInt(0);
+            out.writeInt(1);
+            out.writeObject(new PriorityQueue<>());
+        }
+        assertThrows(InvalidClassException.class, () -> m_serializer.read());
     }
 
     protected GraphBuilder createBuilder() {

--- a/modules/library/metadata/src/main/java/org/geotools/util/Base64.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/Base64.java
@@ -898,7 +898,9 @@ public class Base64 {
      * @param encodedObject The Base64 data to decode
      * @return The decoded and deserialized object
      * @since 1.5
+     * @deprecated This method is not secure and will be removed in a future release.
      */
+    @Deprecated
     @SuppressWarnings("PMD.UseTryWithResources") // works fully in memory
     public static Object decodeToObject(String encodedObject) {
         // Decode and gunzip if necessary

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/Utils.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/Utils.java
@@ -41,8 +41,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.MalformedURLException;
@@ -61,6 +59,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -82,6 +81,7 @@ import javax.xml.bind.Unmarshaller;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.geotools.api.data.DataAccessFactory.Param;
 import org.geotools.api.data.DataStoreFactorySpi;
@@ -235,6 +235,31 @@ public class Utils {
         CLEANUP_FILTER = initCleanUpFilter();
         MOSAIC_SUPPORT_FILES_FILTER = initMosaicSupportFilesFilter();
     }
+
+    /** Specific classes to allow when deserializing SampleImage objects */
+    private static final Class<?>[] SAMPLE_IMAGE_CLASSES = {
+        SampleImage.class,
+        Number.class,
+        String.class,
+        byte[].class,
+        float[].class,
+        int[].class,
+        short[].class,
+        java.math.BigInteger.class,
+        java.net.InetAddress.class,
+        java.util.Hashtable.class
+    };
+
+    /** Patterns for qualified class names to allow when deserializing SampleImage objects */
+    private static final String[] SAMPLE_IMAGE_PATTERNS = {
+        "com.sun.imageio.*", "com.sun.media.*", "java.awt.*", "javax.media.jai.*", "sun.awt.image.*"
+    };
+
+    /**
+     * Regular expression provided through a system property for additional class names to allow
+     * when deserializing SampleImage objects if the default whitelist is insufficient
+     */
+    private static final Pattern SAMPLE_IMAGE_WHITELIST = initSampleImageWhitelist();
 
     /** Check if the provided reader is a MultiCRS Reader and it can support the specified crs. */
     public static boolean isSupportedCRS(GridCoverage2DReader reader, CoordinateReferenceSystem crs)
@@ -677,6 +702,21 @@ public class Utils {
                         FileFilterUtils.suffixFileFilter(Utils.SAMPLE_IMAGE_NAME_LEGACY),
                         FileFilterUtils.suffixFileFilter("db"));
         return filesFilter;
+    }
+
+    private static Pattern initSampleImageWhitelist() {
+        String prop = System.getProperty("org.geotools.gce.imagemosaic.sampleimage.whitelist");
+        if (prop != null) {
+            try {
+                return Pattern.compile(prop);
+            } catch (Exception e) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Error parsing sample image deserialization whitelist regular expression",
+                        e);
+            }
+        }
+        return null;
     }
 
     public static String getMessageFromException(Exception exception) {
@@ -1435,9 +1475,13 @@ public class Utils {
         // serialize it
         // do we have the sample image??
         if (Utils.checkFileReadable(sampleImageFile)) {
-            try (InputStream inStream =
-                            new BufferedInputStream(new FileInputStream(sampleImageFile));
-                    ObjectInputStream oiStream = new ObjectInputStream(inStream)) {
+            try (ValidatingObjectInputStream oiStream =
+                    new ValidatingObjectInputStream(
+                            new BufferedInputStream(new FileInputStream(sampleImageFile)))) {
+                oiStream.accept(SAMPLE_IMAGE_CLASSES).accept(SAMPLE_IMAGE_PATTERNS);
+                if (SAMPLE_IMAGE_WHITELIST != null) {
+                    oiStream.accept(SAMPLE_IMAGE_WHITELIST);
+                }
                 // load the image
                 Object object = oiStream.readObject();
                 if (object instanceof SampleImage) {
@@ -1472,8 +1516,9 @@ public class Utils {
                     return null;
                 }
             } catch (ClassNotFoundException | IOException e) {
-                if (LOGGER.isLoggable(Level.WARNING))
-                    LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
+                if (LOGGER.isLoggable(Level.WARNING)) {
+                    LOGGER.log(Level.WARNING, "Unable to parse sample image", e);
+                }
                 return null;
             }
         } else {
@@ -1892,12 +1937,15 @@ public class Utils {
 
         // No histogram in cache. Deserializing...
         if (histogram == null) {
-            try (ObjectInputStream objectStream =
-                    new ObjectInputStream(new FileInputStream(file))) {
+            try (ValidatingObjectInputStream objectStream =
+                    new ValidatingObjectInputStream(
+                            new BufferedInputStream(new FileInputStream(file)))) {
+                // only allow histogram objects and its fields
+                objectStream.accept(Histogram.class, double[].class, int[].class);
                 histogram = (Histogram) objectStream.readObject();
             } catch (ClassNotFoundException | IOException e) {
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.fine("Unable to parse Histogram:" + e.getLocalizedMessage());
+                if (LOGGER.isLoggable(Level.WARNING)) {
+                    LOGGER.log(Level.WARNING, "Unable to parse histogram", e);
                 }
             }
         }

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/UtilsTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/UtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.PriorityQueue;
+import javax.media.jai.Histogram;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class UtilsTest {
+
+    @ClassRule public static TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testGetHistogramValid() throws Exception {
+        String file = folder.newFile("valid.histogram").getAbsolutePath();
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(file))) {
+            out.writeObject(new Histogram(1, 0.0, 1.0, 1));
+        }
+        assertNotNull(Utils.getHistogram(file));
+    }
+
+    @Test
+    public void testGetHistogramInvalid() throws Exception {
+        String file = folder.newFile("invalid.histogram").getAbsolutePath();
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(file))) {
+            out.writeObject(new PriorityQueue<>());
+        }
+        assertNull(Utils.getHistogram(file));
+    }
+
+    @Test
+    public void testLoadSampleImageValid() throws Exception {
+        File file = folder.newFile("valid.sample.image").getAbsoluteFile();
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(file))) {
+            BufferedImage image = new BufferedImage(1, 1, 1);
+            out.writeObject(new SampleImage(image.getSampleModel(), image.getColorModel()));
+        }
+        assertNotNull(Utils.loadSampleImage(file));
+    }
+
+    @Test
+    public void testLoadSampleImageInvalid() throws Exception {
+        File file = folder.newFile("invalid.sample.image").getAbsoluteFile();
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(file))) {
+            out.writeObject(new PriorityQueue<>());
+        }
+        assertNull(Utils.loadSampleImage(file));
+    }
+}


### PR DESCRIPTION
[![GEOT-7629](https://badgen.net/badge/JIRA/GEOT-7629/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7629) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->
This PR uses ValidatingObjectInputStream from the Commons IO library to to restrict the classes that are allowed when deserializing imagemosaic sample image and histogram files and graph files. There are multiple existing unit tests that test deserializing valid graph files. The sample image files are the primary concern for potential backwards-compatibility issues.

SimpleFeatureIO was restricted to only allow deserialization when the constructor is called with an empty file with a system property to completely enable or disable deserialization. This allows the existing use cases where a new temp file is created and a single SimpleFeatureIO instance will serialize data to the file and then deserialize the data back from the file.

An unused method in the Base64 class was deprecated with a warning to discourage people from using it.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->