### PR TITLE
[GEOT-7687] fixed duplicated escaping when numeric object keys are used in jsonpointer

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
@@ -254,6 +254,48 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
     }
 
     @Test
+    public void testFunctionJsonPointerWithNumericObjectKey() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer = ff.function("jsonPointer", ff.property("testjson"), ff.literal("/'1407'"));
+        Filter startsWith = ff.equals(pointer, ff.literal("value"));
+        filterToSql.encode(startsWith);
+        String sql = writer.toString().toLowerCase().trim();
+        assertEquals("where testjson ::json  ->> '1407' = 'value'", sql);
+    }
+
+    @Test
+    public void testFunctionJsonPointerWithApostropheKey() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer = ff.function("jsonPointer", ff.property("testjson"), ff.literal("/'"));
+        Filter startsWith = ff.equals(pointer, ff.literal("escaped_apostrophe"));
+        filterToSql.encode(startsWith);
+        String sql = writer.toString().toLowerCase().trim();
+        assertEquals("where testjson ::json  ->> '''' = 'escaped_apostrophe'", sql);
+    }
+
+    @Test
+    public void testFunctionJsonPointerWithUnescapedNumericKey() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer = ff.function("jsonPointer", ff.property("testjson"), ff.literal("/'2202"));
+        Filter startsWith = ff.equals(pointer, ff.literal("escaped_literal"));
+        filterToSql.encode(startsWith);
+        String sql = writer.toString().toLowerCase().trim();
+        assertEquals("where testjson ::json  ->> '''2202' = 'escaped_literal'", sql);
+    }
+
+    @Test
+    public void testFunctionJsonPointerWithComplexPath() throws Exception {
+        filterToSql.setFeatureType(testSchema);
+        Function pointer =
+                ff.function("jsonPointer", ff.property("testjson"), ff.literal("/numeric_key/'0714'/array_index/1407"));
+        Filter startsWith = ff.equals(pointer, ff.literal("complex_pointer"));
+        filterToSql.encode(startsWith);
+        String sql = writer.toString().toLowerCase().trim();
+        assertEquals(
+                "where testjson ::json  -> 'numeric_key' -> '0714' -> 'array_index' ->> 1407 = 'complex_pointer'", sql);
+    }
+
+    @Test
     public void testBinaryComparisonWithJsonPointer() throws Exception {
         filterToSql.setFeatureType(testSchema);
         Function pointer = ff.function("jsonPointer", ff.property("testJSON"), ff.literal("/arr/0"));


### PR DESCRIPTION
[![GEOT-7687](https://badgen.net/badge/JIRA/GEOT-7687/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7687) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The issue is tracked under [GEOT-7687](https://osgeo-org.atlassian.net/browse/GEOT-7687)

currently it is not possible to use numeric json(b) keys. When not escaped they are treated as array indices. Possible escaping leads to unwanted additional escapes. This PR should fix the behavior

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).