### PR TITLE
[GEOT-7717] Updating GDAL to latest, 3.10.1

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env: 
-  OSX_GDAL_VERSION: 3.9.0
+  OSX_GDAL_VERSION: 3.10.1
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
   DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
   CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio  -DPoppler_ROOT=/opt/homebrew/Cellar/poppler -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ env:
   OSX_GDAL_VERSION: 3.10.1
   GDAL_INSTALL_PATH: /Users/runner/work/gdal
   DYLD_LIBRARY_PATH: /Users/runner/work/gdal/lib:/Users/runner/work/gdal/lib/jni:/Users/runner/work/gdal/share/java:/opt/homebrew/lib:/usr/lib
-  CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio  -DPoppler_ROOT=/opt/homebrew/Cellar/poppler -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON
+  CMAKE_OPTIONS: -DCFITSIO_ROOT=/opt/homebrew/Cellar/cfitsio -DPROJ_ROOT=/opt/homebrew/Cellar/proj -DSPATIALITE_ROOT=/opt/homebrew/Cellar/libspatialite -DPostgreSQL_ROOT=/opt/homebrew/Cellar/libpq -DEXPAT_ROOT=/opt/homebrew/Cellar/expat -DXercesC_ROOT=/opt/homebrew/Cellar/xerces-c -DSQLite3_ROOT=/opt/homebrew/Cellar/sqlite -DOpenSSL_ROOT=/opt/homebrew/Cellar/openssl -DPNG_ROOT=/opt/homebrew/Cellar/libpng -DJPEG_ROOT=/opt/homebrew/Cellar/jpeg-turbo -DEXPECTED_JPEG_LIB_VERSION=80 -DOpenJPEG_ROOT=/opt/homebrew/Cellar/openjpeg -DCURL_ROOT=/opt/homebrew/Cellar/curl -DGDAL_USE_LIBKML=OFF -DGDAL_USE_ODBC=OFF -DGDAL_USE_ZSTD=OFF -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON
 
 jobs:
   build:
@@ -30,7 +30,7 @@ jobs:
         mkdir $GDAL_INSTALL_PATH
         brew update
         brew upgrade
-        brew install freexl libxml2 libspatialite geos proj libgeotiff openjpeg libaec postgis poppler doxygen unixodbc aom jpeg-xl libheif libarchive libkml boost ccache swig python-setuptools
+        brew install freexl libxml2 libspatialite geos proj libgeotiff openjpeg libaec postgis doxygen unixodbc aom jpeg-xl libheif libarchive libkml boost ccache swig python-setuptools
         : # gdal is automatically installed as a dependency for postgis
         brew uninstall --ignore-dependencies gdal
         wget https://github.com/OSGeo/gdal/releases/download/v$OSX_GDAL_VERSION/gdal-$OSX_GDAL_VERSION.tar.gz
@@ -38,8 +38,8 @@ jobs:
         cd gdal-$OSX_GDAL_VERSION
         mkdir build
         cd build
-        : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet)
-        cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF ${CMAKE_OPTIONS} ..  
+        : # See https://github.com/OSGeo/gdal/issues/6949 (Java bindings) and https://github.com/OSGeo/gdal/pull/8226 (Arrow and Parquet). Poppler is off due to build failures
+        cmake -DCMAKE_INSTALL_PREFIX=$GDAL_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DGDAL_USE_POPPLER=OFF ${CMAKE_OPTIONS} ..
         cmake --build .
         cmake --build . --target install
         : # Sanity test that the gdal bindings actually work


### PR DESCRIPTION
[![GEOT-7717](https://badgen.net/badge/JIRA/GEOT-7717/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7717) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

All OSX builds are failing due to some new incopatibility with a PDF library (or so it seems):

```
In file included from /Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfdataset.cpp:47:
/Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfio.h:67:18: error: virtual function 'reset' has a different return type ('void') than the function it overrides (which has return type 'bool')
    virtual void reset() override;
            ~~~~ ^
/opt/homebrew/Cellar/poppler/25.02.0/include/poppler/Stream.h:129:18: note: overridden virtual function is here
    virtual bool reset() = 0;
            ~~~~ ^
/Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfdataset.cpp:1985:15: error: no viable conversion from 'std::unique_ptr<OCGs>' to 'OCGs *'
        OCGs *poOldOCGs = poCatalog->optContent;
              ^           ~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfdataset.cpp:1999:35: error: no viable overloaded '='
            poCatalog->optContent = poOldOCGs;
            ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:233:71: note: candidate function not viable: no known conversion from 'OCGs *' to 'unique_ptr<OCGs>' for 1st argument
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr&& __u) _NOEXCEPT {
                                                                      ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:243:71: note: candidate template ignored: could not match 'unique_ptr<_Up, _Ep>' against 'OCGs *'
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT {
                                                                      ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:268:71: note: candidate function not viable: no known conversion from 'OCGs *' to 'nullptr_t' (aka 'std::nullptr_t') for 1st argument
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(nullptr_t) _NOEXCEPT {
                                                                      ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:127:59: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'OCGs *' to 'const std::unique_ptr<OCGs>' for 1st argument
class _LIBCPP_UNIQUE_PTR_TRIVIAL_ABI _LIBCPP_TEMPLATE_VIS unique_ptr {
                                                          ^
/Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfdataset.cpp:2005:31: error: no viable overloaded '='
        poCatalog->optContent = poOldOCGs;
        ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:233:71: note: candidate function not viable: no known conversion from 'OCGs *' to 'unique_ptr<OCGs>' for 1st argument
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr&& __u) _NOEXCEPT {
                                                                      ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:243:71: note: candidate template ignored: could not match 'unique_ptr<_Up, _Ep>' against 'OCGs *'
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT {
                                                                      ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:268:71: note: candidate function not viable: no known conversion from 'OCGs *' to 'nullptr_t' (aka 'std::nullptr_t') for 1st argument
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(nullptr_t) _NOEXCEPT {
                                                                      ^
/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/include/c++/v1/__memory/unique_ptr.h:127:59: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'OCGs *' to 'const std::unique_ptr<OCGs>' for 1st argument
class _LIBCPP_UNIQUE_PTR_TRIVIAL_ABI _LIBCPP_TEMPLATE_VIS unique_ptr {
                                                          ^
/Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfdataset.cpp:3747:23: error: cannot initialize a variable of type 'OCGs *' with an rvalue of type 'const OCGs *'
                OCGs *optContentConfig = m_poDocPoppler->getOptContentConfig();
                      ^                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfdataset.cpp:3783:11: error: cannot initialize a variable of type 'OCGs *' with an rvalue of type 'const OCGs *'
    OCGs *optContentConfig = m_poDocPoppler->getOptContentConfig();
          ^                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfdataset.cpp:3787:12: error: cannot initialize a variable of type 'Array *' with an rvalue of type 'const Array *'
    Array *array = optContentConfig->getOrderArray();
           ^       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/geotools/geotools/gdal-3.9.0/frmts/pdf/pdfdataset.cpp:3823:11: error: cannot initialize a variable of type 'OCGs *' with an rvalue of type 'const OCGs *'
    OCGs *optContentConfig = m_poDocPoppler->getOptContentConfig();
          ^                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
8 errors generated.
make[2]: *** [frmts/pdf/CMakeFiles/gdal_PDF.dir/pdfdataset.cpp.o] Error 1
make[1]: *** [frmts/pdf/CMakeFiles/gdal_PDF.dir/all]
```

This PR attempts an update of the GDAL release to see if that helps.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->