### PR TITLE
[GEOT-7545] Wrong log level comparison in LogbackLogger#isLoggable

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/logging/LogbackLogger.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/logging/LogbackLogger.java
@@ -165,7 +165,7 @@ public class LogbackLogger extends LoggerAdapter {
 
     @Override
     public boolean isLoggable(Level level) {
-        return getLevel().intValue() > level.intValue();
+        return getLevel().intValue() <= level.intValue();
     }
 
     @Override

--- a/modules/library/metadata/src/test/java/org/geotools/util/logging/LoggingTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/logging/LoggingTest.java
@@ -202,4 +202,51 @@ public class LoggingTest {
             assertEquals(Logger.class, Logging.getLogger("org.geotools").getClass());
         }
     }
+
+    /** Tests the redirection to Logback. */
+    @Test
+    public void testLogback() throws ClassNotFoundException {
+        try {
+            Logging.GEOTOOLS.setLoggerFactory("org.geotools.util.logging.LogbackLoggerFactory");
+            Logger logger = Logging.getLogger("org.geotools");
+            assertTrue(logger instanceof LogbackLogger);
+            /*
+             * Tests level setting, ending with OFF in order to avoid
+             * polluting the standard output stream with this test.
+             */
+            final Level oldLevel = logger.getLevel();
+
+            logger.setLevel(Level.WARNING);
+            assertSame("java level mapped", Level.WARNING, logger.getLevel());
+            assertTrue(logger.isLoggable(Level.WARNING));
+            assertTrue(logger.isLoggable(Level.SEVERE));
+            assertFalse(logger.isLoggable(Level.CONFIG));
+
+            logger.setLevel(Level.CONFIG);
+            assertSame("java level mapped", Level.CONFIG, logger.getLevel());
+            assertTrue(logger.isLoggable(Level.INFO));
+            assertTrue(logger.isLoggable(Level.CONFIG));
+            assertFalse(logger.isLoggable(Level.FINE));
+
+            logger.setLevel(Level.FINE);
+            assertSame(Level.FINE, logger.getLevel());
+            assertFalse(logger.isLoggable(Level.FINER));
+            assertTrue(logger.isLoggable(Level.FINE));
+            assertTrue(logger.isLoggable(Level.SEVERE));
+
+            logger.setLevel(Level.OFF);
+            assertSame("java level mapped", Level.OFF, logger.getLevel());
+
+            logger.finer("Message to Log4J at FINER level.");
+            logger.fine("Message to Log4J at FINE level.");
+            logger.config("Message to Log4J at CONFIG level.");
+            logger.info("Message to Log4J at INFO level.");
+            logger.warning("Message to Log4J at WARNING level.");
+            logger.severe("Message to Log4J at SEVERE level.");
+            logger.setLevel(oldLevel);
+        } finally {
+            Logging.GEOTOOLS.setLoggerFactory((String) null);
+            assertEquals(Logger.class, Logging.getLogger("org.geotools").getClass());
+        }
+    }
 }


### PR DESCRIPTION
[![GEOT-7545](https://badgen.net/badge/JIRA/GEOT-7545/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7545) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

The logback logger was doing an incorrect log level comparison, suppressing messages that should have been shown based on the configured log level.

This PR fixes the logic and adds a unit test to prevent a regression.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->