### PR TITLE
ColorConverterFactoryTest.testToCss: Fix gray/grey

### DIFF
--- a/modules/library/main/src/test/java/org/geotools/data/util/ColorConverterFactoryTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/util/ColorConverterFactoryTest.java
@@ -20,6 +20,9 @@ import static java.awt.Color.BLACK;
 import static java.awt.Color.GREEN;
 import static java.awt.Color.RED;
 import static java.awt.Color.WHITE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
 
 import java.awt.Color;
 import org.geotools.filter.ConstantExpression;
@@ -88,7 +91,8 @@ public class ColorConverterFactoryTest {
                         Color.class, String.class, new Hints(Hints.COLOR_DEFINITION, "CSS"));
 
         Assert.assertEquals("aliceblue", "aliceblue", converter.convert(ALICE_BLUE, String.class));
-        Assert.assertEquals("gray", "gray", converter.convert(GRAY, String.class));
+        // There are two names so we could get either.
+        assertThat(converter.convert(GRAY, String.class), anyOf(is("gray"), is("grey")));
 
         Assert.assertEquals(
                 "pale blue",


### PR DESCRIPTION
"gray" and "grey" are two names for the same color.  `Converter.convert` could return either depending on `HashMap` ordering.  Adjust the test to accept either.

https://github.com/geotools/geotools/blob/7f79128a9e8c1df6f07eff675ec35a7070e2d6af/modules/library/main/src/main/java/org/geotools/data/util/ColorConverterFactory.java#L119

Alternatively, a `LinkedHashMap` could be used for `CSS_COLORS`, but accepting either seems like a more minimal change.

There are more duplicate colors, but they are not tested:

```
colors.put("aqua", new Color(0, 255, 255));
colors.put("cyan", new Color(0, 255, 255));
colors.put("darkgray", new Color(169, 169, 169));
colors.put("darkgrey", new Color(169, 169, 169));
colors.put("darkslategray", new Color(47, 79, 79));
colors.put("darkslategrey", new Color(47, 79, 79));
colors.put("dimgray", new Color(105, 105, 105));
colors.put("dimgrey", new Color(105, 105, 105));
colors.put("fuchsia", new Color(255, 0, 255));
colors.put("gray", new Color(128, 128, 128));
colors.put("grey", new Color(128, 128, 128));
colors.put("lightgray", new Color(211, 211, 211));
colors.put("lightgrey", new Color(211, 211, 211));
colors.put("lightslategray", new Color(119, 136, 153));
colors.put("lightslategrey", new Color(119, 136, 153));
colors.put("magenta", new Color(255, 0, 255));
colors.put("slategray", new Color(112, 128, 144));
colors.put("slategrey", new Color(112, 128, 144));
```

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation). [Small PR, not needed, see comments.]
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).