### PR TITLE
[GEOT-7788] Function to parse GeoTools time notation to date

### DIFF
--- a/docs/user/artifacts/function_list
+++ b/docs/user/artifacts/function_list
@@ -1,7 +1,7 @@
 ``DefaultFunctionFactory``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Contains 203 functions.
+Contains 204 functions.
 
 ``Area(geometry)``: returns ``area``
 ''''''''''''''''''''''''''''''''''''
@@ -2961,3 +2961,8 @@ Contains 1 functions.
 * ``tolerance`` (``double``) required
 
 * ``labelPoint`` (``Point``)
+
+``parseTime(dateString)``: returns ``date``
+'''''''''''''''''''''''''''''''''''''''''''''''''''
+
+* ``dateString`` (``String``) required. Date in ISO format, or the range in ISO duration format. Only single tokens are allowed ("P1M" or "2008-05-11T15:30:00Z" and not "P1M/P1D" or "2008-05-11T15:30:00Z/2008-05-11T18:30:00Z"). If range or list is provided only first value shall be used.

--- a/modules/library/main/src/main/java/org/geotools/filter/function/ParseTimeFunction.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/function/ParseTimeFunction.java
@@ -1,0 +1,71 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import static org.geotools.filter.capability.FunctionNameImpl.parameter;
+import static org.geotools.util.DateTimeParser.FLAG_GET_TIME_ON_PRESENT;
+import static org.geotools.util.DateTimeParser.FLAG_IS_LENIENT;
+import static org.geotools.util.DateTimeParser.FLAG_SINGLE_DATE_AS_DATERANGE;
+
+import java.text.ParseException;
+import java.util.Collection;
+import java.util.Date;
+import org.geotools.api.filter.capability.FunctionName;
+import org.geotools.filter.FunctionExpressionImpl;
+import org.geotools.filter.LiteralExpressionImpl;
+import org.geotools.filter.capability.FunctionNameImpl;
+import org.geotools.util.DateRange;
+import org.geotools.util.DateTimeParser;
+
+/** Function parses GeoTools time notation into date. */
+public class ParseTimeFunction extends FunctionExpressionImpl {
+
+    public static FunctionName NAME = new FunctionNameImpl("parseTime", parameter("string", String.class));
+
+    DateTimeParser parser;
+
+    public ParseTimeFunction() {
+        super(NAME);
+        parser = new DateTimeParser(1, FLAG_GET_TIME_ON_PRESENT | FLAG_IS_LENIENT | FLAG_SINGLE_DATE_AS_DATERANGE);
+    }
+
+    @Override
+    public Object evaluate(Object object) {
+        Date dateTime = null;
+        try {
+            String value = (String) ((LiteralExpressionImpl) params.get(0)).getValue();
+            if (value.startsWith("P")) {
+                value = value + "/PRESENT";
+            }
+            dateTime = getDate(value, dateTime);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return dateTime;
+    }
+
+    private Date getDate(String value, Date dateTime) throws ParseException {
+        Collection parsedCollection = parser.parse(value);
+        Object parsedObject = parsedCollection.iterator().next();
+        if (parsedObject instanceof DateRange) {
+            dateTime = ((DateRange) parsedObject).getMinValue();
+        } else if (parsedObject instanceof Date) {
+            dateTime = (Date) parsedObject;
+        }
+        return dateTime;
+    }
+}

--- a/modules/library/main/src/main/resources/META-INF/services/org.geotools.api.filter.expression.Function
+++ b/modules/library/main/src/main/resources/META-INF/services/org.geotools.api.filter.expression.Function
@@ -210,3 +210,4 @@ org.geotools.filter.function.OrFunction
 org.geotools.filter.function.NowFunction
 org.geotools.filter.function.BandsFunction
 org.geotools.filter.function.PointOnLineFunction
+org.geotools.filter.function.ParseTimeFunction

--- a/modules/library/main/src/test/java/org/geotools/filter/function/ParseTimeFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/ParseTimeFunctionTest.java
@@ -1,0 +1,90 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.filter.function;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
+import java.util.Date;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.Function;
+import org.geotools.factory.CommonFactoryFinder;
+import org.junit.Test;
+
+public class ParseTimeFunctionTest {
+
+    public static final FilterFactory FF = CommonFactoryFinder.getFilterFactory();
+
+    @Test
+    public void testOrdinaryISODurationNotations() {
+        assertionForParsedInstance("PT30M", Duration.ofMinutes(30));
+
+        assertionForParsedInstance("PT12H", Duration.ofHours(12));
+
+        assertionForParsedInstance("P4D", Duration.ofDays(4));
+
+        assertionForParseLocalDateTIme("P1M", Period.ofMonths(1), ChronoUnit.HOURS);
+
+        assertionForParseLocalDateTIme("P1Y", Period.ofYears(1), ChronoUnit.DAYS);
+    }
+
+    @Test
+    public void testTimestamps() {
+        assertionForTimestamp("2025-07-14T12:30:15.000Z", LocalDateTime.of(2025, 07, 14, 12, 30, 15));
+
+        assertionForTimestamp("20250714T12:30:15.000Z", LocalDateTime.of(2025, 07, 14, 12, 30, 15));
+
+        assertionForTimestamp("2025-07-10T10:30", LocalDateTime.of(2025, 07, 10, 10, 30));
+
+        assertionForTimestamp("20250710T10:30", LocalDateTime.of(2025, 07, 10, 10, 30));
+    }
+
+    private static void assertionForTimestamp(String expression, LocalDateTime localDateTime) {
+        Function parseTime = FF.function("parseTime", FF.literal(expression));
+        Date date = (Date) parseTime.evaluate(null);
+
+        assertEquals(localDateTime, date.toInstant().atZone(ZoneOffset.UTC).toLocalDateTime());
+    }
+
+    private static void assertionForParsedInstance(String expression, TemporalAmount timeInThePast) {
+        Function parseTime = FF.function("parseTime", FF.literal(expression));
+        Date date = (Date) parseTime.evaluate(null);
+
+        Instant generatedDate = Instant.now().minus(timeInThePast).truncatedTo(ChronoUnit.SECONDS);
+
+        Instant evaluatedTime = date.toInstant().truncatedTo(ChronoUnit.SECONDS);
+        assertEquals(generatedDate, evaluatedTime);
+    }
+
+    private static void assertionForParseLocalDateTIme(
+            String expression, TemporalAmount timeInThePast, ChronoUnit chronoUnit) {
+        Function parseTime = FF.function("parseTime", FF.literal(expression));
+        Date date = (Date) parseTime.evaluate(null);
+
+        LocalDateTime generatedDate = LocalDateTime.now().minus(timeInThePast).truncatedTo(chronoUnit);
+
+        LocalDateTime evaluatedTime =
+                date.toInstant().atZone(ZoneOffset.UTC).toLocalDateTime().truncatedTo(chronoUnit);
+        assertEquals(generatedDate, evaluatedTime);
+    }
+}


### PR DESCRIPTION
[![GEOT-7788](https://badgen.net/badge/JIRA/GEOT-7788/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7788) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Add a function that will allow to use GT time notations (for example 'P2M' for past 2 months) in filters.
For example time_attr >= parseTime('P2M')

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->