### PR TITLE
[GEOT-7697] GeoTIFF revision declared to be 1.2, while it's actually 1.0

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffConstants.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/GeoTiffConstants.java
@@ -106,7 +106,7 @@ public final class GeoTiffConstants {
 
     public static final int DEFAULT_KEY_REVISION_MAJOR = 1;
 
-    public static final int DEFAULT_KEY_REVISION_MINOR = 2;
+    public static final int DEFAULT_KEY_REVISION_MINOR = 0;
 
     public static final int UNDEFINED = 0;
 

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/io/imageio/geotiff/CRS2GeoTiffMetadataAdapterTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/io/imageio/geotiff/CRS2GeoTiffMetadataAdapterTest.java
@@ -38,4 +38,19 @@ public class CRS2GeoTiffMetadataAdapterTest {
                 "GCS Name = Mars (2015) - Sphere / Ocentric|Datum = Mars (2015) - Sphere|Ellipsoid = Mars (2015) - Sphere|Primem = Reference Meridian|",
                 value);
     }
+
+    @Test
+    public void testBasic() throws GeoTiffException, FactoryException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:4326", true);
+        CRS2GeoTiffMetadataAdapter adapter = new CRS2GeoTiffMetadataAdapter(crs);
+        GeoTiffIIOMetadataEncoder meta = adapter.parseCoordinateReferenceSystem();
+        // root of the key array, has special meaning, {KeyDirectoryVersion, KeyRevision, MinorRevision, NumberOfKeys}
+        GeoKeyEntry entry = meta.getGeoKeyEntryAt(0);
+        assertEquals(1, entry.getTiffTagLocation()); // this is the major revision)
+        assertEquals(2, entry.getCount()); // this is the major revision)
+
+        // check the CRS
+        assertEquals(GeoTiffGCSCodes.ModelTypeGeographic, meta.getGeoShortParam(GeoTiffConstants.GTModelTypeGeoKey));
+        assertEquals(4326, meta.getGeoShortParam(GeoTiffGCSCodes.GeographicTypeGeoKey));
+    }
 }


### PR DESCRIPTION
See ticket for details, needed to pass the OGC CITE tests for GeoTIFF files

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
