### PR TITLE
[GEOT-7671] Vector mosaic 'count' implementation does not account for max features

### DIFF
--- a/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/GranuleSourceProvider.java
+++ b/modules/unsupported/vector-mosaic/src/main/java/org/geotools/vectormosaic/GranuleSourceProvider.java
@@ -98,6 +98,9 @@ class GranuleSourceProvider implements Closeable {
                                 granuleDataStore, granule.getGranuleTypeName(), query, false);
                 granuleQuery.setPropertyNames(filteredArray);
             }
+            if (query.getMaxFeatures() != Query.DEFAULT_MAX) {
+                granuleQuery.setMaxFeatures(query.getMaxFeatures());
+            }
 
             return granuleDataStore.getFeatureSource(granule.getGranuleTypeName());
         }

--- a/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFeatureSourceTest.java
+++ b/modules/unsupported/vector-mosaic/src/test/java/org/geotools/vectormosaic/VectorMosaicFeatureSourceTest.java
@@ -58,6 +58,19 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
     }
 
     @Test
+    public void testCountAllMaxFeatures() throws Exception {
+        FeatureSource featureSource = MOSAIC_STORE.getFeatureSource(MOSAIC_TYPE_NAME);
+        GranuleTracker tracker = new GranuleTracker();
+        GranuleStoreFinder finder = ((VectorMosaicFeatureSource) featureSource).finder;
+        finder.granuleTracker = tracker;
+
+        Query q = new Query();
+        q.setMaxFeatures(2);
+        assertEquals(2, featureSource.getCount(q));
+        assertEquals(2, tracker.getCount());
+    }
+
+    @Test
     public void testCountFilterDelegate() throws Exception {
         FeatureSource featureSource = MOSAIC_STORE.getFeatureSource(MOSAIC_TYPE_NAME);
         GranuleTracker tracker = new GranuleTracker();
@@ -68,6 +81,20 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
         query.setFilter(FF.lessOrEqual(FF.property("rank"), FF.literal(2)));
         assertEquals(2, featureSource.getCount(query));
         assertEquals(2, tracker.getCount());
+    }
+
+    @Test
+    public void testCountFilterDelegateMaxFeatures() throws Exception {
+        FeatureSource featureSource = MOSAIC_STORE.getFeatureSource(MOSAIC_TYPE_NAME);
+        GranuleTracker tracker = new GranuleTracker();
+        GranuleStoreFinder finder = ((VectorMosaicFeatureSource) featureSource).finder;
+        finder.granuleTracker = tracker;
+
+        Query query = new Query();
+        query.setMaxFeatures(1); // this will stop the counting before the end
+        query.setFilter(FF.lessOrEqual(FF.property("rank"), FF.literal(2)));
+        assertEquals(1, featureSource.getCount(query));
+        assertEquals(1, tracker.getCount());
     }
 
     @Test
@@ -82,6 +109,21 @@ public class VectorMosaicFeatureSourceTest extends VectorMosaicTest {
         query.setFilter(FF.lessOrEqual(FF.property("tractorid"), FF.literal("deere2")));
         assertEquals(2, featureSource.getCount(query));
         assertEquals(4, tracker.getCount());
+    }
+
+    @Test
+    public void testCountFilterGranulesMaxFeatures() throws Exception {
+        FeatureSource featureSource = MOSAIC_STORE.getFeatureSource(MOSAIC_TYPE_NAME);
+        GranuleTracker tracker = new GranuleTracker();
+        GranuleStoreFinder finder = ((VectorMosaicFeatureSource) featureSource).finder;
+        finder.granuleTracker = tracker;
+
+        // this one has to visit all granules to find the actual count, but the max features
+        // will stop it before the end
+        Query q = new Query();
+        q.setMaxFeatures(2);
+        assertEquals(2, featureSource.getCount(q));
+        assertEquals(2, tracker.getCount());
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7671](https://badgen.net/badge/JIRA/GEOT-7671/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7671) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Further optimization (and fix) for count processing.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->