### PR TITLE
Use all cores in github actions, most sport 4 nowadays

### DIFF
--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -40,7 +40,7 @@ jobs:
       run: sudo ethtool -K eth0 tx off rx off
     - name: Build with Maven
       run: |
-        mvn -B clean install -DskipTests -Dall -T2 --file pom.xml
+        mvn -B clean install -DskipTests -Dall -T1C --file pom.xml
     - name: Javadoc build
       run: |
         mvn -B -DskipTests -Dfmt.skip=true javadoc:aggregate --file modules/pom.xml

--- a/.github/workflows/cql2_online.yml
+++ b/.github/workflows/cql2_online.yml
@@ -26,7 +26,7 @@ jobs:
         restore-keys: |
           gt-maven-
     - name: Build GeoTools dependent modules (no tests, prepare fresh artifacts)
-      run: mvn -B clean install -T2 -Dall --file pom.xml -DskipTests -pl :gt-cql2-text,:gt-cql2-json -am -Dspotless.apply.skip=true
+      run: mvn -B clean install -T1C -Dall --file pom.xml -DskipTests -pl :gt-cql2-text,:gt-cql2-json -am -Dspotless.apply.skip=true
     - name: Build GeoPackage module with online tests
       run: | 
         mvn -B clean install -pl :gt-cql2-text,:gt-cql2-json -Ponline -nsu -Dspotless.apply.skip=true

--- a/.github/workflows/db2_online.yml
+++ b/.github/workflows/db2_online.yml
@@ -33,7 +33,7 @@ jobs:
           ./build/ci/db2/start-db2.sh
           ./build/ci/db2/setup-db2.sh
       - name: Build GeoTools dependent modules (no tests)
-        run: mvn -B clean install -T2 -Dall -pl :gt-jdbc-db2 -DskipTests -am -Dspotless.apply.skip=true
+        run: mvn -B clean install -T1C -Dall -pl :gt-jdbc-db2 -DskipTests -am -Dspotless.apply.skip=true
       - name: Test Db2 data store
         run: mvn -B verify -pl :gt-jdbc-db2 -Ponline -Dspotless.apply.skip=true
       - name: Remove SNAPSHOT jars from repository

--- a/.github/workflows/elasticsearch_online.yml
+++ b/.github/workflows/elasticsearch_online.yml
@@ -26,7 +26,7 @@ jobs:
         restore-keys: |
           gt-maven-
     - name: Build GeoTools dependent modules (no tests, prepare fresh artifacts)
-      run: mvn -B clean install -T2 -Dall --file pom.xml -DskipTests -pl modules/unsupported/elasticsearch -am -Dspotless.apply.skip=true
+      run: mvn -B clean install -T1C -Dall --file pom.xml -DskipTests -pl modules/unsupported/elasticsearch -am -Dspotless.apply.skip=true
     - name: Build ElasticSearch module with online tests, using the OSS version 
       run: | 
         mvn -B clean install --file modules/unsupported/elasticsearch/pom.xml -Ponline -nsu -Dspotless.apply.skip=true

--- a/.github/workflows/geopkg_online.yml
+++ b/.github/workflows/geopkg_online.yml
@@ -26,7 +26,7 @@ jobs:
         restore-keys: |
           gt-maven-
     - name: Build GeoTools dependent modules (no tests, prepare fresh artifacts)
-      run: mvn -B clean install -T2 -Dall --file pom.xml -DskipTests -pl modules/plugin/geopkg -am -Dspotless.apply.skip=true
+      run: mvn -B clean install -T1C -Dall --file pom.xml -DskipTests -pl modules/plugin/geopkg -am -Dspotless.apply.skip=true
     - name: Build GeoPackage module with online tests
       run: | 
         mkdir ~/.geotools

--- a/.github/workflows/informix.yml
+++ b/.github/workflows/informix.yml
@@ -33,7 +33,7 @@ jobs:
           ./build/ci/informix/start-informix.sh
           ./build/ci/informix/setup-informix.sh
       - name: Build GeoTools dependent modules (no tests)
-        run: mvn -B clean install -T2 -Dall -pl :gt-jdbc-informix -DskipTests -am -Dspotless.apply.skip=true
+        run: mvn -B clean install -T1C -Dall -pl :gt-jdbc-informix -DskipTests -am -Dspotless.apply.skip=true
       - name: Test Informix data store
         run: mvn -B verify -pl :gt-jdbc-informix -Ponline -Dspotless.apply.skip=true
       - name: Remove SNAPSHOT jars from repository

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
           sudo ethtool -K eth0 tx off rx off
       - name: Build GeoTools (no tests, prepare fresh artifacts)
         run: |
-          mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install -T2 -Dall --file pom.xml -DskipTests
+          mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install -T1C -Dall --file pom.xml -DskipTests
       - name: Checkout GeoWebCache, GeoServer and ...
         run: |
           cd ~
@@ -53,15 +53,15 @@ jobs:
       - name: Build Mapfish-print v2 with tests
         run: |
           cd ~
-          mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f mapfish-print-v2/pom.xml install -nsu -DskipTests -T2
-          mvn -B -f mapfish-print-v2/pom.xml test -fae -nsu -T2
+          mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f mapfish-print-v2/pom.xml install -nsu -DskipTests -T1C
+          mvn -B -f mapfish-print-v2/pom.xml test -fae -nsu -T1C
       - name: Build GeoWebCache with tests
         run: |
           export TEST_OPTS="-XX:+UseStringDeduplication -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10"
           export MAVEN_OPTS="-Xmx1024m $TEST_OPTS"
           cd ~
-          mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f geowebcache/geowebcache/pom.xml install -nsu -Dspotless.apply.skip=true -DskipTests -T2
-          mvn -B -f geowebcache/geowebcache/pom.xml test -fae -nsu -T2 -Dspotless.apply.skip=true
+          mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f geowebcache/geowebcache/pom.xml install -nsu -Dspotless.apply.skip=true -DskipTests -T1C
+          mvn -B -f geowebcache/geowebcache/pom.xml test -fae -nsu -T1C -Dspotless.apply.skip=true
       - name: Build GeoServer with tests
         run: |
           echo "Building GeoServer"
@@ -70,9 +70,9 @@ jobs:
           cd ~
           sed -i "s/<mf.version>2.2.0<\/mf.version>/<mf.version>2.3-SNAPSHOT<\/mf.version>/g" geoserver/src/pom.xml
           sed -i "s/<gf.version>3.6.0<\/gf.version>/<gf.version>3.6-SNAPSHOT<\/gf.version>/g" geoserver/src/pom.xml
-          mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f geoserver/src/pom.xml install -nsu -Prelease -Dspotless.apply.skip=true -DskipTests -T2
-          mvn -B -f geoserver/src/community/pom.xml install -nsu -DcommunityRelease -Dspotless.apply.skip=true -DskipTests -T2
-          mvn -B -f geoserver/src/pom.xml test -fae -T2 -nsu -Dtest.maxHeapSize=512m -Djvm.opts="$TEST_OPTS" -Prelease -Dspotless.apply.skip=true
+          mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f geoserver/src/pom.xml install -nsu -Prelease -Dspotless.apply.skip=true -DskipTests -T1C
+          mvn -B -f geoserver/src/community/pom.xml install -nsu -DcommunityRelease -Dspotless.apply.skip=true -DskipTests -T1C
+          mvn -B -f geoserver/src/pom.xml test -fae -T1C -nsu -Dtest.maxHeapSize=512m -Djvm.opts="$TEST_OPTS" -Prelease -Dspotless.apply.skip=true
       - name: Remove SNAPSHOT jars from repository
         run: |
           find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/linux_jdk11.yml
+++ b/.github/workflows/linux_jdk11.yml
@@ -40,7 +40,7 @@ jobs:
       run: sudo ethtool -K eth0 tx off rx off
     - name: Build with Maven
       run: |
-        mvn -B clean install -Dspotless.apply.skip=true -Dall -T2 -U -Plinux-github-build --file pom.xml
+        mvn -B clean install -Dspotless.apply.skip=true -Dall -T1C -U -Plinux-github-build --file pom.xml
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/linux_jdk17.yml
+++ b/.github/workflows/linux_jdk17.yml
@@ -40,7 +40,7 @@ jobs:
       run: sudo ethtool -K eth0 tx off rx off
     - name: Build with Maven
       run: |
-        mvn -B clean install -Dspotless.apply.skip=true -Dall -T2 -U -Plinux-github-build --file pom.xml
+        mvn -B clean install -Dspotless.apply.skip=true -Dall -T1C -U -Plinux-github-build --file pom.xml
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/linux_jdk21.yml
+++ b/.github/workflows/linux_jdk21.yml
@@ -40,7 +40,7 @@ jobs:
       run: sudo ethtool -K eth0 tx off rx off
     - name: Build with Maven
       run: |
-        mvn -B clean install -Dspotless.apply.skip=true -Dall -T2 -U -Plinux-github-build --file pom.xml
+        mvn -B clean install -Dspotless.apply.skip=true -Dall -T1C -U -Plinux-github-build --file pom.xml
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,7 +58,7 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
     - name: Build with Maven
       run: |
-        mvn -B clean install -T2 -Dall --file pom.xml -Dspotless.apply.skip=true -Dgdal.version=3.2.0
+        mvn -B clean install -T1C -Dall --file pom.xml -Dspotless.apply.skip=true -Dgdal.version=3.2.0
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/mssql_online.yml
+++ b/.github/workflows/mssql_online.yml
@@ -34,9 +34,9 @@ jobs:
         ./build/ci/mssql/start-mssql.sh ${{ matrix.mssql }}
         ./build/ci/mssql/setup-mssql.sh
     - name: Build GeoTools dependent modules (no tests)
-      run: mvn -B clean install -T2 -Dall -pl :gt-jdbc-sqlserver -DskipTests -Dspotless.apply.skip=true -am
+      run: mvn -B clean install -T1C -Dall -pl :gt-jdbc-sqlserver -DskipTests -Dspotless.apply.skip=true -am
     - name: Test MS SQL Server data store
-      run: mvn -B clean install -T2 -Dall -pl :gt-jdbc-sqlserver -Ponline -Dspotless.apply.skip=true
+      run: mvn -B clean install -T1C -Dall -pl :gt-jdbc-sqlserver -Ponline -Dspotless.apply.skip=true
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/mysql_online.yml
+++ b/.github/workflows/mysql_online.yml
@@ -36,9 +36,9 @@ jobs:
         ./build/ci/mysql/start-mysql.sh ${{ matrix.mysql }}
         ./build/ci/mysql/setup-mysql.sh
     - name: Build GeoTools dependent modules (no tests)
-      run: mvn -B clean install -T2 -Dall -pl :gt-jdbc-mysql -DskipTests -Dspotless.apply.skip=true -am
+      run: mvn -B clean install -T1C -Dall -pl :gt-jdbc-mysql -DskipTests -Dspotless.apply.skip=true -am
     - name: Test MySQL data store
-      run: mvn -B clean install -T2 -Dall -pl :gt-jdbc-mysql -Ponline -Dspotless.apply.skip=true
+      run: mvn -B clean install -T1C -Dall -pl :gt-jdbc-mysql -Ponline -Dspotless.apply.skip=true
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/oracle_online.yml
+++ b/.github/workflows/oracle_online.yml
@@ -38,7 +38,7 @@ jobs:
         ./build/ci/oracle/setup-oracle.sh
 
     - name: Build GeoTools dependent modules (no tests)
-      run: mvn -B clean install -T2 -Dall -pl :gt-jdbc-oracle -DskipTests -am
+      run: mvn -B clean install -T1C -Dall -pl :gt-jdbc-oracle -DskipTests -am
 
     - name: Test Oracle data store
       run: mvn -B clean install -pl :gt-jdbc-oracle -Pci-oracle-build -Ponline -Dspotless.apply.skip=true

--- a/.github/workflows/postgis_online.yml
+++ b/.github/workflows/postgis_online.yml
@@ -32,7 +32,7 @@ jobs:
         restore-keys: |
           gt-maven-
     - name: Build GeoTools dependent modules (no tests, prepare fresh artifacts)
-      run: mvn -B clean install -T2 -U -Dall --file pom.xml -DskipTests -pl modules/plugin/jdbc/jdbc-postgis -pl modules/plugin/imagemosaic -am -Dspotless.apply.skip=true
+      run: mvn -B clean install -T1C -U -Dall --file pom.xml -DskipTests -pl modules/plugin/jdbc/jdbc-postgis -pl modules/plugin/imagemosaic -am -Dspotless.apply.skip=true
     - name: Build PostGIS data store with online tests
       run: |
         mkdir ~/.geotools

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ jobs:
       run: Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
     - name: Build with Maven
       run: |
-        mvn --% -B clean install -Dall -T2 --file pom.xml -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
+        mvn --% -B clean install -Dall -T1C --file pom.xml -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
     - name: Remove SNAPSHOT jars from repository
       run: |
         cmd --% /c for /f %i in ('dir /a:d /s /b %userprofile%\*SNAPSHOT*') do rd /s /q %i


### PR DESCRIPTION
Just using -T1C in github actions across the board. This way it will adapt to future core count changes too.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->