### PR TITLE
Update release procedure

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -18,6 +18,9 @@
        
     Change branch from stable to maintenance:
        ant maintenance
+
+    Change branch from maintenance to archive:
+       ant archive
   </description>
   
   <macrodef name="pom-version">
@@ -173,6 +176,26 @@
     </replace>
   </target>
   
+  <target name="archive"
+          description="Update url references from maintenance to archive">
+    <replace dir="..">
+      <include name="docs/common.py"/>
+      <include name="release/src/markdown/README.md"/>
+      <replacefilter token="docs.geotools.org/maintenance" value="docs.geotools.org/archive"/>
+    </replace>
+    <replace dir="..">
+      <include name="build/rename.xml"/>
+      <include name="build/release.xml"/>
+      <replacefilter
+         token="&lt;property name=&quot;series&quot; value=&quot;maintenance&quot;/&quot;"
+         value="&lt;property name=&quot;series&quot; value=&quot;archive&quot;/&gt;"/>
+    </replace>
+    <replace dir="..">
+      <include name="pom.xml"/>
+      <replacefilter token="&lt;series&gt;maintenance&lt;/series&gt;"
+                     value="&lt;series&gt;archive&lt;/series&gt;"/>
+    </replace>
+  </target>
   
   <!-- update release version -->
   <target name="release"

--- a/docs/developer/procedures/release.rst
+++ b/docs/developer/procedures/release.rst
@@ -139,7 +139,7 @@ When creating the first release candidate of a series, there are some extra step
 
 * This is the time to update the README.md, README.html and documentation links
   
-  For the new `stable` branch, and the remote for the official GeoTools is called ``upstream``::
+  For the new `stable` (old `main`) branch, (and assuming the remote for the official GeoTools is called ``upstream``)::
   
     git checkout 28.x
     git pull
@@ -148,16 +148,25 @@ When creating the first release candidate of a series, there are some extra step
     git commit -m "Change 28.x to stable branch"
     git push upstream 28.x
 
-  For the new `maintenance` branch, and the remote for the official GeoTools is called ``upstream``::
+  For the new `maintenance` (old `stable`) branch::
   
-    git checkout 26.x
+    git checkout 27.x
     git pull
     ant -f build/build.xml maintenance
     git add .
-    git commit -m "Change 26.x to stable branch"
+    git commit -m "Change 27.x to maintenance branch"
+    git push upstream 27.x
+  
+  For the old `maintenance` (now `archive`) branch::
+  
+    git checkout 26.x
+    git pull
+    ant -f build/build.xml archive
+    git add .
+    git commit -m "Change 26.x to archive branch"
     git push upstream 26.x
   
-  This change will update the `pom.xml` series used to determine where documentation from the branch is published.
+  This change will update the `pom.xml` series used to determine where documentation from the branch is published (or **not** published, if we ever have to create an emergency release for archived branches - so that the correct maintenance docs are not overwritten.)
 
 Build the Release
 -----------------


### PR DESCRIPTION
If the old maintenance (now archive) branch is not set to archive, and we ever had to create an emergency release for this archived branch, it would overwrite the current maintenence documentation which might be a version or two ahead of the archived version.

Ref: https://github.com/geotools/geotools/pull/4904/commits/3adaca02c310fab68a0b357033a45d5969efc406#r1761480318

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->