### PR TITLE
Allow programmatic registration and de-registration of stores

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/api/data/DataAccessFinder.java
+++ b/modules/library/main/src/main/java/org/geotools/api/data/DataAccessFinder.java
@@ -230,4 +230,20 @@ public final class DataAccessFinder {
             copy.deregisterAll();
         }
     }
+
+    /**
+     * Programmatically registers a store. Mostly useful for tests, normal store registration should
+     * go through the SPI subsystem (META-INF/services files).
+     */
+    public static synchronized void registerFactrory(DataAccessFactory factorySpi) {
+        getServiceRegistry().registerFactory(factorySpi);
+    }
+
+    /**
+     * Programmatically deregisters a store. Mostly useful for tests, normal store registration
+     * should go through the SPI subsystem (META-INF/services files).
+     */
+    public static synchronized void deregisterFactrory(DataAccessFactory factorySpi) {
+        getServiceRegistry().deregisterFactory(factorySpi);
+    }
 }

--- a/modules/library/main/src/main/java/org/geotools/api/data/DataStoreFinder.java
+++ b/modules/library/main/src/main/java/org/geotools/api/data/DataStoreFinder.java
@@ -128,4 +128,20 @@ public final class DataStoreFinder {
             copy.deregisterAll();
         }
     }
+
+    /**
+     * Programmatically registers a store. Mostly useful for tests, normal store registration should
+     * go through the SPI subsystem (META-INF/services files).
+     */
+    public static synchronized void registerFactrory(DataStoreFactorySpi factorySpi) {
+        getServiceRegistry().registerFactory(factorySpi);
+    }
+
+    /**
+     * Programmatically deregisters a store. Mostly useful for tests, normal store registration
+     * should go through the SPI subsystem (META-INF/services files).
+     */
+    public static synchronized void deregisterFactrory(DataStoreFactorySpi factorySpi) {
+        getServiceRegistry().deregisterFactory(factorySpi);
+    }
 }

--- a/modules/library/main/src/test/java/org/geotools/api/data/DataStoreFinderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/api/data/DataStoreFinderTest.java
@@ -1,0 +1,54 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This file is hereby placed into the Public Domain. This means anyone is
+ *    free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.api.data;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.Map;
+import org.junit.Test;
+
+public class DataStoreFinderTest {
+
+    /** Should find at least the {@link org.geotools.data.DataAccessFinderTest} mock store */
+    @Test
+    public void testLookup() throws Exception {
+        Iterator<DataStoreFactorySpi> it = DataStoreFinder.getAvailableDataStores();
+        assertTrue(it.hasNext());
+    }
+
+    @Test
+    public void testDynamicRegistration() throws Exception {
+        // setting up the mocks
+        Map<String, ?> params = Map.of("testKey", "testValue");
+        DataStoreFactorySpi mockFactory = createMock(DataStoreFactorySpi.class);
+        expect(mockFactory.isAvailable()).andReturn(true).anyTimes();
+        expect(mockFactory.canProcess(params)).andReturn(true).anyTimes();
+        DataStore mockStore = createMock(DataStore.class);
+        expect(mockFactory.createDataStore(params)).andReturn(mockStore).anyTimes();
+        replay(mockFactory);
+
+        // first lookup attempt, not registered
+        assertNull(DataStoreFinder.getDataStore(params));
+
+        // register and second lookup
+        DataStoreFinder.registerFactrory(mockFactory);
+        assertEquals(mockStore, DataStoreFinder.getDataStore(params));
+
+        // unregister, should stop working
+        DataStoreFinder.deregisterFactrory(mockFactory);
+        assertNull(DataStoreFinder.getDataStore(params));
+    }
+}


### PR DESCRIPTION
@jodygarnett this is what you suggested in https://github.com/aaime/geoserver/pull/16
(PR with usage following)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->