### PR TITLE
Fix ECQL BNF link and add quote / double / escape examples

### DIFF
--- a/docs/user/library/cql/ecql.rst
+++ b/docs/user/library/cql/ecql.rst
@@ -5,7 +5,7 @@ The ECQL language is intended as an extension of CQL, thus you can write all pre
 
 References
 
-* `ECQL Parser Design <http://old.geotools.org/ECQL-Parser-Design_110493908.html>`__ (design doc with BNF, note, in addition to WKT syntax for geometries 
+* `ECQL Parser Design <https://github.com/geotools/geotools/blob/main/modules/library/cql/ECQL.md>`__ (design doc with BNF, note, in addition to WKT syntax for geometries 
   GeoTools now supports also Extended WKT, same as PostGIS, see example below)
 * `GeoServer CQL Examples <http://docs.geoserver.org/latest/en/user/tutorials/cql/cql_tutorial.html>`_ (GeoServer)
 
@@ -42,11 +42,17 @@ It allows you to try out the ECQL examples on this page; and produces the XML Fi
 
 Examples
 ''''''''
-
+  
 * Filter by Comparing Values
   
   The CQL language limited us to referencing a ``propertyName`` against
-  a more general expression.
+  a more general expression.::
+
+     ECQL.toFilter("population >= 1000");
+
+  Property names can be double quoted if they contain spaces::
+
+     ECQL.toFilter("\"population max\" >= 1000");
 
   ECQL allows you to use full expressions everywhere:
 
@@ -191,7 +197,7 @@ Examples
 
 * Filter Nulls::
   
-        Filter filter = ECQL.toFilter(" Name IS NULL");
+        Filter filter = ECQL.toFilter("Name IS NULL");
         Filter filter = ECQL.toFilter("centroid( the_geom ) IS NULL");
 
 * Property Exist Predicate::
@@ -203,6 +209,14 @@ Examples
   Expressions support is unchanged::
         
         Expression expr = ECQL.toExpression("X + 1");
+
+  Literal string::
+      
+        Expression expr = ECQL.toExpression("'hello world'");
+
+  Literal string with quote::
+
+        Expression expr = ECQL.toExpression("'can''t touch this'");
 
 * Filter list
   

--- a/docs/user/library/cql/ecql.rst
+++ b/docs/user/library/cql/ecql.rst
@@ -214,7 +214,7 @@ Examples
       
         Expression expr = ECQL.toExpression("'hello world'");
 
-  Literal string with quote::
+  Literal string with escaped single quote::
 
         Expression expr = ECQL.toExpression("'can''t touch this'");
 


### PR DESCRIPTION
Fixing a link to the confluence wiki, found this while looking up how to escape quotes, so I added a clear example.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->