### PR TITLE
[GEOT-7643] Add support for vector tiles flags for SLD and CSS

### DIFF
--- a/modules/library/api/src/main/java/org/geotools/api/style/FeatureTypeStyle.java
+++ b/modules/library/api/src/main/java/org/geotools/api/style/FeatureTypeStyle.java
@@ -104,6 +104,26 @@ public interface FeatureTypeStyle {
      * Symbolizers. Possible values are normal, legendOnly, mapOnly.
      */
     String VENDOR_OPTION_INCLUSION = "inclusion";
+    /**
+     * Set of attributes to be included in vector tiles. Used by the GeoServer vector tiles module,
+     * declared here so that it can be referred to from style languages.
+     */
+    String VT_ATTRIBUTES = "vt-attributes";
+    /**
+     * Wheter or not a dedicated label layer should be generated for vector tiles. Useful for
+     * polygon layers, but also for point and line layers, as it will include only features whose
+     * label attributes are not null. Used by the GeoServer vector tiles module, declared here so
+     * that it can be referred to from style languages
+     */
+    String VT_LABELS = "vt-labels";
+    /**
+     * Set of attributes to be included in the vector tiles label layer. Used by the GeoServer
+     * vector tiles module, declared here so that it can be referred to from style languages
+     */
+    String VT_LABEL_ATTRIBUTES = "vt-label-attributes";
+
+    /** Coalesce the geometries of features sharing the same attribute values */
+    String VT_COALESCE = "vt-coalesce";
 
     /**
      * Returns a name for this style. This can be any string that uniquely identifies this style


### PR DESCRIPTION
[![GEOT-7643](https://badgen.net/badge/JIRA/GEOT-7643/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7643) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details. Documentation will follow in the GeoServer follow-up PR.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->