### PR TITLE
[GEOT-7776] Image mosaic property collectors fail with a array access exception when the regex does not match

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/RegExPropertiesCollector.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/RegExPropertiesCollector.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,9 +31,9 @@ public abstract class RegExPropertiesCollector extends PropertiesCollector imple
 
     private static final Logger LOGGER = Logging.getLogger(RegExPropertiesCollector.class);
 
-    private boolean fullPath = false;
+    protected boolean fullPath = false;
 
-    private Pattern pattern;
+    protected Pattern pattern;
 
     @Override
     public boolean isFullPath() {
@@ -98,7 +97,9 @@ public abstract class RegExPropertiesCollector extends PropertiesCollector imple
     private void addMatches(String name) {
         final Matcher matcher = pattern.matcher(name);
 
+        boolean matched = false;
         while (matcher.find()) {
+            matched = true;
             // Chaining group Strings together
             int count = matcher.groupCount();
             String match = "";
@@ -110,6 +111,7 @@ public abstract class RegExPropertiesCollector extends PropertiesCollector imple
             }
             addMatch(match);
         }
+        if (!matched) LOGGER.fine("No matches found for the pattern: " + pattern.pattern() + " in the string: " + name);
     }
 
     @Override
@@ -120,7 +122,7 @@ public abstract class RegExPropertiesCollector extends PropertiesCollector imple
 
         // set the properties, only if we have matches!
         if (matches.isEmpty()) {
-            if (LOGGER.isLoggable(Level.FINE)) LOGGER.fine("No matches found for this property extractor:");
+            throw new IllegalArgumentException("No matches found for: " + this);
         }
         int index = 0;
         for (String propertyName : getPropertyNames()) {
@@ -128,5 +130,10 @@ public abstract class RegExPropertiesCollector extends PropertiesCollector imple
             // do we have more values?
             if (index >= matches.size()) return;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "RegExPropertiesCollector{" + "fullPath=" + fullPath + ", pattern=" + pattern + '}';
     }
 }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/numeric/NumericFileNameExtractor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/numeric/NumericFileNameExtractor.java
@@ -76,7 +76,7 @@ abstract class NumericFileNameExtractor<N extends Number & Comparable<N>> extend
 
     private static final Logger LOGGER = Logging.getLogger(NumericFileNameExtractor.class);
 
-    private Class<? extends Number> targetClasse;
+    private Class<? extends Number> targetClass;
 
     private Converter converter;
 
@@ -84,21 +84,8 @@ abstract class NumericFileNameExtractor<N extends Number & Comparable<N>> extend
             PropertiesCollectorSPI spi, List<String> propertyNames, String regex, final Class<N> targetClass) {
         super(spi, propertyNames, regex, false);
 
-        this.targetClasse = targetClass;
-        this.converter = factory.createConverter(String.class, targetClasse, GeoTools.getDefaultHints());
-        // if (targetClasse != null) {
-        // // look up a converter
-        // final Set<ConverterFactory> converters = Converters.getConverterFactories(String.class,
-        // targetClasse);
-        // if (!converters.isEmpty()) {
-        // this.converter = converters.iterator().next().createConverter(String.class, targetClasse,
-        // GeoTools.getDefaultHints());
-        // return;
-        // }
-        // throw new IllegalArgumentException("Unable to find a proper converter from String to the
-        // class:" + targetClasse);
-        // }
-
+        this.targetClass = targetClass;
+        this.converter = factory.createConverter(String.class, this.targetClass, GeoTools.getDefaultHints());
     }
 
     @Override
@@ -109,7 +96,7 @@ abstract class NumericFileNameExtractor<N extends Number & Comparable<N>> extend
         for (String match : getMatches()) {
             // try to convert to date
             try {
-                values.add(converter.convert(match, targetClasse));
+                values.add(converter.convert(match, targetClass));
             } catch (Exception e) {
                 if (LOGGER.isLoggable(Level.INFO)) LOGGER.log(Level.INFO, e.getLocalizedMessage(), e);
             }
@@ -117,7 +104,7 @@ abstract class NumericFileNameExtractor<N extends Number & Comparable<N>> extend
 
         // set the properties, if we have some
         if (values.isEmpty()) {
-            if (LOGGER.isLoggable(Level.FINE)) LOGGER.fine("No matches found for this property extractor:");
+            throw new IllegalArgumentException("No matches found for: " + this);
         }
         int index = 0;
         for (String propertyName : getPropertyNames()) {
@@ -127,5 +114,13 @@ abstract class NumericFileNameExtractor<N extends Number & Comparable<N>> extend
             // do we have more dates?
             if (index >= values.size()) return;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "NumericFileNameExtractor{" + "targetClass="
+                + targetClass + ", fullPath="
+                + fullPath + ", pattern="
+                + pattern + '}';
     }
 }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/string/StringFileNameExtractor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/string/StringFileNameExtractor.java
@@ -17,13 +17,10 @@
 package org.geotools.gce.imagemosaic.properties.string;
 
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.gce.imagemosaic.properties.PropertiesCollector;
 import org.geotools.gce.imagemosaic.properties.PropertiesCollectorSPI;
 import org.geotools.gce.imagemosaic.properties.RegExPropertiesCollector;
-import org.geotools.util.logging.Logging;
 
 /**
  * {@link PropertiesCollector} that is able to collect properties from a file name.
@@ -31,7 +28,6 @@ import org.geotools.util.logging.Logging;
  * @author Simone Giannecchini, GeoSolutions SAS
  */
 class StringFileNameExtractor extends RegExPropertiesCollector {
-    private static final Logger LOGGER = Logging.getLogger(StringFileNameExtractor.class);
 
     public StringFileNameExtractor(PropertiesCollectorSPI spi, List<String> propertyNames, String regex) {
         super(spi, propertyNames, regex, false);
@@ -45,7 +41,7 @@ class StringFileNameExtractor extends RegExPropertiesCollector {
 
         // set the properties, only if we have matches!
         if (matches.isEmpty()) {
-            if (LOGGER.isLoggable(Level.FINE)) LOGGER.fine("No matches found for this property extractor:");
+            throw new IllegalArgumentException("No matches found for: " + this);
         }
         int index = 0;
         for (String propertyName : getPropertyNames()) {
@@ -55,5 +51,10 @@ class StringFileNameExtractor extends RegExPropertiesCollector {
             // do we have more dates?
             if (index >= matches.size()) return;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "StringFileNameExtractor{" + "pattern=" + pattern + ", fullPath=" + fullPath + '}';
     }
 }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/time/TimestampFileNameExtractor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/properties/time/TimestampFileNameExtractor.java
@@ -101,19 +101,25 @@ class TimestampFileNameExtractor extends RegExPropertiesCollector {
 
         // set the properties, only if we have matches!
         if (dates.isEmpty()) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine("No matches found for this property extractor:");
-            }
-            throw new IllegalArgumentException("No matches found for this property extractor");
+            throw new IllegalArgumentException("No matches found for: " + this);
         }
         int index = 0;
         for (String propertyName : getPropertyNames()) {
             // set the property
-
             feature.setAttribute(propertyName, dates.get(index++));
 
             // do we have more dates?
             if (index >= dates.size()) return;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "TimestampFileNameExtractor{" + "customFormat="
+                + customFormat + ", format='"
+                + format + '\'' + ", useHighTime="
+                + useHighTime + ", fullPath="
+                + fullPath + ", pattern="
+                + pattern + '}';
     }
 }

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/numeric/NumericFileNameExtractorTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/numeric/NumericFileNameExtractorTest.java
@@ -1,0 +1,81 @@
+/*
+ * GeoTools - The Open Source Java GIS Toolkit
+ * http://geotools.org
+ *
+ * (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic.properties.numeric;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Set;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.data.DataUtilities;
+import org.geotools.feature.SchemaException;
+import org.geotools.gce.imagemosaic.properties.PropertiesCollector;
+import org.geotools.gce.imagemosaic.properties.PropertiesCollectorFinder;
+import org.geotools.gce.imagemosaic.properties.PropertiesCollectorSPI;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NumericFileNameExtractorTest {
+
+    private SimpleFeature feature;
+
+    @Before
+    public void setup() throws SchemaException {
+        SimpleFeatureType ft = DataUtilities.createType("test", "id:int,value:Double");
+        feature = DataUtilities.createFeature(ft, "1|null");
+    }
+
+    @Test
+    public void testNoGroupExtraction() {
+        PropertiesCollectorSPI spi = getDoubleFileNameSpi();
+        PropertiesCollector collector = spi.create("regex=[0-9]+\\.[0-9]", Arrays.asList("value"));
+        File file = new File("polyphemus_20.3_.nc");
+        collector.collect(file);
+        collector.setProperties(feature);
+        Double value = (Double) feature.getAttribute("value");
+        assertNotNull(value);
+        assertEquals(20.3, value, 0d);
+    }
+
+    @Test
+    public void testFailedExtraction() {
+        PropertiesCollectorSPI spi = getDoubleFileNameSpi();
+        PropertiesCollector collector = spi.create("regex=[0-9]+\\.[0-9]", Arrays.asList("value"));
+        File file = new File("polyphemus_20130301_.nc");
+        collector.collect(file);
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> collector.setProperties(feature));
+        assertEquals(
+                "No matches found for: NumericFileNameExtractor{targetClass=class java.lang.Double, fullPath=false, pattern=[0-9]+\\.[0-9]}",
+                ex.getMessage());
+    }
+
+    private PropertiesCollectorSPI getDoubleFileNameSpi() {
+        Set<PropertiesCollectorSPI> spis = PropertiesCollectorFinder.getPropertiesCollectorSPI();
+        for (PropertiesCollectorSPI spi : spis) {
+            if (spi.getName().equals(DoubleFileNameExtractorSPI.class.getSimpleName())) {
+                return spi;
+            }
+        }
+
+        return null;
+    }
+}

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/string/StringFileNameExtractorTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/string/StringFileNameExtractorTest.java
@@ -18,6 +18,7 @@ package org.geotools.gce.imagemosaic.properties.string;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.net.URI;
@@ -53,6 +54,19 @@ public class StringFileNameExtractorTest {
         String seq = (String) feature.getAttribute("seq");
         assertNotNull(seq);
         assertEquals("20130301T000000", seq);
+    }
+
+    @Test
+    public void testFailedExtraction() {
+        PropertiesCollectorSPI spi = getStringFileNameSpi();
+        PropertiesCollector collector = spi.create("regex=_([0-9]{8}T[0-9]{6})_", Arrays.asList("seq"));
+        File file = new File("polyphemus_20130301_.nc");
+        collector.collect(file);
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> collector.setProperties(feature));
+        assertEquals(
+                "No matches found for: StringFileNameExtractor{pattern=_([0-9]{8}T[0-9]{6})_, fullPath=false}",
+                ex.getMessage());
     }
 
     @Test

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/time/TimestampFileNameExtractorTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/properties/time/TimestampFileNameExtractorTest.java
@@ -19,6 +19,7 @@ package org.geotools.gce.imagemosaic.properties.time;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -59,6 +60,19 @@ public class TimestampFileNameExtractorTest {
         Date time = (Date) feature.getAttribute("time");
         assertNotNull(time);
         assertEquals("2013-03-01T00:00:00.000Z", df.format(time));
+    }
+
+    @Test
+    public void testFailedExtraction() {
+        PropertiesCollectorSPI spi = getTimestampSpi();
+        PropertiesCollector collector = spi.create("regex=[0-9]{8}T[0-9]{6}", Arrays.asList("time"));
+        File file = new File("polyphemus_20130301.nc");
+        collector.collect(file);
+        IllegalArgumentException exc =
+                assertThrows(IllegalArgumentException.class, () -> collector.setProperties(feature));
+        assertEquals(
+                "No matches found for: TimestampFileNameExtractor{customFormat=null, format='null', useHighTime=false, fullPath=false, pattern=[0-9]{8}T[0-9]{6}}",
+                exc.getMessage());
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7776](https://badgen.net/badge/JIRA/GEOT-7776/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7776) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details, the current behavior makes it pretty hard to debug a mosaic setup having many variables.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->