### PR TITLE
[GEOT-7781] Add a priority to property accessors

### DIFF
--- a/modules/extension/complex/src/main/java/org/geotools/data/complex/expression/FeaturePropertyAccessorFactory.java
+++ b/modules/extension/complex/src/main/java/org/geotools/data/complex/expression/FeaturePropertyAccessorFactory.java
@@ -287,4 +287,11 @@ public class FeaturePropertyAccessorFactory implements PropertyAccessorFactory {
             assert value == context.getValue(xpath);
         }
     }
+
+    @Override
+    public int getPriority() {
+        // this is the default and the most generic property accessor
+        // hence we give it the lowest priority
+        return LOWEST_PRIORITY;
+    }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/expression/PropertyAccessorFactory.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/PropertyAccessorFactory.java
@@ -26,6 +26,15 @@ import org.geotools.util.factory.Hints.Key;
  */
 public interface PropertyAccessorFactory {
 
+    /** The numeric value for highest priority. */
+    int HIGHEST_PRIORITY = 5000;
+
+    /** The numeric value for lowest priority. */
+    int LOWEST_PRIORITY = 0;
+
+    /** The numeric value for the default priority. */
+    int DEFAULT_PRIORITY = 3000;
+
     /**
      * {@link Hints} key used to pass namespace context to {@link #createPropertyAccessor(Class, String, Class, Hints)}
      * in the form of a {@link NamespaceSupport} instance with the prefix/namespaceURI mappings
@@ -43,4 +52,15 @@ public interface PropertyAccessorFactory {
      *     type.
      */
     PropertyAccessor createPropertyAccessor(Class<?> type, String xpath, Class<?> target, Hints hints);
+
+    /**
+     * Return the priority associated with this property accessor. By default, a priority value within the range of the
+     * lowest and highest priorities will be returned. The more generic a property accessor is, the lower its priority
+     * should be.
+     *
+     * @return the priority of this property accessor
+     */
+    default int getPriority() {
+        return DEFAULT_PRIORITY;
+    }
 }

--- a/modules/library/main/src/main/java/org/geotools/filter/expression/PropertyAccessors.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/PropertyAccessors.java
@@ -17,9 +17,15 @@
 package org.geotools.filter.expression;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.ServiceLoader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
 
 /**
  * Convenience class for looking up a property accessor for a particular object type.
@@ -27,6 +33,8 @@ import org.geotools.util.factory.Hints;
  * @author Justin Deoliveira, The Open Planning Project
  */
 public class PropertyAccessors {
+
+    private static final Logger LOGGER = Logging.getLogger(PropertyAccessors.class);
     static final PropertyAccessorFactory[] FACTORY_CACHE;
 
     static {
@@ -44,6 +52,18 @@ public class PropertyAccessors {
             if (!nonCached) {
                 cache.add(factory);
             }
+        }
+        // sort the property accessors by their priority. The sort maintains the order of equal elements.
+        cache.sort(Comparator.comparing(PropertyAccessorFactory::getPriority).reversed());
+        if (LOGGER.isLoggable(Level.CONFIG)) {
+            String log = cache.stream()
+                    .filter(Objects::nonNull)
+                    .map(factory -> {
+                        String name = "[Name=" + factory.getClass().getSimpleName() + ", ";
+                        return name + "Priority=" + factory.getPriority() + "]";
+                    })
+                    .collect(Collectors.joining("; "));
+            LOGGER.config(log);
         }
         FACTORY_CACHE = cache.toArray(new PropertyAccessorFactory[cache.size()]);
     }

--- a/modules/library/main/src/test/java/org/geotools/filter/expression/PropertyAccessorsFactoryTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/expression/PropertyAccessorsFactoryTest.java
@@ -1,0 +1,93 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.expression;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.geotools.util.factory.Hints;
+import org.junit.Test;
+
+public class PropertyAccessorsFactoryTest {
+
+    /** Test to check that priority of {@link PropertyAccessorFactory} instances is respected. */
+    @Test
+    public void testPropertyAccessorsFactoryPriority() {
+        List<PropertyAccessor> propertyAccessors =
+                PropertyAccessors.findPropertyAccessors(new PriorityMockDataObject(), "", null, null);
+        assertEquals(2, propertyAccessors.size());
+        assertTrue(propertyAccessors.get(0) instanceof HighPriorityMockPropertyAccessor);
+        assertTrue(propertyAccessors.get(1) instanceof LowPriorityMockPropertyAccessor);
+    }
+
+    // Below are stubs used for this test
+    public static class LowPriorityMockPropertyAccessorFactory implements PropertyAccessorFactory {
+
+        @Override
+        public int getPriority() {
+            return PropertyAccessorFactory.LOWEST_PRIORITY;
+        }
+
+        @Override
+        public PropertyAccessor createPropertyAccessor(Class type, String xpath, Class target, Hints hints) {
+            if (!PriorityMockDataObject.class.equals(type)) {
+                return null;
+            }
+            return new LowPriorityMockPropertyAccessor();
+        }
+    }
+
+    public static class HighPriorityMockPropertyAccessorFactory implements PropertyAccessorFactory {
+
+        @Override
+        public int getPriority() {
+            return PropertyAccessorFactory.HIGHEST_PRIORITY;
+        }
+
+        @Override
+        public PropertyAccessor createPropertyAccessor(Class type, String xpath, Class target, Hints hints) {
+            if (!PriorityMockDataObject.class.equals(type)) {
+                return null;
+            }
+            return new HighPriorityMockPropertyAccessor();
+        }
+    }
+
+    public static class PriorityMockPropertyAccessor implements PropertyAccessor {
+        @Override
+        public boolean canHandle(Object object, String xpath, Class target) {
+            return object instanceof PriorityMockDataObject;
+        }
+
+        @Override
+        public <T> T get(Object object, String xpath, Class<T> target) throws IllegalArgumentException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(Object object, String xpath, Object value, Class target) throws IllegalArgumentException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static class HighPriorityMockPropertyAccessor extends PriorityMockPropertyAccessor {}
+
+    public static class LowPriorityMockPropertyAccessor extends PriorityMockPropertyAccessor {}
+
+    public static class PriorityMockDataObject {}
+}

--- a/modules/library/main/src/test/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
+++ b/modules/library/main/src/test/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
@@ -1,1 +1,3 @@
 org.geotools.filter.FilterTest$MockPropertyAccessorFactory
+org.geotools.filter.expression.PropertyAccessorsFactoryTest$LowPriorityMockPropertyAccessorFactory
+org.geotools.filter.expression.PropertyAccessorsFactoryTest$HighPriorityMockPropertyAccessorFactory


### PR DESCRIPTION
[![GEOT-7781](https://badgen.net/badge/JIRA/GEOT-7781/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7781) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently multiple property accessor factories can be used by the GeoServer, however this can cause issues because there are no clear priority, and order of them can vary. This changes add support for a priority.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->