### PR TITLE
[GEOT-7773] GeoJSONParser of gt-arcgisrest sets Id of each feature to "features"

### DIFF
--- a/modules/unsupported/arcgis-rest/src/main/java/org/geotools/data/arcgisrest/GeoJSONParser.java
+++ b/modules/unsupported/arcgis-rest/src/main/java/org/geotools/data/arcgisrest/GeoJSONParser.java
@@ -554,8 +554,7 @@ public class GeoJSONParser implements SimpleFeatureIterator {
     public SimpleFeature parseFeature() {
 
         Geometry geom = null;
-        String id =
-                SimpleFeatureBuilder.createDefaultFeatureIdentifier(FEATURES).getID();
+        String id = null;
         Map<String, Object> props = new HashMap<>();
         SimpleFeatureBuilder builder = new SimpleFeatureBuilder(this.featureType);
 

--- a/modules/unsupported/arcgis-rest/src/test/java/org/geotools/data/arcgisrest/GeoJSONParserTest.java
+++ b/modules/unsupported/arcgis-rest/src/test/java/org/geotools/data/arcgisrest/GeoJSONParserTest.java
@@ -29,9 +29,11 @@ import com.google.gson.stream.MalformedJsonException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -419,6 +421,22 @@ public class GeoJSONParserTest {
             assertEquals("value0", feat.getAttribute("vstring"));
             assertTrue((Boolean) (feat.getAttribute("vboolean")));
             assertEquals(12, feat.getAttribute("vint"));
+        }
+    }
+
+    @Test
+    public void parseFeaturesNotSameId() throws Exception {
+        String json = this.json = ArcGISRestDataStoreFactoryTest.readJSONAsString("test-data/properties.geo.json");
+
+        try (GeoJSONParser parser = new GeoJSONParser(new ByteArrayInputStream(json.getBytes()), this.fType, null)) {
+            parser.parseFeatureCollection();
+            Set<String> ids = new HashSet<>();
+            while (parser.hasNext()) {
+                SimpleFeature feat = parser.next();
+                assertNotNull(feat);
+                String id = feat.getID();
+                assertTrue("Id identical to previous feature.", ids.add(id));
+            }
         }
     }
 

--- a/modules/unsupported/arcgis-rest/src/test/java/org/geotools/data/arcgisrest/GeoJSONParserTest.java
+++ b/modules/unsupported/arcgis-rest/src/test/java/org/geotools/data/arcgisrest/GeoJSONParserTest.java
@@ -435,7 +435,7 @@ public class GeoJSONParserTest {
                 SimpleFeature feat = parser.next();
                 assertNotNull(feat);
                 String id = feat.getID();
-                assertTrue("Id identical to previous feature.", ids.add(id));
+                assertTrue("Id should not be identical to previous feature id.", ids.add(id));
             }
         }
     }


### PR DESCRIPTION
[![GEOT-7773](https://badgen.net/badge/JIRA/GEOT-7773/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7773) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->