### PR TITLE
[GEOT-7709] WMTS GetCapabilities will not recognize ServiceException

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/response/WMTSGetCapabilitiesResponse.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/response/WMTSGetCapabilitiesResponse.java
@@ -17,29 +17,25 @@
 
 package org.geotools.ows.wmts.response;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.ParserConfigurationException;
 import net.opengis.wmts.v_1.CapabilitiesType;
 import org.geotools.data.ows.GetCapabilitiesResponse;
+import org.geotools.data.ows.ServiceExceptionParser;
 import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
 import org.geotools.util.logging.Logging;
 import org.geotools.wmts.WMTSConfiguration;
 import org.geotools.xsd.Parser;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * Provides a hook up to parse the capabilties document from inputstream.
+ * Provides a hook up to parse the capabilities document from input stream.
  *
  * <p>(Based on existing work by rgould for WMS service)
  *
@@ -54,43 +50,38 @@ public class WMTSGetCapabilitiesResponse extends GetCapabilitiesResponse {
         this(response, null);
     }
 
+    /**
+     * Constructor that sets capabilities property. Input stream of response is closed immediately.
+     *
+     * @param response the httpResponse from the server
+     * @param hints not used
+     * @throws ServiceException thrown if server responds with ServiceException or a ill-formatted XML
+     * @throws IOException thrown if input stream is wrong
+     */
     public WMTSGetCapabilitiesResponse(HTTPResponse response, Map<String, Object> hints)
             throws ServiceException, IOException {
         super(response);
-
-        try {
-
-            Object object;
-            try (InputStream inputStream = response.getResponseStream()) {
+        Object object;
+        try (InputStream inputStream = response.getResponseStream()) {
+            try {
                 Parser parser = new Parser(WMTS_CONFIGURATION);
-                if (LOGGER.isLoggable(Level.FINEST)) {
-                    StringBuilder stringBuilder = new StringBuilder();
-                    String line = null;
-
-                    try (BufferedReader bufferedReader =
-                            new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-                        while ((line = bufferedReader.readLine()) != null) {
-                            stringBuilder.append(line + "\n");
-                        }
-                    }
-                    String string = stringBuilder.toString();
-                    LOGGER.finest(string);
-
-                    object = parser.parse(new InputSource(new ByteArrayInputStream(string.getBytes())));
-                } else {
-                    object = parser.parse(inputStream);
-                }
+                object = parser.parse(inputStream);
             } catch (SAXException | ParserConfigurationException e) {
-                throw (ServiceException) new ServiceException("Error while parsing XML.").initCause(e);
+                throw new IOException("Error while parsing XML.", e);
             }
-
-            if (object instanceof ServiceException) {
-                throw (ServiceException) object;
+            if (object instanceof CapabilitiesType) {
+                this.capabilities = new WMTSCapabilities((CapabilitiesType) object);
+            } else {
+                inputStream.reset();
+                object = ServiceExceptionParser.parse(inputStream);
+                if (object instanceof ServiceException) {
+                    LOGGER.log(Level.SEVERE, "Server returned ServiceException.", object);
+                    throw (ServiceException) object;
+                } else {
+                    LOGGER.info("Unknown xml returned from server.");
+                    throw new IOException("Unknown XML from server.");
+                }
             }
-
-            this.capabilities = new WMTSCapabilities((CapabilitiesType) object);
-        } finally {
-            response.dispose();
         }
     }
 }

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/response/CapabilitiesResponseTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/response/CapabilitiesResponseTest.java
@@ -1,0 +1,56 @@
+/*
+ * GeoTools - The Open Source Java GIS Toolkit http://geotools.org
+ *
+ * (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; version 2.1 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ */
+package org.geotools.ows.wmts.response;
+
+import java.io.File;
+import org.geotools.http.HTTPResponse;
+import org.geotools.http.MockHttpResponse;
+import org.geotools.ows.ServiceException;
+import org.geotools.test.TestData;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CapabilitiesResponseTest {
+
+    @Test
+    public void testServiceExceptionWithoutContentType() throws Exception {
+        String exception = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\" standalone=\"yes\" ?>\n"
+                + "<ServiceExceptionReport version=\"1.1.0\">\n"
+                + "<ServiceException>"
+                + "Gatekeeper logon denied."
+                + "</ServiceException>\n"
+                + "</ServiceExceptionReport>";
+        String contentType = "application/xml";
+
+        HTTPResponse resp = new MockHttpResponse(exception, contentType);
+        try {
+            WMTSGetCapabilitiesResponse capaResp = new WMTSGetCapabilitiesResponse(resp);
+            Assert.fail("Wrong to get a capabilities response. Content is: " + capaResp);
+        } catch (ServiceException e) {
+            Assert.assertEquals("Gatekeeper logon denied.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testOrdinaryCapabilitiesResponse() throws Exception {
+        File getCaps = TestData.file(null, "ol.getcapa.xml");
+        HTTPResponse resp = new MockHttpResponse(getCaps, "application/xml");
+        WMTSGetCapabilitiesResponse capaResp = new WMTSGetCapabilitiesResponse(resp);
+        try {
+            Assert.assertNotNull(capaResp.getCapabilities());
+        } finally {
+            capaResp.dispose();
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-7709](https://badgen.net/badge/JIRA/GEOT-7709/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7709) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Rearranged the constructor to avoid ClassCastException and added tests for two situations.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->