### PR TITLE
Fix GeoParquet bugs and improve CRS handling

### DIFF
--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
@@ -277,7 +277,7 @@ public class DuckDBDialect extends BasicSQLDialect {
         // Use ST_Envelope to get the envelope
         sql.append("ST_AsWKB(ST_Envelope(");
         encodeColumnName(null, geometryColumn, sql);
-        sql.append(")::GEOMETRY)::BLOB");
+        sql.append(")::GEOMETRY)::BLOB "); // mind the trailing whitespace, JDBCDataStore won't add it
     }
 
     /**


### PR DESCRIPTION
This commit addresses several issues with the GeoParquet DataStore:

- Fix SQL for bbox computation to use correct parameter ordering
- Add CRS handling override to preserve axis order from GeoParquet metadata
- Remove unnecessary Connection parameter from getGeometrySRIDInternal method
- Add trailing whitespace in SQL generation to fix JDBCDataStore handling
- Enhance tests to verify correct CRS axis order and bounds computation
- Add new test for the bbox column fallback method

These fixes ensure proper SQL generation and consistent CRS handling, especially important for coordinate order in different reference systems.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->