### PR TITLE
Updating remaining Ubuntu 20.04 builds to 24.04

### DIFF
--- a/.github/workflows/linux_jdk11.yml
+++ b/.github/workflows/linux_jdk11.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-24.04]
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 11
@@ -19,10 +19,6 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 11
-    - name: Set up GDAL
-      run: |
-        sudo apt update
-        sudo apt install --no-install-recommends -y gdal-bin libgdal-dev libgdal-java
     - name: Setup python for docs
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/linux_jdk17.yml
+++ b/.github/workflows/linux_jdk17.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-24.04]
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17
@@ -19,10 +19,6 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 17
-    - name: Set up GDAL
-      run: |
-        sudo apt update
-        sudo apt install --no-install-recommends -y gdal-bin libgdal-dev libgdal-java
     - name: Setup python for docs
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Ubuntu 20.04 is not running any longer... also removed the GDAL setup step in the java 11 and java 17 builds, we have a dedicated GDAL action.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->