### PR TITLE
[GEOT-7641] Support the "Sweep" parameter in the geostationary projections

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeostationarySatellite.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeostationarySatellite.java
@@ -21,8 +21,6 @@ package org.geotools.referencing.operation.projection;
 
 import java.awt.geom.Point2D;
 import java.util.Collection;
-import java.util.Objects;
-
 import org.geotools.api.geometry.Bounds;
 import org.geotools.api.parameter.GeneralParameterDescriptor;
 import org.geotools.api.parameter.ParameterDescriptor;
@@ -114,6 +112,7 @@ public abstract class GeostationarySatellite extends MapProjection {
     /**
      * Transforms these coordinates to the initialization vector for calculating the satellite view
      * vector.
+     *
      * @param x The X coordinate on Earth.
      * @param y The Y coordinate on Earth.
      * @param yz A point whose location is set to the Y and Z initializers of the view vector.

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeostationarySatellite.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/operation/projection/GeostationarySatellite.java
@@ -21,6 +21,8 @@ package org.geotools.referencing.operation.projection;
 
 import java.awt.geom.Point2D;
 import java.util.Collection;
+import java.util.Objects;
+
 import org.geotools.api.geometry.Bounds;
 import org.geotools.api.parameter.GeneralParameterDescriptor;
 import org.geotools.api.parameter.ParameterDescriptor;
@@ -59,6 +61,7 @@ public abstract class GeostationarySatellite extends MapProjection {
     final double radius_g;
     final double radius_g_1;
     final double C;
+    final boolean flip_axis;
 
     public GeostationarySatellite(ParameterValueGroup parameters)
             throws ParameterNotFoundException {
@@ -80,6 +83,54 @@ public abstract class GeostationarySatellite extends MapProjection {
         radius_g_1 = h / a;
         radius_g = 1d + radius_g_1;
         C = radius_g * radius_g - 1d;
+
+        flip_axis = doubleValue(expected, Provider.SWEEP, parameters) == 0;
+    }
+
+    /**
+     * Transform a satellite view angle to coordinates in the Geostationary projection. Based on
+     * https://github.com/OSGeo/proj.4/blob/5.2/src/PJ_geos.c
+     *
+     * @param Vx X component of the satellite view vector.
+     * @param Vy Y component of the satellite view vector.
+     * @param Vz Z component of the satellite view vector.
+     * @param xy A point whose location is set to the coordinates in this projection.
+     * @return xy for convenience.
+     */
+    final Point2D transformViewVectorToCoordinates(double Vx, double Vy, double Vz, Point2D xy) {
+        double tmp = radius_g - Vx;
+        if (flip_axis) {
+            xy.setLocation(
+                    radius_g_1 * Math.atan(Vy / Math.hypot(Vz, tmp)),
+                    radius_g_1 * Math.atan(Vz / tmp));
+        } else {
+            xy.setLocation(
+                    radius_g_1 * Math.atan(Vy / tmp),
+                    radius_g_1 * Math.atan(Vz / Math.hypot(Vy, tmp)));
+        }
+        return xy;
+    }
+
+    /**
+     * Transforms these coordinates to the initialization vector for calculating the satellite view
+     * vector.
+     * @param x The X coordinate on Earth.
+     * @param y The Y coordinate on Earth.
+     * @param yz A point whose location is set to the Y and Z initializers of the view vector.
+     * @return yz for convenience.
+     */
+    final Point2D transformCoordinatesToViewVectorInitializer(double x, double y, Point2D yz) {
+        double Vy;
+        double Vz;
+        if (flip_axis) {
+            Vz = Math.tan(y / radius_g_1);
+            Vy = Math.tan(x / radius_g_1) * Math.hypot(1., Vz);
+        } else {
+            Vy = Math.tan(x / radius_g_1);
+            Vz = Math.tan(y / radius_g_1) * Math.hypot(1., Vy);
+        }
+        yz.setLocation(Vy, Vz);
+        return yz;
     }
 
     @Override
@@ -93,7 +144,27 @@ public abstract class GeostationarySatellite extends MapProjection {
         final ParameterDescriptorGroup descriptor = getParameterDescriptors();
         final Collection<GeneralParameterDescriptor> expected = descriptor.descriptors();
         set(expected, Provider.SATELLITE_HEIGHT, values, h);
+        set(expected, Provider.SWEEP, values, flip_axis ? 0 : 1);
         return values;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (super.equals(object)) {
+            GeostationarySatellite that = (GeostationarySatellite) object;
+            // Other parameters are derived from these two, plus others already checked in
+            // super.equals().
+            return h == that.h && flip_axis == that.flip_axis;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        long code = super.hashCode();
+        code = code * 37 + Double.doubleToLongBits(h);
+        code = code * 37 + Boolean.hashCode(flip_axis);
+        return (int) code ^ (int) (code >>> 32);
     }
 
     public static class Spherical extends GeostationarySatellite {
@@ -125,14 +196,7 @@ public abstract class GeostationarySatellite extends MapProjection {
             if (((radius_g - Vx) * Vx - Vy * Vy - Vz * Vz) < 0.) {
                 throw new ProjectionException();
             }
-            /* Calculation based on view angles from satellite.*/
-            tmp = radius_g - Vx;
-            double x = radius_g_1 * Math.atan(Vy / tmp);
-            double y = radius_g_1 * Math.atan(Vz / Math.hypot(Vy, tmp));
-
-            p2d.setLocation(x, y);
-
-            return p2d;
+            return transformViewVectorToCoordinates(Vx, Vy, Vz, p2d);
         }
 
         @Override
@@ -141,8 +205,9 @@ public abstract class GeostationarySatellite extends MapProjection {
             // from https://github.com/OSGeo/proj.4/blob/4.9/src/PJ_geos.c
             /* Setting three components of vector from satellite to position.*/
             double Vx = -1.;
-            double Vy = Math.tan(x / (radius_g - 1.));
-            double Vz = Math.tan(y / (radius_g - 1.)) * Math.sqrt(1. + Vy * Vy);
+            transformCoordinatesToViewVectorInitializer(x, y, p2d);
+            double Vy = p2d.getX();
+            double Vz = p2d.getY();
             /* Calculation of terms in cubic equation and determinant.*/
             double a = Vy * Vy + Vz * Vz + Vx * Vx;
             double b = 2. * radius_g * Vx;
@@ -208,14 +273,7 @@ public abstract class GeostationarySatellite extends MapProjection {
             if (((radius_g - Vx) * Vx - Vy * Vy - Vz * Vz * radius_p_inv2) < 0.) {
                 throw new ProjectionException();
             }
-            /* Calculation based on view angles from satellite. */
-            double tmp = radius_g - Vx;
-            double x = radius_g_1 * Math.atan(Vy / tmp);
-            double y = radius_g_1 * Math.atan(Vz / Math.hypot(Vy, tmp));
-
-            p2d.setLocation(x, y);
-
-            return p2d;
+            return transformViewVectorToCoordinates(Vx, Vy, Vz, p2d);
         }
 
         @Override
@@ -224,8 +282,9 @@ public abstract class GeostationarySatellite extends MapProjection {
             // from https://github.com/OSGeo/proj.4/blob/4.9/src/PJ_geos.c
             /* Setting three components of vector from satellite to position.*/
             double Vx = -1.;
-            double Vy = Math.tan(x / radius_g_1);
-            double Vz = Math.tan(y / radius_g_1) * Math.hypot(1., Vy);
+            transformCoordinatesToViewVectorInitializer(x, y, p2d);
+            double Vy = p2d.getX();
+            double Vz = p2d.getY();
             /* Calculation of terms in cubic equation and determinant.*/
             double a = Vz / radius_p;
             a = Vy * Vy + a * a + Vx * Vx;
@@ -339,6 +398,16 @@ public abstract class GeostationarySatellite extends MapProjection {
                         Double.POSITIVE_INFINITY, // maximum
                         SI.METRE);
 
+        static final ParameterDescriptor<Double> SWEEP =
+                createDescriptor(
+                        new NamedIdentifier[] {
+                            new NamedIdentifier(Citations.OGC, "sweep"),
+                        },
+                        1, // default
+                        0, // minimum
+                        1, // maximum
+                        null);
+
         static final ParameterDescriptorGroup PARAMETERS =
                 createDescriptorGroup(
                         new NamedIdentifier[] {
@@ -351,7 +420,8 @@ public abstract class GeostationarySatellite extends MapProjection {
                             CENTRAL_MERIDIAN,
                             SATELLITE_HEIGHT,
                             FALSE_EASTING,
-                            FALSE_NORTHING
+                            FALSE_NORTHING,
+                            SWEEP
                         });
 
         public Provider() {


### PR DESCRIPTION
A fix to the geostationary projection in geotools to allow setting the sweep
axis as appropriate for GOES. The WKT parser only allows parameters
that can be parsed as doubles so I didn't add the sweep_axis as a parameter
with values x,y (which doesn't seem to be done anywhere anyway). We could fix
that, but it's a larger change. Instead, I added a sweep parameter that's
either a 0 (x) or a 1 (y).

All the math is copied over from PROJ of course, as it was before, but now it's
copied from a newer version of PROJ (5.2 instead of 4.9).

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->