### PR TITLE
[GEOT-7726] NPE in Transformer.getTransformedSortBy for SortBy.NATURAL_ORDER

### DIFF
--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureCollection.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/TransformFeatureCollection.java
@@ -143,7 +143,7 @@ class TransformFeatureCollection extends AbstractFeatureCollection {
             throw new RuntimeException("Transform failure: " + e.getMessage(), e);
         } finally {
             // if result is null, an exception has occurred, close the wrapped iterator
-            if (result == null) {
+            if (result == null && fi != null) {
                 fi.close();
             }
         }

--- a/modules/extension/transform/src/main/java/org/geotools/data/transform/Transformer.java
+++ b/modules/extension/transform/src/main/java/org/geotools/data/transform/Transformer.java
@@ -280,6 +280,7 @@ class Transformer {
         for (SortBy sort : original) {
             if (sort == SortBy.NATURAL_ORDER || sort == SortBy.REVERSE_ORDER) {
                 transformed.add(sort);
+                continue;
             }
             PropertyName pname = sort.getPropertyName();
             Expression ex = expressions.get(pname.getPropertyName());

--- a/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformerTest.java
+++ b/modules/extension/transform/src/test/java/org/geotools/data/transform/TransformerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.geotools.api.data.Query;
+import org.geotools.api.filter.sort.SortBy;
 import org.geotools.api.filter.sort.SortOrder;
 import org.junit.Test;
 
@@ -38,6 +39,20 @@ public class TransformerTest extends AbstractTransformTest {
         assertEquals(1, transformedQuery.getSortBy().length);
         assertEquals(
                 "state_name", transformedQuery.getSortBy()[0].getPropertyName().toString());
+    }
+
+    @Test
+    public void testTransformedSortBy_naturalOrder() throws Exception {
+        TransformFeatureSource transformedSource = (TransformFeatureSource) transformWithRename();
+
+        Query query = new Query(Query.ALL);
+        query.setSortBy(SortBy.NATURAL_ORDER);
+
+        Query transformedQuery = transformedSource.transformer.transformQuery(query);
+        assertNotNull(transformedQuery);
+        assertNotNull(transformedQuery.getSortBy());
+        assertEquals(1, transformedQuery.getSortBy().length);
+        assertEquals(SortBy.NATURAL_ORDER, transformedQuery.getSortBy()[0]);
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7726](https://badgen.net/badge/JIRA/GEOT-7726/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7726) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The added `continue` in Transformer.java prevents an NPE which will otherwise happen any time that SortBy.NATURAL_ORDER is supplied, which the code clearly intends to handle without throwing an exception.
See JIRA issue for details.

Also fix NPE in TransformFeatureCollection, which prevents the first NPE from showing up in logs.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] `N/A` [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->