### PR TITLE
[GEOT-7743] HanaGeographyOnlineTest is failing after database upgrade

### DIFF
--- a/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
+++ b/modules/plugin/jdbc/jdbc-hana/src/test/java/org/geotools/data/hana/HanaGeographyOnlineTest.java
@@ -82,12 +82,12 @@ public class HanaGeographyOnlineTest extends JDBCGeographyOnlineTest {
             // Test with estimation disabled
             ReferencedEnvelope env =
                     dataStore.getFeatureSource(tname("geopoint")).getBounds();
-            assertTrue(env.boundsEquals2D(expected, Math.ulp(1.0)));
+            assertTrue(env.boundsEquals2D(expected, Math.ulp(2.0)));
 
             // Test with estimation enabled
             hanaDialect.setEstimatedExtentsEnabled(true);
             env = dataStore.getFeatureSource(tname("geopoint")).getBounds();
-            assertTrue(env.boundsEquals2D(expected, Math.ulp(1.0)));
+            assertTrue(env.boundsEquals2D(expected, Math.ulp(2.0)));
         } finally {
             hanaDialect.setEstimatedExtentsEnabled(false);
         }


### PR DESCRIPTION
[![GEOT-7743](https://badgen.net/badge/JIRA/GEOT-7743/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7743) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

After an upgrade, HANA's envelope computation returns slightly different values in geographic spatial reference systems.

We increase the tolerance from 1 to 2 ULP in the test to accept the envelope returned by the database.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).