### PR TITLE
[GEOT-7631] Support multi-layer output in CSS

### DIFF
--- a/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/FeatureTypeStyleBuilder.java
+++ b/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/FeatureTypeStyleBuilder.java
@@ -117,6 +117,7 @@ public class FeatureTypeStyleBuilder extends AbstractStyleBuilder<FeatureTypeSty
     }
 
     public void setFeatureTypeNames(List<Name> featureTypeNames) {
+        this.featureTypeNames.clear();
         this.featureTypeNames.addAll(featureTypeNames);
     }
 

--- a/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/StyleBuilder.java
+++ b/modules/extension/brewer/src/main/java/org/geotools/brewer/styling/builder/StyleBuilder.java
@@ -46,6 +46,11 @@ public class StyleBuilder extends AbstractStyleBuilder<Style> {
         reset();
     }
 
+    public StyleBuilder defaultStyle() {
+        isDefault = true;
+        return this;
+    }
+
     public StyleBuilder name(String name) {
         this.name = name;
         return this;

--- a/modules/extension/brewer/src/test/java/org/geotools/brewer/styling/builder/CookbookLineTest.java
+++ b/modules/extension/brewer/src/test/java/org/geotools/brewer/styling/builder/CookbookLineTest.java
@@ -18,6 +18,7 @@ import org.geotools.api.style.PointPlacement;
 import org.geotools.api.style.Rule;
 import org.geotools.api.style.Style;
 import org.geotools.api.style.TextSymbolizer;
+import org.geotools.feature.NameImpl;
 import org.geotools.filter.function.RecodeFunction;
 import org.junit.Test;
 import si.uom.SI;
@@ -43,6 +44,7 @@ public class CookbookLineTest extends AbstractStyleTest {
     @Test
     public void testLineWithBorder() {
         StyleBuilder sb = new StyleBuilder();
+        sb.defaultStyle();
         sb.featureTypeStyle()
                 .rule()
                 .line()
@@ -61,6 +63,7 @@ public class CookbookLineTest extends AbstractStyleTest {
         // print(style);
 
         // round up the basic elements and check its simple
+        assertTrue(style.isDefault());
         StyleCollector collector = new StyleCollector();
         style.accept(collector);
         assertEquals(2, collector.featureTypeStyles.size());
@@ -118,9 +121,10 @@ public class CookbookLineTest extends AbstractStyleTest {
 
     @Test
     public void testRailroad() {
-        FeatureTypeStyleBuilder fts = new FeatureTypeStyleBuilder();
-        fts.rule().line().stroke().colorHex("#333333").width(3);
-        fts.rule()
+        FeatureTypeStyleBuilder ftsb = new FeatureTypeStyleBuilder();
+        ftsb.setFeatureTypeNames(List.of(new NameImpl("railways")));
+        ftsb.rule().line().stroke().colorHex("#333333").width(3);
+        ftsb.rule()
                 .line()
                 .stroke()
                 .graphicStroke()
@@ -130,7 +134,7 @@ public class CookbookLineTest extends AbstractStyleTest {
                 .stroke()
                 .colorHex("#333333")
                 .width(1);
-        Style style = fts.buildStyle();
+        Style style = ftsb.buildStyle();
         // print(style);
 
         // round up the elements and check the basics
@@ -139,6 +143,10 @@ public class CookbookLineTest extends AbstractStyleTest {
         assertEquals(1, collector.featureTypeStyles.size());
         assertEquals(2, collector.rules.size());
         assertEquals(2, collector.symbolizers.size());
+
+        // check type name
+        FeatureTypeStyle fts = collector.featureTypeStyles.get(0);
+        fts.featureTypeNames().forEach(n -> assertEquals("railways", n.getLocalPart()));
 
         // check the simple line
         LineSymbolizer ls = (LineSymbolizer) collector.symbolizers.get(0);

--- a/modules/unsupported/css/pom.xml
+++ b/modules/unsupported/css/pom.xml
@@ -97,7 +97,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/CssBaseTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/CssBaseTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
 import org.geotools.api.style.Style;
+import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.styling.css.selector.PseudoClass;
 import org.geotools.util.logging.Logging;
 import org.parboiled.errors.ErrorUtils;
@@ -86,6 +87,12 @@ public class CssBaseTest {
         Stylesheet ss = parse(css);
         CssTranslator translator = new CssTranslator();
         return translator.translate(ss);
+    }
+
+    protected StyledLayerDescriptor translateMultiLayer(String css) {
+        Stylesheet ss = parse(css);
+        CssTranslator translator = new CssTranslator();
+        return translator.translateMultilayer(ss);
     }
 
     protected Stylesheet parse(String css) {


### PR DESCRIPTION
[![GEOT-7631](https://badgen.net/badge/JIRA/GEOT-7631/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7631) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Stepping stone to support GeoServer style groups defined in CSS. There is going to a GeoServer PR following up with this one, with documentation updates.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->