### PR TITLE
[GEOT-7703] Allow usage of fullPath in most common mosaic property collectors

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/FullPathCollector.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/FullPathCollector.java
@@ -1,0 +1,17 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This file is hereby placed into the Public Domain. This means anyone is
+ *    free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.gce.imagemosaic.properties;
+
+/** Marker interface for collectors that can be made to inspect the full file path */
+public interface FullPathCollector {
+    boolean isFullPath();
+
+    void setFullPath(boolean fullPath);
+}

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/RegExPropertiesCollector.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/RegExPropertiesCollector.java
@@ -28,16 +28,20 @@ import java.util.regex.Pattern;
 import org.apache.commons.io.FilenameUtils;
 import org.geotools.util.logging.Logging;
 
-public abstract class RegExPropertiesCollector extends PropertiesCollector {
+public abstract class RegExPropertiesCollector extends PropertiesCollector implements FullPathCollector {
 
     private static final Logger LOGGER = Logging.getLogger(RegExPropertiesCollector.class);
 
     private boolean fullPath = false;
 
+    private Pattern pattern;
+
+    @Override
     public boolean isFullPath() {
         return fullPath;
     }
 
+    @Override
     public void setFullPath(boolean fullPath) {
         this.fullPath = fullPath;
     }
@@ -48,8 +52,6 @@ public abstract class RegExPropertiesCollector extends PropertiesCollector {
         this.fullPath = fullPath;
         pattern = Pattern.compile(regex);
     }
-
-    private Pattern pattern;
 
     @Override
     public RegExPropertiesCollector collect(File file) {

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/string/StringFileNameExtractorTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/string/StringFileNameExtractorTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Set;
 import org.geotools.api.feature.simple.SimpleFeature;
@@ -76,6 +77,18 @@ public class StringFileNameExtractorTest {
         String seq = (String) feature.getAttribute("seq");
         assertNotNull(seq);
         assertEquals("20130301000000", seq);
+    }
+
+    @Test
+    public void testFullPath() throws Exception {
+        PropertiesCollectorSPI spi = getStringFileNameSpi();
+        PropertiesCollector collector =
+                spi.create("regex=(?<=\\/)([sS]\\d+)(?=\\/),fullPath=true", Arrays.asList("seq"));
+        collector.collect(new URI("/var/data/s10/raster.tiff"));
+        collector.setProperties(feature);
+        String seq = (String) feature.getAttribute("seq");
+        assertNotNull(seq);
+        assertEquals("s10", seq);
     }
 
     private PropertiesCollectorSPI getStringFileNameSpi() {


### PR DESCRIPTION
[![GEOT-7703](https://badgen.net/badge/JIRA/GEOT-7703/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7703) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->