### PR TITLE
[GEOT-7638] Add support for zoom level rule filtering in CSS

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/styling/zoom/WellKnownZoomContextFinder.java
+++ b/modules/library/main/src/main/java/org/geotools/styling/zoom/WellKnownZoomContextFinder.java
@@ -44,6 +44,7 @@ public class WellKnownZoomContextFinder implements ZoomContextFinder {
         // Google Spherical Mercator at 96 DPI
         ZoomContext googleMercatorExtended = new RatioZoomContext(559_082_263.9508929, 2);
         contexts.put("WebMercator".toUpperCase(), googleMercatorExtended);
+        contexts.put("WebMercatorQuad".toUpperCase(), googleMercatorExtended); // OGC TMS
         contexts.put("SphericalMercator".toUpperCase(), googleMercatorExtended);
         contexts.put("GoogleMercator".toUpperCase(), googleMercatorExtended);
         contexts.put("EPSG:3587".toUpperCase(), googleMercatorExtended);
@@ -63,6 +64,12 @@ public class WellKnownZoomContextFinder implements ZoomContextFinder {
         contexts.put("CRS84".toUpperCase(), plateCarree);
         contexts.put("GoogleCRS84Quad".toUpperCase(), plateCarree); // The Name used by GWC
         canonicalNames.add("WGS84");
+
+        // EPSG:4326 / WorldCRS84Quad
+        ZoomContext worldCRS84Quad = new RatioZoomContext(279_541_132.0143589, 2);
+        contexts.put("WorldCRS84Quad".toUpperCase(), worldCRS84Quad);
+        contexts.put("EPSG:4326".toUpperCase(), worldCRS84Quad);
+        canonicalNames.add("WorldCRS84Quad");
 
         // Note the above two contexts have identical zoom levels but are conceptually distinct due
         // to the difference in CRS.

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssParser.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/CssParser.java
@@ -39,6 +39,7 @@ import org.geotools.styling.css.selector.PseudoClass;
 import org.geotools.styling.css.selector.ScaleRange;
 import org.geotools.styling.css.selector.Selector;
 import org.geotools.styling.css.selector.TypeName;
+import org.geotools.styling.css.selector.ZoomRange;
 import org.geotools.util.SuppressFBWarnings;
 import org.parboiled.Action;
 import org.parboiled.BaseParser;
@@ -217,6 +218,11 @@ public class CssParser extends BaseParser<Object> {
                 CatchAllSelector(),
                 MinScaleSelector(),
                 MaxScaleSelector(),
+                ZoomGreaterEqualSelector(),
+                ZoomGreaterSelector(),
+                ZoomEqualSelector(),
+                ZoomLessEqualSelector(),
+                ZoomLessSelector(),
                 IdSelector(),
                 PseudoClassSelector(),
                 NumberedPseudoClassSelector(),
@@ -321,6 +327,81 @@ public class CssParser extends BaseParser<Object> {
                                 true,
                                 Double.POSITIVE_INFINITY,
                                 true)), //
+                OptionalWhiteSpace(),
+                "]");
+    }
+
+    Rule ZoomLessSelector() {
+        return Sequence(
+                "[",
+                OptionalWhiteSpace(),
+                "@z",
+                OptionalWhiteSpace(),
+                "<",
+                OptionalWhiteSpace(),
+                IntegralNumber(),
+                push(new ZoomRange(0, true, Integer.valueOf(match()), false)), //
+                OptionalWhiteSpace(),
+                "]");
+    }
+
+    Rule ZoomLessEqualSelector() {
+        return Sequence(
+                "[",
+                OptionalWhiteSpace(),
+                "@z",
+                OptionalWhiteSpace(),
+                "<=",
+                OptionalWhiteSpace(),
+                IntegralNumber(),
+                push(new ZoomRange(0, true, Integer.valueOf(match()), true)), //
+                OptionalWhiteSpace(),
+                "]");
+    }
+
+    Rule ZoomEqualSelector() {
+        return Sequence(
+                "[",
+                OptionalWhiteSpace(),
+                "@z",
+                OptionalWhiteSpace(),
+                "=",
+                OptionalWhiteSpace(),
+                IntegralNumber(),
+                push(
+                        new ZoomRange(
+                                Integer.valueOf(match()),
+                                true,
+                                Integer.valueOf(match()),
+                                true)), //
+                OptionalWhiteSpace(),
+                "]");
+    }
+
+    Rule ZoomGreaterSelector() {
+        return Sequence(
+                "[",
+                OptionalWhiteSpace(),
+                "@z",
+                OptionalWhiteSpace(),
+                ">",
+                OptionalWhiteSpace(),
+                IntegralNumber(),
+                push(new ZoomRange(Integer.valueOf(match()), false, Integer.MAX_VALUE, true)),
+                OptionalWhiteSpace(),
+                "]");
+    }
+
+    Rule ZoomGreaterEqualSelector() {
+        return Sequence(
+                "[",
+                OptionalWhiteSpace(),
+                "@z",
+                OptionalWhiteSpace(),
+                ">=",
+                OptionalWhiteSpace(),
+                IntegralNumber(),
+                push(new ZoomRange(Integer.valueOf(match()), true, Integer.MAX_VALUE, true)),
                 OptionalWhiteSpace(),
                 "]");
     }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/DomainCoverage.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/DomainCoverage.java
@@ -39,6 +39,7 @@ import org.geotools.styling.css.selector.Selector;
 import org.geotools.styling.css.util.OgcFilterBuilder;
 import org.geotools.styling.css.util.ScaleRangeExtractor;
 import org.geotools.styling.css.util.UnboundSimplifyingFilterVisitor;
+import org.geotools.styling.zoom.ZoomContext;
 import org.geotools.util.NumberRange;
 import org.geotools.util.Range;
 import org.geotools.util.logging.Logging;
@@ -219,12 +220,17 @@ class DomainCoverage {
      */
     int complexityThreshold = 0;
 
+    private final ZoomContext zoomContext;
+
     /** Create a new domain coverage for the given feature type */
     public DomainCoverage(
-            FeatureType targetFeatureType, UnboundSimplifyingFilterVisitor simplifier) {
+            FeatureType targetFeatureType,
+            UnboundSimplifyingFilterVisitor simplifier,
+            ZoomContext zoomContext) {
         this.elements = new ArrayList<>();
         this.targetFeatureType = targetFeatureType;
         this.simplifier = simplifier;
+        this.zoomContext = zoomContext;
     }
 
     /**
@@ -384,7 +390,7 @@ class DomainCoverage {
             Selector selector,
             FeatureType targetFeatureType,
             List<SLDSelector> scaleDependentFilters) {
-        Range<Double> range = ScaleRangeExtractor.getScaleRange(selector);
+        Range<Double> range = ScaleRangeExtractor.getScaleRange(selector, zoomContext);
         if (range == null) {
             range = FULL_SCALE_RANGE;
         }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/selector/AbstractSelectorVisitor.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/selector/AbstractSelectorVisitor.java
@@ -70,6 +70,11 @@ public class AbstractSelectorVisitor implements SelectorVisitor {
     }
 
     @Override
+    public Object visit(ZoomRange scaleRange) {
+        return null;
+    }
+
+    @Override
     public Object visit(PseudoClass pseudoClass) {
         return null;
     }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/selector/SelectorVisitor.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/selector/SelectorVisitor.java
@@ -34,5 +34,7 @@ public interface SelectorVisitor {
 
     public Object visit(ScaleRange scaleRange);
 
+    public Object visit(ZoomRange scaleRange);
+
     public Object visit(PseudoClass pseudoClass);
 }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/selector/ZoomRange.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/selector/ZoomRange.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2014, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/selector/ZoomRange.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/selector/ZoomRange.java
@@ -1,0 +1,86 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2014, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.styling.css.selector;
+
+import java.util.List;
+import org.geotools.util.Range;
+
+public class ZoomRange extends Selector {
+
+    public static Selector combineAnd(List<ZoomRange> selectors, Object ctx) {
+        if (selectors.size() == 1) {
+            return selectors.get(0);
+        }
+
+        Range<Integer> range = selectors.get(0).range;
+        for (ZoomRange selector : selectors) {
+            @SuppressWarnings("unchecked")
+            Range<Integer> intersect = (Range<Integer>) range.intersect(selector.range);
+            range = intersect;
+            if (range.isEmpty()) {
+                return REJECT;
+            }
+        }
+
+        return new ZoomRange(range);
+    }
+
+    public Range<Integer> range;
+
+    public ZoomRange(Range<Integer> range) {
+        this.range = range;
+    }
+
+    public ZoomRange(int min, boolean minIncluded, int max, boolean maxIncluded) {
+        this.range = new Range<>(Integer.class, min, minIncluded, max, maxIncluded);
+    }
+
+    @Override
+    public Specificity getSpecificity() {
+        return Specificity.PSEUDO_1;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((range == null) ? 0 : range.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        ZoomRange other = (ZoomRange) obj;
+        if (range == null) {
+            if (other.range != null) return false;
+        } else if (!range.equals(other.range)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "ZoomRange " + range;
+    }
+
+    @Override
+    public Object accept(SelectorVisitor visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/OgcFilterBuilder.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/OgcFilterBuilder.java
@@ -38,6 +38,7 @@ import org.geotools.styling.css.selector.ScaleRange;
 import org.geotools.styling.css.selector.Selector;
 import org.geotools.styling.css.selector.SelectorVisitor;
 import org.geotools.styling.css.selector.TypeName;
+import org.geotools.styling.css.selector.ZoomRange;
 
 /**
  * Turns a Selector into an OGC filter
@@ -124,6 +125,12 @@ public class OgcFilterBuilder implements SelectorVisitor {
 
     @Override
     public Object visit(ScaleRange scaleRange) {
+        // ignore, it has been handled elsewhere
+        return Filter.INCLUDE;
+    }
+
+    @Override
+    public Object visit(ZoomRange zoomRange) {
         // ignore, it has been handled elsewhere
         return Filter.INCLUDE;
     }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/PseudoClassExtractor.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/PseudoClassExtractor.java
@@ -28,6 +28,7 @@ import org.geotools.styling.css.selector.Reject;
 import org.geotools.styling.css.selector.ScaleRange;
 import org.geotools.styling.css.selector.Selector;
 import org.geotools.styling.css.selector.TypeName;
+import org.geotools.styling.css.selector.ZoomRange;
 
 /**
  * Takes a {@link Selector} and collects all available pseudo classes in it
@@ -70,6 +71,12 @@ public class PseudoClassExtractor extends AbstractSelectorVisitor {
 
     @Override
     public Object visit(ScaleRange scaleRange) {
+        getPseudoClasses().add(PseudoClass.ROOT);
+        return null;
+    }
+
+    @Override
+    public Object visit(ZoomRange scaleRange) {
         getPseudoClasses().add(PseudoClass.ROOT);
         return null;
     }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/PseudoClassRemover.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/PseudoClassRemover.java
@@ -29,6 +29,7 @@ import org.geotools.styling.css.selector.ScaleRange;
 import org.geotools.styling.css.selector.Selector;
 import org.geotools.styling.css.selector.SelectorVisitor;
 import org.geotools.styling.css.selector.TypeName;
+import org.geotools.styling.css.selector.ZoomRange;
 
 /**
  * Simplifies out all pseudo classes, replacing them with {@link Selector#ACCEPT}
@@ -105,6 +106,11 @@ public class PseudoClassRemover implements SelectorVisitor {
     @Override
     public Object visit(ScaleRange scaleRange) {
         return scaleRange;
+    }
+
+    @Override
+    public Object visit(ZoomRange zoomRange) {
+        return zoomRange;
     }
 
     @Override

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/ScaleRangeExtractor.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/ScaleRangeExtractor.java
@@ -21,6 +21,9 @@ import org.geotools.styling.css.selector.AbstractSelectorVisitor;
 import org.geotools.styling.css.selector.Or;
 import org.geotools.styling.css.selector.ScaleRange;
 import org.geotools.styling.css.selector.Selector;
+import org.geotools.styling.css.selector.ZoomRange;
+import org.geotools.styling.zoom.WellKnownZoomContextFinder;
+import org.geotools.styling.zoom.ZoomContext;
 import org.geotools.util.Range;
 
 /**
@@ -31,6 +34,9 @@ import org.geotools.util.Range;
  */
 public class ScaleRangeExtractor extends AbstractSelectorVisitor {
 
+    public static final ZoomContext WEB_MERCATOR_ZOOM_CONTEXT =
+            WellKnownZoomContextFinder.getInstance().get("WebMercatorQuad");
+
     /**
      * Flags whether we are inside a OR or not. If a OR contains a range, we are going to reject the
      * extraction
@@ -40,19 +46,36 @@ public class ScaleRangeExtractor extends AbstractSelectorVisitor {
     /** The extracted range */
     private Range<Double> range;
 
+    private ZoomContext zoomContext = WEB_MERCATOR_ZOOM_CONTEXT;
+
     public static Range<Double> getScaleRange(CssRule cssRule) {
         Selector selector = cssRule.getSelector();
-        return getScaleRange(selector);
+        return getScaleRange(selector, WEB_MERCATOR_ZOOM_CONTEXT);
+    }
+
+    public static Range<Double> getScaleRange(CssRule cssRule, ZoomContext zoomContext) {
+        Selector selector = cssRule.getSelector();
+        return getScaleRange(selector, zoomContext);
     }
 
     public static Range<Double> getScaleRange(Selector selector) {
+        return getScaleRange(selector, WEB_MERCATOR_ZOOM_CONTEXT);
+    }
+
+    public static Range<Double> getScaleRange(Selector selector, ZoomContext zoomContext) {
         try {
-            ScaleRangeExtractor extractor = new ScaleRangeExtractor();
+            ScaleRangeExtractor extractor = new ScaleRangeExtractor(zoomContext);
             selector.accept(extractor);
             return extractor.range;
         } catch (IllegalStateException e) {
             throw new IllegalArgumentException("Failed to extract scale range from: " + selector);
         }
+    }
+
+    public ScaleRangeExtractor() {}
+
+    public ScaleRangeExtractor(ZoomContext zoomContext) {
+        this.zoomContext = zoomContext;
     }
 
     @Override
@@ -76,6 +99,40 @@ public class ScaleRangeExtractor extends AbstractSelectorVisitor {
             range = scaleRange.range;
         } else {
             range.intersect(scaleRange.range);
+        }
+        return null;
+    }
+
+    @Override
+    public Object visit(ZoomRange zoomRange) {
+        if (insideOr) {
+            throw new IllegalStateException(
+                    "Cannot translate to SLD when a scale range is used inside a OR in the selector");
+        }
+
+        // convert between the expectactions of ZoomRange and ZoomContext:
+        // - ZoomRange does not use nulls for non bounded ranges, ZoomContext does
+        // - ZoomRange can have bounds included or not, ZoomContext assumes always included
+        Integer min = zoomRange.range.getMinValue();
+        Integer max = zoomRange.range.getMaxValue();
+        if (min == 0) {
+            min = null;
+        } else if (!zoomRange.range.isMinIncluded()) {
+            min++;
+        }
+        if (max == Integer.MAX_VALUE) {
+            max = null;
+        } else if (!zoomRange.range.isMaxIncluded()) {
+            max--;
+        }
+
+        org.geotools.styling.zoom.ScaleRange scaleRange = zoomContext.getRange(min, max);
+        Range<Double> localRange =
+                new Range<>(Double.class, scaleRange.getMinDenom(), scaleRange.getMaxDenom());
+        if (range == null) {
+            range = localRange;
+        } else {
+            range.intersect(localRange);
         }
         return null;
     }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/TypeNameExtractor.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/TypeNameExtractor.java
@@ -28,6 +28,7 @@ import org.geotools.styling.css.selector.Reject;
 import org.geotools.styling.css.selector.ScaleRange;
 import org.geotools.styling.css.selector.Selector;
 import org.geotools.styling.css.selector.TypeName;
+import org.geotools.styling.css.selector.ZoomRange;
 
 /**
  * Grabs the type names mentioned in the selectors given to it
@@ -70,6 +71,12 @@ public class TypeNameExtractor extends AbstractSelectorVisitor {
 
     @Override
     public Object visit(ScaleRange scaleRange) {
+        getTypeNames().add(TypeName.DEFAULT);
+        return null;
+    }
+
+    @Override
+    public Object visit(ZoomRange scaleRange) {
         getTypeNames().add(TypeName.DEFAULT);
         return null;
     }

--- a/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/TypeNameSimplifier.java
+++ b/modules/unsupported/css/src/main/java/org/geotools/styling/css/util/TypeNameSimplifier.java
@@ -30,6 +30,7 @@ import org.geotools.styling.css.selector.ScaleRange;
 import org.geotools.styling.css.selector.Selector;
 import org.geotools.styling.css.selector.SelectorVisitor;
 import org.geotools.styling.css.selector.TypeName;
+import org.geotools.styling.css.selector.ZoomRange;
 
 /**
  * Extracts a subset of a Selector that is compatible with the given TypeName. In case the default
@@ -121,6 +122,11 @@ public class TypeNameSimplifier implements SelectorVisitor {
     @Override
     public Object visit(ScaleRange scaleRange) {
         return scaleRange;
+    }
+
+    @Override
+    public Object visit(ZoomRange zoomRange) {
+        return zoomRange;
     }
 
     @Override

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/ParserSyntheticTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/ParserSyntheticTest.java
@@ -19,6 +19,7 @@ package org.geotools.styling.css;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -49,6 +50,7 @@ import org.geotools.styling.css.selector.PseudoClass;
 import org.geotools.styling.css.selector.ScaleRange;
 import org.geotools.styling.css.selector.Selector;
 import org.geotools.styling.css.selector.TypeName;
+import org.geotools.styling.css.selector.ZoomRange;
 import org.junit.Test;
 import org.parboiled.errors.ParseError;
 import org.parboiled.parserunners.ReportingParseRunner;
@@ -335,6 +337,102 @@ public class ParserSyntheticTest extends CssBaseTest {
         ScaleRange sr = (ScaleRange) r.getSelector();
         assertEquals(0, sr.range.getMinValue(), 0d);
         assertEquals(1000, sr.range.getMaxValue(), 0d);
+    }
+
+    @Test
+    public void zoomGreaterSelector() throws IOException, CQLException {
+        String css = "[@z > 10] { stroke: #000000; }";
+        ParsingResult<Stylesheet> result =
+                new ReportingParseRunner<Stylesheet>(parser.StyleSheet()).run(css);
+
+        assertNoErrors(result);
+
+        Stylesheet ss = result.parseTreeRoot.getValue();
+        assertEquals(1, ss.getRules().size());
+        CssRule r = ss.getRules().get(0);
+        assertNull(r.getComment());
+        assertTrue(r.getSelector() instanceof ZoomRange);
+        ZoomRange zr = (ZoomRange) r.getSelector();
+        assertEquals(10, (int) zr.range.getMinValue());
+        assertFalse(zr.range.isMinIncluded());
+        assertEquals(Integer.MAX_VALUE, (int) zr.range.getMaxValue());
+    }
+
+    @Test
+    public void zoomGreaterEqualSelector() throws IOException, CQLException {
+        String css = "[@z >= 10] { stroke: #000000; }";
+        ParsingResult<Stylesheet> result =
+                new ReportingParseRunner<Stylesheet>(parser.StyleSheet()).run(css);
+
+        assertNoErrors(result);
+
+        Stylesheet ss = result.parseTreeRoot.getValue();
+        assertEquals(1, ss.getRules().size());
+        CssRule r = ss.getRules().get(0);
+        assertNull(r.getComment());
+        assertTrue(r.getSelector() instanceof ZoomRange);
+        ZoomRange zr = (ZoomRange) r.getSelector();
+        assertEquals(10, (int) zr.range.getMinValue());
+        assertTrue(zr.range.isMinIncluded());
+        assertEquals(Integer.MAX_VALUE, (int) zr.range.getMaxValue());
+    }
+
+    @Test
+    public void equalZoomSelector() throws IOException, CQLException {
+        String css = "[@z = 5] { stroke: #000000; }";
+        ParsingResult<Stylesheet> result =
+                new ReportingParseRunner<Stylesheet>(parser.StyleSheet()).run(css);
+
+        assertNoErrors(result);
+
+        Stylesheet ss = result.parseTreeRoot.getValue();
+        assertEquals(1, ss.getRules().size());
+        CssRule r = ss.getRules().get(0);
+        assertNull(r.getComment());
+        assertTrue(r.getSelector() instanceof ZoomRange);
+        ZoomRange zr = (ZoomRange) r.getSelector();
+        assertEquals(5, (int) zr.range.getMinValue());
+        assertTrue(zr.range.isMinIncluded());
+        assertEquals(5, (int) zr.range.getMaxValue(), 0d);
+        assertTrue(zr.range.isMaxIncluded());
+    }
+
+    @Test
+    public void zoomLessSelector() throws IOException, CQLException {
+        String css = "[@z < 5] { stroke: #000000; }";
+        ParsingResult<Stylesheet> result =
+                new ReportingParseRunner<Stylesheet>(parser.StyleSheet()).run(css);
+
+        assertNoErrors(result);
+
+        Stylesheet ss = result.parseTreeRoot.getValue();
+        assertEquals(1, ss.getRules().size());
+        CssRule r = ss.getRules().get(0);
+        assertNull(r.getComment());
+        assertTrue(r.getSelector() instanceof ZoomRange);
+        ZoomRange zr = (ZoomRange) r.getSelector();
+        assertEquals(0, (int) zr.range.getMinValue());
+        assertEquals(5, (int) zr.range.getMaxValue(), 0d);
+        assertFalse(zr.range.isMaxIncluded());
+    }
+
+    @Test
+    public void zoomLessEqualSelector() throws IOException, CQLException {
+        String css = "[@z <= 5] { stroke: #000000; }";
+        ParsingResult<Stylesheet> result =
+                new ReportingParseRunner<Stylesheet>(parser.StyleSheet()).run(css);
+
+        assertNoErrors(result);
+
+        Stylesheet ss = result.parseTreeRoot.getValue();
+        assertEquals(1, ss.getRules().size());
+        CssRule r = ss.getRules().get(0);
+        assertNull(r.getComment());
+        assertTrue(r.getSelector() instanceof ZoomRange);
+        ZoomRange zr = (ZoomRange) r.getSelector();
+        assertEquals(0, (int) zr.range.getMinValue());
+        assertEquals(5, (int) zr.range.getMaxValue(), 0d);
+        assertTrue(zr.range.isMaxIncluded());
     }
 
     @Test

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/TranslatorSyntheticTest.java
@@ -1538,6 +1538,29 @@ public class TranslatorSyntheticTest extends CssBaseTest {
     }
 
     @Test
+    public void testZoomLevelNotIncluded() throws Exception {
+        assertScaleMinMax("[@z < 10] {stroke: black}", 772130, null);
+        assertScaleMinMax("[@z > 10] {stroke: black}", null, 386065);
+    }
+
+    @Test
+    public void testZoomLevelIncluded() throws Exception {
+        assertScaleMinMax("[@z <= 10] {stroke: black}", 386065, null);
+        assertScaleMinMax("[@z >= 10] {stroke: black}", null, 772130);
+    }
+
+    @Test
+    public void testZoomLevelEquals() throws Exception {
+        assertScaleMinMax("[@z = 10] {stroke: black}", 386065, 772130);
+    }
+
+    @Test
+    public void testZoomLevelEqualsWorldCRS84Quad() throws Exception {
+        assertScaleMinMax(
+                "@tileMatrixSet 'WorldCRS84Quad'; [@z = 10] {stroke: black}", 193032, 386065);
+    }
+
+    @Test
     public void testCQLErrorSelector() throws Exception {
         String css = "[thisFunctionDoesNotExists() > 10] {\nstroke: blue\n}";
         try {
@@ -1735,18 +1758,27 @@ public class TranslatorSyntheticTest extends CssBaseTest {
         assertExpression("Concatenate(a * 10, 'm')", stroke.getWidth());
     }
 
+    private void assertScaleMinMax(String css, Integer min, Integer max) {
+        assertScaleMinMax(css, toDouble(min), toDouble(max));
+    }
+
+    private Double toDouble(Integer value) {
+        if (value == null) return null;
+        return value.doubleValue();
+    }
+
     private void assertScaleMinMax(String css, Double min, Double max) {
         Style style = translate(css);
         Rule rule = assertSingleRule(style);
         if (min == null) {
-            assertEquals(0, rule.getMinScaleDenominator(), 0d);
+            assertEquals(0, rule.getMinScaleDenominator(), 1d);
         } else {
-            assertEquals(min, rule.getMinScaleDenominator(), 0d);
+            assertEquals(min, rule.getMinScaleDenominator(), 1d);
         }
         if (max == null) {
-            assertEquals(Double.POSITIVE_INFINITY, rule.getMaxScaleDenominator(), 0d);
+            assertEquals(Double.POSITIVE_INFINITY, rule.getMaxScaleDenominator(), 1d);
         } else {
-            assertEquals(max, rule.getMaxScaleDenominator(), 0d);
+            assertEquals(max, rule.getMaxScaleDenominator(), 1d);
         }
     }
 


### PR DESCRIPTION
[![GEOT-7638](https://badgen.net/badge/JIRA/GEOT-7638/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7638) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

As the title says

Followed up by https://github.com/geoserver/geoserver/pull/7861

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->