### PR TITLE
Fix Eclipse maven integration for non-standard source folders in modules/ogc/pom.xml

### DIFF
--- a/modules/ogc/net.opengis.wmts/build.properties
+++ b/modules/ogc/net.opengis.wmts/build.properties
@@ -4,8 +4,7 @@ bin.includes = .,\
                model/,\
                META-INF/,\
                plugin.xml,\
-               plugin.properties,\
-               src/main/resources/
+               plugin.properties
 jars.compile.order = .
-source.. = src/main/java/
+source.. = src/
 output.. = bin/

--- a/modules/ogc/net.opengis.wmts/pom.xml
+++ b/modules/ogc/net.opengis.wmts/pom.xml
@@ -20,4 +20,18 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+  
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${basedir}</directory>
+        <includes>
+          <include>*.ecore</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
 </project>


### PR DESCRIPTION
Fix 'cannot nest resources inside src' for `modules/ogc/net.opengis.wmts`

With this change, GeoTools can be imported as a maven project in Eclipse instead of having to use the deprecated `mvn eclipse:eclipse` command.

* Update POM to add custom resources configuration that handles both
   src/main/resources and .ecore files in the root directory
* Update build.properties to use src/ as the source directory to match
   the actual project structure

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->