### PR TITLE
[GEOT-7636] GetFeatures call of WFSContentComplexFeatureSource should set srs according to query

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
@@ -17,7 +17,6 @@
 package org.geotools.data.wfs;
 
 import java.io.IOException;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
@@ -57,8 +56,6 @@ import org.geotools.feature.FeatureTypes;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.gml2.SrsSyntax;
-import org.geotools.gml2.bindings.GML2EncodingUtils;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
@@ -262,9 +259,8 @@ class WFSFeatureSource extends ContentFeatureSource {
         request.setPropertyNames(query.getPropertyNames());
         request.setSortBy(query.getSortBy());
 
-        String srsName = getSupportedSrsName(request, query);
+        request.findSupportedSrsName(query.getCoordinateSystem());
 
-        request.setSrsName(srsName);
         LOGGER.fine("request = " + request.toString());
         return request;
     }
@@ -337,24 +333,6 @@ class WFSFeatureSource extends ContentFeatureSource {
             }
         }
         return reader;
-    }
-
-    protected String getSupportedSrsName(GetFeatureRequest request, Query query) {
-        String identifier =
-                GML2EncodingUtils.toURI(query.getCoordinateSystem(), SrsSyntax.AUTH_CODE, false);
-        if (identifier == null) return null;
-
-        int idx = identifier.lastIndexOf(':');
-        String authority = identifier.substring(0, idx);
-        String code = identifier.substring(idx + 1);
-        Set<String> supported =
-                request.getStrategy().getSupportedCRSIdentifiers(request.getTypeName());
-        for (String supportedSrs : supported) {
-            if (supportedSrs.contains(authority) && supportedSrs.endsWith(":" + code)) {
-                return supportedSrs;
-            }
-        }
-        return null;
     }
 
     protected FeatureReader<SimpleFeatureType, SimpleFeature> applyReprojectionDecorator(

--- a/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/GetFeature_sted_25833.xml
+++ b/modules/unsupported/wfs-ng/src/test/resources/org/geotools/data/wfs/test-data/KartverketNo/GetFeature_sted_25833.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wfs:FeatureCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115 https://wfs.geonorge.no/skwms1/wfs.stedsnavn?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;OUTPUTFORMAT=text%2Fxml%3B+subtype%3Dgml%2F3.2.1&amp;TYPENAME=app:Sted&amp;NAMESPACES=xmlns(app,http%3A%2F%2Fskjema.geonorge.no%2FSOSI%2Fproduktspesifikasjon%2FStedsnavnForVanligBruk%2F20181115)" xmlns:wfs="http://www.opengis.net/wfs/2.0" timeStamp="2024-08-24T10:00:13Z" xmlns:gml="http://www.opengis.net/gml/3.2" numberMatched="unknown" numberReturned="0">
+  <!--NOTE: numberReturned attribute should be 'unknown' as well, but this would not validate against the current version of the WFS 2.0 schema (change upcoming). See change request (CR 144): https://portal.opengeospatial.org/files?artifact_id=43925.-->
+  <wfs:member>
+    <app:Sted xmlns:app="http://skjema.geonorge.no/SOSI/produktspesifikasjon/StedsnavnForVanligBruk/20181115" gml:id="1">
+      <app:identifikasjon>
+        <app:Identifikasjon>
+          <app:lokalId>1</app:lokalId>
+          <app:navnerom>https://data.geonorge.no/sosi/stedsnavn</app:navnerom>
+          <app:versjonId>20221201</app:versjonId>
+        </app:Identifikasjon>
+      </app:identifikasjon>
+      <app:oppdateringsdato>2020-02-14T23:13:20</app:oppdateringsdato>
+      <app:datauttaksdato>2024-08-23T02:45:44.783</app:datauttaksdato>
+      <app:posisjon>
+        <!--Inlined geometry '1_APP_POSISJON'-->
+        <gml:Point gml:id="1_APP_POSISJON" srsName="urn:ogc:def:crs:EPSG::25833">
+          <gml:pos>60132.795 6532844.030</gml:pos>
+        </gml:Point>
+      </app:posisjon>
+      <app:stedsnavn>
+        <app:Stedsnavn>
+          <app:offentligBruk>true</app:offentligBruk>
+          <app:navnesakstatus>ubehandlet</app:navnesakstatus>
+          <app:navnestatus>hovednavn</app:navnestatus>
+          <app:navnesaksstatusdato>1991-07-01T00:00:00</app:navnesaksstatusdato>
+          <app:språk>norsk</app:språk>
+          <app:stedsnavnnummer>1</app:stedsnavnnummer>
+          <app:skrivemåte>
+            <app:Skrivemåte>
+              <app:komplettskrivemåte>Stornesodden</app:komplettskrivemåte>
+              <app:skrivemåtestatus>godkjent</app:skrivemåtestatus>
+              <app:statusdato>1991-07-01</app:statusdato>
+              <app:skrivemåtenummer>1</app:skrivemåtenummer>
+            </app:Skrivemåte>
+          </app:skrivemåte>
+        </app:Stedsnavn>
+      </app:stedsnavn>
+      <app:land>Norge</app:land>
+      <app:navneobjekthovedgruppe>ferskvann</app:navneobjekthovedgruppe>
+      <app:navneobjektgruppe>ferskvannskontur</app:navneobjektgruppe>
+      <app:navneobjekttype>nes</app:navneobjekttype>
+      <app:sortering>viktighetF</app:sortering>
+      <app:språkprioritering>norsk-sørsamisk-lulesamisk-nordsamisk-kvensk</app:språkprioritering>
+      <app:stedsnummer>1</app:stedsnummer>
+      <app:kommune>
+        <app:Kommune>
+          <app:kommunenummer>4224</app:kommunenummer>
+          <app:kommunenavn>Åseral</app:kommunenavn>
+          <app:fylkesnummer>42</app:fylkesnummer>
+          <app:fylkesnavn>Agder</app:fylkesnavn>
+        </app:Kommune>
+      </app:kommune>
+    </app:Sted>
+  </wfs:member>
+</wfs:FeatureCollection>


### PR DESCRIPTION
[![GEOT-7636](https://badgen.net/badge/JIRA/GEOT-7636/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7636) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Set SRS by the same approach as WFSFeatureSource.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->