### PR TITLE
[GEOT-7798] Make WebCRSFactory extensible

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/datum/DefaultEllipsoid.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/datum/DefaultEllipsoid.java
@@ -75,7 +75,7 @@ public class DefaultEllipsoid extends AbstractIdentifiedObject implements Ellips
      * @since 2.2
      */
     public static final DefaultEllipsoid CLARKE_1866 =
-            createFlattenedSphere("Clarke 1866", 6378206.4, 294.9786982, SI.METRE);
+            createFlattenedSphere("Clarke 1866", 6378206.4, 294.9786982138982, SI.METRE);
 
     /**
      * A sphere with a radius of 6371000 {@linkplain SI#METER metres}. Spheres use a simplier algorithm for


### PR DESCRIPTION
[![GEOT-7798](https://badgen.net/badge/JIRA/GEOT-7798/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7798) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Simple refactor to enable https://github.com/geoserver/geoserver/pull/8706



# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->