### PR TITLE
Improve GeoParquet DataStore performance by delaying view registration

### DIFF
--- a/modules/unsupported/geoparquet/pom.xml
+++ b/modules/unsupported/geoparquet/pom.xml
@@ -1,10 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- =======================================================================
-        Maven Project Configuration File
-        The Geotools Project
-            http://www.geotools.org/
-        Version: $Id$
-     ======================================================================= -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/duckdb/AbstractDuckDBDataStoreFactory.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/duckdb/AbstractDuckDBDataStoreFactory.java
@@ -68,8 +68,9 @@ public abstract class AbstractDuckDBDataStoreFactory extends JDBCDataStoreFactor
      * Enables usage of a simplification function, when the queries contain geometry simplification hints. The
      * simplification function used depends on SIMPLIFICATION_METHOD setting, and is ST_Simplify by default.
      */
-    public static final Param SIMPLIFY = new ParamBuilder("Support on the fly geometry simplification")
+    public static final Param SIMPLIFY = new ParamBuilder("simplification")
             .type(Boolean.class)
+            .title("Support on the fly geometry simplification")
             .description(
                     "When enabled, operations such as map rendering will pass a hint that will enable the usage of a simplification function")
             .required(false)

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/ForwardingDataStore.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/ForwardingDataStore.java
@@ -1,0 +1,149 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.geoparquet;
+
+import java.io.IOException;
+import java.util.List;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.FeatureReader;
+import org.geotools.api.data.FeatureWriter;
+import org.geotools.api.data.LockingManager;
+import org.geotools.api.data.Query;
+import org.geotools.api.data.ServiceInfo;
+import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.data.Transaction;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.Name;
+import org.geotools.api.filter.Filter;
+
+/**
+ * A decorator implementation of the DataStore interface that forwards all method calls to a delegate DataStore
+ * instance.
+ *
+ * <p>This class is used as a base for creating specialized DataStore implementations that need to modify or extend the
+ * behavior of an existing DataStore without modifying the original class.
+ *
+ * @param <S> The type of DataStore being decorated
+ */
+public class ForwardingDataStore<S extends DataStore> implements DataStore {
+
+    protected final S delegate;
+
+    /**
+     * Creates a new forwarding datastore that delegates all calls to the provided datastore.
+     *
+     * @param delegate The datastore to forward calls to
+     */
+    public ForwardingDataStore(S delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ServiceInfo getInfo() {
+        return delegate.getInfo();
+    }
+
+    @Override
+    public String[] getTypeNames() throws IOException {
+        return delegate.getTypeNames();
+    }
+
+    @Override
+    public List<Name> getNames() throws IOException {
+        return delegate.getNames();
+    }
+
+    @Override
+    public SimpleFeatureType getSchema(Name name) throws IOException {
+        return delegate.getSchema(name);
+    }
+
+    @Override
+    public SimpleFeatureType getSchema(String typeName) throws IOException {
+        return delegate.getSchema(typeName);
+    }
+
+    @Override
+    public SimpleFeatureSource getFeatureSource(String typeName) throws IOException {
+        return delegate.getFeatureSource(typeName);
+    }
+
+    @Override
+    public SimpleFeatureSource getFeatureSource(Name typeName) throws IOException {
+        return delegate.getFeatureSource(typeName);
+    }
+
+    @Override
+    public FeatureReader<SimpleFeatureType, SimpleFeature> getFeatureReader(Query query, Transaction transaction)
+            throws IOException {
+        return delegate.getFeatureReader(query, transaction);
+    }
+
+    @Override
+    public void dispose() {
+        delegate.dispose();
+    }
+
+    @Override
+    public void createSchema(SimpleFeatureType featureType) throws IOException {
+        delegate.createSchema(featureType);
+    }
+
+    @Override
+    public void updateSchema(String typeName, SimpleFeatureType featureType) throws IOException {
+        delegate.updateSchema(typeName, featureType);
+    }
+
+    @Override
+    public void updateSchema(Name typeName, SimpleFeatureType featureType) throws IOException {
+        delegate.updateSchema(typeName, featureType);
+    }
+
+    @Override
+    public void removeSchema(Name typeName) throws IOException {
+        delegate.removeSchema(typeName);
+    }
+
+    @Override
+    public void removeSchema(String typeName) throws IOException {
+        delegate.removeSchema(typeName);
+    }
+
+    @Override
+    public FeatureWriter<SimpleFeatureType, SimpleFeature> getFeatureWriter(
+            String typeName, Filter filter, Transaction transaction) throws IOException {
+        return delegate.getFeatureWriter(typeName, filter, transaction);
+    }
+
+    @Override
+    public FeatureWriter<SimpleFeatureType, SimpleFeature> getFeatureWriter(String typeName, Transaction transaction)
+            throws IOException {
+        return delegate.getFeatureWriter(typeName, transaction);
+    }
+
+    @Override
+    public FeatureWriter<SimpleFeatureType, SimpleFeature> getFeatureWriterAppend(
+            String typeName, Transaction transaction) throws IOException {
+        return delegate.getFeatureWriterAppend(typeName, transaction);
+    }
+
+    @Override
+    public LockingManager getLockingManager() {
+        return delegate.getLockingManager();
+    }
+}

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/ForwardingDataStoreFactory.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/ForwardingDataStoreFactory.java
@@ -1,0 +1,83 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.geoparquet;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.DataStoreFactorySpi;
+
+/**
+ * A decorator implementation of the DataStoreFactorySpi interface that forwards all method calls to a delegate
+ * DataStoreFactorySpi instance.
+ *
+ * <p>This class follows the decorator pattern, allowing specialized DataStoreFactory implementations to extend or
+ * modify the behavior of an existing factory without modifying the original class. It's particularly useful when
+ * implementing adapter or wrapper factories that need to adjust the behavior of another factory.
+ *
+ * @param <D> The type of DataStoreFactorySpi being decorated
+ */
+public class ForwardingDataStoreFactory<D extends DataStoreFactorySpi> implements DataStoreFactorySpi {
+
+    protected final D delegate;
+
+    /**
+     * Creates a new forwarding factory that delegates all calls to the provided factory.
+     *
+     * @param delegate The factory to forward calls to (must not be null)
+     * @throws NullPointerException if delegate is null
+     */
+    public ForwardingDataStoreFactory(D delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return delegate.getDisplayName();
+    }
+
+    @Override
+    public String getDescription() {
+        return delegate.getDescription();
+    }
+
+    @Override
+    public Param[] getParametersInfo() {
+        return delegate.getParametersInfo();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return delegate.isAvailable();
+    }
+
+    @Override
+    public boolean canProcess(java.util.Map<String, ?> params) {
+        return delegate.canProcess(params);
+    }
+
+    @Override
+    public DataStore createDataStore(Map<String, ?> params) throws IOException {
+        return delegate.createDataStore(params);
+    }
+
+    @Override
+    public DataStore createNewDataStore(Map<String, ?> params) throws IOException {
+        return delegate.createNewDataStore(params);
+    }
+}

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoParquetDataStoreFactoryDelegate.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoParquetDataStoreFactoryDelegate.java
@@ -1,0 +1,244 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.geoparquet;
+
+import java.io.IOException;
+import java.util.Map;
+import org.geotools.api.data.DataAccessFactory;
+import org.geotools.api.data.DataStoreFactorySpi;
+import org.geotools.data.duckdb.AbstractDuckDBDataStoreFactory;
+import org.geotools.data.duckdb.ParamBuilder;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.SQLDialect;
+
+/**
+ * DataStoreFactory for GeoParquet files, powered by DuckDB.
+ *
+ * <p>This factory creates DataStore instances that can read and query GeoParquet format files, both local and remote.
+ * GeoParquet is an open format for geospatial data that builds on the Apache Parquet columnar storage format, providing
+ * efficient access to large geospatial datasets.
+ *
+ * <p>The implementation uses DuckDB and its extensions (spatial, parquet, httpfs) to handle the heavy lifting of
+ * reading and querying Parquet files. This provides excellent performance and compatibility with various storage
+ * backends including local files, HTTP/HTTPS, and S3.
+ *
+ * <p>Usage example:
+ *
+ * <pre>{@code
+ * Map<String, Object> params = new HashMap<>();
+ * params.put("dbtype", "geoparquet");
+ * params.put("uri", "file:/path/to/data.parquet");
+ *
+ * DataStore store = DataStoreFinder.getDataStore(params);
+ * }</pre>
+ */
+class GeoParquetDataStoreFactoryDelegate extends AbstractDuckDBDataStoreFactory implements DataStoreFactorySpi {
+
+    static final String GEOPARQUET = "geoparquet";
+
+    /**
+     * Parameter for database type.
+     *
+     * <p>Must be "geoparquet" for this DataStore.
+     */
+    public static final DataAccessFactory.Param DBTYPE = new ParamBuilder("dbtype")
+            .type(String.class)
+            .title("DataStore type identifier")
+            .required(true)
+            .defaultValue(GEOPARQUET)
+            .programLevel()
+            .build();
+    /**
+     * Parameter for GeoParquet URI.
+     *
+     * <p>Must be a valid URI pointing to a GeoParquet file or directory. Supported schemes:
+     *
+     * <ul>
+     *   <li>file:// - for local files and directories
+     *   <li>https:// - for remote files
+     *   <li>s3:// - for files in S3 storage (requires credentials)
+     * </ul>
+     *
+     * <p>For S3 URIs, additional parameters can be included in the query string:
+     *
+     * <pre>
+     * s3://bucket/path/to/file.parquet?region=us-west-2&access_key=ACCESS_KEY&secret_key=SECRET_KEY
+     * </pre>
+     */
+    public static final DataAccessFactory.Param URI_PARAM = new ParamBuilder("uri")
+            .type(String.class)
+            .description("URI to GeoParquet local or remote file")
+            .required(true)
+            .userLevel()
+            .build();
+
+    /**
+     * Parameter for controlling Hive partition depth in GeoParquet datasets.
+     *
+     * <p>This parameter determines how many levels of key=value directories are used for partitioning:
+     *
+     * <ul>
+     *   <li>null (default): Use all partition levels found
+     *   <li>0: No partitioning, treat all files as a single dataset
+     *   <li>1+: Use this many levels of partitioning
+     * </ul>
+     *
+     * <p>For example, with a dataset structure like: {@code s3://bucket/data/year=2023/month=01/day=01/file.parquet}
+     *
+     * <ul>
+     *   <li>max_hive_depth=1: Only "year=2023" is used for partitioning
+     *   <li>max_hive_depth=2: "year=2023/month=01" is used
+     *   <li>max_hive_depth=3 or null: "year=2023/month=01/day=01" is used
+     * </ul>
+     */
+    public static final DataAccessFactory.Param MAX_HIVE_DEPTH = new ParamBuilder("max_hive_depth")
+            .type(Integer.class)
+            .title("Max Hive partition depth")
+            .description("Max number Hive partitions to use when resolving feature types")
+            .required(false)
+            .defaultValue(null)
+            .advancedLevel()
+            .build();
+
+    /** Parameter for specifying the namespace URI for the feature type. */
+    public static final Param NAMESPACE = AbstractDuckDBDataStoreFactory.NAMESPACE;
+
+    /** Parameter for controlling the number of features to fetch at once. */
+    public static final Param FETCHSIZE = AbstractDuckDBDataStoreFactory.FETCHSIZE;
+
+    /** Parameter for enabling/disabling screen map optimization for rendering. */
+    public static final Param SCREENMAP = AbstractDuckDBDataStoreFactory.SCREENMAP;
+
+    /** Parameter for enabling/disabling geometry simplification when rendering. */
+    public static final Param SIMPLIFY = AbstractDuckDBDataStoreFactory.SIMPLIFY;
+
+    /**
+     * Returns the database ID for this factory.
+     *
+     * @return The database ID ("geoparquet")
+     */
+    @Override
+    protected String getDatabaseID() {
+        return GEOPARQUET;
+    }
+
+    /**
+     * Returns the human-readable display name for this datastore.
+     *
+     * @return The display name ("GeoParquet")
+     */
+    @Override
+    public String getDisplayName() {
+        return "GeoParquet";
+    }
+
+    /**
+     * Returns a human-readable description of this datastore.
+     *
+     * @return The description of the datastore
+     */
+    @Override
+    public String getDescription() {
+        return "GeoParquet format data files (*.parquet)";
+    }
+
+    /**
+     * Adds GeoParquet-specific parameters to the parameter map.
+     *
+     * @param parameters The parameter map to add to
+     */
+    @Override
+    protected void addDatabaseSpecificParameters(Map<String, Object> parameters) {
+        // Add GeoParquet specific parameters
+        parameters.put(DBTYPE.key, DBTYPE);
+        parameters.put(URI_PARAM.key, URI_PARAM);
+        parameters.put(MAX_HIVE_DEPTH.key, MAX_HIVE_DEPTH);
+    }
+
+    /**
+     * Creates a GeoParquetDialect for handling GeoParquet-specific SQL operations.
+     *
+     * @param dataStore The datastore to create a dialect for
+     * @param params The connection parameters
+     * @return A new GeoParquetDialect instance
+     */
+    @Override
+    protected GeoParquetDialect createSQLDialect(JDBCDataStore dataStore, Map<String, ?> params) {
+        return new GeoParquetDialect(dataStore);
+    }
+
+    /**
+     * Unused method since we override {@link #createSQLDialect(JDBCDataStore, Map)} instead.
+     *
+     * @param dataStore The datastore to create a dialect for
+     * @return Never returns, always throws UnsupportedOperationException
+     * @throws UnsupportedOperationException Always
+     */
+    @Override
+    protected SQLDialect createSQLDialect(JDBCDataStore dataStore) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Sets up the datastore with GeoParquet-specific configuration.
+     *
+     * <p>This method:
+     *
+     * <ol>
+     *   <li>Sets up the primary key finder for feature ID handling
+     *   <li>Creates a configuration object from the parameters
+     *   <li>Registers the GeoParquet views based on the configuration
+     * </ol>
+     *
+     * @param dataStore The datastore to set up
+     * @param params The connection parameters
+     * @return The configured datastore
+     * @throws IOException If there's an error setting up the datastore
+     */
+    @Override
+    protected JDBCDataStore setupDataStore(JDBCDataStore dataStore, Map<String, ?> params) throws IOException {
+        GeoParquetDialect dialect = (GeoParquetDialect) dataStore.getSQLDialect();
+        dataStore.setPrimaryKeyFinder(dialect.getPrimaryKeyFinder());
+
+        GeoParquetConfig config = GeoParquetConfig.valueOf(params);
+        dialect.initialize(config);
+        return dataStore;
+    }
+
+    /**
+     * Creates a JDBC URL for a persistent DuckDB database tied to the GeoParquet dataset configuration.
+     *
+     * <p>This implementation uses {@link GeoParquetDatabaseUtils} to create a temporary on-disk database that's shared
+     * among all connections to the same GeoParquet dataset configuration, ensuring that:
+     *
+     * <ul>
+     *   <li>SQL views created for GeoParquet files persist across connections
+     *   <li>Metadata caching is properly shared between connections
+     *   <li>When {@link GeoParquetDialect#initializeConnection(Connection)} is called for each connection from the
+     *       pool, the views don't need to be re-registered
+     *   <li>Temporary database files are properly managed and cleaned up when the JVM exits
+     * </ul>
+     *
+     * @param params The parameter map containing the connection parameters
+     * @return A JDBC URL pointing to a persistent DuckDB database for this dataset configuration
+     * @throws IOException If there's an error creating the temporary directory
+     */
+    @Override
+    protected String getJDBCUrl(Map<String, ?> params) throws IOException {
+        return GeoParquetDatabaseUtils.getJDBCUrl(params, getParametersInfo());
+    }
+}

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoparquetDataStore.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoparquetDataStore.java
@@ -1,0 +1,153 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.geoparquet;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.Name;
+import org.geotools.feature.NameImpl;
+import org.geotools.jdbc.JDBCDataStore;
+
+/**
+ * A GeoParquet DataStore implementation that decorates a JDBCDataStore.
+ *
+ * <p>This implementation uses lazy initialization for performance, delaying the creation of database views until they
+ * are needed. This improves response time when working with large datasets, especially over remote connections.
+ *
+ * <p>The class overrides key methods from DataStore to intercept calls that require schema information, ensuring that
+ * the necessary database views are created before the underlying JDBC store handles the request.
+ */
+public class GeoparquetDataStore extends ForwardingDataStore<JDBCDataStore> implements DataStore {
+
+    /**
+     * Creates a new GeoParquet datastore that delegates to the provided JDBC datastore.
+     *
+     * @param delegate The JDBC datastore to delegate operations to
+     */
+    public GeoparquetDataStore(JDBCDataStore delegate) {
+        super(delegate);
+    }
+
+    /**
+     * Returns the names of all feature types available in this datastore.
+     *
+     * <p>This implementation retrieves type names directly from the GeoParquet dialect, which maintains a mapping of
+     * available GeoParquet datasets.
+     *
+     * @return An array of type names
+     * @throws IOException If there is a problem retrieving the type names
+     */
+    @Override
+    public String[] getTypeNames() throws IOException {
+        return getSQLDialect().getTypeNames().toArray(String[]::new);
+    }
+
+    /**
+     * Returns a list of qualified names for all feature types in this datastore.
+     *
+     * <p>This implementation creates proper Name objects for each type name, using the datastore's namespace if
+     * available.
+     *
+     * @return A list of qualified names
+     * @throws IOException If there is a problem retrieving the names
+     */
+    @Override
+    public List<Name> getNames() throws IOException {
+        String namespaceURI = delegate.getNamespaceURI();
+        return Arrays.stream(getTypeNames())
+                .map(localName -> new NameImpl(namespaceURI, localName))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the feature type schema for the given name.
+     *
+     * <p>This implementation ensures the database view exists for the requested schema before delegating to the JDBC
+     * datastore.
+     *
+     * @param name The qualified name of the feature type
+     * @return The feature type schema
+     * @throws IOException If there is a problem retrieving the schema
+     */
+    @Override
+    public SimpleFeatureType getSchema(Name name) throws IOException {
+        getSQLDialect().ensureSchema(name.getLocalPart());
+        return delegate.getSchema(name);
+    }
+
+    /**
+     * Returns the feature type schema for the given type name.
+     *
+     * <p>This implementation ensures the database view exists for the requested schema before delegating to the JDBC
+     * datastore.
+     *
+     * @param typeName The name of the feature type
+     * @return The feature type schema
+     * @throws IOException If there is a problem retrieving the schema
+     */
+    @Override
+    public SimpleFeatureType getSchema(String typeName) throws IOException {
+        getSQLDialect().ensureSchema(typeName);
+        return delegate.getSchema(typeName);
+    }
+
+    /**
+     * Returns a feature source for the given type name.
+     *
+     * <p>This implementation ensures the database view exists for the requested feature source before delegating to the
+     * JDBC datastore.
+     *
+     * @param typeName The name of the feature type
+     * @return A feature source for reading features
+     * @throws IOException If there is a problem creating the feature source
+     */
+    @Override
+    public SimpleFeatureSource getFeatureSource(String typeName) throws IOException {
+        getSQLDialect().ensureSchema(typeName);
+        return delegate.getFeatureSource(typeName);
+    }
+
+    /**
+     * Returns a feature source for the given qualified name.
+     *
+     * <p>This implementation ensures the database view exists for the requested feature source before delegating to the
+     * JDBC datastore.
+     *
+     * @param typeName The qualified name of the feature type
+     * @return A feature source for reading features
+     * @throws IOException If there is a problem creating the feature source
+     */
+    @Override
+    public SimpleFeatureSource getFeatureSource(Name typeName) throws IOException {
+        getSQLDialect().ensureSchema(typeName.getLocalPart());
+        return delegate.getFeatureSource(typeName);
+    }
+
+    /**
+     * Helper method to get the GeoParquet SQL dialect from the delegate datastore.
+     *
+     * @return The GeoParquet SQL dialect
+     */
+    GeoParquetDialect getSQLDialect() {
+        return (GeoParquetDialect) delegate.getSQLDialect();
+    }
+}

--- a/modules/unsupported/geoparquet/src/test/java/org/geotools/data/geoparquet/GeoParquetDataStoreFactoryTest.java
+++ b/modules/unsupported/geoparquet/src/test/java/org/geotools/data/geoparquet/GeoParquetDataStoreFactoryTest.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import org.geotools.api.data.DataStore;
 import org.geotools.api.data.DataStoreFactorySpi;
 import org.geotools.api.data.DataStoreFinder;
-import org.geotools.jdbc.JDBCDataStore;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -85,11 +84,9 @@ public class GeoParquetDataStoreFactoryTest {
         DataStore ds = factory.createDataStore(worldGridDirParams);
 
         assertNotNull(ds);
-        assertTrue(ds instanceof JDBCDataStore);
+        assertTrue(ds instanceof GeoparquetDataStore);
 
-        // Check the dialect is correctly set
-        JDBCDataStore jdbcDS = (JDBCDataStore) ds;
-        assertTrue(jdbcDS.getSQLDialect() instanceof GeoParquetDialect);
+        assertNotNull(((GeoparquetDataStore) ds).getSQLDialect());
     }
 
     @Test

--- a/modules/unsupported/geoparquet/src/test/java/org/geotools/data/geoparquet/GeoParquetTestSupport.java
+++ b/modules/unsupported/geoparquet/src/test/java/org/geotools/data/geoparquet/GeoParquetTestSupport.java
@@ -38,9 +38,9 @@ import org.junit.rules.TemporaryFolder;
  *
  * <p>Usage:
  *
- * <pre>
+ * <pre><code>
  * public class MyTest {
- *     &#64;Rule
+ *     @Rule
  *     public GeoParquetTestSupport testData = new GeoParquetTestSupport();
  *
  *     @Test
@@ -50,6 +50,7 @@ import org.junit.rules.TemporaryFolder;
  *         // Test with the GeoParquet files
  *     }
  * }
+ * </code>
  * </pre>
  *
  * <p>This support class will create the following directories and files in the {@link #getTemporaryFolder() temp


### PR DESCRIPTION
Refactors GeoParquet implementation to use the decorator pattern, with GeoparquetDataStore as a decorator over JDBCDataStore and GeoParquetDataStoreFactory as a decorator over a new delegate factory.

Key improvements:
- Available type names are now resolved quickly using a fast path query
- Database view registration is delayed until the feature type is actually needed
- Adds proper thread safety for concurrent initialization of views
- Adds comprehensive Javadocs to all new and modified classes

This enhancement significantly improves responsiveness when working with large GeoParquet datasets, particularly with Hive partitioning and remote URIs, by avoiding unnecessary view registrations during initial data store setup.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->