### PR TITLE
ImageN evolution: do not use DataBufferUtils

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/RecyclingTileFactory.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/RecyclingTileFactory.java
@@ -20,6 +20,8 @@ import java.awt.Point;
 import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
+import java.awt.image.DataBufferDouble;
+import java.awt.image.DataBufferFloat;
 import java.awt.image.DataBufferInt;
 import java.awt.image.DataBufferShort;
 import java.awt.image.DataBufferUShort;
@@ -37,7 +39,6 @@ import org.eclipse.imagen.CachedTile;
 import org.eclipse.imagen.TileCache;
 import org.eclipse.imagen.TileFactory;
 import org.eclipse.imagen.TileRecycler;
-import org.eclipse.imagen.media.util.DataBufferUtils;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -163,10 +164,10 @@ public class RecyclingTileFactory extends java.util.Observable
                 array = ((DataBufferInt) db).getBankData();
                 break;
             case DataBuffer.TYPE_FLOAT:
-                array = DataBufferUtils.getBankDataFloat(db);
+                array = ((DataBufferFloat) db).getBankData();
                 break;
             case DataBuffer.TYPE_DOUBLE:
-                array = DataBufferUtils.getBankDataDouble(db);
+                array = ((DataBufferDouble) db).getBankData();
                 break;
             default:
                 throw new UnsupportedOperationException("");
@@ -308,7 +309,7 @@ public class RecyclingTileFactory extends java.util.Observable
                             for (int i = 0; i < numBanks; i++) {
                                 Arrays.fill(bankData[i], 0.0F);
                             }
-                            db = DataBufferUtils.createDataBufferFloat(bankData, (int) size);
+                            db = new DataBufferFloat(bankData, (int) size);
                         }
                         break;
                     case DataBuffer.TYPE_DOUBLE:
@@ -317,7 +318,7 @@ public class RecyclingTileFactory extends java.util.Observable
                             for (int i = 0; i < numBanks; i++) {
                                 Arrays.fill(bankData[i], 0.0);
                             }
-                            db = DataBufferUtils.createDataBufferDouble(bankData, (int) size);
+                            db = new DataBufferDouble(bankData, (int) size);
                         }
                         break;
                     default:


### PR DESCRIPTION
In preparation for moving DataBufferUtils to legacy in ImageN (it was used to support JDK older than v1.4 and reflectively instance/manipulate float/double buffer using either the JDK version or the JAI version of the class)

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
