### PR TITLE
GEOT-7750 WMTSCapabilities: Legend URLs in Styles not processed

### DIFF
--- a/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
+++ b/modules/extension/wmts/src/main/java/org/geotools/ows/wmts/model/WMTSCapabilities.java
@@ -40,6 +40,7 @@ import net.opengis.wmts.v_1.CapabilitiesType;
 import net.opengis.wmts.v_1.ContentsType;
 import net.opengis.wmts.v_1.DimensionType;
 import net.opengis.wmts.v_1.LayerType;
+import net.opengis.wmts.v_1.LegendURLType;
 import net.opengis.wmts.v_1.StyleType;
 import net.opengis.wmts.v_1.TileMatrixLimitsType;
 import net.opengis.wmts.v_1.TileMatrixSetLimitsType;
@@ -247,8 +248,9 @@ public class WMTSCapabilities extends Capabilities {
                     wmtsLayer.getBoundingBoxes().put(srs, new CRSEnvelope(wgs84Env.transform(tmsCRS, true)));
 
                 } catch (TransformException | FactoryException e) {
-                    if (LOGGER.isLoggable(Level.INFO))
+                    if (LOGGER.isLoggable(Level.INFO)) {
                         LOGGER.log(Level.INFO, "Not adding CRS " + srs + " for layer " + wmtsLayer.getName(), e);
+                    }
                 }
             }
         }
@@ -271,8 +273,9 @@ public class WMTSCapabilities extends Capabilities {
                 } catch (Exception ex) {
                     // the RE can't be projected on WGS84,
                     // so let's try another one
-                    if (LOGGER.isLoggable(Level.FINE))
+                    if (LOGGER.isLoggable(Level.FINE)) {
                         LOGGER.fine("Can't use " + tms.getIdentifier() + " for bbox: " + ex.getMessage());
+                    }
                     continue;
                 }
             }
@@ -370,13 +373,29 @@ public class WMTSCapabilities extends Capabilities {
             style.setName(styleType.getIdentifier().getValue());
             StringBuilder t = new StringBuilder();
             for (Object title1 : styleType.getTitle()) {
-                t.append(title1.toString());
+                if (title1 instanceof LanguageStringType) {
+                    t.append(((LanguageStringType) title1).getValue());
+                } else {
+                    t.append(title1.toString());
+                }
             }
-            style.setTitle(new SimpleInternationalString(t.toString()));
+
+            if (!t.isEmpty()) {
+                style.setTitle(new SimpleInternationalString(t.toString()));
+            }
+
             style.setDefault(styleType.isIsDefault());
             if (styleType.isIsDefault()) {
                 layer.setDefaultStyle(style);
             }
+
+            List<String> legendURLS = new ArrayList<>();
+            for (LegendURLType legendURLType : styleType.getLegendURL()) {
+                legendURLS.add(legendURLType.getHref());
+            }
+
+            style.setLegendURLs(legendURLS);
+
             sList.add(style);
         }
         layer.setStyles(sList);

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/model/WMTSCapabilitiesTest.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 import org.geotools.api.metadata.citation.Address;
 import org.geotools.data.ows.OperationType;
 import org.geotools.ows.wms.CRSEnvelope;
+import org.geotools.ows.wms.StyleImpl;
 import org.geotools.ows.wmts.WMTSSpecification;
 import org.geotools.ows.wmts.WebMapTileServer;
 import org.geotools.util.logging.Logging;
@@ -102,6 +103,25 @@ public class WMTSCapabilitiesTest {
 
             CRSEnvelope bbox = layers.get(1).getBoundingBoxes().get("EPSG:4326");
             Assert.assertNotNull(bbox);
+
+            List<StyleImpl> styles = l0.getStyles();
+            Assert.assertNotNull(styles);
+            Assert.assertEquals(1, styles.size());
+
+            StyleImpl style0 = styles.get(0);
+            Assert.assertNull(style0.getName());
+            Assert.assertNull(style0.getTitle());
+            Assert.assertNull(style0.getAbstract());
+            Assert.assertTrue(style0.isDefault());
+
+            List<?> legendUrls = style0.getLegendURLs();
+            Assert.assertNotNull(legendUrls);
+            Assert.assertEquals(1, legendUrls.size());
+
+            Assert.assertEquals(
+                    "http://astun-desktop:8080/geoserver/ows?service=WMS&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=openmap-local%3AOML_Foreshore",
+                    legendUrls.get(0));
+
         } catch (Exception e) {
             Logger.getGlobal().log(Level.INFO, "", e);
             if (e.getMessage() != null && e.getMessage().indexOf("timed out") > 0) {
@@ -184,6 +204,24 @@ public class WMTSCapabilitiesTest {
                     capabilities.getMatrixSets().get(0).getMatrices().get(0).getDenominator(),
                     0d);
 
+            List<StyleImpl> styles = l0.getStyles();
+            Assert.assertNotNull(styles);
+            Assert.assertEquals(1, styles.size());
+
+            StyleImpl style0 = styles.get(0);
+            Assert.assertEquals("ch.are.agglomerationen_isolierte_staedte", style0.getName());
+            Assert.assertEquals(
+                    "Agglomerationen und isolierte Städte", style0.getTitle().toString());
+            Assert.assertNull(style0.getAbstract());
+            Assert.assertFalse(style0.isDefault());
+
+            List<?> legendUrls = style0.getLegendURLs();
+            Assert.assertNotNull(legendUrls);
+            Assert.assertEquals(1, legendUrls.size());
+
+            Assert.assertEquals(
+                    "http://api3.geo.admin.ch/static/images/legends/ch.are.agglomerationen_isolierte_staedte_de.png",
+                    legendUrls.get(0));
         } catch (Exception e) {
             Logger.getGlobal().log(Level.INFO, "", e);
             if (e.getMessage() != null && e.getMessage().indexOf("timed out") > 0) {
@@ -234,6 +272,19 @@ public class WMTSCapabilitiesTest {
             CRSEnvelope bbox = layers.get(1).getBoundingBoxes().get("CRS:84");
             Assert.assertNotNull(bbox);
 
+            List<StyleImpl> styles = l0.getStyles();
+            Assert.assertNotNull(styles);
+            Assert.assertEquals(1, styles.size());
+
+            StyleImpl style0 = styles.get(0);
+            Assert.assertEquals("default", style0.getName());
+            Assert.assertEquals("default", style0.getTitle().toString());
+            Assert.assertNull(style0.getAbstract());
+            Assert.assertTrue(style0.isDefault());
+
+            List<?> legendUrls = style0.getLegendURLs();
+            Assert.assertNotNull(legendUrls);
+            Assert.assertEquals(0, legendUrls.size());
         } catch (Exception e) {
             Logger.getGlobal().log(Level.INFO, "", e);
             if (e.getMessage() != null && e.getMessage().indexOf("timed out") > 0) {
@@ -261,6 +312,22 @@ public class WMTSCapabilitiesTest {
                     "urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
                     matrixSets.get(0).getWellKnownScaleSet());
 
+            List<WMTSLayer> layers = capabilities.getLayerList();
+            WMTSLayer l0 = layers.get(0);
+
+            List<StyleImpl> styles = l0.getStyles();
+            Assert.assertNotNull(styles);
+            Assert.assertEquals(1, styles.size());
+
+            StyleImpl style0 = styles.get(0);
+            Assert.assertEquals("style=39", style0.getName());
+            Assert.assertEquals("Weighted point styles", style0.getTitle().toString());
+            Assert.assertNull(style0.getAbstract());
+            Assert.assertTrue(style0.isDefault());
+
+            List<?> legendUrls = style0.getLegendURLs();
+            Assert.assertNotNull(legendUrls);
+            Assert.assertEquals(0, legendUrls.size());
         } catch (Exception e) {
             // a standard catch block shared with the other tests
             if (e.getMessage() != null && e.getMessage().indexOf("timed out") > 0) {
@@ -296,6 +363,19 @@ public class WMTSCapabilitiesTest {
             Assert.assertEquals("brtachtergrondkaart", l0.getName());
             Assert.assertTrue(l0.getSrs().contains("EPSG:28992")); // case
 
+            List<StyleImpl> styles = l0.getStyles();
+            Assert.assertNotNull(styles);
+            Assert.assertEquals(1, styles.size());
+
+            StyleImpl style0 = styles.get(0);
+            Assert.assertNull(style0.getName());
+            Assert.assertNull(style0.getTitle());
+            Assert.assertNull(style0.getAbstract());
+            Assert.assertTrue(style0.isDefault());
+
+            List<?> legendUrls = style0.getLegendURLs();
+            Assert.assertNotNull(legendUrls);
+            Assert.assertEquals(0, legendUrls.size());
         } catch (Exception e) {
             // a standard catch block shared with the other tests
             if (e.getMessage() != null && e.getMessage().indexOf("timed out") > 0) {


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  Add support for parsing LegendURLs in WMTS Capabilities parsing
See issue: https://osgeo-org.atlassian.net/browse/GEOT-7750

Note: while adding a test for styles, i found that LegendTitle is also not processed correctly. This is also fixed. 

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
