### PR TITLE
[GEOT-7713]  FeatureTypeRegistry of gt-complex is not thread-safe

### DIFF
--- a/modules/extension/complex/src/main/java/org/geotools/data/complex/feature/type/FeatureTypeRegistry.java
+++ b/modules/extension/complex/src/main/java/org/geotools/data/complex/feature/type/FeatureTypeRegistry.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
@@ -610,7 +611,7 @@ public class FeatureTypeRegistry {
 
     /** Caches the basic types */
     private static Map<Class<? extends FeatureTypeRegistryConfiguration>, Map<Name, AttributeType>> FOUNDATION_TYPES =
-            new HashMap<>();
+            new ConcurrentHashMap<>();
 
     private void createFoundationTypes() {
         Map<Name, AttributeType> foundationTypes =


### PR DESCRIPTION
[![GEOT-7713](https://badgen.net/badge/JIRA/GEOT-7713/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7713) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Just want to place synchronize at the right object. More should probably be done to get it thread-safe.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->