### PR TITLE
[GEOT-7632]  WMS capabilities parsing should not fail if 'units' for a dimension is empty

### DIFF
--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/Dimension.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/Dimension.java
@@ -31,6 +31,11 @@ package org.geotools.ows.wms.xml;
  * type="string"/> <attribute name="multipleValues" type="boolean"/> <attribute name="nearestValue" type="boolean"/>
  * <attribute name="current" type="boolean"/> </extension> </simpleContent> </complexType> </element>
  *
+ * <p>According to <a href="https://portal.ogc.org/files/?artifact_id=14416">OpenGIS Web Map Service WMS Implementation
+ * Specification - C.2 Declaring dimensions and their allowed value (page 52)</a>, units must not be missing, but their
+ * values are allowed to be empty: <i>"If the dimensional quantity has no units (e.g. band number in a multi-wavelength
+ * sensor), use the null string: units=""."</i>
+ *
  * @version SVN $Id$
  * @author Per Engstrom, Curalia AB, pereng@gmail.com
  */
@@ -38,6 +43,7 @@ public class Dimension {
     /** This name is often used as a lookup key */
     protected String name;
 
+    /** Must not be missing, but can be empty according to WMS spec 1.3, page 52 */
     protected String units;
 
     protected String unitSymbol;
@@ -51,7 +57,7 @@ public class Dimension {
         if (name == null || name.length() == 0) {
             throw new IllegalArgumentException("Error creating Extent: parameter name must not be null!");
         }
-        // unit must not be null, but can be empty
+        // unit must not be null, but can be empty according to WMS spec 1.3, page 52
         if (units == null) {
             throw new IllegalArgumentException("Error creating Extent: parameter units must not be null!");
         }
@@ -65,7 +71,7 @@ public class Dimension {
         if (name == null || name.length() == 0) {
             throw new IllegalArgumentException("Error creating Extent: parameter name must not be null!");
         }
-        // unit must not be null, but can be empty
+        // unit must not be null, but can be empty according to WMS spec 1.3, page 52
         if (units == null) {
             throw new IllegalArgumentException("Error creating Extent: parameter units must not be null!");
         }

--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/Dimension.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/Dimension.java
@@ -20,21 +20,49 @@ package org.geotools.ows.wms.xml;
  * Property class for holding and handling of property values declared in Dimension-element of a layer. In WMS 1.3.0
  * this is expanded to include Extent information documenting the valid data values for this range.
  *
- * <p>http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd
- * <!-- The Dimension element declares
- * the _existence_ of a dimension. -->
- * <!ELEMENT Dimension EMPTY > <!ATTLIST Dimension name CDATA #REQUIRED units CDATA #REQUIRED unitSymbol CDATA #IMPLIED>
+ * <p><a href="http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd">
+ * http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd</a>:
  *
- * <p>http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd <element name="Dimension"> <complexType>
- * <simpleContent> <extension base="string"> <attribute name="name" type="string" use="required"/> <attribute
- * name="units" type="string" use="required"/> <attribute name="unitSymbol" type="string"/> <attribute name="default"
- * type="string"/> <attribute name="multipleValues" type="boolean"/> <attribute name="nearestValue" type="boolean"/>
- * <attribute name="current" type="boolean"/> </extension> </simpleContent> </complexType> </element>
+ * <pre>{@code
+ * <!-- The Dimension element declares the _existence_ of a dimension. -->
+ * <!ELEMENT Dimension EMPTY >
+ * <!ATTLIST Dimension
+ *           name CDATA #REQUIRED
+ *           units CDATA #REQUIRED
+ *           unitSymbol CDATA #IMPLIED>
+ * }</pre>
+ *
+ * <p><a href="http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
+ * http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd</a>:
+ *
+ * <pre>{@code
+ * <element name="Dimension">
+ *   <complexType>
+ *     <simpleContent>
+ *       <extension base="string">
+ *         <attribute name="name" type="string" use="required"/>
+ *         <attribute name="units" type="string" use="required"/>
+ *         <attribute name="unitSymbol" type="string"/>
+ *         <attribute name="default" type="string"/>
+ *         <attribute name="multipleValues" type="boolean"/>
+ *         <attribute name="nearestValue" type="boolean"/>
+ *         <attribute name="current" type="boolean"/>
+ *       </extension>
+ *     </simpleContent>
+ *   </complexType>
+ * </element>
+ * }</pre>
  *
  * <p>According to <a href="https://portal.ogc.org/files/?artifact_id=14416">OpenGIS Web Map Service WMS Implementation
- * Specification - C.2 Declaring dimensions and their allowed value (page 52)</a>, units must not be missing, but their
- * values are allowed to be empty: <i>"If the dimensional quantity has no units (e.g. band number in a multi-wavelength
- * sensor), use the null string: units=""."</i>
+ * Specification - C.2 Declaring dimensions and their allowed value (page 52)</a>, the 'units' attribute must not be
+ * missing, but its value is allowed to be empty:
+ *
+ * <blockquote cite="https://portal.ogc.org/files/?artifact_id=14416">
+ *
+ * If the dimensional quantity has no units (e.g. band number in a multi-wavelength sensor), use the null string:
+ * units="".
+ *
+ * </blockquote>
  *
  * @version SVN $Id$
  * @author Per Engstrom, Curalia AB, pereng@gmail.com
@@ -54,30 +82,44 @@ public class Dimension {
     protected Extent extent = null;
 
     public Dimension(String name, String units, String unitSymbol) {
-        if (name == null || name.length() == 0) {
-            throw new IllegalArgumentException("Error creating Extent: parameter name must not be null!");
-        }
-        // unit must not be null, but can be empty according to WMS spec 1.3, page 52
-        if (units == null) {
-            throw new IllegalArgumentException("Error creating Extent: parameter units must not be null!");
-        }
-
+        // check arguments and throw IllegalArgumentException if not valid
+        validateArguments(name, units);
         this.name = name;
         this.units = units;
         this.unitSymbol = unitSymbol;
     }
 
     public Dimension(String name, String units) {
-        if (name == null || name.length() == 0) {
-            throw new IllegalArgumentException("Error creating Extent: parameter name must not be null!");
-        }
-        // unit must not be null, but can be empty according to WMS spec 1.3, page 52
-        if (units == null) {
-            throw new IllegalArgumentException("Error creating Extent: parameter units must not be null!");
-        }
-
+        // check arguments and throw IllegalArgumentException if not valid
+        validateArguments(name, units);
         this.name = name;
         this.units = units;
+    }
+
+    /**
+     * Check the two input arguments 'name' and 'units' for validity.
+     *
+     * <ul>
+     *   <li>'name': must neither be {@code null} nor empty
+     *   <li>'units': must not be {@code null}
+     * </ul>
+     *
+     * @param name the name attribute
+     * @param units the units attribute
+     */
+    private static void validateArguments(String name, String units) throws IllegalArgumentException {
+        // 'name' must not be null
+        if (name == null) {
+            throw new IllegalArgumentException("Error creating Dimension: parameter 'name' must not be null!");
+        }
+        // 'name' must not be empty
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("Error creating Dimension: parameter 'name' must not be empty!");
+        }
+        // 'units' must not be null, but can be empty according to WMS spec 1.3, page 52
+        if (units == null) {
+            throw new IllegalArgumentException("Error creating Dimension: parameter 'units' must not be null!");
+        }
     }
 
     public String getName() {

--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/Dimension.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/Dimension.java
@@ -51,7 +51,8 @@ public class Dimension {
         if (name == null || name.length() == 0) {
             throw new IllegalArgumentException("Error creating Extent: parameter name must not be null!");
         }
-        if (units == null || units.length() == 0) {
+        // unit must not be null, but can be empty
+        if (units == null) {
             throw new IllegalArgumentException("Error creating Extent: parameter units must not be null!");
         }
 
@@ -64,7 +65,8 @@ public class Dimension {
         if (name == null || name.length() == 0) {
             throw new IllegalArgumentException("Error creating Extent: parameter name must not be null!");
         }
-        if (units == null || units.length() == 0) {
+        // unit must not be null, but can be empty
+        if (units == null) {
             throw new IllegalArgumentException("Error creating Extent: parameter units must not be null!");
         }
 

--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/WMSComplexTypes.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/WMSComplexTypes.java
@@ -3480,7 +3480,8 @@ public class WMSComplexTypes {
             }
 
             String units = attrs.getValue("units");
-            if (units == null || units.length() == 0) {
+            // unit must not be null, but can be empty
+            if (units == null) {
                 throw new SAXException("Dimension element contains no 'units' attribute");
             }
 

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSComplexTypesTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSComplexTypesTest.java
@@ -174,7 +174,7 @@ public class WMSComplexTypesTest {
     }
 
     /**
-     * Runs a test that should make te WMS capabilities parsing fail, because some given dimension has the 'units'
+     * Runs a test that should make the WMS capabilities parsing fail, because some given dimension has the 'units'
      * attribute missing.
      *
      * @throws Exception in case loading of test data fails.

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSComplexTypesTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSComplexTypesTest.java
@@ -25,6 +25,7 @@ import org.geotools.ows.wms.Layer;
 import org.geotools.ows.wms.StyleImpl;
 import org.geotools.ows.wms.WMSCapabilities;
 import org.geotools.ows.wms.xml.Attribution;
+import org.geotools.ows.wms.xml.Dimension;
 import org.geotools.ows.wms.xml.LogoURL;
 import org.geotools.ows.wms.xml.MetadataURL;
 import org.geotools.ows.wms.xml.WMSSchema;
@@ -170,5 +171,128 @@ public class WMSComplexTypesTest {
         Assert.assertEquals(capabilities.getService().getTitle(), "World Map");
         // empty Service OnlineResource element should be null, preventing npe
         Assert.assertNull(capabilities.getService().getOnlineResource());
+    }
+
+    /**
+     * Runs a test that should make te WMS capabilities parsing fail, because some given dimension has the 'units'
+     * attribute missing.
+     *
+     * @throws Exception in case loading of test data fails.
+     */
+    @Test
+    public void testDimensionMissingUnits() throws Exception {
+
+        File getCaps = TestData.file(this, "1.3.0Capabilities_Dimensions_missingUnits.xml");
+        URL getCapsURL = getCaps.toURI().toURL();
+        Map<String, Object> hints = new HashMap<>();
+        hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+
+        Exception exception = null;
+        try {
+            DocumentFactory.getInstance(getCapsURL.openStream(), hints, Level.WARNING);
+            Assert.fail("Parsing the document should fail, because a layer dimension is missing a unit");
+        } catch (Exception e) {
+            exception = e;
+        }
+
+        Assert.assertNotNull(
+                "Capabilities should fail to parse, because a layer dimension is missing a unit.", exception);
+    }
+
+    /**
+     * Run some basic tests on WMS dimensions. Various questions should be answered:
+     *
+     * <p>
+     *
+     * <ul>
+     *   <li>root layer has no dimensions
+     *   <li>for given dimensions, 'units' attribute must not be missing
+     *   <li>'units' values can be empty: GEOS-7632
+     *   <li>some basic 'units' values tests
+     *   <li>'unitSymbols' is optional
+     *   <li>'default' is optional
+     *   <li>some basic 'default' values tests
+     * </ul>
+     *
+     * @throws Exception in case loading of test data fails.
+     */
+    @Test
+    public void testDimensionUnits() throws Exception {
+
+        File getCaps = TestData.file(this, "1.3.0Capabilities_Dimensions.xml");
+        URL getCapsURL = getCaps.toURI().toURL();
+        Map<String, Object> hints = new HashMap<>();
+        hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+        Object object = null;
+
+        try {
+            object = DocumentFactory.getInstance(getCapsURL.openStream(), hints, Level.WARNING);
+        } catch (NullPointerException e) {
+            Assert.fail("Parsing document with empty xlink URL should not cause NPE");
+        }
+
+        Assert.assertTrue("Capabilities failed to parse", object instanceof WMSCapabilities);
+        WMSCapabilities capabilities = (WMSCapabilities) object;
+
+        // root layer
+        Layer layer = capabilities.getLayerList().get(0);
+        Assert.assertNotNull(layer);
+        Map<String, Dimension> layerDimensions = layer.getDimensions();
+        Assert.assertTrue("Root layer has no dimensions", layerDimensions.isEmpty());
+
+        // radar layer
+        // ===========
+        layer = capabilities.getLayerList().get(1);
+        Assert.assertNotNull(layer);
+        // time dimension
+        Dimension dimension = layer.getDimension("time");
+        Assert.assertNotNull(dimension);
+        // unit
+        String units = dimension.getUnits();
+        Assert.assertNotNull("Units must not be missing", units);
+        Assert.assertEquals("Unit of dimension time should be ISO8601.", "ISO8601", units);
+        // unit symbol
+        Assert.assertNull("Unit symbol should be null", dimension.getUnitSymbol());
+
+        // NWP layer : check time dimension
+        // ================================
+        layer = capabilities.getLayerList().get(2);
+        Assert.assertNotNull(layer);
+
+        // time dimension
+        dimension = layer.getDimension("time");
+        Assert.assertNotNull(dimension);
+        // default value
+        Assert.assertEquals(
+                "Default value should be 'current'",
+                "current",
+                dimension.getExtent().getDefaultValue());
+        // unit
+        units = dimension.getUnits();
+        Assert.assertNotNull("Units must not be missing", units);
+        Assert.assertEquals("Unit of dimension time should be ISO8601.", "ISO8601", units);
+        // unit symbol
+        Assert.assertEquals("Unit symbol should be 't'", "t", dimension.getUnitSymbol());
+
+        // ref time dimension
+        dimension = layer.getDimension("REFERENCE_TIME");
+        Assert.assertNotNull(dimension);
+        // unit
+        units = dimension.getUnits();
+        Assert.assertNotNull("Units must not be missing", units);
+        Assert.assertEquals("Unit of dimension time should be ISO8601.", "ISO8601", units);
+        // unit symbol
+        Assert.assertEquals("Unit symbol should be 't'", "t", dimension.getUnitSymbol());
+
+        // elevation dimension:
+        // GEOS-7632: units must not be missing, but can be empty
+        dimension = layer.getDimension("ELEVATION");
+        Assert.assertNotNull(dimension);
+        // unit
+        units = dimension.getUnits();
+        Assert.assertNotNull("Units must not be missing", units);
+        Assert.assertEquals("Unit should be empty .", "", units);
+        // unit symbol
+        Assert.assertEquals("Unit symbol should be 'm'", "m", dimension.getUnitSymbol());
     }
 }

--- a/modules/extension/wms/src/test/resources/org/geotools/ows/wms/xml/test/test-data/1.3.0Capabilities_Dimensions.xml
+++ b/modules/extension/wms/src/test/resources/org/geotools/ows/wms/xml/test/test-data/1.3.0Capabilities_Dimensions.xml
@@ -115,7 +115,7 @@
 				<Dimension name="REFERENCE_TIME" units="ISO8601" unitSymbol="t">
 					2025-03-12T00:00:00.000Z
 				</Dimension>
-				<!-- GEOS-7632: 'units' must not be missing, but could be empty -->
+				<!-- GEOS-7632: 'units' must not be missing, but could be empty according to WMS spec 1.3, page 52 -->
 				<Dimension name="ELEVATION" units="" unitSymbol="m">
 					2
 				</Dimension>

--- a/modules/extension/wms/src/test/resources/org/geotools/ows/wms/xml/test/test-data/1.3.0Capabilities_Dimensions.xml
+++ b/modules/extension/wms/src/test/resources/org/geotools/ows/wms/xml/test/test-data/1.3.0Capabilities_Dimensions.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms capabilities_1_3_0.xsd">
+	<!-- Service Metadata -->
+	<Service>
+		<!-- The WMT-defined name for this type of service -->
+		<Name>WMS</Name>
+		<!-- Human-readable title for pick lists -->
+		<Title>World Map</Title>
+		<!-- Narrative description providing additional information -->
+		<Abstract>None</Abstract>
+		<!-- Top-level web address of service or service provider.  See also OnlineResource
+  elements under <DCPType>. -->
+		<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl"/>
+		<!-- Contact information -->
+		<ContactInformation>
+			<ContactPersonPrimary>
+				<ContactPerson></ContactPerson>
+				<ContactOrganization></ContactOrganization>
+			</ContactPersonPrimary>
+			<ContactPosition>None</ContactPosition>
+			<ContactAddress>
+				<AddressType>None</AddressType>
+				<Address>None</Address>
+				<City>None</City>
+				<StateOrProvince>None</StateOrProvince>
+				<PostCode>None</PostCode>
+				<Country>None</Country>
+			</ContactAddress>
+			<ContactVoiceTelephone>None</ContactVoiceTelephone>
+			<ContactElectronicMailAddress></ContactElectronicMailAddress>
+		</ContactInformation>
+		<!-- Fees or access constraints imposed. -->
+		<Fees>none</Fees>
+		<AccessConstraints>none</AccessConstraints>
+		<LayerLimit>40</LayerLimit>
+		<MaxWidth>2000</MaxWidth>
+		<MaxHeight>2000</MaxHeight>
+	</Service>
+	<Capability>
+		<Request>
+			<GetCapabilities>
+				<Format>text/xml</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+						<Post>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Post>
+					</HTTP>
+				</DCPType>
+			</GetCapabilities>
+			<GetMap>
+				<Format>image/gif</Format>
+				<Format>image/png</Format>
+				<Format>image/jpeg</Format>
+				<Format>image/bmp</Format>
+				<Format>image/swf</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<!-- The URL here for invoking GetCapabilities using HTTP GET
+            is only a prefix to which a query string is appended. -->
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetMap>
+			<GetFeatureInfo>
+				<Format>text/xml</Format>
+				<Format>text/plain</Format>
+				<Format>text/html</Format>
+				<Format>text/swf</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetFeatureInfo>
+		</Request>
+		<Exception>
+			<Format>XML</Format>
+			<Format>INIMAGE</Format>
+			<Format>BLANK</Format>
+		</Exception>
+		<Layer>
+			<Title>World Map</Title>
+			<CRS>CRS:84</CRS>
+			<!-- all layers are available in at least this CRS -->
+			<EX_GeographicBoundingBox>
+				<westBoundLongitude>-180</westBoundLongitude>
+				<eastBoundLongitude>180</eastBoundLongitude>
+				<southBoundLatitude>-90</southBoundLatitude>
+				<northBoundLatitude>90</northBoundLatitude>
+			</EX_GeographicBoundingBox>
+			<BoundingBox CRS="CRS:84" minx="-184" miny="-90.0000000017335" maxx="180" maxy="90"/>
+			<Layer queryable="1" opaque="0">
+				<Name>radar</Name>
+				<Title>radar observations</Title>
+				<BoundingBox CRS="CRS:84" minx="-180" miny="-62.9231796264648" maxx="179.999420166016" maxy="68.6906585693359"/>
+				<Dimension name="time" units="ISO8601">
+					025-03-12T00:05:00.000Z,2025-03-12T00:10:00.000Z,2025-03-12T00:15:00.000Z
+				</Dimension>
+			</Layer>
+			<Layer queryable="1" opaque="0">
+				<Name>nwp_t2m</Name>
+				<Title>model forecast of temperature 2m</Title>
+				<BoundingBox CRS="CRS:84" minx="-180" miny="-62.9231796264648" maxx="179.999420166016" maxy="68.6906585693359"/>
+				<Dimension name="time" default="current" units="ISO8601" unitSymbol="t">
+					2025-03-12T00:05:00.000Z,2025-03-12T00:10:00.000Z,2025-03-12T00:15:00.000Z
+				</Dimension>
+				<Dimension name="REFERENCE_TIME" units="ISO8601" unitSymbol="t">
+					2025-03-12T00:00:00.000Z
+				</Dimension>
+				<!-- GEOS-7632: 'units' must not be missing, but could be empty -->
+				<Dimension name="ELEVATION" units="" unitSymbol="m">
+					2
+				</Dimension>
+			</Layer>
+		</Layer>
+	</Capability>
+</WMS_Capabilities>
+

--- a/modules/extension/wms/src/test/resources/org/geotools/ows/wms/xml/test/test-data/1.3.0Capabilities_Dimensions_missingUnits.xml
+++ b/modules/extension/wms/src/test/resources/org/geotools/ows/wms/xml/test/test-data/1.3.0Capabilities_Dimensions_missingUnits.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wms capabilities_1_3_0.xsd">
+	<!-- Service Metadata -->
+	<Service>
+		<!-- The WMT-defined name for this type of service -->
+		<Name>WMS</Name>
+		<!-- Human-readable title for pick lists -->
+		<Title>World Map</Title>
+		<!-- Narrative description providing additional information -->
+		<Abstract>None</Abstract>
+		<!-- Top-level web address of service or service provider.  See also OnlineResource
+  elements under <DCPType>. -->
+		<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl"/>
+		<!-- Contact information -->
+		<ContactInformation>
+			<ContactPersonPrimary>
+				<ContactPerson></ContactPerson>
+				<ContactOrganization></ContactOrganization>
+			</ContactPersonPrimary>
+			<ContactPosition>None</ContactPosition>
+			<ContactAddress>
+				<AddressType>None</AddressType>
+				<Address>None</Address>
+				<City>None</City>
+				<StateOrProvince>None</StateOrProvince>
+				<PostCode>None</PostCode>
+				<Country>None</Country>
+			</ContactAddress>
+			<ContactVoiceTelephone>None</ContactVoiceTelephone>
+			<ContactElectronicMailAddress></ContactElectronicMailAddress>
+		</ContactInformation>
+		<!-- Fees or access constraints imposed. -->
+		<Fees>none</Fees>
+		<AccessConstraints>none</AccessConstraints>
+		<LayerLimit>40</LayerLimit>
+		<MaxWidth>2000</MaxWidth>
+		<MaxHeight>2000</MaxHeight>
+	</Service>
+	<Capability>
+		<Request>
+			<GetCapabilities>
+				<Format>text/xml</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+						<Post>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Post>
+					</HTTP>
+				</DCPType>
+			</GetCapabilities>
+			<GetMap>
+				<Format>image/gif</Format>
+				<Format>image/png</Format>
+				<Format>image/jpeg</Format>
+				<Format>image/bmp</Format>
+				<Format>image/swf</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<!-- The URL here for invoking GetCapabilities using HTTP GET
+            is only a prefix to which a query string is appended. -->
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetMap>
+			<GetFeatureInfo>
+				<Format>text/xml</Format>
+				<Format>text/plain</Format>
+				<Format>text/html</Format>
+				<Format>text/swf</Format>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www2.demis.nl/wms/wms.asp?wms=WorldMap&amp;"/>
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetFeatureInfo>
+		</Request>
+		<Exception>
+			<Format>XML</Format>
+			<Format>INIMAGE</Format>
+			<Format>BLANK</Format>
+		</Exception>
+		<Layer>
+			<Title>World Map</Title>
+			<CRS>CRS:84</CRS>
+			<!-- all layers are available in at least this CRS -->
+			<EX_GeographicBoundingBox>
+				<westBoundLongitude>-180</westBoundLongitude>
+				<eastBoundLongitude>180</eastBoundLongitude>
+				<southBoundLatitude>-90</southBoundLatitude>
+				<northBoundLatitude>90</northBoundLatitude>
+			</EX_GeographicBoundingBox>
+			<BoundingBox CRS="CRS:84" minx="-184" miny="-90.0000000017335" maxx="180" maxy="90"/>
+			<Layer queryable="1" opaque="0">
+				<Name>nwp_t2m</Name>
+				<Title>model forecast of temperature 2m</Title>
+				<BoundingBox CRS="CRS:84" minx="-180" miny="-62.9231796264648" maxx="179.999420166016" maxy="68.6906585693359"/>
+				<!-- GEOS-7632: 'units' must not be missing -->
+				<Dimension name="ELEVATION" unitSymbol="m">
+					2
+				</Dimension>
+			</Layer>
+		</Layer>
+	</Capability>
+</WMS_Capabilities>
+


### PR DESCRIPTION
[![GEOT-7632](https://badgen.net/badge/JIRA/GEOT-7632/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7632) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is to fix [[GEOT-7632]  WMS capabilities parsing should not fail if 'units' for a dimension is empty](https://osgeo-org.atlassian.net/browse/GEOT-7632). According to [OpenGIS Web Map Service WMS Implementation Specification](https://portal.ogc.org/files/?artifact_id=14416), for layer dimensions, `units` must **not** be missing, **but are allowed to be empty**:

> If the dimensional quantity has no units (e.g. band number in a multi-wavelength sensor), use the null string: units="".

`gt-wms` currently throws a `SAXException` in case `units.length == 0`. The two affected classes are `org.geotools.ows.wms.xml.WMSComplexTypes._DimensionType` and `org.geotools.ows.wms.xml.Dimension#Dimension`.

This PR fixes the problem by modifying the two above mentioned places to remove the length check while parsing the `units` attribute. Two unit tests have been added for some basic dimension value checks (it looks no such test-cases ever existed before). These checks include the described case. 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->