### PR TITLE
[32.x backport] [GEOT-7689] Logic filter equality checks incorrectly implemented

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/BinaryLogicAbstract.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/BinaryLogicAbstract.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.filter;
 
+import static java.util.Collections.frequency;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -27,6 +29,7 @@ public abstract class BinaryLogicAbstract extends AbstractFilter {
     protected BinaryLogicAbstract(List<org.geotools.api.filter.Filter> children) {
         this.children = children;
     }
+
     /** Returned list is unmodifieable. For a cheaper access option use visitor */
     public List<org.geotools.api.filter.Filter> getChildren() {
         return Collections.unmodifiableList(children);
@@ -43,7 +46,15 @@ public abstract class BinaryLogicAbstract extends AbstractFilter {
         BinaryLogicAbstract that = (BinaryLogicAbstract) o;
         if (children == null) return that.children == null;
         if (children.size() != that.children.size()) return false;
-        return children.containsAll(that.children);
+        // order is not important, but the values must be the same, and the comparison
+        // should take into account duplicates ("a AND a" is not the same as "a AND a AND a"
+        // even if the actual result is the same, the filter is different)
+
+        // this method takes all the elements from the first list and checks if they are present
+        // in the second list the same number of times. Couple with the size comparison above
+        // it should do the trick
+        return children.stream()
+                .allMatch(e -> frequency(children, e) == frequency(that.children, e));
     }
 
     @Override

--- a/modules/library/main/src/test/java/org/geotools/filter/FiltersTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/FiltersTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.awt.Color;
 import java.util.Arrays;
+import java.util.List;
 import org.geotools.api.filter.And;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
@@ -209,5 +210,22 @@ public class FiltersTest {
     public void testEmptyEscape() {
         PropertyIsLike like = ff.like(ff.literal("abc def"), "*de*", "*", "_", "");
         assertTrue(like.evaluate(null));
+    }
+
+    @Test
+    public void testLogicFilterEquality() {
+        // this used to fail, as ["a, b"] returned true to containsAll(["a", "a"])
+        Filter andAB = ff.and(a, b);
+        Filter andAA = ff.and(a, a);
+        assertNotEquals(andAB, andAA);
+
+        // another test for a case where the filter is not the same, while the result woul be same
+        Filter andAAA = ff.and(List.of(a, a, a));
+        assertNotEquals(andAA, andAAA);
+
+        // but make sure order is not important
+        Filter andAAB = ff.and(List.of(a, a, b));
+        Filter andABA = ff.and(List.of(a, b, a));
+        assertEquals(andAAB, andABA);
     }
 }


### PR DESCRIPTION
[![GEOT-7689](https://badgen.net/badge/JIRA/GEOT-7689/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7689) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->