### PR TITLE
Avoiding class not found exception in Quickstart

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/JsonArrayContainsFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/JsonArrayContainsFunction.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -39,7 +38,7 @@ public class JsonArrayContainsFunction extends FunctionExpressionImpl {
             org.geotools.util.logging.Logging.getLogger(JsonArrayContainsFunction.class);
 
     private static final HashMap<String, JsonPointer> jsonPointerCache = new HashMap<>();
-    private static final JsonToken END_OF_STREAM = null;
+    private static final Object END_OF_STREAM = null;
     private final JsonFactory factory;
 
     public static FunctionName NAME =


### PR DESCRIPTION
As reported by Peter, running the Quickstart from command line will result in:

```
Nov 18, 2024 4:11:23 PM org.geotools.util.factory.FactoryRegistry scanForPlugins
WARNING: Can't load a service for category "Function". Cause is "ServiceConfigurationError: org.geotools.api.filter.expression.Function: Provider org.geotools.filter.function.JsonArrayContainsFunction could not be instantiated".
java.util.ServiceConfigurationError: org.geotools.api.filter.expression.Function: Provider org.geotools.filter.function.JsonArrayContainsFunction could not be instantiated
        at java.base/[java.util.ServiceLoader.fail](http://java.util.serviceloader.fail/)([ServiceLoader.java:582](http://serviceloader.java:582/))
...
Caused by: java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/JsonFactory
        at org.geotools.filter.function.JsonArrayContainsFunction.<init>([JsonArrayContainsFunction.java:55](http://jsonarraycontainsfunction.java:55/))
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance([NativeConstructorAccessorImpl.java:62](http://nativeconstructoraccessorimpl.java:62/))
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance([DelegatingConstructorAccessorImpl.java:45](http://delegatingconstructoraccessorimpl.java:45/))
        at java.base/java.lang.reflect.Constructor.newInstance([Constructor.java:490](http://constructor.java:490/))
        at java.base/java.util.ServiceLoader$ProviderImpl.newInstance([ServiceLoader.java:780](http://serviceloader.java:780/))
        ... 43 more
Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.core.JsonFactory
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass([BuiltinClassLoader.java:581](http://builtinclassloader.java:581/))
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass([ClassLoaders.java:178](http://classloaders.java:178/))
        at java.base/java.lang.ClassLoader.loadClass([ClassLoader.java:527](http://classloader.java:527/))
        ... 49 more
```

This is an educated guess as to what causes it, with a fix. It's actually happening because "/lib" does not contain jackson, and I don't know why... but this change should make it optional anyways (and maybe it's for the best, an extra dependency for a single function may be too much anyways).

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->