### PR TITLE
only use jts snapshot repo when requested with jts profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1526,18 +1526,6 @@
       <url>https://repo.osgeo.org/repository/snapshot/</url>
     </repository>
 
-    <!-- jts repo as a temp measure to try out 1.20.0-SNAPSHOT -->
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>jts-snapshots</id>
-      <url>https://repo.eclipse.org/content/repositories/jts-snapshots</url>
-    </repository>
-
   </repositories>
 
   <!-- =========================================================== -->
@@ -2643,6 +2631,23 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <!-- jts test -->
+    <profile>
+      <id>jts</id>
+      <repositories>
+        <!-- jts repo as a temp measure to try out 1.20.0-SNAPSHOT -->
+        <repository>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <id>jts-snapshots</id>
+          <url>https://repo.eclipse.org/content/repositories/jts-snapshots</url>
+        </repository>
+      </repositories>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Noticed its snapshot repo being scanned (slowing down the build). 
Although the comment indicates this was a temporary measure I accidentally left it in when JTS release was made - sorry!

Set this up as a profile for future use rather than just throw out; this is a non functional build change.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->