### PR TITLE
[Backport 30.x] [GEOT-7528] GeoPackage: Timestamp is not written correctly

### DIFF
--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -37,6 +37,7 @@ import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1408,6 +1409,26 @@ public class GeoPackageTest {
 
         assertEquals(coordinate.x, coordinateYX.y, 0);
         assertEquals(coordinate.y, coordinateYX.x, 0);
+    }
+
+    @Test
+    public void testTimestamp() throws Exception {
+        Timestamp timestamp = new Timestamp(new Date().getTime());
+        SimpleFeatureType featureType =
+                createFeatureTypeWithAttribute("timestamp", "timestamp", Timestamp.class);
+        SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureType);
+        SimpleFeature simpleFeature = createSimpleFeatureWithValue(featureBuilder, timestamp);
+        SimpleFeatureCollection collection = DataUtilities.collection(simpleFeature);
+        FeatureEntry entry = new FeatureEntry();
+        geopkg.add(entry, collection);
+
+        FeatureEntry readFeature = geopkg.features().get(0);
+        try (SimpleFeatureReader reader = geopkg.reader(readFeature, null, null)) {
+            Object attribute = reader.next().getAttribute("timestamp");
+            assertTrue(attribute instanceof Timestamp);
+            Timestamp readValue = (Timestamp) attribute;
+            assertEquals(timestamp, readValue);
+        }
     }
 
     /**


### PR DESCRIPTION
[![GEOT-7528](https://badgen.net/badge/JIRA/GEOT-7528/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7528) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #4874
 **Authored by:** @mprins