### PR TITLE
[GEOT-7779] ImageMosaic read in a data hole returns data filled with zeros, should be using nodata instead

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterLayerResponse.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterLayerResponse.java
@@ -963,6 +963,11 @@ public class RasterLayerResponse {
                 .setTileHeight((int) tileSize.getHeight());
         final RenderingHints renderingHints = new RenderingHints(JAI.KEY_IMAGE_LAYOUT, il);
 
+        // the output image is empty, if background values are not provided we use the noData value
+        Double noData = rasterManager.getConfiguration().getNoData();
+        if (backgroundValues == null && noData != null) {
+            backgroundValues = new double[] {noData};
+        }
         final Number[] values = ImageUtilities.getBackgroundValues(rasterManager.defaultSM, backgroundValues);
         RenderedImage finalImage;
         if (ImageUtilities.isMediaLibAvailable()) {
@@ -1032,7 +1037,6 @@ public class RasterLayerResponse {
                     },
                     new Range[] {RangeFactory.create(0, 0)});
             // there was really nothing here, so make sure this comes out in the output
-            Double noData = rasterManager.getConfiguration().getNoData();
             if (noData != null) {
                 w.setNoData(RangeFactory.create(noData, noData));
             }


### PR DESCRIPTION
[![GEOT-7779](https://badgen.net/badge/JIRA/GEOT-7779/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7779) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details (the conditions to reproduce are a bit convoluted)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->