### PR TITLE
[GEOT-7636] Line densification on reprojection can lead to OOM

### DIFF
--- a/modules/library/main/src/test/java/org/geotools/renderer/crs/ProjectionHandlerTest.java
+++ b/modules/library/main/src/test/java/org/geotools/renderer/crs/ProjectionHandlerTest.java
@@ -171,6 +171,28 @@ public class ProjectionHandlerTest {
         assertEquals(44, densified.getCoordinates().length);
     }
 
+    /**
+     * Test that the densification can defend itself against OOMs
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDensificationOOM() throws Exception {
+        ReferencedEnvelope wgs84Envelope = new ReferencedEnvelope(-190, 60, -90, 45, WGS84);
+
+        // this setup would result in 40 million densified points
+        Map<String, Object> params = new HashMap<>();
+        params.put(ProjectionHandler.ADVANCED_PROJECTION_DENSIFY, 1e-9);
+        ProjectionHandler handler =
+                ProjectionHandlerFinder.getHandler(wgs84Envelope, WGS84, true, params);
+        Geometry line =
+                gf.createLineString(
+                        new Coordinate[] {new Coordinate(40, 45), new Coordinate(40, 85)});
+        LineString densified = (LineString) handler.preProcess(line);
+        // the value has been reduced below the max threshold
+        assertEquals(152589, densified.getCoordinates().length);
+    }
+
     @Test
     public void testQueryWrappingWGS84() throws Exception {
         ReferencedEnvelope wgs84Envelope = new ReferencedEnvelope(-190, 60, -90, 45, WGS84);

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -1317,7 +1317,7 @@ public class StreamingRenderer implements GTRenderer {
         return query;
     }
 
-    private void setupDensificationHints(
+    void setupDensificationHints(
             CoordinateReferenceSystem mapCRS,
             CoordinateReferenceSystem featCrs,
             Rectangle screenSize,
@@ -1344,7 +1344,9 @@ public class StreamingRenderer implements GTRenderer {
                         sourceEnvelope.getHeight());
         WarpBuilder wb = new WarpBuilder(tolerance);
         double densifyDistance = 0.0;
-        int[] actualSplit =
+        // the splits are communicated as the number of rows and columns the area need to be
+        // divided into, in order to have each cell contain a straight line without noticing issues
+        int[] rowCol =
                 wb.isValidDomain(sourceDomain)
                         ? wb.getRowColsSplit(fullTranform, sourceDomain)
                         : null;
@@ -1352,16 +1354,17 @@ public class StreamingRenderer implements GTRenderer {
                 Math.min(
                         MAX_PIXELS_DENSIFY * sourceEnvelope.getWidth() / screenSize.getWidth(),
                         MAX_PIXELS_DENSIFY * sourceEnvelope.getHeight() / screenSize.getHeight());
-        if (actualSplit == null) {
+        if (rowCol == null) {
             // alghoritm gave up, we decide to use a fixed distance value
             densifyDistance = minDistance;
-        } else if (actualSplit[0] != 1 || actualSplit[1] != 1) {
-
+        } else if (rowCol[0] != 1 || rowCol[1] != 1) {
+            int columns = rowCol[1];
+            int rows = rowCol[0];
             densifyDistance =
                     Math.max(
                             Math.min(
-                                    sourceEnvelope.getWidth() / actualSplit[0],
-                                    sourceEnvelope.getHeight() / actualSplit[1]),
+                                    sourceEnvelope.getWidth() / columns,
+                                    sourceEnvelope.getHeight() / rows),
                             minDistance);
         }
         if (densifyDistance > 0.0) {


### PR DESCRIPTION
[![GEOT-7636](https://badgen.net/badge/JIRA/GEOT-7636/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7636) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details.
This needs to go along with https://github.com/geoserver/geoserver/pull/7858

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->