### PR TITLE
[GEOT-7682] Expose JDBCInserrtFeatureWriter flush method

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCInsertFeatureWriter.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCInsertFeatureWriter.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.jdbc;
 
+import java.io.Flushable;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -36,7 +37,7 @@ import org.geotools.filter.identity.FeatureIdImpl;
  * writer is closed.
  */
 public class JDBCInsertFeatureWriter extends JDBCFeatureReader
-        implements FeatureWriter<SimpleFeatureType, SimpleFeature> {
+        implements FeatureWriter<SimpleFeatureType, SimpleFeature>, Flushable {
     /** Grouping elements together in order to have a decent batch size. */
     private final ResultSetFeature[] buffer;
 
@@ -119,7 +120,8 @@ public class JDBCInsertFeatureWriter extends JDBCFeatureReader
         }
     }
 
-    private void flush() throws IOException {
+    @Override
+    public void flush() throws IOException {
         if (curBufferPos == 0) {
             return;
         }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
@@ -37,7 +37,6 @@ public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
 
     @Test
     public void testNext() throws Exception {
-
         try (FeatureWriter writer =
                 dataStore.getFeatureWriter(tname("ft1"), Transaction.AUTO_COMMIT)) {
             assertTrue(writer.hasNext());
@@ -46,7 +45,6 @@ public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
             assertEquals(0, (int) (Integer) feature.getAttribute(1));
             assertEquals(0.0, (double) (Double) feature.getAttribute(2), 0.0);
             assertEquals("zero", feature.getAttribute(3));
-            assertTrue(writer instanceof Flushable);
         }
         try (FeatureWriter writer =
                 dataStore.getFeatureWriter(tname("ft1"), Transaction.AUTO_COMMIT)) {
@@ -56,6 +54,20 @@ public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
             for (Object attribute : attributes) {
                 assertNotNull(attribute);
             }
+        }
+    }
+
+    @Test
+    public void testFlushableAppends() throws Exception {
+        try (FeatureWriter writer =
+                     dataStore.getFeatureWriterAppend(tname("ft1"), Transaction.AUTO_COMMIT)) {
+            assertTrue(writer.hasNext());
+            final SimpleFeature feature = (SimpleFeature) writer.next();
+            assertEquals("POINT (0 0)", feature.getAttribute(0).toString());
+            assertEquals(0, (int) (Integer) feature.getAttribute(1));
+            assertEquals(0.0, (double) (Double) feature.getAttribute(2), 0.0);
+            assertEquals("zero", feature.getAttribute(3));
+            assertTrue(writer instanceof Flushable);
         }
     }
 }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.Flushable;
 import java.util.List;
 import org.geotools.api.data.FeatureWriter;
 import org.geotools.api.data.Transaction;
@@ -45,6 +46,7 @@ public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
             assertEquals(0, (int) (Integer) feature.getAttribute(1));
             assertEquals(0.0, (double) (Double) feature.getAttribute(2), 0.0);
             assertEquals("zero", feature.getAttribute(3));
+            assertTrue(writer instanceof Flushable);
         }
         try (FeatureWriter writer =
                 dataStore.getFeatureWriter(tname("ft1"), Transaction.AUTO_COMMIT)) {

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
@@ -17,6 +17,7 @@
 package org.geotools.jdbc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -61,12 +62,7 @@ public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
     public void testFlushableAppends() throws Exception {
         try (FeatureWriter writer =
                 dataStore.getFeatureWriterAppend(tname("ft1"), Transaction.AUTO_COMMIT)) {
-            assertTrue(writer.hasNext());
-            final SimpleFeature feature = (SimpleFeature) writer.next();
-            assertEquals("POINT (0 0)", feature.getAttribute(0).toString());
-            assertEquals(0, (int) (Integer) feature.getAttribute(1));
-            assertEquals(0.0, (double) (Double) feature.getAttribute(2), 0.0);
-            assertEquals("zero", feature.getAttribute(3));
+            assertFalse(writer.hasNext());
             assertTrue(writer instanceof Flushable);
         }
     }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCFeatureWriterOnlineTest.java
@@ -60,7 +60,7 @@ public abstract class JDBCFeatureWriterOnlineTest extends JDBCTestSupport {
     @Test
     public void testFlushableAppends() throws Exception {
         try (FeatureWriter writer =
-                     dataStore.getFeatureWriterAppend(tname("ft1"), Transaction.AUTO_COMMIT)) {
+                dataStore.getFeatureWriterAppend(tname("ft1"), Transaction.AUTO_COMMIT)) {
             assertTrue(writer.hasNext());
             final SimpleFeature feature = (SimpleFeature) writer.next();
             assertEquals("POINT (0 0)", feature.getAttribute(0).toString());


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

This PR exposes the `flush` method of JDBCInserrtFeatureWriter, by making the method public and implementing `java.io.Flushable`. The rationale is to allow for finer-grained control over when features get written out.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
