### PR TITLE
Fix json nested property access

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/simple/SimpleFeatureTypeBuilder.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -949,6 +950,14 @@ public class SimpleFeatureTypeBuilder {
         return retype(original, Arrays.asList(attributes));
     }
 
+    /** Returns first AttributeDescriptor whose localName is a prefix of the provided name. */
+    private static final Optional<AttributeDescriptor> findFirstWithPrefixingName(
+            List<AttributeDescriptor> descriptors, String name) {
+        return descriptors.stream()
+                .filter(ad -> name.startsWith(ad.getLocalName()))
+                .findFirst();
+    }
+
     /**
      * Create a SimpleFeatureType containing just the attribute descriptors indicated.
      *
@@ -965,10 +974,14 @@ public class SimpleFeatureTypeBuilder {
         // clear the attributes
         b.attributes().clear();
 
-        // add attributes in order
-        for (String type : attributes) {
-            b.add(original.getDescriptor(type));
-        }
+        // add recognized attributes in order and only once
+        List<AttributeDescriptor> ads = attributes.stream()
+                .flatMap(attr -> Optional.ofNullable(original.getDescriptor(attr))
+                        .or(() -> findFirstWithPrefixingName(original.getAttributeDescriptors(), attr))
+                        .stream())
+                .distinct()
+                .toList();
+        b.addAll(ads);
 
         // handle default geometry
         GeometryDescriptor defaultGeometry = original.getGeometryDescriptor();

--- a/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleTypeBuilderTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/simple/SimpleTypeBuilderTest.java
@@ -16,15 +16,21 @@
  */
 package org.geotools.feature.simple;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Stream;
 import org.geotools.api.data.Query;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.feature.type.AttributeType;
 import org.geotools.api.feature.type.GeometryType;
 import org.geotools.api.feature.type.Schema;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.feature.NameImpl;
+import org.geotools.feature.SampleFeatureFixtures;
 import org.geotools.feature.type.FeatureTypeFactoryImpl;
 import org.geotools.feature.type.SchemaImpl;
 import org.geotools.referencing.CRS;
@@ -169,6 +175,85 @@ public class SimpleTypeBuilderTest {
         Assert.assertNull(retyped.getGeometryDescriptor());
         Assert.assertEquals(1, retyped.getAttributeCount());
         Assert.assertEquals("integer", retyped.getAttributeDescriptors().get(0).getLocalName());
+    }
+
+    private static final List<String> attributeNames(SimpleFeatureType ft) {
+        return ft.getAttributeDescriptors().stream().map(d -> d.getLocalName()).toList();
+    }
+
+    @Test
+    public void testRetypeWithAllAttributes() throws Exception {
+        SimpleFeatureType ft = SampleFeatureFixtures.createTestType();
+        SimpleFeatureType result = SimpleFeatureTypeBuilder.retype(ft, attributeNames(ft));
+        Assert.assertEquals(ft.getAttributeDescriptors(), result.getAttributeDescriptors());
+    }
+
+    @Test
+    public void testRetypeWithNoAttributes() throws Exception {
+        SimpleFeatureType ft = SampleFeatureFixtures.createTestType();
+        SimpleFeatureType result = SimpleFeatureTypeBuilder.retype(ft, List.of());
+        Assert.assertEquals(0, result.getAttributeCount());
+    }
+
+    @Test
+    public void testRetypeWithNonexistentAttribute() throws Exception {
+        SimpleFeatureType ft = SampleFeatureFixtures.createTestType();
+        SimpleFeatureType result = SimpleFeatureTypeBuilder.retype(
+                ft,
+                Stream.concat(
+                                Stream.of("<nonexistent>"),
+                                Stream.of(attributeNames(ft).toArray(String[]::new)))
+                        .toList());
+        Assert.assertEquals(ft.getAttributeDescriptors(), result.getAttributeDescriptors());
+    }
+
+    @Test
+    public void testRetypeWithOnlyNonexistentAttribute() throws Exception {
+        SimpleFeatureType ft = SampleFeatureFixtures.createTestType();
+        SimpleFeatureType result = SimpleFeatureTypeBuilder.retype(ft, List.of("<nonexistent>"));
+        Assert.assertEquals(0, result.getAttributeCount());
+    }
+
+    @Test
+    public void testRetypeWithPrefixingAttribute() throws Exception {
+        SimpleFeatureType ft = SampleFeatureFixtures.createTestType();
+        AttributeDescriptor ad = ft.getAttributeDescriptors().get(0);
+        SimpleFeatureType result = SimpleFeatureTypeBuilder.retype(ft, List.of(ad.getLocalName() + "suffix"));
+        Assert.assertEquals(List.of(ad), result.getAttributeDescriptors());
+    }
+
+    @Test
+    public void testRetypeOnlyPrefixesIfNoExactMatch() throws Exception {
+        SimpleFeatureType ft = SampleFeatureFixtures.createTestType();
+        AttributeDescriptor ad = ft.getAttributeDescriptors().get(0);
+        SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
+        b.init(ft);
+        b.add(ad.getLocalName() + "suffix", ad.getType().getBinding());
+        ft = b.buildFeatureType();
+
+        SimpleFeatureType result = SimpleFeatureTypeBuilder.retype(ft, List.of(ad.getLocalName() + "suffix"));
+        Assert.assertEquals(List.of(ft.getDescriptor(ad.getLocalName() + "suffix")), result.getAttributeDescriptors());
+    }
+
+    @Test
+    public void testRetypeOrder() throws Exception {
+        SimpleFeatureType ft = SampleFeatureFixtures.createTestType();
+        List<String> ads = new ArrayList<>(attributeNames(ft));
+        Collections.shuffle(ads, new Random());
+
+        SimpleFeatureType result = SimpleFeatureTypeBuilder.retype(ft, ads);
+        Assert.assertEquals(ads, attributeNames(result));
+    }
+
+    @Test
+    public void testRetypeNoDuplicates() throws Exception {
+        SimpleFeatureType ft = SampleFeatureFixtures.createTestType();
+
+        SimpleFeatureType result = SimpleFeatureTypeBuilder.retype(
+                ft,
+                Stream.concat(attributeNames(ft).stream(), attributeNames(ft).stream())
+                        .toList());
+        Assert.assertEquals(ft.getAttributeDescriptors(), result.getAttributeDescriptors());
     }
 
     @Test

--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorFactory.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorFactory.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.Map;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.data.geojson.GeoJSONReader;
 import org.geotools.filter.expression.PropertyAccessor;
 import org.geotools.filter.expression.PropertyAccessorFactory;
@@ -54,19 +55,25 @@ public class JSONNodePropertyAccessorFactory implements PropertyAccessorFactory 
         @Override
         public boolean canHandle(Object object, String xpath, Class target) {
             try {
-                if (xpath != null && object != null && object instanceof SimpleFeature) {
+                if (xpath != null && object != null) {
                     String[] parts = stripAndReturnHeadAndRest(xpath);
-                    SimpleFeature feature = (SimpleFeature) object;
-                    Object value = getValue(parts, feature);
-                    if (value != null && value instanceof JsonNode) {
-                        if (parts.length < 2) {
-                            // only one part means return whole JsonNode
-                            return true;
-                        } else {
-                            JsonPointer pointer = JsonPointer.compile(parts[1]);
-                            JsonNode jsonNode = ((JsonNode) value).at(pointer);
-                            return !jsonNode.isMissingNode();
+                    if (object instanceof SimpleFeature) {
+                        SimpleFeature feature = (SimpleFeature) object;
+                        Object value = getValue(parts, feature);
+                        if (value != null && value instanceof JsonNode) {
+                            if (parts.length < 2) {
+                                // only one part means return whole JsonNode
+                                return true;
+                            } else {
+                                JsonPointer pointer = JsonPointer.compile(parts[1]);
+                                JsonNode jsonNode = ((JsonNode) value).at(pointer);
+                                return !jsonNode.isMissingNode();
+                            }
                         }
+                    } else if (object instanceof SimpleFeatureType) {
+                        SimpleFeatureType type = (SimpleFeatureType) object;
+                        AttributeDescriptor ad = type.getDescriptor(parts[0]);
+                        return ad != null && ad.getType().getBinding().equals(Object.class);
                     }
                 }
             } catch (IllegalArgumentException e) {
@@ -111,26 +118,35 @@ public class JSONNodePropertyAccessorFactory implements PropertyAccessorFactory 
         @SuppressWarnings("unchecked")
         public <T> T get(Object object, String xpath, Class<T> target) throws IllegalArgumentException {
             JsonNode jsonNode = null;
-            if (xpath != null && object != null && object instanceof SimpleFeature) {
+            if (xpath != null && object != null) {
                 String[] parts = stripAndReturnHeadAndRest(xpath);
-                SimpleFeature feature = (SimpleFeature) object;
-                Object value = getValue(parts, feature);
-                if (value != null && value instanceof JsonNode) {
-                    if (parts.length < 2) {
-                        // only one part means return whole JsonNode
-                        return (T) value;
-                    } else {
-                        JsonPointer pointer = JsonPointer.compile(parts[1]);
-                        jsonNode = ((JsonNode) value).at(pointer);
-                        if (jsonNode.isMissingNode()) {
-                            throw new IllegalArgumentException("Cannot get property " + xpath + " from " + object);
+                if (object instanceof SimpleFeature) {
+                    SimpleFeature feature = (SimpleFeature) object;
+                    Object value = getValue(parts, feature);
+                    if (value != null && value instanceof JsonNode) {
+                        if (parts.length < 2) {
+                            // only one part means return whole JsonNode
+                            return (T) value;
+                        } else {
+                            JsonPointer pointer = JsonPointer.compile(parts[1]);
+                            jsonNode = ((JsonNode) value).at(pointer);
+                            if (jsonNode.isMissingNode()) {
+                                throw new IllegalArgumentException("Cannot get property " + xpath + " from " + object);
+                            }
+                            return (T) getMostPrimitive(jsonNode);
                         }
-                        return (T) getMostPrimitive(jsonNode);
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Property at " + xpath + " from " + object + " is not a JSON Node");
                     }
-                } else {
-                    throw new IllegalArgumentException(
-                            "Property at " + xpath + " from " + object + " is not a JSON Node");
+                } else if (object instanceof SimpleFeatureType) {
+                    SimpleFeatureType type = (SimpleFeatureType) object;
+                    AttributeDescriptor ad = type.getDescriptor(parts[0]);
+                    if (ad != null && (target == null || target.isInstance(ad))) {
+                        return (T) ad;
+                    }
                 }
+                return null;
             } else {
                 throw new IllegalArgumentException("Xpath or object is null or not an Attribute");
             }

--- a/modules/unsupported/geojson-core/src/test/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/org/geotools/filter/expression/geojson/JSONNodePropertyAccessorTest.java
@@ -46,6 +46,7 @@ public class JSONNodePropertyAccessorTest {
         String jsonString =
                 new Scanner(url.openStream(), "UTF-8").useDelimiter("\\A").next();
         feature = GeoJSONReader.parseFeature(jsonString);
+        type = feature.getType();
         accessor = JSONNodePropertyAccessorFactory.JSONNODEPROPERTY;
     }
 
@@ -54,6 +55,9 @@ public class JSONNodePropertyAccessorTest {
         // Root element is not an ObjectNode or ArrayNode
         Assert.assertFalse(accessor.canHandle(feature, "aString", null));
         Assert.assertTrue(accessor.canHandle(feature, "aThreeLevelObject/secondLevel", null));
+
+        Assert.assertFalse(accessor.canHandle(type, "aString", null));
+        Assert.assertTrue(accessor.canHandle(type, "aThreeLevelObject/secondLevel", null));
     }
 
     @Test


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR fixes `org.geotools.filter.expression.geojson.JSONNodePropertyAccessorFactory.JSONNodePropertyAccessor` to allow getting nested property values from GEOJson data with `someProperty/someNestedProperty`. This is much less verbose syntax than using the jsonPointer function. The earlier implementation couldn't handle FeatureType objects, which some code paths passed to it, so I'm guessing this class didn't work at all.

This PR also changes how `org.geotools.feature.simple.SimpleFeatureTypeBuilder.retype` handles copying attribute descriptors. Now it
1) doesn't produce duplicates even if the caller requests for them,
2) doesn't produce nulls if attribute is not found,
3) includes descriptors whose local name is a prefix of a requested attribute, if no exact match exists.
Since getting nulls in the list (from non-existent attributes) fails in a later code path, I'm guessing that no piece of code has ever called this with a nonexistent attribute and thus accepting prefixes shouldn't break anything.

Please let me know if this change seems like unwanted behavior, or if you'd prefer some alternative approach.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
