### PR TITLE
[BACKPORT 33.x][GEOT-7765] Improve PropertyIsLike filter to work for numeric columns in postgres

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/data/jdbc/FilterToSQL.java
@@ -512,23 +512,28 @@ public class FilterToSQL implements FilterVisitor, ExpressionVisitor {
         String pattern = LikeFilterImpl.convertToSQL92(esc, multi, single, matchCase, literal, false);
 
         try {
-            if (!matchCase) {
-                out.write(" UPPER(");
-            }
-
-            att.accept(this, extraData);
-
-            if (!matchCase) {
-                out.write(") LIKE ");
-            } else {
-                out.write(" LIKE ");
-            }
+            processLikeLeftOperand(extraData, matchCase, att, attributeType);
 
             writeLiteral(pattern);
         } catch (java.io.IOException ioe) {
             throw new RuntimeException(IO_ERROR, ioe);
         }
         return extraData;
+    }
+
+    protected void processLikeLeftOperand(Object extraData, boolean matchCase, Expression att, Class attributeType)
+            throws IOException {
+        if (!matchCase) {
+            out.write(" UPPER(");
+        }
+
+        att.accept(this, extraData);
+
+        if (!matchCase) {
+            out.write(") LIKE ");
+        } else {
+            out.write(" LIKE ");
+        }
     }
 
     /**

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/PostgisFilterToSQL.java
@@ -262,4 +262,23 @@ public class PostgisFilterToSQL extends FilterToSQL {
         }
         return result;
     }
+
+    @Override
+    protected void processLikeLeftOperand(Object extraData, boolean matchCase, Expression att, Class attributeType)
+            throws IOException {
+        if (!matchCase) {
+            out.write(" UPPER(");
+        }
+
+        att.accept(this, extraData);
+
+        if (attributeType != null && Number.class.isAssignableFrom(attributeType)) {
+            out.write("::text");
+        }
+        if (!matchCase) {
+            out.write(") LIKE ");
+        } else {
+            out.write(" LIKE ");
+        }
+    }
 }


### PR DESCRIPTION
[![GEOT-7765](https://badgen.net/badge/JIRA/GEOT-7765/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7765) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

port https://github.com/geotools/geotools/pull/5207