### PR TITLE
[GEOT-7706] fixed class comparison for Date/Time instances

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/filter/function/InFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/InFunction.java
@@ -173,6 +173,12 @@ public class InFunction extends FunctionExpressionImpl {
             return Double.class; // StaticGeometry.equalTo will convert to double
         } else if (Boolean.class.isAssignableFrom(target)) {
             return Boolean.class;
+        } else if (java.sql.Timestamp.class.isAssignableFrom(target)) {
+            return java.sql.Timestamp.class;
+        } else if (java.sql.Date.class.isAssignableFrom(target)) {
+            return java.sql.Date.class;
+        } else if (java.sql.Time.class.isAssignableFrom(target)) {
+            return java.sql.Time.class;
         } else if (Date.class.isAssignableFrom(target)) {
             return Date.class;
         } else if (String.class.isAssignableFrom(target)) {

--- a/modules/library/main/src/test/java/org/geotools/filter/FilterTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/FilterTest.java
@@ -61,6 +61,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.filter.capability.FunctionNameImpl;
 import org.geotools.filter.expression.PropertyAccessor;
 import org.geotools.filter.expression.PropertyAccessorFactory;
+import org.geotools.filter.function.InFunction;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.util.factory.Hints;
 import org.junit.Assert;
@@ -1259,5 +1260,24 @@ public class FilterTest {
         Intersects intersects = fac.intersects(fac.function("boundedBy"), fac.literal(box));
 
         Assert.assertTrue(intersects.evaluate(testFeature));
+    }
+
+    @Test
+    public void testInConditionWithDateClassesGEOS11591() {
+        InFunction inFunctionTimestamp = new InFunction();
+        inFunctionTimestamp.setParameters(List.of(fac.property("datetime2"), fac.literal("2007-08-15 12:00:00")));
+        Assert.assertTrue(fac.equals(inFunctionTimestamp, fac.literal(true)).evaluate(testFeature));
+
+        InFunction inFunctionUtilDate = new InFunction();
+        inFunctionUtilDate.setParameters(List.of(fac.property("datetime1"), fac.literal("2007-08-15 12:00:00PM")));
+        Assert.assertTrue(fac.equals(inFunctionUtilDate, fac.literal(true)).evaluate(testFeature));
+
+        InFunction inFunctionSqlDate = new InFunction();
+        inFunctionSqlDate.setParameters(List.of(fac.property("date"), fac.literal("2007-08-15")));
+        Assert.assertTrue(fac.equals(inFunctionSqlDate, fac.literal(true)).evaluate(testFeature));
+
+        InFunction inFunctionSqlTime = new InFunction();
+        inFunctionSqlTime.setParameters(List.of(fac.property("time"), fac.literal("12:00:00")));
+        Assert.assertTrue(fac.equals(inFunctionSqlTime, fac.literal(true)).evaluate(testFeature));
     }
 }


### PR DESCRIPTION
[![GEOT-7706](https://badgen.net/badge/JIRA/GEOT-7706/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11591) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The ticket is being tracked under [GEOT-7706](https://osgeo-org.atlassian.net/browse/GEOT-7706)

The problem is (was) that `java.util.Date` is assignable from `java.sql.Timestamp` class instances but not vice-versa. This may cause problems when an in-condition (containing Date/Time) should be applied on a timestamp column. One needs to distinguish between assignable date sub-classes within the `InFunction#getContextFromCandidate`.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->