### PR TITLE
[GEOT-7757] Disallow usage of var in GeoTools source code

### DIFF
--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -48,6 +48,7 @@ GeoTools ruleset. See https://pmd.github.io/latest/pmd_userdocs_understanding_ru
 
   <rule ref="category/java/codestyle.xml/EmptyControlStatement"/>
   <rule ref="category/java/codestyle.xml/UnnecessarySemicolon"/>
+  <rule ref="category/java/codestyle.xml/UseExplicitTypes" />
   <rule ref="category/java/codestyle.xml/ExtendsObject"/>
   <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
   <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFUnitParserTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFUnitParserTest.java
@@ -159,16 +159,16 @@ public class NetCDFUnitParserTest {
         public void testReconfigureAliases() {
             Map<String, String> aliases = NetCDFUnitFormat.builtInAliases();
             aliases.put("foobar", "m^3");
-            var format = NetCDFUnitFormat.create(NetCDFUnitFormat.builtInReplacements(), aliases);
+            NetCDFUnitFormat format = NetCDFUnitFormat.create(NetCDFUnitFormat.builtInReplacements(), aliases);
             Unit<?> parsed = format.parse("foobar");
             assertEquals(parsed, METRE.pow(3));
         }
 
         @Test
         public void testReconfigureReplacements() {
-            var replacements = NetCDFUnitFormat.builtInReplacements();
+            Map<String, String> replacements = NetCDFUnitFormat.builtInReplacements();
             replacements.put("one two three four!", "g*m^2*s^-2");
-            var format = NetCDFUnitFormat.create(replacements, NetCDFUnitFormat.builtInAliases());
+            NetCDFUnitFormat format = NetCDFUnitFormat.create(replacements, NetCDFUnitFormat.builtInAliases());
             Unit<?> parsed = format.parse("one two three four!");
             Unit<?> expected = GRAM.multiply(METRE.pow(2)).multiply(SECOND.pow(-2));
             assertEquals(expected, parsed);

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPackage.java
@@ -56,6 +56,7 @@ import org.geotools.api.data.SimpleFeatureWriter;
 import org.geotools.api.data.Transaction;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.feature.type.GeometryDescriptor;
 import org.geotools.api.feature.type.PropertyDescriptor;
@@ -742,8 +743,8 @@ public class GeoPackage implements Closeable {
         // remove the attributes, we are going to put in new ones
         builder.setAttributes(new ArrayList<>());
 
-        for (var attribute : schema.getAttributeDescriptors()) {
-            var modifiedAttribute = new AttributeDescriptorImpl(
+        for (AttributeDescriptor attribute : schema.getAttributeDescriptors()) {
+            AttributeDescriptor modifiedAttribute = new AttributeDescriptorImpl(
                     attribute.getType(),
                     attribute.getName(),
                     attribute.getMinOccurs(),

--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -664,14 +664,14 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
                 ps.setString(column, value.toString());
                 break;
             case Types.TIME:
-                var time = value.toString();
+                String time = value.toString();
                 ps.setString(column, time);
                 break;
             case Types.TIMESTAMP:
                 // 2020-02-19 23:00:00.0  --> 2020-02-19T23:00:00.0Z
                 // We need the "Z" or sql lite will interpret the value as local time
                 // geopkg - format will be ISO-8601 - YYYY-MM-DDTHH:MM[:SS.SSS]Z
-                var v = ((Timestamp) value).toInstant().toString();
+                String v = ((Timestamp) value).toInstant().toString();
                 ps.setString(column, v);
                 break;
             default:
@@ -957,7 +957,7 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
                 return null;
             }
             // geopkg - format will be ISO-8601 - YYYY-MM-DDTHH:MM[:SS.SSS]Z
-            var strValue = (String) value;
+            String strValue = (String) value;
             // this is for support with "bad" geopkgs
             if (!strValue.endsWith("Z")) {
                 strValue += "Z";
@@ -969,7 +969,7 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
             } catch (Exception e) {
                 // could be an old GT datetime i.e. '2024-02-27 00:13:00.0Z'
                 try {
-                    var dateFormat = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss");
+                    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss");
                     dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
                     java.util.Date date = dateFormat.parse(strValue);
                     Instant dateInstant = date.toInstant();

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -589,7 +589,7 @@ public class GeoPackageTest {
         builder.add("float1", Float.class);
         builder.add("float2", Double.class);
 
-        var schema = builder.buildFeatureType();
+        SimpleFeatureType schema = builder.buildFeatureType();
 
         schema.getDescriptor("int1").getUserData().put(JDBC_NATIVE_TYPENAME, JDBCType.SMALLINT.getName());
         schema.getDescriptor("int1").getUserData().put(JDBC_NATIVE_TYPE, JDBCType.SMALLINT.getVendorTypeNumber());
@@ -615,8 +615,8 @@ public class GeoPackageTest {
     // metadata
     @Test
     public void testCorrectSchema() {
-        var schema = createJDBCSchema();
-        var schema2 = geopkg.correctSchema(schema);
+        SimpleFeatureType schema = createJDBCSchema();
+        SimpleFeatureType schema2 = geopkg.correctSchema(schema);
 
         // JDBC_NATIVE_TYPENAME and JDBC_NATIVE_TYPE are in the userdata #size() == 0 means
         // not there
@@ -635,7 +635,7 @@ public class GeoPackageTest {
     // JDBC_NATIVE_TYPENAME and JDBC_NATIVE_TYPE metadata are attached to the schema.
     @Test
     public void testMetadataColumns() throws IOException {
-        var schema = createJDBCSchema();
+        SimpleFeatureType schema = createJDBCSchema();
         FeatureEntry entry = new FeatureEntry();
         entry.setBounds(new ReferencedEnvelope());
         entry.setTableName(schema.getTypeName());

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTestWriteDatetime.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTestWriteDatetime.java
@@ -34,6 +34,7 @@ import org.apache.commons.io.FileUtils;
 import org.geotools.api.data.SimpleFeatureReader;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -107,24 +108,24 @@ public class GeoPackageTestWriteDatetime {
      */
     @Test
     public void testOldGTDateFormat() throws Exception {
-        var dialect = new GeoPkgDialect(null);
+        GeoPkgDialect dialect = new GeoPkgDialect(null);
 
         SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
         builder.setName("testCaseFT");
         builder.setCRS(DefaultGeographicCRS.WGS84);
         builder.add("the_geom", LineString.class);
         builder.add("datetime", Timestamp.class);
-        var descriptor = builder.buildFeatureType().getDescriptor(1);
+        AttributeDescriptor descriptor = builder.buildFeatureType().getDescriptor(1);
 
-        var oldGTFormat = "2024-02-27 00:13:00.0Z";
-        var converted = (Timestamp) dialect.convertValue(oldGTFormat, descriptor);
+        String oldGTFormat = "2024-02-27 00:13:00.0Z";
+        Timestamp converted = (Timestamp) dialect.convertValue(oldGTFormat, descriptor);
 
         // convert to standard GMT format
         SimpleDateFormat sdf = new SimpleDateFormat();
         sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
         sdf.applyPattern("dd MMM yyyy HH:mm:ss z");
 
-        var result = sdf.format(converted);
+        String result = sdf.format(converted);
         assertEquals("27 Feb 2024 00:13:00 GMT", result);
     }
 

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDateTestSetup.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDateTestSetup.java
@@ -19,7 +19,7 @@ public class GeoPkgDateTestSetup extends JDBCDateTestSetup {
         // dates MUST be in ISO-8601 date/time string in the form YYYY-MM-DDTHH:MM[:SS.SSS]Z
         // However, the online test cases use local time
 
-        var localStr = "2009-06-28 15:12:41";
+        String localStr = "2009-06-28 15:12:41";
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
         Date parsedDate = dateFormat.parse(localStr);
 
@@ -27,7 +27,7 @@ public class GeoPkgDateTestSetup extends JDBCDateTestSetup {
                 parsedDate.getTime() - Calendar.getInstance().getTimeZone().getOffset(parsedDate.getTime()));
 
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        var gmt2 = sdf.format(gmt);
+        String gmt2 = sdf.format(gmt);
 
         // NOTE: geopackage does NOT support TIME columns - just DATE and DATETIME
         // For TIME columns, we use a time like '15:12:41Z' to explicitly show it is Zulu-time

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDatetimeTest.java
@@ -282,8 +282,8 @@ public class GeoPkgDatetimeTest {
         // ListFeatureCollection(features).stream().collect(Collectors.toList());
         assertEquals(3, features.size());
 
-        var lower = gmt2Local("2020-02-19T23:00:00Z");
-        var upper = gmt2Local("2020-03-19T00:00:00Z");
+        String lower = gmt2Local("2020-02-19T23:00:00Z");
+        String upper = gmt2Local("2020-03-19T00:00:00Z");
 
         between = ECQL.toFilter("time BETWEEN '" + lower + "' AND '" + upper + "'");
 
@@ -300,7 +300,7 @@ public class GeoPkgDatetimeTest {
                 parsedDate.getTime() + Calendar.getInstance().getTimeZone().getOffset(parsedDate.getTime()));
 
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        var localStr = sdf.format(local);
+        String localStr = sdf.format(local);
         return localStr;
     }
 }

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/TestUtils.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/TestUtils.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.media.jai.PlanarImage;
@@ -228,7 +229,7 @@ final class TestUtils extends Assert {
         // Remove the default handlers
         Logger rootLogger = Logger.getLogger("");
         rootLogger.setLevel(Level.ALL);
-        for (var handler : rootLogger.getHandlers()) {
+        for (Handler handler : rootLogger.getHandlers()) {
             rootLogger.removeHandler(handler);
         }
 

--- a/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/AttributeRoundtripTest.java
+++ b/modules/unsupported/flatgeobuf/src/test/java/org/geotools/data/flatgeobuf/AttributeRoundtripTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Date;
+import java.util.List;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.data.geojson.GeoJSONReader;
@@ -110,8 +111,8 @@ public class AttributeRoundtripTest {
         SimpleFeatureCollection actual = FeatureCollectionConversions.deserializeSFC(new ByteArrayInputStream(bytes));
         SimpleFeature expectedFeature = (SimpleFeature) expected.toArray()[0];
         SimpleFeature actualFeature = (SimpleFeature) actual.toArray()[0];
-        var e = expectedFeature.getAttributes();
-        var a = actualFeature.getAttributes();
+        List<Object> e = expectedFeature.getAttributes();
+        List<Object> a = actualFeature.getAttributes();
         assertEquals(e.get(1), a.get(1));
         assertEquals(e.get(2), a.get(2));
         assertEquals(ISO_LOCAL_DATE_TIME.format((LocalDateTime) e.get(3)), a.get(3));


### PR DESCRIPTION
[![GEOT-7757](https://badgen.net/badge/JIRA/GEOT-7757/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7757) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Same as https://github.com/geoserver/geoserver/pull/8511, as per PMC meeting discussion

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->