### PR TITLE
[GEOT-7635] Error in read empty DBF using FileDataStore

### DIFF
--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapefileTest.java
@@ -53,6 +53,7 @@ import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.shapefile.shp.IndexFile;
 import org.geotools.data.shapefile.shp.ShapefileReader;
 import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.util.ScreenMap;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.DefaultFeatureCollection;
@@ -313,13 +314,23 @@ public class ShapefileTest extends TestCaseSupport {
                 cnt++;
             }
         }
-        assertEquals("Did not read all Geometries from sparse file.", 1, cnt);
+        assertEquals("Did not read all Geometries from shapefile with missing datafile.", 1, cnt);
 
         FileDataStore ds = FileDataStoreFinder.getDataStore(file);
-        assert ds.getFeatureSource().getSchema() != null;
+        assertNotNull("Null schema", ds.getFeatureSource().getSchema());
         File missingFile = TestData.file(TestCaseSupport.class, "missing/aaa2.shp");
         FileDataStore ds2 = FileDataStoreFinder.getDataStore(missingFile);
-        assert ds2.getFeatureSource().getSchema() != null;
+        assertNotNull("null datastore", ds2);
+        assertNotNull("null schema", ds2.getFeatureSource().getSchema());
+        String name = ds2.getTypeNames()[0];
+        assertEquals("bad name", "aaa2", name);
+
+        try (SimpleFeatureIterator itr = ds2.getFeatureSource().getFeatures().features()) {
+            while (itr.hasNext()) {
+                SimpleFeature f = itr.next();
+                assertNotNull(f);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7635](https://badgen.net/badge/JIRA/GEOT-7635/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7635) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adds some more tests on shapefiles with missing dbf files.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->