### PR TITLE
[GEOT-7658] [MongoDB Plugin] The filter spliter may drop part of the filter

### DIFF
--- a/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFilterSplitter.java
+++ b/modules/plugin/mongodb/src/main/java/org/geotools/data/mongodb/MongoFilterSplitter.java
@@ -87,15 +87,17 @@ public class MongoFilterSplitter extends PostPreProcessFilterSplittingVisitor {
                 if (geometry instanceof Point) {
                     processPoint(filter);
                 } else {
-                    super.visitBinarySpatialOperator(filter);
+                    preStack.push(filter);
                 }
+                return;
             }
         }
+        super.visitBinarySpatialOperator(filter);
     }
 
     /**
      * Checking for presence of spatial index, because DWithin with point will be delegated to $near
-     * operator, which requires geospatial index.
+     * operator, which requires geospatial index. Otherwise, will delegate to memory.
      *
      * @param filter
      */

--- a/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFilterSplitterTest.java
+++ b/modules/plugin/mongodb/src/test/java/org/geotools/data/mongodb/MongoFilterSplitterTest.java
@@ -22,6 +22,7 @@ import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.filter.LiteralExpressionImpl;
 import org.geotools.filter.spatial.DWithinImpl;
+import org.geotools.filter.spatial.IntersectsImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,6 +38,12 @@ public class MongoFilterSplitterTest {
                     new AttributeExpressionImpl("geometry"),
                     new LiteralExpressionImpl(
                             "LINESTRING (1.669922 42.617791, 9.667969 47.100045, 8.085938 52.160455)"));
+
+    private static final IntersectsImpl INTERSECTS =
+            new IntersectsImpl(
+                    new AttributeExpressionImpl("geometry"),
+                    new LiteralExpressionImpl(
+                            "POLYGON ((10.567627244276403 60.81420914025842, 10.787353806776403 60.81420914025842, 10.787353806776403 61.03393570275842, 10.567627244276403 61.03393570275842, 10.567627244276403 60.81420914025842))"));
 
     private static final FilterCapabilities FCS = new FilterCapabilities(DWithin.class);
 
@@ -76,5 +83,12 @@ public class MongoFilterSplitterTest {
         MongoFilterSplitter splitter = new MongoFilterSplitter(FCS, null, null, null);
         splitter.visit(D_WITHIN_LINE, null);
         Assert.assertEquals(D_WITHIN_LINE, splitter.getFilterPre());
+    }
+
+    @Test
+    public void testIntersects() {
+        MongoFilterSplitter splitter = new MongoFilterSplitter(FCS, null, null, null);
+        splitter.visit(INTERSECTS, null);
+        Assert.assertEquals(INTERSECTS, splitter.getFilterPost());
     }
 }


### PR DESCRIPTION
[![GEOT-7658](https://badgen.net/badge/JIRA/GEOT-7658/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7658) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The issue was introduced in GEOT-7634. For the WMS GetFeatureInfo request the filter part was not handled properly, which resulted in inclusion of all features on layer into response. This behavior was corrected and test added.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->