### PR TITLE
[GEOT-7761] SerializableRenderedImage usage removal

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/GridCoverageFactory.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/GridCoverageFactory.java
@@ -108,20 +108,7 @@ public class GridCoverageFactory extends AbstractFactory {
      *
      * @param userHints An optional set of hints to use for coverage constructions.
      */
-    public GridCoverageFactory(final Hints userHints) {
-        String tileEncoding = null;
-        if (userHints != null) {
-
-            tileEncoding = (String) userHints.get(Hints.TILE_ENCODING);
-            if (tileEncoding != null) {
-                tileEncoding = tileEncoding.trim();
-                if (tileEncoding.length() == 0) {
-                    tileEncoding = null;
-                }
-            }
-        }
-        hints.put(Hints.TILE_ENCODING, tileEncoding);
-    }
+    public GridCoverageFactory(final Hints userHints) {}
 
     /**
      * Returns the default coordinate reference system to use when no CRS were explicitly specified by the user. If a
@@ -537,7 +524,6 @@ public class GridCoverageFactory extends AbstractFactory {
         }
         final GridCoverage2D coverage = new GridCoverage2D(
                 name, PlanarImage.wrapRenderedImage(image), gridGeometry, bands, sources, properties, userHints);
-        coverage.tileEncoding = (String) hints.get(Hints.TILE_ENCODING);
         return coverage;
     }
 }

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTest.java
@@ -18,20 +18,16 @@ package org.geotools.coverage.grid;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.awt.Rectangle;
 import java.io.IOException;
-import java.net.InetAddress;
 import javax.imageio.ImageReadParam;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.geometry.GeneralBounds;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -42,19 +38,6 @@ import org.junit.Test;
  */
 public final class GridCoverageTest extends GridCoverageTestBase {
 
-    /** Used to avoid errors if building on a system where hostname is not defined */
-    private boolean hostnameDefined;
-
-    @Before
-    public void setup() {
-        try {
-            InetAddress.getLocalHost();
-            hostnameDefined = true;
-        } catch (Exception ex) {
-            hostnameDefined = false;
-        }
-    }
-
     /** Tests a grid coverage filled with random values. */
     @Test
     public void testRandomCoverage() {
@@ -63,25 +46,6 @@ public final class GridCoverageTest extends GridCoverageTestBase {
         assertRasterEquals(coverage, coverage); // Actually a test of assertEqualRasters(...).
         assertSame(
                 coverage.getRenderedImage(), coverage.getRenderableImage(0, 1).createDefaultRendering());
-    }
-
-    /**
-     * Tests the serialization of a grid coverage.
-     *
-     * @throws IOException if an I/O operation was needed and failed.
-     * @throws ClassNotFoundException Should never happen.
-     */
-    @Test
-    public void testSerialization() throws IOException, ClassNotFoundException {
-        // will fail on GitHub linux build, due to TCP port opening by SerializableRenderedImage
-        Assume.assumeFalse(Boolean.getBoolean("linux-github-build"));
-        if (hostnameDefined) {
-            GridCoverage2D coverage = EXAMPLES.get(0);
-            GridCoverage2D serial = serialize(coverage);
-            assertNotSame(coverage, serial);
-            assertEquals(GridCoverage2D.class, serial.getClass());
-            assertRasterEquals(coverage, serial);
-        }
     }
 
     @Test

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTestBase.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTestBase.java
@@ -19,7 +19,6 @@ package org.geotools.coverage.grid;
 import static java.awt.Color.decode;
 import static org.geotools.util.NumberRange.create;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
 import java.awt.Color;
@@ -29,12 +28,8 @@ import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.AbstractList;
 import java.util.List;
 import java.util.Random;
@@ -51,7 +46,6 @@ import org.geotools.geometry.GeneralBounds;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.test.TestData;
-import org.geotools.util.factory.Hints;
 import si.uom.SI;
 
 /**
@@ -121,12 +115,10 @@ public class GridCoverageTestBase extends CoverageTestBase {
             final double min = 10 * i;
             envelope.setRange(i, min, min + 5);
         }
-        final Hints hints = new Hints(Hints.TILE_ENCODING, "raw");
-        final GridCoverageFactory factory = CoverageFactoryFinder.getGridCoverageFactory(hints);
+        final GridCoverageFactory factory = CoverageFactoryFinder.getGridCoverageFactory(null);
         // The final grid coverage.
         final GridCoverage2D coverage =
                 factory.create("Test", image, envelope, new GridSampleDimension[] {band}, null, null);
-        assertEquals("raw", coverage.tileEncoding);
         /*
          * Grid coverage construction finished.  Now test it.
          */
@@ -339,33 +331,4 @@ public class GridCoverageTestBase extends CoverageTestBase {
             return factory.create(filename, image, envelope, bands, null, null);
         }
     };
-
-    /**
-     * Tests the serialization of the packed and geophysics views of a grid coverage.
-     *
-     * @param coverage The coverage to serialize.
-     * @return The deserialized grid coverage as packed view.
-     * @throws IOException if an I/O operation was needed and failed.
-     * @throws ClassNotFoundException Should never happen.
-     */
-    @SuppressWarnings("BanSerializableRead")
-    protected static GridCoverage2D serialize(GridCoverage2D coverage) throws IOException, ClassNotFoundException {
-        coverage.tileEncoding = null;
-        /*
-         * The previous line is not something that we should do.
-         * But we want to test the default GridCoverage2D encoding.
-         */
-        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        try (ObjectOutputStream out = new ObjectOutputStream(buffer)) {
-            out.writeObject(coverage);
-        }
-
-        GridCoverage2D read;
-        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
-            read = (GridCoverage2D) in.readObject();
-        }
-        assertNotSame(read, coverage);
-        coverage = read;
-        return coverage;
-    }
 }

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/InterpolatorTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/InterpolatorTest.java
@@ -17,7 +17,6 @@
 package org.geotools.coverage.grid;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
 
 import it.geosolutions.jaiext.range.NoDataContainer;
 import it.geosolutions.jaiext.range.Range;
@@ -26,8 +25,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.image.Raster;
 import java.awt.image.RenderedImage;
-import java.io.IOException;
-import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
 import javax.media.jai.BorderExtender;
@@ -39,8 +36,6 @@ import org.geotools.api.geometry.Bounds;
 import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.util.CoverageUtilities;
 import org.geotools.referencing.operation.matrix.XAffineTransform;
-import org.geotools.util.factory.Hints;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,9 +49,6 @@ public final class InterpolatorTest extends GridCoverageTestBase {
     /** The interpolators to use. */
     private Interpolation[] interpolations;
 
-    /** Used to avoid errors if building on a system where hostname is not defined */
-    private boolean hostnameDefined;
-
     /** Setup the {@linkplain #interpolations} values. */
     @Before
     public void setup() {
@@ -64,14 +56,6 @@ public final class InterpolatorTest extends GridCoverageTestBase {
         interpolations = new Interpolation[types.length];
         for (int i = 0; i < interpolations.length; i++) {
             interpolations[i] = Interpolation.getInstance(types[i]);
-        }
-
-        try {
-            InetAddress.getLocalHost();
-            hostnameDefined = true;
-
-        } catch (Exception ex) {
-            hostnameDefined = false;
         }
     }
 
@@ -126,8 +110,7 @@ public final class InterpolatorTest extends GridCoverageTestBase {
         // Following constant is pixel size (in degrees).
         // This constant must be identical to the one defined in 'getRandomCoverage()'
         GridCoverage2D coverage = getRandomCoverage();
-        final Hints hints = new Hints(Hints.TILE_ENCODING, "raw");
-        final GridCoverageFactory factory = CoverageFactoryFinder.getGridCoverageFactory(hints);
+        final GridCoverageFactory factory = CoverageFactoryFinder.getGridCoverageFactory(null);
         Map<String, Object> properties = new HashMap<>();
         RenderedImage src = coverage.getRenderedImage();
         // Setting ROI and NoData
@@ -184,27 +167,6 @@ public final class InterpolatorTest extends GridCoverageTestBase {
                     }
                 }
             }
-        }
-    }
-
-    /**
-     * Tests the serialization of a grid coverage.
-     *
-     * @throws IOException if an I/O operation was needed and failed.
-     * @throws ClassNotFoundException Should never happen.
-     */
-    @Test
-    public void testSerialization() throws IOException, ClassNotFoundException {
-        // will fail on GitHub linux build, due to TCP port opening by SerializableRenderedImage
-        Assume.assumeFalse(Boolean.getBoolean("linux-github-build"));
-        if (hostnameDefined) {
-            GridCoverage2D coverage = EXAMPLES.get(0);
-            coverage = Interpolator2D.create(coverage, interpolations);
-            GridCoverage2D serial = serialize(coverage);
-            assertNotSame(coverage, serial);
-            assertEquals(Interpolator2D.class, serial.getClass());
-            // conversions of NaN values which may be the expected ones.
-            assertRasterEquals(coverage, serial);
         }
     }
 }

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
@@ -658,19 +658,6 @@ public class Hints extends RenderingHints {
      */
     public static final Key DECIMATION_POLICY = new Key("org.geotools.coverage.grid.io.DecimationPolicy");
 
-    /**
-     * The {@linkplain javax.media.jai.tilecodec.TileEncoder tile encoder} name (as a {@link String} value) to use
-     * during serialization of image data in a {@link org.geotools.coverage.grid.GridCoverage2D} object. This encoding
-     * is given to the {@link javax.media.jai.remote.SerializableRenderedImage} constructor. Valid values include (but
-     * is not limited to) {@code "raw"}, {@code "gzip"} and {@code "jpeg"}.
-     *
-     * <p><strong>Note:</strong> We recommend to avoid the {@code "jpeg"} codec for grid coverages.
-     *
-     * @see org.geotools.coverage.FactoryFinder#getGridCoverageFactory
-     * @since 2.3
-     */
-    public static final Key TILE_ENCODING = new Key(String.class);
-
     /** The {@link javax.media.jai.JAI} instance to use. */
     public static final Key JAI_INSTANCE = new Key("javax.media.jai.JAI");
 

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/Utils.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/Utils.java
@@ -71,7 +71,6 @@ import javax.media.jai.JAI;
 import javax.media.jai.ROI;
 import javax.media.jai.TileCache;
 import javax.media.jai.TileScheduler;
-import javax.media.jai.remote.SerializableRenderedImage;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -1439,31 +1438,6 @@ public class Utils {
                 if (object instanceof SampleImage) {
                     SampleImage si = (SampleImage) object;
                     return si.toBufferedImage();
-                } else if (object instanceof SerializableRenderedImage) {
-                    SerializableRenderedImage sri = (SerializableRenderedImage) object;
-                    // SerializableRenderedImage is both insecure and a finalization thread killer, try to replace
-                    // it with SampleImage on disk instead
-                    if (sampleImageFile.canWrite()) {
-                        try {
-                            storeSampleImage(sampleImageFile, sri.getSampleModel(), sri.getColorModel());
-                            LOGGER.info(
-                                    () -> "Upgraded sample image to new storage format for path " + sampleImageFile);
-                        } catch (Exception e) {
-                            LOGGER.log(
-                                    Level.WARNING,
-                                    e,
-                                    () -> "Failed to upgrade sample image to new storage format for path "
-                                            + sampleImageFile);
-                        }
-                    } else {
-                        LOGGER.warning(
-                                () -> "Insuffient permissions to upgrade sample image to new storage format for path "
-                                        + sampleImageFile);
-                    }
-                    // note, disposing the SerializableRenderedImage here is not done on purpose,
-                    // as it will hang, timeout and fail, and then on finalize
-                    // it will do it again, so there is really no point in doing that
-                    return new SampleImage(sri.getSampleModel(), sri.getColorModel()).toBufferedImage();
                 } else {
                     LOGGER.warning(() -> "Unrecognized sample image content '"
                             + object.getClass().getName() + "' for path " + sampleImageFile);

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/UtilsTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/UtilsTest.java
@@ -25,7 +25,6 @@ import java.io.FileOutputStream;
 import java.io.ObjectOutputStream;
 import java.util.PriorityQueue;
 import javax.media.jai.Histogram;
-import javax.media.jai.remote.SerializableRenderedImage;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -79,23 +78,5 @@ public class UtilsTest {
             out.writeObject(new PriorityQueue<>());
         }
         assertNull(Utils.loadSampleImage(file));
-    }
-
-    @Test
-    public void testLoadSampleImageSerializableRenderedImage() throws Exception {
-        File file = folder.newFile("serializable.rendered.image").getAbsoluteFile();
-        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(file))) {
-            out.writeObject(new SerializableRenderedImage(new BufferedImage(1, 1, 1)));
-        }
-        // javax.media.jai.remote.SerializableRenderedImage fields blocked by default
-        assertNull(Utils.loadSampleImage(file));
-        // javax.media.jai.remote.SerializableRenderedImage fields allowed by system property
-        System.setProperty(Utils.SAMPLE_IMAGE_ALLOWLIST_KEY, "^java\\.(net\\.InetAddress|util\\.Hashtable)$");
-        assertNotNull(Utils.resetSampleImageAllowlist());
-        assertNotNull(Utils.loadSampleImage(file));
-        // file will have been converted to org.geotools.gce.imagemosaic.SampleImage
-        System.clearProperty(Utils.SAMPLE_IMAGE_ALLOWLIST_KEY);
-        assertNull(Utils.resetSampleImageAllowlist());
-        assertNotNull(Utils.loadSampleImage(file));
     }
 }


### PR DESCRIPTION
[![GEOT-7761](https://badgen.net/badge/JIRA/GEOT-7761/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7761) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

One bit of preparation for the JAI -> ImageN switch

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->