### PR TITLE
[GEOT-7785] Bounds computation fails when a null geometry is present on SingleStore datastore

### DIFF
--- a/modules/unsupported/jdbc-singlestore/src/main/java/org/geotools/data/singlestore/SingleStoreDialect.java
+++ b/modules/unsupported/jdbc-singlestore/src/main/java/org/geotools/data/singlestore/SingleStoreDialect.java
@@ -105,7 +105,12 @@ public class SingleStoreDialect extends SQLDialect {
     @Override
     public Envelope decodeGeometryEnvelope(ResultSet rs, int column, Connection cx) throws SQLException, IOException {
         try {
-            Geometry geom = new WKTReader().read(rs.getString(column));
+            String wkt = rs.getString(column);
+            // If the column is null no geometry or envelope is available, return null
+            if (wkt == null) {
+                return null;
+            }
+            Geometry geom = new WKTReader().read(wkt);
             return geom.getEnvelopeInternal();
         } catch (ParseException e) {
             String msg = "Error decoding wkb for envelope";

--- a/modules/unsupported/jdbc-singlestore/src/test/java/org/geotools/data/singlestore/SingleStoreFeatureSourceNullGeomOnlineTest.java
+++ b/modules/unsupported/jdbc-singlestore/src/test/java/org/geotools/data/singlestore/SingleStoreFeatureSourceNullGeomOnlineTest.java
@@ -1,0 +1,79 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.singlestore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.geotools.api.data.Query;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.PropertyIsEqualTo;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.jdbc.JDBCFeatureStore;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.junit.Test;
+
+/**
+ * * Test for SingleStore feature source with null geometries.
+ *
+ * <p>This test checks the bounds of a feature source that contains null geometries, ensuring that the bounds are
+ * calculated correctly and that queries with filters return expected results.
+ */
+public class SingleStoreFeatureSourceNullGeomOnlineTest extends JDBCTestSupport {
+    protected JDBCFeatureStore featureSource;
+
+    @Override
+    protected void connect() throws Exception {
+        super.connect();
+
+        featureSource = (JDBCFeatureStore) dataStore.getFeatureSource(tname("ft1"));
+    }
+
+    @Test
+    public void testBounds() throws Exception {
+        ReferencedEnvelope bounds = featureSource.getBounds();
+        assertEquals(0l, Math.round(bounds.getMinX()));
+        assertEquals(0l, Math.round(bounds.getMinY()));
+        assertEquals(2l, Math.round(bounds.getMaxX()));
+        assertEquals(2l, Math.round(bounds.getMaxY()));
+
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
+    }
+
+    @Test
+    public void testBoundsWithQuery() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+        PropertyIsEqualTo filter = ff.equals(ff.property(aname("stringProperty")), ff.literal("one"));
+
+        Query query = new Query();
+        query.setFilter(filter);
+
+        ReferencedEnvelope bounds = featureSource.getBounds(query);
+        assertEquals(0l, Math.round(bounds.getMinX()));
+        assertEquals(0l, Math.round(bounds.getMinY()));
+        assertEquals(-1l, Math.round(bounds.getMaxX()));
+        assertEquals(-1l, Math.round(bounds.getMaxY()));
+
+        assertTrue(areCRSEqual(decodeEPSG(4326), bounds.getCoordinateReferenceSystem()));
+    }
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new SingleStoreNullGeomTestSetup();
+    }
+}

--- a/modules/unsupported/jdbc-singlestore/src/test/java/org/geotools/data/singlestore/SingleStoreNullGeomTestSetup.java
+++ b/modules/unsupported/jdbc-singlestore/src/test/java/org/geotools/data/singlestore/SingleStoreNullGeomTestSetup.java
@@ -1,0 +1,141 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.singlestore;
+
+import java.sql.Connection;
+import java.util.Properties;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.jdbc.JDBCDataStoreFactory;
+import org.geotools.jdbc.JDBCTestSetup;
+
+/**
+ * Test setup for SingleStore with null geometries.
+ *
+ * <p>This setup creates a test database with a table containing null geometries and various properties. It is used to
+ * test the handling of null geometries in SingleStore.
+ */
+public class SingleStoreNullGeomTestSetup extends JDBCTestSetup {
+
+    @Override
+    protected void initializeDataSource(BasicDataSource ds, Properties db) {
+        super.initializeDataSource(ds, db);
+
+        ds.setDefaultTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    }
+
+    @Override
+    protected JDBCDataStoreFactory createDataStoreFactory() {
+        return new SingleStoreDataStoreFactory();
+    }
+
+    @Override
+    protected void setUpData() throws Exception {
+        // allow time parsing in str_to_date
+        run("SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'NO_ZERO_IN_DATE',''));");
+        run("SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'NO_ZERO_DATE',''));");
+
+        // drop old data
+        runSafe("DROP TABLE IF EXISTS ft1;");
+        runSafe("DROP TABLE IF EXISTS ft2;");
+        runSafe("DROP TABLE IF EXISTS ft4;");
+        runSafe("DELETE FROM geometry_columns");
+
+        // create some data
+        StringBuffer sb = new StringBuffer();
+        // COLLATE utf8_bin is necessary to ensure case-sensitive string comparisons
+        sb.append("CREATE TABLE ft1 ")
+                .append("(id int PRIMARY KEY , ")
+                .append("geometry GEOGRAPHYPOINT, intProperty int, ")
+                .append("doubleProperty DOUBLE(8,2), stringProperty varchar(255) COLLATE utf8_bin);");
+        run(sb.toString());
+
+        // setup so that we can start counting from 0, otherwise 0 is treated as a special value
+        run("SET sql_mode='NO_AUTO_VALUE_ON_ZERO';");
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft1 VALUES (").append("0, GEOGRAPHY_POINT(0, 0), 0, 0.0, 'zero');");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft1 VALUES (").append("1, null, 1, 1.1, 'one');");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft1 VALUES (").append("2, GEOGRAPHY_POINT(2, 2), 2, 2.2, 'two');");
+        run(sb.toString());
+
+        runft4();
+    }
+
+    private void runft4() throws Exception {
+        StringBuffer sb = new StringBuffer();
+        // JD: COLLATE latin1_general_cs is neccesary to ensure case-sensitive string comparisons
+        sb.append("CREATE TABLE ft4 (")
+                .append("id int AUTO_INCREMENT PRIMARY KEY,")
+                .append("geometry GEOGRAPHYPOINT, intProperty int, ")
+                .append("doubleProperty double, stringProperty varchar(255) COLLATE latin1_general_cs);");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft4 VALUES (").append("-1, GEOGRAPHY_POINT(0, 0), 0, 0.0, 'zero');");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft4 VALUES (").append("1, GEOGRAPHY_POINT(0, 0), 1, 1.1, 'one');");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft4 VALUES (").append("2, null, 1, 1.1, 'one_2');");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft4 VALUES (").append("3, GEOGRAPHY_POINT(3, 3), 1, 1.1, 'one_2');");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft4 VALUES (").append("4, GEOGRAPHY_POINT(4, 4), 2, 2.2,'two');");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft4 VALUES (").append("5, GEOGRAPHY_POINT(5, 5), 2, 2.2,'two_2');");
+        run(sb.toString());
+
+        sb = new StringBuffer();
+        sb.append("INSERT INTO ft4 VALUES (").append("6, GEOGRAPHY_POINT(6, 6), 3, 3.3,'three');");
+        run(sb.toString());
+    }
+
+    @Override
+    protected void setUpDataStore(JDBCDataStore dataStore) {
+        dataStore.setDatabaseSchema(null);
+    }
+
+    @Override
+    protected Properties createExampleFixture() {
+        Properties p = new Properties();
+
+        p.put("driver", "com.singlestore.jdbc.Driver");
+        p.put("url", "jdbc:singlestore://localhost/geotools");
+        p.put("host", "localhost");
+        p.put("port", "3306");
+        p.put("user", "geotools");
+        p.put("password", "geotools");
+
+        return p;
+    }
+}


### PR DESCRIPTION
[![GEOT-7785](https://badgen.net/badge/JIRA/GEOT-7785/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7785) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

JIRA ticket:
https://osgeo-org.atlassian.net/browse/GEOT-7785

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->