### PR TITLE
[GEOT-7670] Fix synchronization between DataStoreFinder and DataAccessFinder

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/api/data/DataAccessFinder.java
+++ b/modules/library/main/src/main/java/org/geotools/api/data/DataAccessFinder.java
@@ -252,7 +252,7 @@ public final class DataAccessFinder {
      * Programmatically registers a store. Mostly useful for tests, normal store registration should
      * go through the SPI subsystem (META-INF/services files).
      */
-    public static void registerFactrory(DataAccessFactory factorySpi) {
+    public static void registerFactory(DataAccessFactory factorySpi) {
         synchronized (DataAccessFinder.class) {
             getServiceRegistry().registerFactory(factorySpi);
         }
@@ -262,9 +262,19 @@ public final class DataAccessFinder {
      * Programmatically deregisters a store. Mostly useful for tests, normal store registration
      * should go through the SPI subsystem (META-INF/services files).
      */
-    public static void deregisterFactrory(DataAccessFactory factorySpi) {
+    public static void deregisterFactory(DataAccessFactory factorySpi) {
         synchronized (DataAccessFinder.class) {
             getServiceRegistry().deregisterFactory(factorySpi);
         }
+    }
+
+    @Deprecated
+    public static void registerFactrory(DataAccessFactory factorySpi) {
+        registerFactory(factorySpi);
+    }
+
+    @Deprecated
+    public static void deregisterFactrory(DataAccessFactory factorySpi) {
+        deregisterFactory(factorySpi);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/api/data/DataAccessFinder.java
+++ b/modules/library/main/src/main/java/org/geotools/api/data/DataAccessFinder.java
@@ -47,7 +47,7 @@ import org.geotools.util.factory.FactoryRegistry;
  */
 public final class DataAccessFinder {
     /** The logger for the filter module. */
-    protected static final Logger LOGGER =
+    private static final Logger LOGGER =
             org.geotools.util.logging.Logging.getLogger(DataAccessFinder.class);
 
     /** The service registry for this manager. Will be initialized only when first needed. */
@@ -55,6 +55,12 @@ public final class DataAccessFinder {
 
     // Singleton pattern
     private DataAccessFinder() {}
+
+    /*
+     * Implementation note: because this class and DataStoreFinder call each other, all
+     * non-thread-safe methods are synchronized on a common object (DataAccessFinder.class)
+     * in order to prevent potential deadlocks.
+     */
 
     /**
      * Checks each available datasource implementation in turn and returns the first one which
@@ -68,10 +74,12 @@ public final class DataAccessFinder {
      *     specified resource without errors.
      */
     @SuppressWarnings("unchecked")
-    public static synchronized DataAccess<FeatureType, Feature> getDataStore(Map<String, ?> params)
+    public static DataAccess<FeatureType, Feature> getDataStore(Map<String, ?> params)
             throws IOException {
-        Iterator<DataAccessFactory> ps = getAvailableDataStores();
-        return (DataAccess<FeatureType, Feature>) getDataStore(params, ps);
+        synchronized (DataAccessFinder.class) {
+            Iterator<DataAccessFactory> ps = getAvailableDataStores();
+            return (DataAccess<FeatureType, Feature>) getDataStore(params, ps);
+        }
     }
 
     static DataAccess<? extends FeatureType, ? extends Feature> getDataStore(
@@ -141,60 +149,67 @@ public final class DataAccessFinder {
     }
 
     /**
-     * Finds all implemtaions of DataAccessFactory which have registered using the services
+     * Finds all implementations of DataAccessFactory which have registered using the services
      * mechanism, regardless weather it has the appropriate libraries on the classpath.
      *
      * @return An iterator over all discovered datastores which have registered factories
      */
-    public static synchronized Iterator<DataAccessFactory> getAllDataStores() {
-        Set<DataAccessFactory> all = new HashSet<>();
-        Iterator<DataStoreFactorySpi> allDataStores = DataStoreFinder.getAllDataStores();
-        Iterator<DataAccessFactory> allDataAccess =
-                getAllDataStores(getServiceRegistry(), DataAccessFactory.class);
-        while (allDataStores.hasNext()) {
-            DataStoreFactorySpi next = allDataStores.next();
-            all.add(next);
-        }
+    public static Iterator<DataAccessFactory> getAllDataStores() {
+        synchronized (DataAccessFinder.class) {
+            Set<DataAccessFactory> all = new HashSet<>();
+            Iterator<DataStoreFactorySpi> allDataStores = DataStoreFinder.getAllDataStores();
+            Iterator<DataAccessFactory> allDataAccess =
+                    getAllDataStores(getServiceRegistry(), DataAccessFactory.class);
+            while (allDataStores.hasNext()) {
+                DataStoreFactorySpi next = allDataStores.next();
+                all.add(next);
+            }
 
-        while (allDataAccess.hasNext()) {
-            all.add(allDataAccess.next());
-        }
+            while (allDataAccess.hasNext()) {
+                all.add(allDataAccess.next());
+            }
 
-        return all.iterator();
+            return all.iterator();
+        }
     }
 
-    static synchronized <T extends DataAccessFactory> Iterator<T> getAllDataStores(
+    static <T extends DataAccessFactory> Iterator<T> getAllDataStores(
             FactoryRegistry registry, Class<T> category) {
-        return registry.getFactories(category, null, null).iterator();
+        synchronized (DataAccessFinder.class) {
+            return registry.getFactories(category, null, null).iterator();
+        }
     }
 
     /**
-     * Finds all implemtaions of DataAccessFactory which have registered using the services
+     * Finds all implementations of DataAccessFactory which have registered using the services
      * mechanism, and that have the appropriate libraries on the classpath.
      *
      * @return An iterator over all discovered datastores which have registered factories, and whose
      *     available method returns true.
      */
-    public static synchronized Iterator<DataAccessFactory> getAvailableDataStores() {
+    public static Iterator<DataAccessFactory> getAvailableDataStores() {
+        synchronized (DataAccessFinder.class) {
+            FactoryRegistry serviceRegistry = getServiceRegistry();
+            Set<DataAccessFactory> availableDS =
+                    getAvailableDataStores(serviceRegistry, DataAccessFactory.class);
 
-        FactoryRegistry serviceRegistry = getServiceRegistry();
-        Set<DataAccessFactory> availableDS =
-                getAvailableDataStores(serviceRegistry, DataAccessFactory.class);
+            Iterator<DataStoreFactorySpi> availableDataStores =
+                    DataStoreFinder.getAvailableDataStores();
+            while (availableDataStores.hasNext()) {
+                availableDS.add(availableDataStores.next());
+            }
 
-        Iterator<DataStoreFactorySpi> availableDataStores =
-                DataStoreFinder.getAvailableDataStores();
-        while (availableDataStores.hasNext()) {
-            availableDS.add(availableDataStores.next());
+            return availableDS.iterator();
         }
-
-        return availableDS.iterator();
     }
 
-    static synchronized <T extends DataAccessFactory> Set<T> getAvailableDataStores(
+    static <T extends DataAccessFactory> Set<T> getAvailableDataStores(
             FactoryRegistry registry, Class<T> targetClass) {
-        return registry.getFactories(targetClass, null, null)
-                .filter(DataAccessFactory::isAvailable)
-                .collect(toSet());
+        synchronized (DataAccessFinder.class) {
+            return registry.getFactories(targetClass, null, null)
+                    .filter(DataAccessFactory::isAvailable)
+                    .collect(toSet());
+        }
     }
 
     /**
@@ -217,9 +232,11 @@ public final class DataAccessFinder {
      * re-scan. Thus this method need only be invoked by sophisticated applications which
      * dynamically make new plug-ins available at runtime.
      */
-    public static synchronized void scanForPlugins() {
-        DataStoreFinder.scanForPlugins();
-        getServiceRegistry().scanForPlugins();
+    public static void scanForPlugins() {
+        synchronized (DataAccessFinder.class) {
+            DataStoreFinder.scanForPlugins();
+            getServiceRegistry().scanForPlugins();
+        }
     }
 
     /** Resets the factory finder and prepares for a new full scan of the SPI subsystems */
@@ -235,15 +252,19 @@ public final class DataAccessFinder {
      * Programmatically registers a store. Mostly useful for tests, normal store registration should
      * go through the SPI subsystem (META-INF/services files).
      */
-    public static synchronized void registerFactrory(DataAccessFactory factorySpi) {
-        getServiceRegistry().registerFactory(factorySpi);
+    public static void registerFactrory(DataAccessFactory factorySpi) {
+        synchronized (DataAccessFinder.class) {
+            getServiceRegistry().registerFactory(factorySpi);
+        }
     }
 
     /**
      * Programmatically deregisters a store. Mostly useful for tests, normal store registration
      * should go through the SPI subsystem (META-INF/services files).
      */
-    public static synchronized void deregisterFactrory(DataAccessFactory factorySpi) {
-        getServiceRegistry().deregisterFactory(factorySpi);
+    public static void deregisterFactrory(DataAccessFactory factorySpi) {
+        synchronized (DataAccessFinder.class) {
+            getServiceRegistry().deregisterFactory(factorySpi);
+        }
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/api/data/DataStoreFinder.java
+++ b/modules/library/main/src/main/java/org/geotools/api/data/DataStoreFinder.java
@@ -144,7 +144,7 @@ public final class DataStoreFinder {
      * Programmatically registers a store. Mostly useful for tests, normal store registration should
      * go through the SPI subsystem (META-INF/services files).
      */
-    public static void registerFactrory(DataStoreFactorySpi factorySpi) {
+    public static void registerFactory(DataStoreFactorySpi factorySpi) {
         synchronized (DataAccessFinder.class) {
             getServiceRegistry().registerFactory(factorySpi);
         }
@@ -154,9 +154,19 @@ public final class DataStoreFinder {
      * Programmatically deregisters a store. Mostly useful for tests, normal store registration
      * should go through the SPI subsystem (META-INF/services files).
      */
-    public static void deregisterFactrory(DataStoreFactorySpi factorySpi) {
+    public static void deregisterFactory(DataStoreFactorySpi factorySpi) {
         synchronized (DataAccessFinder.class) {
             getServiceRegistry().deregisterFactory(factorySpi);
         }
+    }
+
+    @Deprecated
+    public static void registerFactrory(DataStoreFactorySpi factorySpi) {
+        registerFactory(factorySpi);
+    }
+
+    @Deprecated
+    public static void deregisterFactrory(DataStoreFactorySpi factorySpi) {
+        deregisterFactory(factorySpi);
     }
 }

--- a/modules/library/main/src/main/java/org/geotools/api/data/DataStoreFinder.java
+++ b/modules/library/main/src/main/java/org/geotools/api/data/DataStoreFinder.java
@@ -16,16 +16,15 @@
  */
 package org.geotools.api.data;
 
-import org.geotools.api.feature.Feature;
-import org.geotools.api.feature.type.FeatureType;
-import org.geotools.util.factory.FactoryCreator;
-import org.geotools.util.factory.FactoryRegistry;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import org.geotools.api.feature.Feature;
+import org.geotools.api.feature.type.FeatureType;
+import org.geotools.util.factory.FactoryCreator;
+import org.geotools.util.factory.FactoryRegistry;
 
 /**
  * Enable programs to find all available datastore implementations.

--- a/modules/library/main/src/test/java/org/geotools/api/data/DataStoreFinderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/api/data/DataStoreFinderTest.java
@@ -9,18 +9,22 @@
  */
 package org.geotools.api.data;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Test;
 
 public class DataStoreFinderTest {
+
+    private static final Logger LOGGER =
+            org.geotools.util.logging.Logging.getLogger(DataStoreFinderTest.class);
 
     /** Should find at least the {@link org.geotools.data.DataAccessFinderTest} mock store */
     @Test
@@ -44,11 +48,141 @@ public class DataStoreFinderTest {
         assertNull(DataStoreFinder.getDataStore(params));
 
         // register and second lookup
-        DataStoreFinder.registerFactrory(mockFactory);
+        DataStoreFinder.registerFactory(mockFactory);
         assertEquals(mockStore, DataStoreFinder.getDataStore(params));
 
         // unregister, should stop working
-        DataStoreFinder.deregisterFactrory(mockFactory);
+        DataStoreFinder.deregisterFactory(mockFactory);
         assertNull(DataStoreFinder.getDataStore(params));
+    }
+
+    /**
+     * Test that synchronization between calling DataStoreFinder and DataAccessFinder does not
+     * result in a deadlock.
+     *
+     * @throws Exception unhandled exceptions during test run
+     */
+    @Test
+    public void testDataAccessDeadlock() throws Exception {
+        SlowFactory slowFactory = new SlowFactory();
+
+        CountDownLatch latch = new CountDownLatch(2);
+        Runnable t1 =
+                () -> {
+                    try {
+                        DataAccessFinder.getDataStore(new HashMap<>());
+                        latch.countDown();
+                    } catch (IOException e) {
+                        LOGGER.log(Level.WARNING, "Error calling DataAccessFinder.getDataStore", e);
+                    }
+                };
+        Runnable t2 =
+                () -> {
+                    try {
+                        DataStoreFinder.getDataStore(new HashMap<>());
+                        latch.countDown();
+                    } catch (IOException e) {
+                        LOGGER.log(Level.WARNING, "Error calling DataStoreFinder.getDataStore", e);
+                    }
+                };
+        ExecutorService es = Executors.newFixedThreadPool(3);
+        try {
+            DataAccessFinder.registerFactory(slowFactory);
+            try {
+                DataStoreFinder.registerFactory(slowFactory);
+                try {
+                    Future<?> f1 = es.submit(t1);
+                    slowFactory.waitForIsAvailable();
+                    Future<?> f2 = es.submit(t2);
+                    // wait for t2 to hit the synchronization block in DataStoreFinder
+                    // note: this is bad as it's based on timing, but there aren't any other hooks
+                    // we can use to declaratively determine when to proceed
+                    Thread.sleep(1000);
+                    // allow all the rest of the calls to go through
+                    slowFactory.allowIsAvailable();
+                    // note: DataAccessFinder calls isAvailable twice since it delegates to
+                    // DataStoreFinder
+                    slowFactory.waitForIsAvailable();
+                    slowFactory.allowIsAvailable();
+                    slowFactory.waitForIsAvailable();
+                    slowFactory.allowIsAvailable();
+                    f1.get(10, TimeUnit.SECONDS);
+                    f2.get(10, TimeUnit.SECONDS);
+                } finally {
+                    // note: if the test fails, this call is likely to hang on a deadlocked sync
+                    // lock
+                    DataStoreFinder.deregisterFactory(slowFactory);
+                }
+            } finally {
+                // note: if the test fails, this call is likely to hang on a deadlocked sync lock
+                DataAccessFinder.deregisterFactory(slowFactory);
+            }
+        } finally {
+            es.shutdownNow();
+        }
+
+        boolean success = latch.await(1, TimeUnit.SECONDS);
+        assertTrue(success);
+    }
+
+    static class SlowFactory implements DataStoreFactorySpi {
+
+        private final LinkedBlockingQueue<Boolean> isAvailableGate = new LinkedBlockingQueue<>();
+        private final SynchronousQueue<Boolean> isAvailableNotifier = new SynchronousQueue<>();
+
+        /** Allow isAvailable to return for one method call */
+        public void allowIsAvailable() {
+            LOGGER.finest("allow isAvailable " + Thread.currentThread().getId());
+            isAvailableGate.offer(false);
+        }
+
+        public void waitForIsAvailable() {
+            LOGGER.finest("wait for isAvailable " + Thread.currentThread().getId());
+            try {
+                isAvailableNotifier.poll(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.WARNING, "Interrupted in waitForIsAvailable", e);
+            }
+        }
+
+        @Override
+        public DataStore createDataStore(Map<String, ?> params) {
+            return null;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "";
+        }
+
+        @Override
+        public String getDescription() {
+            return "";
+        }
+
+        @Override
+        public DataAccessFactory.Param[] getParametersInfo() {
+            return new DataAccessFactory.Param[0];
+        }
+
+        @Override
+        public boolean isAvailable() {
+            LOGGER.log(
+                    Level.FINEST,
+                    "call isAvailable " + Thread.currentThread().getId(),
+                    new Exception());
+            try {
+                isAvailableNotifier.offer(false, 10, TimeUnit.SECONDS);
+                isAvailableGate.poll(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.WARNING, "Interrupted in isAvailable", e);
+            }
+            return false;
+        }
+
+        @Override
+        public DataStore createNewDataStore(Map<String, ?> params) {
+            return null;
+        }
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/api/data/DataStoreFinderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/api/data/DataStoreFinderTest.java
@@ -59,10 +59,12 @@ public class DataStoreFinderTest {
 
         // register and second lookup
         DataStoreFinder.registerFactory(mockFactory);
-        assertEquals(mockStore, DataStoreFinder.getDataStore(params));
-
-        // unregister, should stop working
-        DataStoreFinder.deregisterFactory(mockFactory);
+        try {
+            assertEquals(mockStore, DataStoreFinder.getDataStore(params));
+        } finally {
+            // unregister, should stop working
+            DataStoreFinder.deregisterFactory(mockFactory);
+        }
         assertNull(DataStoreFinder.getDataStore(params));
     }
 

--- a/modules/library/main/src/test/java/org/geotools/api/data/DataStoreFinderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/api/data/DataStoreFinderTest.java
@@ -9,14 +9,24 @@
  */
 package org.geotools.api.data;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Test;

--- a/modules/library/main/src/test/java/org/geotools/data/DataAccessFinderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataAccessFinderTest.java
@@ -219,11 +219,11 @@ public class DataAccessFinderTest {
         assertNull(DataAccessFinder.getDataStore(params));
 
         // register and second lookup
-        DataAccessFinder.registerFactrory(mockFactory);
+        DataAccessFinder.registerFactory(mockFactory);
         assertEquals(mockAccess, DataAccessFinder.getDataStore(params));
 
         // unregister, should stop working
-        DataAccessFinder.deregisterFactrory(mockFactory);
+        DataAccessFinder.deregisterFactory(mockFactory);
         assertNull(DataAccessFinder.getDataStore(params));
     }
 

--- a/modules/library/main/src/test/java/org/geotools/data/DataAccessFinderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/DataAccessFinderTest.java
@@ -220,10 +220,12 @@ public class DataAccessFinderTest {
 
         // register and second lookup
         DataAccessFinder.registerFactory(mockFactory);
-        assertEquals(mockAccess, DataAccessFinder.getDataStore(params));
-
-        // unregister, should stop working
-        DataAccessFinder.deregisterFactory(mockFactory);
+        try {
+            assertEquals(mockAccess, DataAccessFinder.getDataStore(params));
+        } finally {
+            // unregister, should stop working
+            DataAccessFinder.deregisterFactory(mockFactory);
+        }
         assertNull(DataAccessFinder.getDataStore(params));
     }
 


### PR DESCRIPTION
[![GEOT-7670](https://badgen.net/badge/JIRA/GEOT-7670/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7670) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This changes DataStoreFinder and DataAccessFinder to synchronize on a common object (DataAccessFinder.class) to avoid potential thread deadlocks.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->