### PR TITLE
[GEOT-7787] Boolean attributes don't get stored as a true boolean in geopackages

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDialect.java
@@ -251,7 +251,6 @@ public class GeoPkgDialect extends PreparedStatementSQLDialect {
         mappings.put(Integer.class, Types.INTEGER);
         mappings.put(Float.class, Types.FLOAT);
         mappings.put(Double.class, Types.DOUBLE);
-        mappings.put(Boolean.class, Types.INTEGER);
         // SQLite has no native support for UUID datatype.
         // Map Java UUID to varchar instead
         mappings.put(UUID.class, Types.VARCHAR);

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPackageTest.java
@@ -472,6 +472,14 @@ public class GeoPackageTest {
         } catch (Exception e) {
             fail(e.getMessage());
         }
+
+        FeatureEntry readFeature = geopkg.features().get(0);
+        try (SimpleFeatureReader reader = geopkg.reader(readFeature, null, null)) {
+            SimpleFeature feature = reader.next();
+            Object attribute = feature.getAttribute("special_ne");
+            assertTrue(attribute instanceof Boolean);
+            assertTrue((Boolean) attribute);
+        }
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7787](https://badgen.net/badge/JIRA/GEOT-7787/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7787) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

As described in [GEOT-7787](https://osgeo-org.atlassian.net/browse/GEOT-7787), it appears that right now a Boolean is mapped to a SQL INTEGER type instead of a SQL BOOLEAN when we're dealing with geopackages.
The goal of this PR is to change this to BOOLEAN, since that makes more sense when looking at features in QGIS.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/browse/GEOT-7787) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).