### PR TITLE
[Backport 32.x] Speed up reprojected rendering of large amounts of points

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/ReferencedEnvelope.java
@@ -717,6 +717,18 @@ public class ReferencedEnvelope extends Envelope implements Bounds, BoundingBox 
                         "Unable to transform referenced envelope, crs has not yet been provided.");
             }
         }
+        if (!this.isEmpty() && this.getWidth() == 0 && this.getHeight() == 0) {
+            // single point envelope, no need to perform complex operations
+            CoordinateOperationFactory coordinateOperationFactory =
+                    CRS.getCoordinateOperationFactory(lenient);
+
+            final CoordinateOperation operation =
+                    coordinateOperationFactory.createOperation(crs, targetCRS);
+            double[] position = {getMinX(), getMinY()};
+            operation.getMathTransform().transform(position, 0, position, 0, 1);
+            return new ReferencedEnvelope(
+                    position[0], position[0], position[1], position[1], targetCRS);
+        }
         if (getDimension() != targetCRS.getCoordinateSystem().getDimension()) {
             if (lenient) {
                 return JTS.transformTo3D(this, targetCRS, lenient, numPointsForTransformation);

--- a/modules/library/main/src/main/java/org/geotools/renderer/crs/WrappingProjectionHandler.java
+++ b/modules/library/main/src/main/java/org/geotools/renderer/crs/WrappingProjectionHandler.java
@@ -114,10 +114,13 @@ public class WrappingProjectionHandler extends ProjectionHandler {
         if (geometry == null) {
             return null;
         }
+        // no need to check about size on point layers
+        if (geometry instanceof Point) return geometry;
+
         // if the object was already a large one, clone it and set the user data to indicate it was
         // if it was preflipped, clone it and set the user data to indicate it was
         // hopefully it will happen for few objects
-        final double width = getWidth(geometry.getEnvelopeInternal(), sourceCRS);
+        final double width = getWidth(geometry.getEnvelopeInternal(), sourceAxisOrder);
         if (width > sourceHalfCircle) {
             Geometry copy = geometry.copy();
             if (preflipped(width)) {
@@ -131,8 +134,8 @@ public class WrappingProjectionHandler extends ProjectionHandler {
         return geometry;
     }
 
-    private double getWidth(Envelope envelope, CoordinateReferenceSystem crs) {
-        final boolean northEast = CRS.getAxisOrder(crs) == CRS.AxisOrder.NORTH_EAST;
+    private double getWidth(Envelope envelope, CRS.AxisOrder axisOrder) {
+        final boolean northEast = axisOrder == CRS.AxisOrder.NORTH_EAST;
         if (northEast) {
             return envelope.getHeight();
         } else {
@@ -144,8 +147,8 @@ public class WrappingProjectionHandler extends ProjectionHandler {
     public Geometry postProcess(MathTransform mt, Geometry geometry) {
         // Let's check if the geometry is undoubtedly not going to need processing
         Envelope env = geometry.getEnvelopeInternal();
-        final double width = getWidth(env, targetCRS);
-        final double reWidth = getWidth(renderingEnvelope, targetCRS);
+        final double width = getWidth(env, targetAxisOrder);
+        final double reWidth = getWidth(renderingEnvelope, targetAxisOrder);
 
         // if it was large and still larger, or small and still small, it likely did not wrap
         if (width < targetHalfCircle

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/AbstractCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/AbstractCRS.java
@@ -51,6 +51,9 @@ public abstract class AbstractCRS extends AbstractReferenceSystem
     /** The coordinate system. */
     protected final CoordinateSystem coordinateSystem;
 
+    // Lazily initialized, cached hashCode (see "Effective Java", Item 71)
+    private volatile int hashCode;
+
     /**
      * Constructs a new coordinate reference system with the same values than the specified one.
      * This copy constructor provides a way to wrap an arbitrary implementation into a Geotools one
@@ -161,7 +164,17 @@ public abstract class AbstractCRS extends AbstractReferenceSystem
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
+    public final int hashCode() {
+        int result = hashCode;
+        if (result == 0) {
+            result = calculateHashCode();
+            hashCode = result;
+        }
+        return result;
+    }
+
+    /** Subclasses should override and compute hash code. See also {@link #hashCode()}. */
+    protected int calculateHashCode() {
         return (int) serialVersionUID ^ coordinateSystem.hashCode();
     }
 

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/AbstractDerivedCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/AbstractDerivedCRS.java
@@ -340,7 +340,7 @@ public class AbstractDerivedCRS extends AbstractSingleCRS implements GeneralDeri
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
+    public int calculateHashCode() {
         /*
          * Do not invoke 'conversionFromBase.hashCode()' in order to avoid a never-ending loop.
          * This is because Conversion has a 'sourceCRS' field (in the AbstractCoordinateOperation

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/AbstractSingleCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/AbstractSingleCRS.java
@@ -160,8 +160,8 @@ public class AbstractSingleCRS extends AbstractCRS implements SingleCRS {
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return super.hashCode() ^ datum.hashCode();
+    protected int calculateHashCode() {
+        return super.calculateHashCode() ^ datum.hashCode();
     }
 
     /** {@inheritDoc} */

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultCompoundCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultCompoundCRS.java
@@ -267,7 +267,7 @@ public class DefaultCompoundCRS extends AbstractCRS implements CompoundCRS {
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
+    public int calculateHashCode() {
         // Don't call superclass method since 'coordinateSystem' and 'datum' may be null.
         return crs.hashCode() ^ (int) serialVersionUID;
     }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultDerivedCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultDerivedCRS.java
@@ -175,7 +175,7 @@ public class DefaultDerivedCRS extends AbstractDerivedCRS implements DerivedCRS 
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return (int) serialVersionUID ^ super.hashCode();
+    public int calculateHashCode() {
+        return (int) serialVersionUID ^ super.calculateHashCode();
     }
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultEngineeringCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultEngineeringCRS.java
@@ -202,8 +202,8 @@ public class DefaultEngineeringCRS extends AbstractSingleCRS implements Engineer
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return (int) serialVersionUID ^ super.hashCode();
+    public int calculateHashCode() {
+        return (int) serialVersionUID ^ super.calculateHashCode();
     }
 
     /**

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultGeocentricCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultGeocentricCRS.java
@@ -155,8 +155,8 @@ public class DefaultGeocentricCRS extends AbstractSingleCRS implements Geocentri
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return (int) serialVersionUID ^ super.hashCode();
+    public int calculateHashCode() {
+        return (int) serialVersionUID ^ super.calculateHashCode();
     }
 
     /**

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultGeographicCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultGeographicCRS.java
@@ -208,8 +208,8 @@ public class DefaultGeographicCRS extends AbstractSingleCRS implements Geographi
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return (int) serialVersionUID ^ super.hashCode();
+    public int calculateHashCode() {
+        return (int) serialVersionUID ^ super.calculateHashCode();
     }
 
     /**

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultImageCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultImageCRS.java
@@ -104,7 +104,7 @@ public class DefaultImageCRS extends AbstractSingleCRS implements ImageCRS {
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return (int) serialVersionUID ^ super.hashCode();
+    public int calculateHashCode() {
+        return (int) serialVersionUID ^ super.calculateHashCode();
     }
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultProjectedCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultProjectedCRS.java
@@ -238,8 +238,8 @@ public class DefaultProjectedCRS extends AbstractDerivedCRS implements Projected
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return (int) serialVersionUID ^ super.hashCode();
+    public int calculateHashCode() {
+        return (int) serialVersionUID ^ super.calculateHashCode();
     }
 
     /**

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultTemporalCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultTemporalCRS.java
@@ -258,7 +258,7 @@ public class DefaultTemporalCRS extends AbstractSingleCRS implements TemporalCRS
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return (int) serialVersionUID ^ super.hashCode();
+    public int calculateHashCode() {
+        return (int) serialVersionUID ^ super.calculateHashCode();
     }
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultVerticalCRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/crs/DefaultVerticalCRS.java
@@ -150,8 +150,8 @@ public class DefaultVerticalCRS extends AbstractSingleCRS implements VerticalCRS
      */
     @Override
     @SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
-    public int hashCode() {
-        return (int) serialVersionUID ^ super.hashCode();
+    public int calculateHashCode() {
+        return (int) serialVersionUID ^ super.calculateHashCode();
     }
 
     /**


### PR DESCRIPTION
Backport of #4914, minus the hash code API change in AbstractCRS (hashCode is not final in this PR).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->