### PR TITLE
[GEOT-7755] Most GeoParquet tests fail under the italian locale

### DIFF
--- a/modules/unsupported/geoparquet/src/test/java/org/geotools/data/geoparquet/GeoParquetLocalFileTest.java
+++ b/modules/unsupported/geoparquet/src/test/java/org/geotools/data/geoparquet/GeoParquetLocalFileTest.java
@@ -34,14 +34,11 @@ import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
 
 /** Tests for GeoParquet DataStore with local files. */
 public class GeoParquetLocalFileTest extends GeoParquetTestBase {
@@ -121,10 +118,16 @@ public class GeoParquetLocalFileTest extends GeoParquetTestBase {
         // Get total count
         int totalCount = source.getFeatures().size();
 
-        Geometry geom = JTS.toGeometry(new Envelope(-10, 0, 0, 10));
+        String geomName = source.getSchema().getGeometryDescriptor().getLocalName();
 
-        Filter filter = FF.intersects(
-                FF.property(source.getSchema().getGeometryDescriptor().getLocalName()), FF.literal(geom));
+        // Avoid using WKT (to workaround DuckDB issues when parsing with specific locale defined)
+        Filter filter = FF.bbox(
+                geomName,
+                -10,
+                0, // minx, miny
+                0,
+                10, // maxx, maxy
+                "EPSG:4326");
 
         // Get filtered features
         SimpleFeatureCollection filtered = source.getFeatures(filter);

--- a/modules/unsupported/geoparquet/src/test/resources/org/geotools/data/geoparquet/setup_test_data.sql
+++ b/modules/unsupported/geoparquet/src/test/resources/org/geotools/data/geoparquet/setup_test_data.sql
@@ -62,7 +62,7 @@ SELECT
     {
         'primary': 'Point ' || id,
         'common': MAP(
-            ['en', 'es', 'fr'], 
+            ['en', 'es', 'fr'],
             ['Point ' || id, 'Punto ' || id, 'Point ' || id]
         ),
         'rules': {'variant': 'standard'}
@@ -114,7 +114,7 @@ SELECT
     'MP_' || quadrant AS id,
     -- Create a multipoint geometry from all points in each quadrant
     ST_GeomFromText('MULTIPOINT(' || 
-        STRING_AGG(x || ' ' || y, ',') || 
+        STRING_AGG('(' || x || ' ' || y || ')', ',' ORDER BY x, y) ||
     ')') AS geometry,
     {
         'xmin': MIN(x)::FLOAT, 
@@ -125,7 +125,7 @@ SELECT
     {
         'primary': 'MultiPoint ' || quadrant,
         'common': MAP(
-            ['en', 'es', 'fr'], 
+            ['en', 'es', 'fr'],
             ['MultiPoint ' || quadrant, 'Multipunto ' || quadrant, 'MultiPoint ' || quadrant]
         ),
         'rules': {'variant': 'standard'}
@@ -166,14 +166,16 @@ WITH horizontal_lines AS (
         END AS quadrant,
         1000 + ROW_NUMBER() OVER (ORDER BY y) AS id,
         -- Create a horizontal line for each latitude value
-        ST_GeomFromText(
-            CASE
-                WHEN y < 0 AND quad_x < 0 THEN 'LINESTRING(-180 ' || y || ', 0 ' || y || ')'  -- SW
-                WHEN y < 0 AND quad_x >= 0 THEN 'LINESTRING(0 ' || y || ', 180 ' || y || ')' -- SE
-                WHEN y >= 0 AND quad_x < 0 THEN 'LINESTRING(-180 ' || y || ', 0 ' || y || ')' -- NW
-                ELSE 'LINESTRING(0 ' || y || ', 180 ' || y || ')' -- NE
-            END
-        ) AS geometry,
+        CASE
+		  WHEN y < 0 AND quad_x < 0
+		    THEN ST_MakeLine(ST_Point(-180::DOUBLE, y::DOUBLE), ST_Point(0::DOUBLE,   y::DOUBLE))  -- SW
+		  WHEN y < 0 AND quad_x >= 0
+		    THEN ST_MakeLine(ST_Point(  0::DOUBLE, y::DOUBLE), ST_Point(180::DOUBLE,  y::DOUBLE))  -- SE
+		  WHEN y >= 0 AND quad_x < 0
+		    THEN ST_MakeLine(ST_Point(-180::DOUBLE, y::DOUBLE), ST_Point(0::DOUBLE,   y::DOUBLE))  -- NW
+		  ELSE
+		    ST_MakeLine(ST_Point(  0::DOUBLE, y::DOUBLE), ST_Point(180::DOUBLE,  y::DOUBLE))       -- NE
+		END AS geometry,
         CASE WHEN quad_x < 0 THEN -180 ELSE 0 END AS x_min,
         CASE WHEN quad_x < 0 THEN 0 ELSE 180 END AS x_max,
         y AS y_min,
@@ -194,14 +196,16 @@ vertical_lines AS (
         END AS quadrant,
         3000 + ROW_NUMBER() OVER (ORDER BY x) AS id,
         -- Create a vertical line for each longitude value
-        ST_GeomFromText(
-            CASE
-                WHEN x < 0 AND quad_y < 0 THEN 'LINESTRING(' || x || ' -90, ' || x || ' 0)'  -- SW
-                WHEN x >= 0 AND quad_y < 0 THEN 'LINESTRING(' || x || ' -90, ' || x || ' 0)' -- SE
-                WHEN x < 0 AND quad_y >= 0 THEN 'LINESTRING(' || x || ' 0, ' || x || ' 90)' -- NW
-                ELSE 'LINESTRING(' || x || ' 0, ' || x || ' 90)' -- NE
-            END
-        ) AS geometry,
+        CASE
+		  WHEN x < 0 AND quad_y < 0
+		    THEN ST_MakeLine(ST_Point(x::DOUBLE, -90), ST_Point(x::DOUBLE, 0))
+		  WHEN x >= 0 AND quad_y < 0
+		    THEN ST_MakeLine(ST_Point(x::DOUBLE, -90), ST_Point(x::DOUBLE, 0))
+		  WHEN x < 0 AND quad_y >= 0
+		    THEN ST_MakeLine(ST_Point(x::DOUBLE, 0),   ST_Point(x::DOUBLE, 90))
+		  ELSE
+		    ST_MakeLine(ST_Point(x::DOUBLE, 0),        ST_Point(x::DOUBLE, 90))
+		END AS geometry,
         x AS x_min,
         x AS x_max,
         CASE WHEN quad_y < 0 THEN -90 ELSE 0 END AS y_min,
@@ -223,7 +227,7 @@ SELECT
     {
         'primary': 'Line ' || id,
         'common': MAP(
-            ['en', 'es', 'fr'], 
+            ['en', 'es', 'fr'],
             ['Line ' || id, 'Línea ' || id, 'Ligne ' || id]
         ),
         'rules': {'variant': 'standard'}
@@ -235,47 +239,59 @@ FROM all_lines;
 -- Add MultiLineString records (one for each quadrant)
 INSERT INTO lines
 WITH line_points AS (
-    -- Create sample points in each quadrant
-    SELECT 
-        CASE
-            WHEN x < 0 AND y < 0 THEN 'sw'
-            WHEN x >= 0 AND y < 0 THEN 'se'
-            WHEN x < 0 AND y >= 0 THEN 'nw'
-            ELSE 'ne'
-        END AS quadrant,
-        x, y
-    FROM 
-        (SELECT range * 5 AS x FROM range(-36, 37)) x_range,
-        (SELECT range * 5 AS y FROM range(-18, 19)) y_range
-    WHERE (x % 20 = 0 OR y % 20 = 0) -- Use only some points for lines
-    ORDER BY quadrant, x, y
+  SELECT
+    CASE
+      WHEN x < 0 AND y < 0 THEN 'sw'
+      WHEN x >= 0 AND y < 0 THEN 'se'
+      WHEN x < 0 AND y >= 0 THEN 'nw'
+      ELSE 'ne'
+    END AS quadrant,
+    x, y
+  FROM
+    (SELECT range * 5 AS x FROM range(-36, 37)) x_range,
+    (SELECT range * 5 AS y FROM range(-18, 19)) y_range
+  WHERE (x % 20 = 0 OR y % 20 = 0)
+),
+quad_lines AS (
+  SELECT
+    quadrant,
+    ST_MakeLine(
+      ST_Point(x::DOUBLE, y::DOUBLE),
+      ST_Point((x + 5)::DOUBLE, (y + 5)::DOUBLE)
+    ) AS geom
+  FROM line_points
+),
+collected AS (
+  SELECT
+    quadrant,
+    LIST(geom)                         AS geoms,
+    MIN(ST_XMin(geom))                 AS xmin,
+    MAX(ST_XMax(geom))                 AS xmax,
+    MIN(ST_YMin(geom))                 AS ymin,
+    MAX(ST_YMax(geom))                 AS ymax
+  FROM quad_lines
+  GROUP BY quadrant
 )
 SELECT
-    'ML_' || quadrant AS id,
-    -- Create a multilinestring with lines along grid in each quadrant
-    ST_GeomFromText(
-        'MULTILINESTRING(' || STRING_AGG( '(' || (x) || ' ' || (y) || ', ' || (x+5) || ' ' || (y+5) || ')', ',' ) ||  ')'
-    ) AS geometry,
-    {
-        'xmin': MIN(x)::FLOAT, 
-        'xmax': MAX(x+5)::FLOAT, 
-        'ymin': MIN(y)::FLOAT, 
-        'ymax': MAX(y+5)::FLOAT
-    } AS bbox,
-    {
-        'primary': 'MultiLine ' || quadrant,
-        'common': MAP(
-            ['en', 'es', 'fr'], 
-            ['MultiLine ' || quadrant, 'Multilínea ' || quadrant, 'MultiLigne ' || quadrant]
-        ),
-        'rules': {'variant': 'standard'}
-    } AS names,
-    'lines' AS theme,
-    'multiline' AS type
-FROM 
-    line_points
-GROUP BY
-    quadrant;
+  'ML_' || quadrant AS id,
+  ST_Multi(ST_Collect(geoms))          AS geometry,
+  {
+    'xmin': xmin::FLOAT,
+    'xmax': xmax::FLOAT,
+    'ymin': ymin::FLOAT,
+    'ymax': ymax::FLOAT
+  }                                     AS bbox,
+  {
+    'primary': 'MultiLine ' || quadrant,
+    'common': MAP(
+      ['en', 'es', 'fr'],
+      ['MultiLine ' || quadrant, 'Multilínea ' || quadrant, 'MultiLigne ' || quadrant]
+    ),
+    'rules': {'variant': 'standard'}
+  }                                     AS names,
+  'lines'                               AS theme,
+  'multiline'                           AS type
+FROM collected;
 
 -- Create the polygons table with square polygons
 CREATE TABLE polygons AS
@@ -292,9 +308,17 @@ WITH
             END AS quadrant,
             ROW_NUMBER() OVER (ORDER BY y, x) AS id,
             -- Create a polygon square for each grid cell
-            ST_GeomFromText(
-                'POLYGON((' || x || ' ' || y || ', ' || (x+1) || ' ' || y || ', ' || (x+1) || ' ' || (y+1) || ', ' || x || ' ' || (y+1) || ', ' || x || ' ' || y ||  '))'
-            ) AS geometry,
+            ST_MakePolygon(
+			  ST_MakeLine(
+			    LIST_VALUE(
+			      ST_Point(x::DOUBLE,       y::DOUBLE),
+			      ST_Point((x+1)::DOUBLE,   y::DOUBLE),
+			      ST_Point((x+1)::DOUBLE,  (y+1)::DOUBLE),
+			      ST_Point(x::DOUBLE,      (y+1)::DOUBLE),
+			      ST_Point(x::DOUBLE,       y::DOUBLE)
+			    )
+			  )
+			) AS geometry,
             x AS x_min,
             (x+1) AS x_max,
             y AS y_min,
@@ -326,56 +350,62 @@ FROM grid_cells;
 -- Add MultiPolygon records (one for each quadrant)
 INSERT INTO polygons
 WITH poly_points AS (
-    -- Create sample points in each quadrant for polygon creation
-    SELECT 
-        CASE
-            WHEN x < 0 AND y < 0 THEN 'sw'
-            WHEN x >= 0 AND y < 0 THEN 'se'
-            WHEN x < 0 AND y >= 0 THEN 'nw'
-            ELSE 'ne'
-        END AS quadrant,
-        x, y
-    FROM 
-        (SELECT range * 10 AS x FROM range(-18, 19)) x_range,
-        (SELECT range * 10 AS y FROM range(-9, 10)) y_range
-    WHERE (x % 30 = 0 AND y % 30 = 0) -- Use only some points for smaller multipolygon
-    ORDER BY quadrant, x, y
+  SELECT
+    CASE
+      WHEN x < 0 AND y < 0 THEN 'sw'
+      WHEN x >= 0 AND y < 0 THEN 'se'
+      WHEN x < 0 AND y >= 0 THEN 'nw'
+      ELSE 'ne'
+    END AS quadrant,
+    x, y
+  FROM
+    (SELECT range * 10 AS x FROM range(-18, 19)) x_range,
+    (SELECT range * 10 AS y FROM range(-9, 10))  y_range
+  WHERE (x % 30 = 0 AND y % 30 = 0)
+),
+squares AS (
+  SELECT
+    quadrant,
+    ST_MakePolygon(
+      ST_MakeLine(LIST_VALUE(
+        ST_Point(x::DOUBLE,       y::DOUBLE),
+        ST_Point((x+5)::DOUBLE,   y::DOUBLE),
+        ST_Point((x+5)::DOUBLE,  (y+5)::DOUBLE),
+        ST_Point(x::DOUBLE,      (y+5)::DOUBLE),
+        ST_Point(x::DOUBLE,       y::DOUBLE)
+      ))
+    ) AS poly
+  FROM poly_points
+),
+agg AS (
+  SELECT
+    quadrant,
+    LIST(poly)                          AS polys,
+    MIN(ST_XMin(poly))                  AS xmin,
+    MAX(ST_XMax(poly))                  AS xmax,
+    MIN(ST_YMin(poly))                  AS ymin,
+    MAX(ST_YMax(poly))                  AS ymax
+  FROM squares
+  GROUP BY quadrant
 )
 SELECT
-    'MPG_' || quadrant AS id,
-    -- Create a multipolygon with square polygons in each quadrant
-    ST_GeomFromText(
-        'MULTIPOLYGON(' || 
-        STRING_AGG(
-            '((' || x || ' ' || y || ', ' || 
-            (x+5) || ' ' || y || ', ' || 
-            (x+5) || ' ' || (y+5) || ', ' || 
-            x || ' ' || (y+5) || ', ' || 
-            x || ' ' || y || '))',
-            ','
-        ) || 
-        ')'
-    ) AS geometry,
-    {
-        'xmin': MIN(x)::FLOAT, 
-        'xmax': MAX(x+5)::FLOAT, 
-        'ymin': MIN(y)::FLOAT, 
-        'ymax': MAX(y+5)::FLOAT
-    } AS bbox,
-    {
-        'primary': 'MultiPolygon ' || quadrant,
-        'common': MAP(
-            ['en', 'es', 'fr'], 
-            ['MultiPolygon ' || quadrant, 'Multipolígono ' || quadrant, 'MultiPolygone ' || quadrant]
-        ),
-        'rules': {'variant': 'standard'}
-    } AS names,
-    'polygons' AS theme,
-    'multipolygon' AS type
-FROM 
-    poly_points
-GROUP BY
-    quadrant;
+  'MPG_' || quadrant AS id,
+  ST_Multi(ST_Collect(polys))           AS geometry,
+  {
+    'xmin': xmin::FLOAT, 'xmax': xmax::FLOAT,
+    'ymin': ymin::FLOAT, 'ymax': ymax::FLOAT
+  }                                   AS bbox,
+  {
+    'primary': 'MultiPolygon ' || quadrant,
+    'common': MAP(
+      ['en','es','fr'],
+      ['MultiPolygon '||quadrant, 'Multipolígono '||quadrant, 'MultiPolygone '||quadrant]
+    ),
+    'rules': {'variant':'standard'}
+  }                                   AS names,
+  'polygons'                           AS theme,
+  'multipolygon'                       AS type
+FROM agg;
 
 
 -- Verify


### PR DESCRIPTION
DuckDB’s WKT parser in the spatial extension is still a bit strict and sometimes fragile. It requires the input text to match the WKT grammar exactly, and small formatting differences that other systems (like PostGIS or JTS) accept can cause errors.

For example, DuckDB expects

`POLYGON ((x1 y1, x2 y2, ...))`

with a space between the geometry type and the first parenthesis. If you give it

`POLYGON((x1 y1, x2 y2, ...))`

without the space, it throws an Invalid Input Error.

So the root issue is not the geometry—it’s that DuckDB’s WKT parser fails on certain valid-but-slightly-different text encodings of geometries.
That’s why using constructors like ST_MakeEnvelope, ST_Point, ST_MakePolygon, or FF.bbox (which generate geometries directly in SQL) avoids the problem completely: those functions bypass WKT parsing and work reliably.

Proposed changes on this PR attempts to avoid using WKT for the definition of the datasets used in the tests.
As mentioned in the detected issue, using  en_US work fine, but as much as you use  en_US.UTF-8 or any other locale, then it fails (in the reported issue, it_IT)


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).
