### PR TITLE
[GEOT-7711] 32.x upgrade log4j to 2.24.1, slf4j to 2.0.16, and logback 1.5.14

### DIFF
--- a/modules/library/metadata/src/main/java/org/geotools/util/logging/LogbackLogger.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/logging/LogbackLogger.java
@@ -165,7 +165,7 @@ public class LogbackLogger extends LoggerAdapter {
 
     @Override
     public boolean isLoggable(Level level) {
-        return getLevel().intValue() > level.intValue();
+        return getLevel().intValue() <= level.intValue();
     }
 
     @Override

--- a/modules/library/metadata/src/test/java/org/geotools/util/logging/LoggingTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/logging/LoggingTest.java
@@ -202,4 +202,51 @@ public class LoggingTest {
             assertEquals(Logger.class, Logging.getLogger("org.geotools").getClass());
         }
     }
+
+    /** Tests the redirection to Logback. */
+    @Test
+    public void testLogback() throws ClassNotFoundException {
+        try {
+            Logging.GEOTOOLS.setLoggerFactory("org.geotools.util.logging.LogbackLoggerFactory");
+            Logger logger = Logging.getLogger("org.geotools");
+            assertTrue(logger instanceof LogbackLogger);
+            /*
+             * Tests level setting, ending with OFF in order to avoid
+             * polluting the standard output stream with this test.
+             */
+            final Level oldLevel = logger.getLevel();
+
+            logger.setLevel(Level.WARNING);
+            assertSame("java level mapped", Level.WARNING, logger.getLevel());
+            assertTrue(logger.isLoggable(Level.WARNING));
+            assertTrue(logger.isLoggable(Level.SEVERE));
+            assertFalse(logger.isLoggable(Level.CONFIG));
+
+            logger.setLevel(Level.CONFIG);
+            assertSame("java level mapped", Level.CONFIG, logger.getLevel());
+            assertTrue(logger.isLoggable(Level.INFO));
+            assertTrue(logger.isLoggable(Level.CONFIG));
+            assertFalse(logger.isLoggable(Level.FINE));
+
+            logger.setLevel(Level.FINE);
+            assertSame(Level.FINE, logger.getLevel());
+            assertFalse(logger.isLoggable(Level.FINER));
+            assertTrue(logger.isLoggable(Level.FINE));
+            assertTrue(logger.isLoggable(Level.SEVERE));
+
+            logger.setLevel(Level.OFF);
+            assertSame("java level mapped", Level.OFF, logger.getLevel());
+
+            logger.finer("Message to Log4J at FINER level.");
+            logger.fine("Message to Log4J at FINE level.");
+            logger.config("Message to Log4J at CONFIG level.");
+            logger.info("Message to Log4J at INFO level.");
+            logger.warning("Message to Log4J at WARNING level.");
+            logger.severe("Message to Log4J at SEVERE level.");
+            logger.setLevel(oldLevel);
+        } finally {
+            Logging.GEOTOOLS.setLoggerFactory((String) null);
+            assertEquals(Logger.class, Logging.getLogger("org.geotools").getClass());
+        }
+    }
 }

--- a/modules/unsupported/elasticsearch/pom.xml
+++ b/modules/unsupported/elasticsearch/pom.xml
@@ -161,7 +161,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>${sl4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
     <jt.version>1.6.0</jt.version>
     <jtds.jdbc.version>1.3.1</jtds.jdbc.version>
     <jts.version>1.20.0</jts.version>
-    <log4j2.version>2.17.2</log4j2.version>
+    <log4j2.version>2.24.1</log4j2.version>
     <logback.version>1.5.14</logback.version>
     <mockito.version>5.12.0</mockito.version>
     <mssql-jdbc.version>9.4.0.jre8</mssql-jdbc.version>
@@ -497,7 +497,7 @@
     <ojdbc8.version>19.18.0.0</ojdbc8.version>
     <postgresql.jdbc.version>42.7.3</postgresql.jdbc.version>
     <reload4j.version>1.2.19</reload4j.version>
-    <sl4j.version>1.7.32</sl4j.version>
+    <sl4j.version>2.0.16</sl4j.version>
     <solrj.version>8.11.3</solrj.version>
     <!-- javadoc configuration -->
     <javadoc.maxHeapSize>1536M</javadoc.maxHeapSize>

--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
     <jtds.jdbc.version>1.3.1</jtds.jdbc.version>
     <jts.version>1.20.0</jts.version>
     <log4j2.version>2.17.2</log4j2.version>
-    <logback.version>1.3.12</logback.version>
+    <logback.version>1.5.14</logback.version>
     <mockito.version>5.12.0</mockito.version>
     <mssql-jdbc.version>9.4.0.jre8</mssql-jdbc.version>
     <mysql-connector-java.version>9.1.0</mysql-connector-java.version>

--- a/release/src/it/log4j/pom.xml
+++ b/release/src/it/log4j/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.deploy.skip>true</maven.deploy.skip>
     <geotools.version>32-SNAPSHOT</geotools.version>
-    <log4j2.version>2.17.2</log4j2.version>
+    <log4j2.version>2.24.1</log4j2.version>
   </properties>
   <dependencies>
     <dependency>

--- a/release/src/it/logback/pom.xml
+++ b/release/src/it/logback/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.deploy.skip>true</maven.deploy.skip>
     <geotools.version>32-SNAPSHOT</geotools.version>
-    <logback.version>1.3.12</logback.version>
+    <logback.version>1.5.14</logback.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
An update of slf4j 2.x introduced an incompatibility with logback which was not covered by test cases.

- https://github.com/geotools/geotools/pull/4979

This was detected by https://github.com/geotools/geotools/pull/5063 which introduced a test case.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
