### PR TITLE
ImageN evolution: do not depend on GraphicsJAI

### DIFF
--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/Viewer.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/Viewer.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
-import org.eclipse.imagen.GraphicsJAI;
 import org.eclipse.imagen.PlanarImage;
 import org.geotools.api.parameter.ParameterValueGroup;
 import org.geotools.api.util.InternationalString;
@@ -88,8 +87,7 @@ public class Viewer extends JPanel {
     @Override
     public void paintComponent(final Graphics graphics) {
         super.paintComponent(graphics);
-        final GraphicsJAI g = GraphicsJAI.createGraphicsJAI((Graphics2D) graphics, this);
-        g.drawRenderedImage(image, gridToCoordinateSystem);
+        ((Graphics2D) graphics).drawRenderedImage(image, gridToCoordinateSystem);
     }
 
     /**


### PR DESCRIPTION
Just replacing GraphicsJAI with equivalent functionality from Graphics2D, as GraphicsJAI is getting moved to the legacy module in ImageN. This is to prevent a compile error when GeoTools will upgrade to ImageN 0.9.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->