### PR TITLE
Add Dependabot configuration to update workflow actions across branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    target-branch: 'main'
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    target-branch: '31.x'
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    target-branch: '30.x'
+    open-pull-requests-limit: 10

--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -27,7 +27,7 @@ jobs:
         restore-keys: |
           gt-maven-
     - name: Setup python for docs
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: 'pip' # caching pip dependencies from requirements.txt below

--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: [ubuntu-20.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 11

--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -20,7 +20,7 @@ jobs:
         distribution: 'temurin'
         java-version: 11
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/db2_online.yml
+++ b/.github/workflows/db2_online.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: 'temurin'
       - uses: actions/checkout@v4
       - name: Maven repository caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/db2_online.yml
+++ b/.github/workflows/db2_online.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Maven repository caching
         uses: actions/cache@v2
         with:

--- a/.github/workflows/elasticsearch_online.yml
+++ b/.github/workflows/elasticsearch_online.yml
@@ -19,7 +19,7 @@ jobs:
         distribution: 'temurin'
     - uses: actions/checkout@v4
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/elasticsearch_online.yml
+++ b/.github/workflows/elasticsearch_online.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 11
         distribution: 'temurin'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Maven repository caching
       uses: actions/cache@v2
       with:

--- a/.github/workflows/geopkg_online.yml
+++ b/.github/workflows/geopkg_online.yml
@@ -19,7 +19,7 @@ jobs:
         distribution: 'temurin'
     - uses: actions/checkout@v4
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/geopkg_online.yml
+++ b/.github/workflows/geopkg_online.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 11
         distribution: 'temurin'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Maven repository caching
       uses: actions/cache@v2
       with:

--- a/.github/workflows/hana_online.yml
+++ b/.github/workflows/hana_online.yml
@@ -16,11 +16,11 @@ jobs:
     
     steps:
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Maven repository caching
       uses: actions/cache@v2
       with:

--- a/.github/workflows/hana_online.yml
+++ b/.github/workflows/hana_online.yml
@@ -22,7 +22,7 @@ jobs:
         distribution: 'temurin'
     - uses: actions/checkout@v4
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/informix.yml
+++ b/.github/workflows/informix.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: 'temurin'
       - uses: actions/checkout@v4
       - name: Maven repository caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/informix.yml
+++ b/.github/workflows/informix.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Maven repository caching
         uses: actions/cache@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'temurin'
       - uses: actions/checkout@v4
       - name: Maven repository caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: 'temurin'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Maven repository caching
         uses: actions/cache@v2
         with:

--- a/.github/workflows/linux_gdal.yml
+++ b/.github/workflows/linux_gdal.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: [ubuntu-22.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 11

--- a/.github/workflows/linux_gdal.yml
+++ b/.github/workflows/linux_gdal.yml
@@ -26,7 +26,7 @@ jobs:
         sudo tar xvf "$FILE" -C /
         sudo mv /usr/lib/jni/libgdalalljni.so /usr/lib
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/linux_jdk11.yml
+++ b/.github/workflows/linux_jdk11.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pip install -r requirements.txt
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/linux_jdk11.yml
+++ b/.github/workflows/linux_jdk11.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: [ubuntu-20.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 11

--- a/.github/workflows/linux_jdk11.yml
+++ b/.github/workflows/linux_jdk11.yml
@@ -24,7 +24,7 @@ jobs:
         sudo apt update
         sudo apt install --no-install-recommends -y gdal-bin libgdal-dev libgdal-java
     - name: Setup python for docs
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: 'pip' # caching pip dependencies from requirements.txt below

--- a/.github/workflows/linux_jdk17.yml
+++ b/.github/workflows/linux_jdk17.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pip install -r requirements.txt
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/linux_jdk17.yml
+++ b/.github/workflows/linux_jdk17.yml
@@ -24,7 +24,7 @@ jobs:
         sudo apt update
         sudo apt install --no-install-recommends -y gdal-bin libgdal-dev libgdal-java
     - name: Setup python for docs
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: 'pip' # caching pip dependencies from requirements.txt below

--- a/.github/workflows/linux_jdk17.yml
+++ b/.github/workflows/linux_jdk17.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: [ubuntu-20.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 17

--- a/.github/workflows/linux_jdk21.yml
+++ b/.github/workflows/linux_jdk21.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: [ubuntu-20.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 21
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 21

--- a/.github/workflows/linux_jdk21.yml
+++ b/.github/workflows/linux_jdk21.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         pip install -r requirements.txt
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/linux_jdk21.yml
+++ b/.github/workflows/linux_jdk21.yml
@@ -20,7 +20,7 @@ jobs:
         distribution: 'temurin'
         java-version: 21
     - name: Setup python for docs
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: 'pip' # caching pip dependencies from requirements.txt below

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,7 @@ jobs:
         : # Sanity test that the gdal bindings actually work
         ctest --output-on-failure -R java 
     - name: Maven repository caching
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: [macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 11
         distribution: 'temurin'

--- a/.github/workflows/mssql_online.yml
+++ b/.github/workflows/mssql_online.yml
@@ -23,7 +23,7 @@ jobs:
         distribution: 'temurin'
     - uses: actions/checkout@v4
     - name: Maven repository caching
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/mssql_online.yml
+++ b/.github/workflows/mssql_online.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Maven repository caching
       uses: actions/cache@v3
       with:

--- a/.github/workflows/mysql_online.yml
+++ b/.github/workflows/mysql_online.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
     - uses: actions/checkout@v4
     - name: Maven repository caching
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/oracle_online.yml
+++ b/.github/workflows/oracle_online.yml
@@ -23,7 +23,7 @@ jobs:
         distribution: ${{ matrix.java-dist }}
     - uses: actions/checkout@v4
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/oracle_online.yml
+++ b/.github/workflows/oracle_online.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: ${{ matrix.java-dist }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Maven repository caching
       uses: actions/cache@v2
       with:

--- a/.github/workflows/postgis_online.yml
+++ b/.github/workflows/postgis_online.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
     - uses: actions/checkout@v4
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/postgis_online.yml
+++ b/.github/workflows/postgis_online.yml
@@ -19,11 +19,11 @@ jobs:
         postgresql user: 'geotools'
         postgresql db: 'gttest'
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 11
         distribution: 'temurin'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Maven repository caching
       uses: actions/cache@v2
       with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: [ubuntu-20.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 11

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -20,7 +20,7 @@ jobs:
         distribution: 'temurin'
         java-version: 11
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: [windows-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 11
         distribution: 'temurin'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
         java-version: 11
         distribution: 'temurin'
     - name: Maven repository caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: gt-maven-${{ hashFiles('**/pom.xml') }}

--- a/docs/developer/procedures/release.rst
+++ b/docs/developer/procedures/release.rst
@@ -95,6 +95,17 @@ When creating the first release candidate of a series, there are some extra step
     git checkout main
     ant -f build/build.xml latest -Drelease=28-SNAPSHOT
 
+* Add a new section to the Dependabot configuration file, `.github/dependabot.yml`, of the main branch to ensure that the new stable branch (eg. ``27-SNAPSHOT``) is monitored for updates::
+
+      - package-ecosystem: 'github-actions'
+        directory: '/'
+        schedule:
+          interval: 'monthly'
+        target-branch: '27.x'
+        open-pull-requests-limit: 10
+
+  There is no need to edit the file in other branches, as the configuration is inherited from the main branch.
+
 * Commit the changes and push to the main branch on GitHub::
 
     git commit -am "Update version to 28-SNAPSHOT"


### PR DESCRIPTION
This adds a Dependabot configuration to keep any workflow actions across branches up-to-date.

see also https://dailystuff.nl/blog/2020/start-using-github-dependabot

To prevent flooding us with PRs for all the old action versions update the following actions to the current release:

- actions/checkout@v4
- actions/setup-java@v4
- actions/cache@v4
- actions/setup-python@v5

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->