### PR TITLE
Fix build failing due to extreama not being available

### DIFF
--- a/modules/library/referencing/pom.xml
+++ b/modules/library/referencing/pom.xml
@@ -189,6 +189,11 @@
       <artifactId>scale</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.imagen</groupId>
+      <artifactId>stats</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/modules/library/referencing/src/test/java/org/geotools/parameter/ImagingParametersTest.java
+++ b/modules/library/referencing/src/test/java/org/geotools/parameter/ImagingParametersTest.java
@@ -148,7 +148,7 @@ public final class ImagingParametersTest {
         // Gets the descriptors for extrema  JAI operation
         final OperationRegistry registry = JAI.getDefaultInstance().getOperationRegistry();
         final OperationDescriptor operation =
-                (OperationDescriptor) registry.getDescriptor(RenderedRegistryMode.MODE_NAME, "Extrema");
+                (OperationDescriptor) registry.getDescriptor(RenderedRegistryMode.MODE_NAME, "Stats");
 
         // Gets the ImagingParameterDescriptors to replace xPeriod
         final List<ParameterDescriptor> replacingDescriptors = new ArrayList<>(1);


### PR DESCRIPTION
This test was using the Extrema ImageN operator, which has been moved to legacy and replaced by Stats.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->