### PR TITLE
[GEOT-7634] Update DWITHIN delegation in Mongo to support linestring

### DIFF
--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/FilterToMongo.java
@@ -17,7 +17,6 @@
  */
 package org.geotools.data.mongodb;
 
-import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.feature.type.PropertyDescriptor;
 import org.geotools.api.filter.expression.Expression;
@@ -37,22 +36,9 @@ public class FilterToMongo extends AbstractFilterToMongo {
 
     final CollectionMapper mapper;
 
-    /** The schmema the encoder will use as reference to drive filter encoding */
-    SimpleFeatureType featureType;
-
     public FilterToMongo(CollectionMapper mapper) {
         super();
         this.mapper = mapper;
-    }
-
-    /**
-     * Sets the feature type the encoder is encoding a filter for.
-     *
-     * <p>The type of the attributes may drive how the filter is translated to a mongodb query
-     * document.
-     */
-    public void setFeatureType(SimpleFeatureType featureType) {
-        this.featureType = featureType;
     }
 
     private Class getJsonSelectType(Expression expression) {

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/FilterToMongoTest.java
@@ -40,8 +40,12 @@ import org.geotools.api.filter.spatial.BBOX;
 import org.geotools.api.filter.spatial.DWithin;
 import org.geotools.api.filter.spatial.Intersects;
 import org.geotools.api.filter.spatial.Within;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,20 +55,26 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 public class FilterToMongoTest {
 
     static final String DATE_LITERAL = "2015-07-01T00:00:00.000+01:00";
+    public static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
 
     FilterFactory ff;
     FilterToMongo filterToMongo;
+    FilterToMongo filterToMongo3857;
     MongoGeometryBuilder geometryBuilder;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws FactoryException {
         ff = CommonFactoryFinder.getFilterFactory();
         filterToMongo = new FilterToMongo(new GeoJSONMapper());
+        filterToMongo3857 = new FilterToMongo(new GeoJSONMapper());
 
         SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
         tb.setName("ftTest");
@@ -72,6 +82,13 @@ public class FilterToMongoTest {
         tb.add("geometry", Point.class);
         tb.add("dateProperty", Date.class);
         filterToMongo.setFeatureType(tb.buildFeatureType());
+
+        SimpleFeatureTypeBuilder tb3857 = new SimpleFeatureTypeBuilder();
+        tb3857.setName("ftTest");
+        tb3857.setCRS(CRS.decode("EPSG:3857"));
+        tb3857.add("geometry", Point.class);
+        tb3857.add("dateProperty", Date.class);
+        filterToMongo3857.setFeatureType(tb3857.buildFeatureType());
 
         geometryBuilder = new MongoGeometryBuilder();
     }
@@ -212,8 +229,9 @@ public class FilterToMongoTest {
     }
 
     @Test
-    public void testDWithin() {
-        DWithin dwithin = ff.dwithin(ff.property("geom"), getPointParameter(), 1, "kilometers");
+    public void testDWithin() throws FactoryException, TransformException {
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(10.0, 10.0));
+        DWithin dwithin = ff.dwithin(ff.property("geom"), ff.literal(point), 1, "kilometers");
         BasicDBObject obj = (BasicDBObject) dwithin.accept(filterToMongo, null);
         Assert.assertNotNull(obj);
 
@@ -235,6 +253,101 @@ public class FilterToMongoTest {
 
         Assert.assertEquals("Point", geometry.get("type"));
         Assert.assertEquals(coordinates, geometry.get("coordinates"));
+    }
+
+    @Test
+    public void testDWithinLinestring() {
+        Coordinate[] coordinates = {
+            new Coordinate(10.458984, 59.888937),
+            new Coordinate(7.910156, 58.745407),
+            new Coordinate(5.405273, 60.413852)
+        };
+        LineString line = GEOMETRY_FACTORY.createLineString(coordinates);
+
+        Point[] pointsWithin5km = {
+            GEOMETRY_FACTORY.createPoint(new Coordinate(10.2281, 59.729754)),
+            GEOMETRY_FACTORY.createPoint(new Coordinate(8.154602, 58.849279)),
+            GEOMETRY_FACTORY.createPoint(new Coordinate(5.899658, 60.159533))
+        };
+
+        Point[] pointsOutOf5km = {
+            GEOMETRY_FACTORY.createPoint(new Coordinate(10.240803, 59.730014)),
+            GEOMETRY_FACTORY.createPoint(new Coordinate(8.265152, 58.801651)),
+            GEOMETRY_FACTORY.createPoint(new Coordinate(5.913563, 60.164999))
+        };
+
+        DWithin dwithin = ff.dwithin(ff.property("geom"), ff.literal(line), 5, "kilometers");
+        BasicDBObject obj = (BasicDBObject) dwithin.accept(filterToMongo, null);
+        Assert.assertNotNull(obj);
+
+        BasicDBObject filterDWithin = (BasicDBObject) obj.get("geometry");
+        Assert.assertNotNull(filterDWithin);
+
+        BasicDBObject near = (BasicDBObject) filterDWithin.get("$geoIntersects");
+        Assert.assertNotNull(near);
+
+        BasicDBObject geometry = (BasicDBObject) near.get("$geometry");
+        Assert.assertNotNull(geometry);
+
+        Assert.assertEquals("Polygon", geometry.get("type"));
+
+        BasicDBList generatedCoordinates = (BasicDBList) geometry.get("coordinates");
+        Polygon polygon = convertBasicDBListToPolygon((BasicDBList) generatedCoordinates.get(0));
+
+        for (Point p : pointsWithin5km) {
+            Assert.assertTrue(p.within(polygon));
+        }
+        for (Point p : pointsOutOf5km) {
+            Assert.assertFalse(p.within(polygon));
+        }
+    }
+
+    @Test
+    public void testDWithinLinestring3857() {
+
+        Coordinate[] coordinates = {
+            new Coordinate(1164288.773095, 8375052.33805727),
+            new Coordinate(880554.53801536, 8125561.8615686),
+            new Coordinate(601712.23795863, 8492459.51157844)
+        };
+        LineString line = GEOMETRY_FACTORY.createLineString(coordinates);
+
+        Point[] pointsWithin5km = {
+            GEOMETRY_FACTORY.createPoint(new Coordinate(1116668.521323449, 8345509.311262323)),
+            GEOMETRY_FACTORY.createPoint(new Coordinate(861139.5282650845, 8164850.444119697)),
+            GEOMETRY_FACTORY.createPoint(new Coordinate(653340.7706351702, 8408627.216349771))
+        };
+
+        Point[] pointsOutOf5km = {
+            GEOMETRY_FACTORY.createPoint(new Coordinate(1113305.3368676028, 8345776.956413542)),
+            GEOMETRY_FACTORY.createPoint(new Coordinate(863967.7112481785, 8166799.653481186)),
+            GEOMETRY_FACTORY.createPoint(new Coordinate(652657.6029201719, 8407686.15925105))
+        };
+
+        DWithin dwithin = ff.dwithin(ff.property("geom"), ff.literal(line), 5, "kilometers");
+        BasicDBObject obj = (BasicDBObject) dwithin.accept(filterToMongo3857, null);
+        Assert.assertNotNull(obj);
+
+        BasicDBObject filterDWithin = (BasicDBObject) obj.get("geometry");
+        Assert.assertNotNull(filterDWithin);
+
+        BasicDBObject near = (BasicDBObject) filterDWithin.get("$geoIntersects");
+        Assert.assertNotNull(near);
+
+        BasicDBObject geometry = (BasicDBObject) near.get("$geometry");
+        Assert.assertNotNull(geometry);
+
+        Assert.assertEquals("Polygon", geometry.get("type"));
+
+        BasicDBList generatedCoordinates = (BasicDBList) geometry.get("coordinates");
+        Polygon polygon = convertBasicDBListToPolygon((BasicDBList) generatedCoordinates.get(0));
+
+        for (Point p : pointsWithin5km) {
+            Assert.assertTrue(p.within(polygon));
+        }
+        for (Point p : pointsOutOf5km) {
+            Assert.assertFalse(p.within(polygon));
+        }
     }
 
     @Test
@@ -451,10 +564,6 @@ public class FilterToMongoTest {
         return ff.literal(new GeometryFactory().createPolygon(coordinates));
     }
 
-    private Literal getPointParameter() {
-        return ff.literal(new GeometryFactory().createPoint(new Coordinate(10.0, 10.0)));
-    }
-
     private void testIntersectMongoQuery(BasicDBObject mongoQuery) {
         Assert.assertNotNull(mongoQuery);
 
@@ -482,5 +591,22 @@ public class FilterToMongoTest {
         Assert.assertNotNull(filterIntersectsCrsPropertiesName);
         Assert.assertEquals(
                 "urn:x-mongodb:crs:strictwinding:EPSG:4326", filterIntersectsCrsPropertiesName);
+    }
+
+    public static Polygon convertBasicDBListToPolygon(BasicDBList basicDBList) {
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        // Convert BasicDBList to an array of Coordinates
+        Coordinate[] coordinates = new Coordinate[basicDBList.size()];
+        for (int i = 0; i < basicDBList.size(); i++) {
+            BasicDBList point = (BasicDBList) basicDBList.get(i);
+            coordinates[i] = new Coordinate((double) point.get(0), (double) point.get(1));
+        }
+
+        // Create a LinearRing from the coordinates (needed to create a Polygon)
+        LinearRing linearRing = geometryFactory.createLinearRing(coordinates);
+
+        // Create the Polygon (no holes, hence null for the second argument)
+        return geometryFactory.createPolygon(linearRing, null);
     }
 }

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFilterSplitterTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFilterSplitterTest.java
@@ -27,10 +27,17 @@ import org.junit.Test;
 
 public class MongoFilterSplitterTest {
 
-    private static final DWithinImpl D_WITHIN =
+    private static final DWithinImpl D_WITHIN_POINT =
             new DWithinImpl(
                     new AttributeExpressionImpl("geometry"),
                     new LiteralExpressionImpl("POINT (5.006253 60.701807)"));
+
+    private static final DWithinImpl D_WITHIN_LINE =
+            new DWithinImpl(
+                    new AttributeExpressionImpl("geometry"),
+                    new LiteralExpressionImpl(
+                            "LINESTRING (1.669922 42.617791, 9.667969 47.100045, 8.085938 52.160455)"));
+
     private static final FilterCapabilities FCS = new FilterCapabilities(DWithin.class);
 
     @Test
@@ -41,8 +48,8 @@ public class MongoFilterSplitterTest {
                         null,
                         null,
                         new MongoCollectionMeta(Collections.singletonMap("geometry", "2dsphere")));
-        splitter.visit(D_WITHIN, null);
-        Assert.assertEquals(D_WITHIN, splitter.getFilterPre());
+        splitter.visit(D_WITHIN_POINT, null);
+        Assert.assertEquals(D_WITHIN_POINT, splitter.getFilterPre());
     }
 
     @Test
@@ -53,14 +60,21 @@ public class MongoFilterSplitterTest {
                         null,
                         null,
                         new MongoCollectionMeta(Collections.singletonMap("_id", "1")));
-        splitter.visit(D_WITHIN, null);
-        Assert.assertEquals(D_WITHIN, splitter.getFilterPost());
+        splitter.visit(D_WITHIN_POINT, null);
+        Assert.assertEquals(D_WITHIN_POINT, splitter.getFilterPost());
     }
 
     @Test
     public void testDWithinSplitWithoutIndex() {
         MongoFilterSplitter splitter = new MongoFilterSplitter(FCS, null, null, null);
-        splitter.visit(D_WITHIN, null);
-        Assert.assertEquals(D_WITHIN, splitter.getFilterPost());
+        splitter.visit(D_WITHIN_POINT, null);
+        Assert.assertEquals(D_WITHIN_POINT, splitter.getFilterPost());
+    }
+
+    @Test
+    public void testDWithinSplitLinestring() {
+        MongoFilterSplitter splitter = new MongoFilterSplitter(FCS, null, null, null);
+        splitter.visit(D_WITHIN_LINE, null);
+        Assert.assertEquals(D_WITHIN_LINE, splitter.getFilterPre());
     }
 }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOT-7634

Current implementation of DWITHIN for Mongo is being delegated to Mongo's $near operator, however, this operator accepts only points. This commit refactors delegation to instead make use of $geoIntersects, which accepts other geometry types.
The buffer is being applied to input geometry, and resulting geometry is being used in $geoIntersects.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->