### PR TITLE
[32.x backport] [GEOT-7666] Parsing empty Rotation style element throws a ClassCastException

### DIFF
--- a/modules/extension/xsd/xsd-sld/src/main/java/org/geotools/sld/bindings/SLDGraphicBinding.java
+++ b/modules/extension/xsd/xsd-sld/src/main/java/org/geotools/sld/bindings/SLDGraphicBinding.java
@@ -121,9 +121,9 @@ public class SLDGraphicBinding extends AbstractComplexBinding {
 
         List<Symbol> symbols = node.getChildValues(Symbol.class);
 
-        Expression opacity = (Expression) node.getChildValue("Opacity");
-        Expression size = (Expression) node.getChildValue("Size");
-        Expression rotation = (Expression) node.getChildValue("Rotation");
+        Expression opacity = (Expression) getChildValue(node, "Opacity");
+        Expression size = (Expression) getChildValue(node, "Size");
+        Expression rotation = (Expression) getChildValue(node, "Rotation");
 
         Graphic graphic =
                 styleFactory.createGraphic(
@@ -142,5 +142,20 @@ public class SLDGraphicBinding extends AbstractComplexBinding {
         }
 
         return graphic;
+    }
+
+    /**
+     * Returns the child value of a node. If it's an empty string, <code>null</code> will be
+     * returned.
+     */
+    private Object getChildValue(Node node, String name) {
+        Object value = node.getChildValue(name);
+        if (value instanceof String) {
+            String text = (String) value;
+            if (text.isEmpty()) {
+                return null;
+            }
+        }
+        return value;
     }
 }

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/bindings/SLDGraphicBindingTest.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/bindings/SLDGraphicBindingTest.java
@@ -32,9 +32,69 @@ public class SLDGraphicBindingTest extends SLDTestSupport {
     }
 
     @Test
-    public void test() throws Exception {
+    public void testGraphic() throws Exception {
         SLDMockData.graphic(document, document);
 
+        Graphic graphic = (Graphic) parse();
+        assertNotNull(graphic);
+
+        assertEquals(graphic.graphicalSymbols().size(), 1);
+
+        Mark mark = (Mark) graphic.graphicalSymbols().get(0);
+
+        Color c = org.geotools.styling.SLD.color(mark.getFill().getColor());
+        assertEquals(Integer.parseInt("12", 16), c.getRed());
+        assertEquals(Integer.parseInt("34", 16), c.getGreen());
+        assertEquals(Integer.parseInt("56", 16), c.getBlue());
+
+        assertEquals(1, Filters.asInt(graphic.getSize()));
+        assertEquals(1, Filters.asInt(graphic.getOpacity()));
+        assertEquals(90, Filters.asInt(graphic.getRotation()));
+    }
+
+    @Test
+    public void testGraphicEmptyRotation() throws Exception {
+        SLDMockData.graphicWithEmptyRotation(document, document);
+        Graphic graphic = (Graphic) parse();
+        assertNotNull(graphic);
+
+        assertEquals(graphic.graphicalSymbols().size(), 1);
+
+        Mark mark = (Mark) graphic.graphicalSymbols().get(0);
+
+        Color c = org.geotools.styling.SLD.color(mark.getFill().getColor());
+        assertEquals(Integer.parseInt("12", 16), c.getRed());
+        assertEquals(Integer.parseInt("34", 16), c.getGreen());
+        assertEquals(Integer.parseInt("56", 16), c.getBlue());
+
+        assertEquals(1, Filters.asInt(graphic.getSize()));
+        assertEquals(1, Filters.asInt(graphic.getOpacity()));
+        assertEquals(0, Filters.asInt(graphic.getRotation()));
+    }
+
+    @Test
+    public void testGraphicEmptySize() throws Exception {
+        SLDMockData.graphicWithEmptySize(document, document);
+        Graphic graphic = (Graphic) parse();
+        assertNotNull(graphic);
+
+        assertEquals(graphic.graphicalSymbols().size(), 1);
+
+        Mark mark = (Mark) graphic.graphicalSymbols().get(0);
+
+        Color c = org.geotools.styling.SLD.color(mark.getFill().getColor());
+        assertEquals(Integer.parseInt("12", 16), c.getRed());
+        assertEquals(Integer.parseInt("34", 16), c.getGreen());
+        assertEquals(Integer.parseInt("56", 16), c.getBlue());
+
+        assertEquals(-1, Filters.asInt(graphic.getSize()));
+        assertEquals(1, Filters.asInt(graphic.getOpacity()));
+        assertEquals(90, Filters.asInt(graphic.getRotation()));
+    }
+
+    @Test
+    public void testGraphicEmptyOpacity() throws Exception {
+        SLDMockData.graphicWithEmptyOpacity(document, document);
         Graphic graphic = (Graphic) parse();
         assertNotNull(graphic);
 

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/bindings/SLDMockData.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/bindings/SLDMockData.java
@@ -54,6 +54,10 @@ public class SLDMockData {
         return size;
     }
 
+    static Element emptySize(Document document, Node parent) {
+        return element(SLD.SIZE, document, parent);
+    }
+
     static Element opacity(Document document, Node parent) {
         Element opacity = element(SLD.OPACITY, document, parent);
         opacity.appendChild(document.createTextNode("1"));
@@ -61,11 +65,19 @@ public class SLDMockData {
         return opacity;
     }
 
+    static Element emptyOpacity(Document document, Node parent) {
+        return element(SLD.OPACITY, document, parent);
+    }
+
     static Element rotation(Document document, Node parent) {
         Element rotation = element(SLD.ROTATION, document, parent);
         rotation.appendChild(document.createTextNode("90"));
 
         return rotation;
+    }
+
+    static Element emptyRotation(Document document, Node parent) {
+        return element(SLD.ROTATION, document, parent);
     }
 
     static Element pointPlacement(Document document, Node parent) {
@@ -131,6 +143,33 @@ public class SLDMockData {
         opacity(document, graphic);
         rotation(document, graphic);
 
+        return graphic;
+    }
+
+    static Element graphicWithEmptyRotation(Document document, Node parent) {
+        Element graphic = element(SLD.GRAPHIC, document, parent);
+        mark(document, graphic);
+        size(document, graphic);
+        opacity(document, graphic);
+        emptyRotation(document, graphic);
+        return graphic;
+    }
+
+    static Element graphicWithEmptySize(Document document, Node parent) {
+        Element graphic = element(SLD.GRAPHIC, document, parent);
+        mark(document, graphic);
+        emptySize(document, graphic);
+        opacity(document, graphic);
+        rotation(document, graphic);
+        return graphic;
+    }
+
+    static Element graphicWithEmptyOpacity(Document document, Node parent) {
+        Element graphic = element(SLD.GRAPHIC, document, parent);
+        mark(document, graphic);
+        size(document, graphic);
+        emptyOpacity(document, graphic);
+        rotation(document, graphic);
         return graphic;
     }
 


### PR DESCRIPTION
* [GEOT-7666] Parsing empty Rotation style element throws a ClassCastException

---------

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->