### PR TITLE
[GEOT-7606] Support fast extent estimation in HANA provider

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaCloudVersion.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaCloudVersion.java
@@ -1,0 +1,100 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.hana;
+
+import java.util.Objects;
+
+/**
+ * HANA Cloud version.
+ *
+ * <p>The version string has the format "<year>.<week>.<patch>-<addendum>".
+ *
+ * @author Johannes Quast, SAP SE
+ */
+class HanaCloudVersion implements Comparable<HanaCloudVersion> {
+
+    public static final HanaCloudVersion INVALID_VERSION = new HanaCloudVersion(0, 0, 0);
+
+    private int year;
+
+    private int week;
+
+    private int patch;
+
+    /**
+     * Constructor.
+     *
+     * @param versionString The version string in the format "<year>.<week>.<patch>-<addendum>"..
+     */
+    public HanaCloudVersion(String versionString) {
+        String[] components = versionString.replace('-', '.').split("\\.");
+        if (components.length < 3) {
+            throw new IllegalArgumentException(
+                    "Invalid HANA Cloud version string " + versionString);
+        }
+        try {
+            this.year = Integer.parseInt(components[0]);
+            this.week = Integer.parseInt(components[1]);
+            this.patch = Integer.parseInt(components[2]);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Invalid HANA Cloud version string " + versionString);
+        }
+    }
+
+    public HanaCloudVersion(int year, int week, int patch) {
+        this.year = year;
+        this.week = week;
+        this.patch = patch;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getWeek() {
+        return week;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    @Override
+    public int compareTo(HanaCloudVersion that) {
+        if (that == null) throw new NullPointerException();
+
+        if (this.year != that.year) return Integer.compare(this.year, that.year);
+        if (this.week != that.week) return Integer.compare(this.week, that.week);
+        if (this.patch != that.patch) return Integer.compare(this.patch, that.patch);
+
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HanaCloudVersion that = (HanaCloudVersion) o;
+        return year == that.year && week == that.week && patch == that.patch;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(year, week, patch);
+    }
+}

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDataStoreFactory.java
@@ -100,10 +100,10 @@ public class HanaDataStoreFactory extends JDBCDataStoreFactory {
                     null,
                     Collections.singletonMap(Parameter.IS_LARGE_TEXT, Boolean.TRUE));
 
-    /** parameter that enables estimated extends instead of exact ones */
+    /** parameter that enables estimated extents instead of exact ones */
     public static final Param ESTIMATED_EXTENTS =
             new Param(
-                    "Estimated extends",
+                    "Estimated extents",
                     Boolean.class,
                     "Use cached data to quickly get an estimate of the data bounds",
                     false,

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDataStoreFactory.java
@@ -100,6 +100,15 @@ public class HanaDataStoreFactory extends JDBCDataStoreFactory {
                     null,
                     Collections.singletonMap(Parameter.IS_LARGE_TEXT, Boolean.TRUE));
 
+    /** parameter that enables estimated extends instead of exact ones */
+    public static final Param ESTIMATED_EXTENTS =
+            new Param(
+                    "Estimated extends",
+                    Boolean.class,
+                    "Use cached data to quickly get an estimate of the data bounds",
+                    false,
+                    Boolean.FALSE);
+
     private static final String DESCRIPTION = "SAP HANA";
 
     private static final String DRIVER_CLASS_NAME = "com.sap.db.jdbc.Driver";
@@ -155,6 +164,7 @@ public class HanaDataStoreFactory extends JDBCDataStoreFactory {
             if (EXPOSE_PK.key.equals(param.getKey())) {
                 parameters.put(ENCODE_FUNCTIONS.key, ENCODE_FUNCTIONS);
                 parameters.put(DISABLE_SIMPLIFY.key, DISABLE_SIMPLIFY);
+                parameters.put(ESTIMATED_EXTENTS.key, ESTIMATED_EXTENTS);
                 parameters.put(SELECT_HINTS.key, SELECT_HINTS);
             }
         }
@@ -196,6 +206,8 @@ public class HanaDataStoreFactory extends JDBCDataStoreFactory {
         dialect.setSimplifyDisabled((disableSimplify != null) && disableSimplify);
         String selectHints = (String) SELECT_HINTS.lookUp(params);
         dialect.setSelectHints(selectHints);
+        Boolean estimated = (Boolean) ESTIMATED_EXTENTS.lookUp(params);
+        dialect.setEstimatedExtentsEnabled((estimated != null) && estimated);
         return dataStore;
     }
 }

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaDialect.java
@@ -18,14 +18,22 @@ package org.geotools.data.hana;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
-
 import org.geotools.api.data.Query;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.AttributeDescriptor;

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaJNDIDataStoreFactory.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaJNDIDataStoreFactory.java
@@ -48,6 +48,9 @@ public class HanaJNDIDataStoreFactory extends JDBCJNDIDataStoreFactory {
                         HanaDataStoreFactory.DISABLE_SIMPLIFY.key,
                         HanaDataStoreFactory.DISABLE_SIMPLIFY);
                 parameters.put(
+                        HanaDataStoreFactory.ESTIMATED_EXTENTS.key,
+                        HanaDataStoreFactory.ESTIMATED_EXTENTS);
+                parameters.put(
                         HanaDataStoreFactory.SELECT_HINTS.key, HanaDataStoreFactory.SELECT_HINTS);
             }
         }

--- a/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaVersion.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/main/java/org/geotools/data/hana/HanaVersion.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.data.hana;
 
+import java.util.Objects;
+
 /**
  * HANA version.
  *
@@ -23,7 +25,7 @@ package org.geotools.data.hana;
  *
  * @author Stefan Uhrig, SAP SE
  */
-class HanaVersion {
+class HanaVersion implements Comparable<HanaVersion> {
 
     /**
      * Constructor.
@@ -44,6 +46,13 @@ class HanaVersion {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid HANA version string " + versionString);
         }
+    }
+
+    public HanaVersion(int version, int revision, int patchLevel, long buildId) {
+        this.version = version;
+        this.revision = revision;
+        this.patchLevel = patchLevel;
+        this.buildId = buildId;
     }
 
     private int version;
@@ -68,5 +77,33 @@ class HanaVersion {
 
     public long getBuildId() {
         return buildId;
+    }
+
+    @Override
+    public int compareTo(HanaVersion that) {
+        if (that == null) throw new NullPointerException();
+
+        if (this.version != that.version) return Integer.compare(this.version, that.version);
+        if (this.revision != that.revision) return Integer.compare(this.revision, that.revision);
+        if (this.patchLevel != that.patchLevel)
+            return Integer.compare(this.patchLevel, that.patchLevel);
+
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HanaVersion that = (HanaVersion) o;
+        return version == that.version
+                && revision == that.revision
+                && patchLevel == that.patchLevel
+                && buildId == that.buildId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, revision, patchLevel, buildId);
     }
 }

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaFeatureSourceOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaFeatureSourceOnlineTest.java
@@ -16,8 +16,16 @@
  */
 package org.geotools.data.hana;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.geotools.api.data.Query;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.PropertyIsEqualTo;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.JDBCFeatureSourceOnlineTest;
 import org.geotools.jdbc.JDBCTestSetup;
+import org.junit.Test;
 
 /** @author Stefan Uhrig, SAP SE */
 public class HanaFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest {
@@ -25,5 +33,52 @@ public class HanaFeatureSourceOnlineTest extends JDBCFeatureSourceOnlineTest {
     @Override
     protected JDBCTestSetup createTestSetup() {
         return new HanaTestSetupDefault();
+    }
+
+    @Test
+    public void testEstimatedBounds() throws Exception {
+        // enable fast bbox
+        ((HanaDialect) dataStore.getSQLDialect()).setEstimatedExtentsEnabled(true);
+
+        ReferencedEnvelope bounds = dataStore.getFeatureSource(tname("ft1")).getBounds();
+        assertEquals(0L, Math.round(bounds.getMinX()));
+        assertEquals(0L, Math.round(bounds.getMinY()));
+        assertEquals(2L, Math.round(bounds.getMaxX()));
+        assertEquals(2L, Math.round(bounds.getMaxY()));
+
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
+    }
+
+    @Test
+    public void testEstimatedBoundsWithQuery() throws Exception {
+        // enable fast bbox
+        ((HanaDialect) dataStore.getSQLDialect()).setEstimatedExtentsEnabled(true);
+
+        FilterFactory ff = dataStore.getFilterFactory();
+        PropertyIsEqualTo filter =
+                ff.equals(ff.property(aname("stringProperty")), ff.literal("one"));
+
+        Query query = new Query();
+        query.setFilter(filter);
+
+        ReferencedEnvelope bounds = dataStore.getFeatureSource(tname("ft1")).getBounds(query);
+        assertEquals(1L, Math.round(bounds.getMinX()));
+        assertEquals(1L, Math.round(bounds.getMinY()));
+        assertEquals(1L, Math.round(bounds.getMaxX()));
+        assertEquals(1L, Math.round(bounds.getMaxY()));
+
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
+    }
+
+    @Test
+    public void testEstimatedBoundsWithLimit() throws Exception {
+        ((HanaDialect) dataStore.getSQLDialect()).setEstimatedExtentsEnabled(true);
+        super.testBoundsWithLimit();
+    }
+
+    @Test
+    public void testEstimatedBoundsWithOffset() throws Exception {
+        ((HanaDialect) dataStore.getSQLDialect()).setEstimatedExtentsEnabled(true);
+        super.testBoundsWithOffset();
     }
 }

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
@@ -79,8 +79,19 @@ public class HanaGeographyOnlineTest extends JDBCGeographyOnlineTest {
     public void testBounds() throws Exception {
         assumeTrue(isGeographySupportAvailable());
 
-        ReferencedEnvelope env = dataStore.getFeatureSource(tname("geopoint")).getBounds();
+        HanaDialect hanaDialect = (HanaDialect) dataStore.getSQLDialect();
         ReferencedEnvelope expected = new ReferencedEnvelope(-110, 0, 29, 49, decodeEPSG(4326));
-        assertTrue(env.boundsEquals2D(expected, Math.ulp(1.0)));
+        try {
+            // Test with estimation disabled
+            ReferencedEnvelope env = dataStore.getFeatureSource(tname("geopoint")).getBounds();
+            assertTrue(env.boundsEquals2D(expected, Math.ulp(1.0)));
+
+            // Test with estimation enabled
+            hanaDialect.setEstimatedExtentsEnabled(true);
+            env = dataStore.getFeatureSource(tname("geopoint")).getBounds();
+            assertTrue(env.boundsEquals2D(expected, Math.ulp(1.0)));
+        } finally {
+            hanaDialect.setEstimatedExtentsEnabled(false);
+        }
     }
 }

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaVirtualTableOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaVirtualTableOnlineTest.java
@@ -1,3 +1,19 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    https://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
 package org.geotools.data.hana;
 
 import static org.junit.Assert.fail;

--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaVirtualTableOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaVirtualTableOnlineTest.java
@@ -1,0 +1,71 @@
+package org.geotools.data.hana;
+
+import static org.junit.Assert.fail;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.geotools.jdbc.JDBCDataStoreAPITestSetup;
+import org.geotools.jdbc.JDBCVirtualTableOnlineTest;
+import org.geotools.util.logging.Logging;
+import org.junit.Test;
+
+/*
+ * @author Johannes Quast, SAP SE
+ */
+public class HanaVirtualTableOnlineTest extends JDBCVirtualTableOnlineTest {
+
+    @Override
+    protected JDBCDataStoreAPITestSetup createTestSetup() {
+        return new HanaDataStoreAPITestSetup(new HanaTestSetupPSPooling());
+    }
+
+    @Override
+    protected void connect() throws Exception {
+        dbSchemaName = getFixture().getProperty("schema", "geotools");
+        super.connect();
+    }
+
+    @Test
+    public void testOptimizedBounds() throws Exception {
+        Handler handler = getHandler();
+        ((HanaDialect) dataStore.getSQLDialect()).setEstimatedExtentsEnabled(true);
+        Logger logger = Logging.getLogger(HanaVirtualTableOnlineTest.class);
+        Level oldLevel = logger.getLevel();
+        try {
+            logger.setLevel(Level.WARNING);
+            logger.addHandler(handler);
+
+            super.testBounds();
+        } finally {
+            ((HanaDialect) dataStore.getSQLDialect()).setEstimatedExtentsEnabled(false);
+            logger.setLevel(oldLevel);
+            logger.removeHandler(handler);
+        }
+    }
+
+    private static Handler getHandler() {
+        Handler handler =
+                new Handler() {
+                    @Override
+                    public synchronized void publish(LogRecord record) {
+                        fail(
+                                "Fast extent estimation should not have been triggered on virtual "
+                                        + "tables, but we received a log message anyway.");
+                    }
+
+                    @Override
+                    public void flush() {
+                        // nothing to do
+                    }
+
+                    @Override
+                    public void close() throws SecurityException {
+                        // nothing to do
+                    }
+                };
+        handler.setLevel(Level.WARNING);
+        return handler;
+    }
+}


### PR DESCRIPTION
[![GEOT-7606](https://badgen.net/badge/JIRA/GEOT-7606/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7606) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Description

With QRC/1 2024 a new and faster way to estimate extents of spatial column has been added to HANA.
More precisely, users can now use special columns in [this table](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-spatial-reference/spatial-extent-with-sys-m-st-geometry-columns?locale=en-US) to get an estimation of the extent of a spatial column.
Even though the stored extent is only an estimation, it is often good enough.
Especially for very large tables costly aggregation functions are avoided every time the extent is recomputed.
The extent information in the mentioned HANA table is only available after a delta-merge, so a fallback to the standard behaviour, i.e. via aggregation functions, was added in case the data is unavailable or has not yet been computed.  

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).