### PR TITLE
[GEOT-7806] TransformProcess doesn't accept string literals

### DIFF
--- a/modules/unsupported/process-feature/src/test/java/org/geotools/process/vector/TransformProcessTest.java
+++ b/modules/unsupported/process-feature/src/test/java/org/geotools/process/vector/TransformProcessTest.java
@@ -26,6 +26,7 @@ import org.geotools.api.data.DataStore;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.AttributeDescriptor;
+import org.geotools.api.filter.expression.Literal;
 import org.geotools.api.filter.expression.PropertyName;
 import org.geotools.data.property.PropertyDataStore;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -123,5 +124,14 @@ public class TransformProcessTest {
         SimpleFeatureType schema = result.getSchema();
         AttributeDescriptor number = schema.getDescriptor("number");
         assertTrue(Long.class.isAssignableFrom(number.getType().getBinding()));
+    }
+
+    @Test
+    public void testStringLiteral() throws Exception {
+        String definition = "dato='2025-06-21'";
+        List<Definition> definitions = TransformProcess.toDefinition(definition);
+        assertEquals(1, definitions.size());
+        assertEquals("dato", definitions.get(0).name);
+        assertTrue(definitions.get(0).expression instanceof Literal);
     }
 }


### PR DESCRIPTION
Added test for proper handling of String literals in a Transform. For setting a constant into a feature collection.

In addition I added logging to the class.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
