### PR TITLE
[31.x backport] [GEOT-7734] Update to jai-ext 1.1.31

### DIFF
--- a/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/JiffleProcess.java
+++ b/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/JiffleProcess.java
@@ -26,6 +26,8 @@ import it.geosolutions.jaiext.jiffle.parser.node.ScalarLiteral;
 import it.geosolutions.jaiext.jiffle.runtime.BandTransform;
 import it.geosolutions.jaiext.jiffleop.JiffleDescriptor;
 import it.geosolutions.jaiext.jiffleop.JiffleRIF;
+import it.geosolutions.jaiext.range.NoDataContainer;
+import it.geosolutions.jaiext.range.Range;
 import it.geosolutions.jaiext.range.Range.DataType;
 import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
@@ -152,6 +154,19 @@ public class JiffleProcess implements RasterProcess {
             }
         }
 
+        // grab the source nodata
+        Range[] nodatas = new Range[sources.length];
+        for (int i = 0; i < sources.length; i++) {
+            GridCoverage2D coverage = coverages[i];
+            NoDataContainer coverageNoData = CoverageUtilities.getNoDataProperty(coverage);
+            if (coverageNoData != null) {
+                nodatas[i] = coverageNoData.getAsRange();
+            }
+        }
+        if (Arrays.stream(nodatas).filter(n -> n != null).count() == 0) {
+            nodatas = null;
+        }
+
         // in case we have optimized out band selection, need to remap the band access
         BandTransform[] bandTransforms = null;
         if (sources.length == 1) {
@@ -173,6 +188,7 @@ public class JiffleProcess implements RasterProcess {
                 outputBandCount,
                 null,
                 bandTransforms,
+                nodatas,
                 GeoTools.getDefaultHints());
 
         GridSampleDimension[] sampleDimensions = getSampleDimensions(result, outputBandNames);

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
     <informix.jdbc.version>4.50.7.1</informix.jdbc.version>
     <jackson2.version>2.17.2</jackson2.version>
     <jackson2.databind.version>${jackson2.version}</jackson2.databind.version>
-    <jaiext.version>1.1.28</jaiext.version>
+    <jaiext.version>1.1.29</jaiext.version>
     <javax.activation-api.version>1.2.0</javax.activation-api.version>
     <jaxb.api.version>2.4.0-b180830.0359</jaxb.api.version>
     <jaxb.runtime.version>2.4.0-b180830.0438</jaxb.runtime.version>

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
     <informix.jdbc.version>4.50.7.1</informix.jdbc.version>
     <jackson2.version>2.17.2</jackson2.version>
     <jackson2.databind.version>${jackson2.version}</jackson2.databind.version>
-    <jaiext.version>1.1.29</jaiext.version>
+    <jaiext.version>1.1.31</jaiext.version>
     <javax.activation-api.version>1.2.0</javax.activation-api.version>
     <jaxb.api.version>2.4.0-b180830.0359</jaxb.api.version>
     <jaxb.runtime.version>2.4.0-b180830.0438</jaxb.runtime.version>


### PR DESCRIPTION
[![GEOT-7734](https://badgen.net/badge/JIRA/GEOT-7734/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7734) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Comes with [[GEOT-7719]](https://github.com/geotools/geotools/commit/4a4f33a6c442e083b7cfb7c1e4167ec50c907dc5)
as it's necessary to keep GeoTools compiling.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->