### PR TITLE
Switch home page links to https, hopefully this will restore the blog post list as well

### DIFF
--- a/docs/themes/geotools-web/page.html
+++ b/docs/themes/geotools-web/page.html
@@ -2,7 +2,7 @@
 {%- macro index_sidebar() %}
     <div class="sphinxsidebar">
         <div class="sphinxsidebarwrapper">
-            <h1><a href="http://geotoolsnews.blogspot.com">News</a></h1>
+            <h1><a href="https://geotoolsnews.blogspot.com">News</a></h1>
             <ul id="bloglist"></ul>
             <script type="text/javascript">
                 function prettyDate(theTime){
@@ -30,18 +30,16 @@
                     }
                 }
         	</script>
-            <script  type="text/javascript" src="http://geotoolsnews.blogspot.com/feeds/posts/default?alt=json-in-script&amp;callback=showPosts">
+            <script  type="text/javascript" src="https://geotoolsnews.blogspot.com/feeds/posts/default?alt=json-in-script&amp;callback=showPosts">
             </script>
         </div>
         <div class="sphinxsidebarwrapper">
           
-          <a href="http://sourceforge.net/projects/geotools/"><img src="_static/img/sflogo.gif" width=88 heigh=33 style="padding: 2; border: 0;"></a><br/>
+          <a href="https://sourceforge.net/projects/geotools/"><img src="_static/img/sflogo.gif" width=88 heigh=33 style="padding: 2; border: 0;"></a><br/>
           
-          <a href="http://www.yourkit.com/"><img src="_static/img/yjp.png" width=100 height=26 style="padding: 2; border: 0;"></a><br/>
+          <a href="https://www.yourkit.com/"><img src="_static/img/yjp.png" width=100 height=26 style="padding: 2; border: 0;"></a><br/>
           
-          <a href="http://www.java.net/"><img src="_static/img/javanet_button_90.gif" width=90 height=25 style="padding: 2; border: 0;"></a><br/>
-
-          If you are looking for <a href="http://geotools.com/">geotools.com</a> or <a href="http://geotoolsnet.sourceforge.net/">geotools.net</a> you are in the wrong spot!
+          If you are looking for <a href="https://geotools.com/">geotools.com</a> or <a href="https://geotoolsnet.sourceforge.net/">geotools.net</a> you are in the wrong spot!
         </div>
     </div>
 {%- endmacro %}
@@ -50,8 +48,8 @@
   {%- if pagename == 'index' %}
   <div id="quicklinks">
   	<ul>
-	  <li><a href="http://docs.geotools.org/latest/userguide/tutorial/quickstart/index.html" style="background-image: url(_static/img/quickstart.png)">Quickstart</a></li>
-	  <li><a href="http://docs.geotools.org" style="background-image: url(_static/img/docs.png)">Documentation</a></li>
+	  <li><a href="https://docs.geotools.org/latest/userguide/tutorial/quickstart/index.html" style="background-image: url(_static/img/quickstart.png)">Quickstart</a></li>
+	  <li><a href="https://docs.geotools.org" style="background-image: url(_static/img/docs.png)">Documentation</a></li>
 	  <li><a href="{{ pathto('getinvolved')}}" style="background-image: url(_static/img/getinvolved.png)">Get Involved</a></li>
 	  <li><a href="{{ pathto('about') }}" style="background-image: url(_static/img/info.png)">About GeoTools</a></li>
 	</ul>


### PR DESCRIPTION
Noticed errors about mixed http/https usage in the JS console, preventing loading of blog posts. Then found other HTTP links in the same HTML template. Ended up switching all to https (java.net is gone, removed it altogether)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->