### PR TITLE
Updating dependencies to support building with java 25

### DIFF
--- a/.github/workflows/linux_jdk25.yml
+++ b/.github/workflows/linux_jdk25.yml
@@ -1,0 +1,46 @@
+name: Linux JDK 25 GitHub CI
+
+on: [pull_request]
+
+env:
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: [ubuntu-24.04]
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: 25
+    - name: Setup python for docs
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        cache: 'pip' # caching pip dependencies from requirements.txt below
+    - name: Setup python pip requirements for building docs
+      working-directory: docs
+      run: |
+        pip install -r requirements.txt
+    - name: Maven repository caching
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: gt-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          gt-maven-
+    - name: Disable checksum offloading
+      # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
+      run: sudo ethtool -K eth0 tx off rx off
+    - name: Build with Maven
+      run: |
+        mvn -B clean install -Dspotless.apply.skip=true -Dall -T1C -U -Plinux-github-build --file pom.xml
+    - name: Remove SNAPSHOT jars from repository
+      run: |
+        find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/TypeMap.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/TypeMap.java
@@ -294,7 +294,7 @@ public final class TypeMap {
                         return UNSIGNED_4BITS;
                     case 5:
                         return UNSIGNED_8BITS; // for BufferedImages TYPE_USHORT_555_RGB
-                        // TYPE_USHORT_565_RGB
+                    // TYPE_USHORT_565_RGB
                     case 8:
                         return signed ? SIGNED_8BITS : UNSIGNED_8BITS;
                     case 16:

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/CRS2GeoTiffMetadataAdapter.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/imageio/geotiff/CRS2GeoTiffMetadataAdapter.java
@@ -143,18 +143,18 @@ public final class CRS2GeoTiffMetadataAdapter {
         metadata.addGeoShortParam(GeoTiffConstants.GTModelTypeGeoKey, modelType);
         switch (modelType) {
 
-                //
-                // GEOGRAPHIC COORDINATE REFERENCE SYSTEMCREATING METADATA AND SETTING
-                // BASE FIELDS FOR THEM
-                //
+            //
+            // GEOGRAPHIC COORDINATE REFERENCE SYSTEMCREATING METADATA AND SETTING
+            // BASE FIELDS FOR THEM
+            //
             case GeoTiffGCSCodes.ModelTypeGeographic:
                 parseGeoGCS((DefaultGeographicCRS) crs, metadata);
                 break;
 
-                //
-                // PROJECTED COORDINATE REFERENCE SYSTEMCREATING METADATA AND SETTING
-                // BASE FIELDS FOR THEM
-                //
+            //
+            // PROJECTED COORDINATE REFERENCE SYSTEMCREATING METADATA AND SETTING
+            // BASE FIELDS FOR THEM
+            //
             case GeoTiffPCSCodes.ModelTypeProjected:
                 parseProjCRS((ProjectedCRS) crs, metadata);
                 break;

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTestBase.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/GridCoverageTestBase.java
@@ -189,19 +189,19 @@ public class GridCoverageTestBase extends CoverageTestBase {
                 default: {
                     throw new IndexOutOfBoundsException(String.valueOf(number));
                 }
-                    /* ------------------------------------------------------------
-                     * Thematic           :  Sea Surface Temperature (SST) in °C
-                     * Data packaging     :  Indexed 8-bits
-                     * Nodata values      :  [0 .. 29] and [240 .. 255] inclusive.
-                     * Conversion formula :  (°C) = (packed value)/10 + 10
-                     * Geographic extent  :  (41°S, 35°E) - (5°N, 80°E)
-                     * Image size         :  (450 x 460) pixels
-                     *
-                     * This is a raster from Earth observations using a relatively straightforward
-                     * conversion formula to geophysics values (a linear transform using the usual
-                     * scale and offset parameters, in this case 0.1 and 10 respectively).     The
-                     * interesting part of this example is that it contains a lot of nodata values.
-                     */
+                /* ------------------------------------------------------------
+                 * Thematic           :  Sea Surface Temperature (SST) in °C
+                 * Data packaging     :  Indexed 8-bits
+                 * Nodata values      :  [0 .. 29] and [240 .. 255] inclusive.
+                 * Conversion formula :  (°C) = (packed value)/10 + 10
+                 * Geographic extent  :  (41°S, 35°E) - (5°N, 80°E)
+                 * Image size         :  (450 x 460) pixels
+                 *
+                 * This is a raster from Earth observations using a relatively straightforward
+                 * conversion formula to geophysics values (a linear transform using the usual
+                 * scale and offset parameters, in this case 0.1 and 10 respectively).     The
+                 * interesting part of this example is that it contains a lot of nodata values.
+                 */
                 case 0: {
                     path = "QL95209.png";
                     crs = DefaultGeographicCRS.WGS84;
@@ -218,18 +218,18 @@ public class GridCoverageTestBase extends CoverageTestBase {
                     bands = new GridSampleDimension[] {new GridSampleDimension("Measure", categories, SI.CELSIUS)};
                     break;
                 }
-                    /* ------------------------------------------------------------
-                     * Thematic           :  Chlorophyle-a concentration in mg/m³
-                     * Data packaging     :  Indexed 8-bits
-                     * Nodata values      :  0 and 255
-                     * Conversion formula :  (mg/m³) = 10 ^ ((packed value)*0.015 - 1.985)
-                     * Geographic extent  :  (34°N, 07°W) - (45°N, 12°E)
-                     * Image size         :  (300 x 175) pixels
-                     *
-                     * This is a raster from Earth observations using a more complex conversion
-                     * formula to geophysics values (an exponential one). The usual scale and
-                     * offset parameters are not enough in this case.
-                     */
+                /* ------------------------------------------------------------
+                 * Thematic           :  Chlorophyle-a concentration in mg/m³
+                 * Data packaging     :  Indexed 8-bits
+                 * Nodata values      :  0 and 255
+                 * Conversion formula :  (mg/m³) = 10 ^ ((packed value)*0.015 - 1.985)
+                 * Geographic extent  :  (34°N, 07°W) - (45°N, 12°E)
+                 * Image size         :  (300 x 175) pixels
+                 *
+                 * This is a raster from Earth observations using a more complex conversion
+                 * formula to geophysics values (an exponential one). The usual scale and
+                 * offset parameters are not enough in this case.
+                 */
                 case 1: {
                     path = "CHL01195.png";
                     crs = DefaultGeographicCRS.WGS84;
@@ -248,10 +248,10 @@ public class GridCoverageTestBase extends CoverageTestBase {
                     };
                     break;
                 }
-                    /* ------------------------------------------------------------
-                     * Thematic           :  World Digital Elevation Model (DEM)
-                     * Geographic extent  :  (90°S, 180°W) - (90°N, 180°E)
-                     */
+                /* ------------------------------------------------------------
+                 * Thematic           :  World Digital Elevation Model (DEM)
+                 * Geographic extent  :  (90°S, 180°W) - (90°N, 180°E)
+                 */
                 case 2: {
                     path = "world_dem.gif";
                     bounds = new Rectangle2D.Double(-180, -90, 360, 180);
@@ -259,10 +259,10 @@ public class GridCoverageTestBase extends CoverageTestBase {
                     bands = null;
                     break;
                 }
-                    /* ------------------------------------------------------------
-                     * Thematic           :  World Bathymetry (DEM)
-                     * Geographic extent  :  (90°S, 180°W) - (90°N, 180°E)
-                     */
+                /* ------------------------------------------------------------
+                 * Thematic           :  World Bathymetry (DEM)
+                 * Geographic extent  :  (90°S, 180°W) - (90°N, 180°E)
+                 */
                 case 3: {
                     path = "BATHY.png";
                     bounds = new Rectangle2D.Double(-180, -90, 360, 180);
@@ -270,11 +270,11 @@ public class GridCoverageTestBase extends CoverageTestBase {
                     bands = null;
                     break;
                 }
-                    /*
-                     * A float coverage. Because we use only one tile with one band, the code below
-                     * is pretty similar to the code we would have if we were just setting the values
-                     * in a matrix.
-                     */
+                /*
+                 * A float coverage. Because we use only one tile with one band, the code below
+                 * is pretty similar to the code we would have if we were just setting the values
+                 * in a matrix.
+                 */
                 case 4: {
                     final int width = 500;
                     final int height = 500;
@@ -296,10 +296,10 @@ public class GridCoverageTestBase extends CoverageTestBase {
                             new Color[][] {colors},
                             null);
                 }
-                    /*
-                     * A single band fictitious coverage with type UINT 16.
-                     *
-                     */
+                /*
+                 * A single band fictitious coverage with type UINT 16.
+                 *
+                 */
                 case 5: {
                     final int width = 500;
                     final int height = 500;

--- a/modules/library/cql/src/main/java/org/geotools/filter/text/cql2/CQLCompiler.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/cql2/CQLCompiler.java
@@ -181,9 +181,9 @@ public class CQLCompiler extends CQLParser implements ICompiler {
      */
     private Object build(Node cqlNode) throws CQLException {
         switch (cqlNode.getType()) {
-                // Literals
-                // note, these should never throw because the parser grammar
-                // constrains input before we ever reach here!
+            // Literals
+            // note, these should never throw because the parser grammar
+            // constrains input before we ever reach here!
             case JJTINTEGERNODE:
                 return this.builder.buildLiteralInteger(getToken(0).image);
 
@@ -192,27 +192,27 @@ public class CQLCompiler extends CQLParser implements ICompiler {
 
             case JJTSTRINGNODE:
                 return this.builder.buildLiteralString(getToken(0).image);
-                // ----------------------------------------
-                // Identifier
-                // ----------------------------------------
+            // ----------------------------------------
+            // Identifier
+            // ----------------------------------------
             case JJTIDENTIFIER_NODE:
                 return this.builder.buildIdentifier(JJTIDENTIFIER_PART_NODE);
 
             case JJTIDENTIFIER_PART_NODE:
                 return this.builder.buildIdentifierPart(getTokenInPosition(0));
 
-                // ----------------------------------------
-                // attribute
-                // ----------------------------------------
+            // ----------------------------------------
+            // attribute
+            // ----------------------------------------
             case JJTSIMPLE_ATTRIBUTE_NODE:
                 return this.builder.buildSimpleAttribute();
 
             case JJTCOMPOUND_ATTRIBUTE_NODE:
                 return this.builder.buildCompoundAttribute(JJTSIMPLE_ATTRIBUTE_NODE, ATTRIBUTE_PATH_SEPARATOR);
 
-                // ----------------------------------------
-                // function
-                // ----------------------------------------
+            // ----------------------------------------
+            // function
+            // ----------------------------------------
             case JJTFUNCTION_NODE:
                 return this.builder.buildFunction(JJTFUNCTIONNAME_NODE);
 
@@ -222,14 +222,14 @@ public class CQLCompiler extends CQLParser implements ICompiler {
             case JJTFUNCTIONARG_NODE:
                 return cqlNode; // used as mark of args in stack
 
-                // Math Nodes
+            // Math Nodes
             case JJTADDNODE:
             case JJTSUBTRACTNODE:
             case JJTMULNODE:
             case JJTDIVNODE:
                 return buildBinaryExpression(cqlNode.getType());
 
-                // Boolean expression
+            // Boolean expression
             case JJTBOOLEAN_AND_NODE:
                 return buildLogicFilter(JJTBOOLEAN_AND_NODE);
 
@@ -239,18 +239,18 @@ public class CQLCompiler extends CQLParser implements ICompiler {
             case JJTBOOLEAN_NOT_NODE:
                 return buildLogicFilter(JJTBOOLEAN_NOT_NODE);
 
-                // ----------------------------------------
-                // between predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // between predicate actions
+            // ----------------------------------------
             case JJTBETWEEN_NODE:
                 return this.builder.buildBetween();
 
             case JJTNOT_BETWEEN_NODE:
                 return this.builder.buildNotBetween();
 
-                // ----------------------------------------
-                // Compare predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // Compare predicate actions
+            // ----------------------------------------
             case JJTCOMPARISONPREDICATE_EQ_NODE:
             case JJTCOMPARISONPREDICATE_GT_NODE:
             case JJTCOMPARISONPREDICATE_LT_NODE:
@@ -264,27 +264,27 @@ public class CQLCompiler extends CQLParser implements ICompiler {
 
                 return notFilter;
 
-                // ----------------------------------------
-                // Text predicate (Like)
-                // ----------------------------------------
+            // ----------------------------------------
+            // Text predicate (Like)
+            // ----------------------------------------
             case JJTLIKE_NODE:
                 return this.builder.buildLikeFilter(true);
 
             case JJTNOT_LIKE_NODE:
                 return this.builder.buildNotLikeFilter(true);
 
-                // ----------------------------------------
-                // Null predicate
-                // ----------------------------------------
+            // ----------------------------------------
+            // Null predicate
+            // ----------------------------------------
             case JJTNULLPREDICATENODE:
                 return this.builder.buildPropertyIsNull();
 
             case JJTNOTNULLPREDICATENODE:
                 return this.builder.buildPorpertyNotIsNull();
 
-                // ----------------------------------------
-                // temporal predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // temporal predicate actions
+            // ----------------------------------------
             case JJTDATETIME_NODE:
                 return this.builder.buildDateTimeExpression(getTokenInPosition(0));
 
@@ -318,9 +318,9 @@ public class CQLCompiler extends CQLParser implements ICompiler {
             case JJTTPDURING_OR_AFTER_PERIOD_NODE:
                 return buildDuringOrAfter();
 
-                // ----------------------------------------
-                // existence predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // existence predicate actions
+            // ----------------------------------------
             case JJTEXISTENCE_PREDICATE_EXISTS_NODE:
                 return this.builder.buildPropertyExists();
 
@@ -330,9 +330,9 @@ public class CQLCompiler extends CQLParser implements ICompiler {
 
                 return filterPropNotExist;
 
-                // ----------------------------------------
-                // routine invocation Geo Operation
-                // -------------------TokenAdapter.newAdapterFor(cqlNode.getToken())---------------------
+            // ----------------------------------------
+            // routine invocation Geo Operation
+            // -------------------TokenAdapter.newAdapterFor(cqlNode.getToken())---------------------
             case JJTROUTINEINVOCATION_GEOOP_EQUAL_NODE:
             case JJTROUTINEINVOCATION_GEOOP_DISJOINT_NODE:
             case JJTROUTINEINVOCATION_GEOOP_INTERSECT_NODE:
@@ -353,9 +353,9 @@ public class CQLCompiler extends CQLParser implements ICompiler {
             case JJTDE9IM_NODE:
                 return this.builder.buildDE9IM(getToken(0).image);
 
-                // ----------------------------------------
-                // routine invocation RelGeo Operatiosn
-                // ----------------------------------------
+            // ----------------------------------------
+            // routine invocation RelGeo Operatiosn
+            // ----------------------------------------
             case JJTTOLERANCE_NODE:
                 return this.builder.buildTolerance();
 
@@ -366,9 +366,9 @@ public class CQLCompiler extends CQLParser implements ICompiler {
             case JJTROUTINEINVOCATION_RELOP_DWITHIN_NODE:
                 return buildDistanceBufferOperator(cqlNode.getType());
 
-                // ----------------------------------------
-                // Geometries:
-                // ----------------------------------------
+            // ----------------------------------------
+            // Geometries:
+            // ----------------------------------------
             case JJTWKTNODE:
                 return this.builder.buildGeometry(TokenAdapter.newAdapterFor(cqlNode.getToken()));
 

--- a/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/ECQLCompiler.java
+++ b/modules/library/cql/src/main/java/org/geotools/filter/text/ecql/ECQLCompiler.java
@@ -185,9 +185,9 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
 
         switch (n.getType()) {
 
-                // ----------------------------------------
-                // (+|-) Integer and Float
-                // ----------------------------------------
+            // ----------------------------------------
+            // (+|-) Integer and Float
+            // ----------------------------------------
             case JJTINTEGERNODE:
                 return this.builder.buildLiteralInteger(getTokenInPosition(0).toString());
             case JJTFLOATINGNODE:
@@ -195,33 +195,33 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
             case JJTNEGATIVENUMBER_NODE:
                 return this.builder.bulidNegativeNumber();
 
-                // ----------------------------------------
-                // String
-                // ----------------------------------------
+            // ----------------------------------------
+            // String
+            // ----------------------------------------
             case JJTSTRINGNODE:
                 return this.builder.buildLiteralString(getTokenInPosition(0).toString());
 
-                // ----------------------------------------
-                // Identifier
-                // ----------------------------------------
+            // ----------------------------------------
+            // Identifier
+            // ----------------------------------------
             case JJTIDENTIFIER_NODE:
                 return this.builder.buildIdentifier(JJTIDENTIFIER_PART_NODE);
 
             case JJTIDENTIFIER_PART_NODE:
                 return this.builder.buildIdentifierPart(getTokenInPosition(0));
 
-                // ----------------------------------------
-                // attribute
-                // ----------------------------------------
+            // ----------------------------------------
+            // attribute
+            // ----------------------------------------
             case JJTSIMPLE_ATTRIBUTE_NODE:
                 return this.builder.buildSimpleAttribute();
 
             case JJTCOMPOUND_ATTRIBUTE_NODE:
                 return this.builder.buildCompoundAttribute(JJTSIMPLE_ATTRIBUTE_NODE, ATTRIBUTE_PATH_SEPARATOR);
 
-                // ----------------------------------------
-                // function
-                // ----------------------------------------
+            // ----------------------------------------
+            // function
+            // ----------------------------------------
             case JJTFUNCTION_NODE:
                 return this.builder.buildFunction(JJTFUNCTIONNAME_NODE);
 
@@ -231,14 +231,14 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
             case JJTFUNCTIONARG_NODE:
                 return n; // used as mark of args in stack
 
-                // Math Nodes
+            // Math Nodes
             case JJTADDNODE:
             case JJTSUBTRACTNODE:
             case JJTMULNODE:
             case JJTDIVNODE:
                 return buildBinaryExpression(n.getType());
 
-                // Boolean expression
+            // Boolean expression
             case JJTBOOLEAN_AND_NODE:
                 return buildLogicFilter(JJTBOOLEAN_AND_NODE);
 
@@ -248,18 +248,18 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
             case JJTBOOLEAN_NOT_NODE:
                 return buildLogicFilter(JJTBOOLEAN_NOT_NODE);
 
-                // ----------------------------------------
-                // between predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // between predicate actions
+            // ----------------------------------------
             case JJTBETWEEN_NODE:
                 return this.builder.buildBetween();
 
             case JJTNOT_BETWEEN_NODE:
                 return this.builder.buildNotBetween();
 
-                // ----------------------------------------
-                // Compare predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // Compare predicate actions
+            // ----------------------------------------
             case JJTCOMPARISONPREDICATE_EQ_NODE:
             case JJTCOMPARISONPREDICATE_GT_NODE:
             case JJTCOMPARISONPREDICATE_LT_NODE:
@@ -273,36 +273,36 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
 
                 return notFilter;
 
-                // ----------------------------------------
-                // Text predicate (Like)
-                // ----------------------------------------
+            // ----------------------------------------
+            // Text predicate (Like)
+            // ----------------------------------------
             case JJTLIKE_NODE:
                 return this.builder.buildLikeFilter(true);
 
             case JJTNOT_LIKE_NODE:
                 return this.builder.buildNotLikeFilter(true);
 
-                // ----------------------------------------
-                // Text predicate (ILike)
-                // ----------------------------------------
+            // ----------------------------------------
+            // Text predicate (ILike)
+            // ----------------------------------------
             case JJTILIKE_NODE:
                 return this.builder.buildLikeFilter(false);
 
             case JJTNOT_ILIKE_NODE:
                 return this.builder.buildNotLikeFilter(false);
 
-                // ----------------------------------------
-                // Null predicate
-                // ----------------------------------------
+            // ----------------------------------------
+            // Null predicate
+            // ----------------------------------------
             case JJTNULLPREDICATENODE:
                 return this.builder.buildPropertyIsNull();
 
             case JJTNOTNULLPREDICATENODE:
                 return this.builder.buildPorpertyNotIsNull();
 
-                // ----------------------------------------
-                // temporal predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // temporal predicate actions
+            // ----------------------------------------
             case JJTDATE_NODE:
                 return this.builder.buildDateExpression(getTokenInPosition(0));
 
@@ -339,9 +339,9 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
             case JJTTPDURING_OR_AFTER_PERIOD_NODE:
                 return buildDuringOrAfter();
 
-                // ----------------------------------------
-                // existence predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // existence predicate actions
+            // ----------------------------------------
             case JJTEXISTENCE_PREDICATE_EXISTS_NODE:
                 return this.builder.buildPropertyExists();
 
@@ -351,9 +351,9 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
 
                 return filterPropNotExist;
 
-                // ----------------------------------------
-                // routine invocation Geo Operation
-                // ----------------------------------------
+            // ----------------------------------------
+            // routine invocation Geo Operation
+            // ----------------------------------------
             case JJTROUTINEINVOCATION_GEOOP_EQUAL_NODE:
             case JJTROUTINEINVOCATION_GEOOP_DISJOINT_NODE:
             case JJTROUTINEINVOCATION_GEOOP_INTERSECT_NODE:
@@ -374,9 +374,9 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
             case JJTDE9IM_NODE:
                 return this.builder.buildDE9IM(getToken(0).image);
 
-                // ----------------------------------------
-                // routine invocation RelGeo Operation
-                // ----------------------------------------
+            // ----------------------------------------
+            // routine invocation RelGeo Operation
+            // ----------------------------------------
             case JJTTOLERANCE_NODE:
                 return this.builder.buildTolerance();
 
@@ -387,9 +387,9 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
             case JJTROUTINEINVOCATION_RELOP_DWITHIN_NODE:
                 return buildDistanceBufferOperator(n.getType());
 
-                // ----------------------------------------
-                // Geometries:
-                // ----------------------------------------
+            // ----------------------------------------
+            // Geometries:
+            // ----------------------------------------
             case JJTPOINT_NODE:
                 return this.builder.buildCoordinate();
 
@@ -441,17 +441,17 @@ public class ECQLCompiler extends ECQLParser implements org.geotools.filter.text
             case JJTFALSENODE:
                 return this.builder.buildFalseLiteral();
 
-                // ----------------------------------------
-                //  ID Predicate
-                // ----------------------------------------
+            // ----------------------------------------
+            //  ID Predicate
+            // ----------------------------------------
             case JJTFEATURE_ID_NODE:
                 return this.builder.buildFeatureID(getTokenInPosition(0));
 
             case JJTID_PREDICATE_NODE:
                 return this.builder.buildFilterId(JJTFEATURE_ID_NODE);
-                // ----------------------------------------
-                //  IN Predicate
-                // ----------------------------------------
+            // ----------------------------------------
+            //  IN Predicate
+            // ----------------------------------------
             case JJTIN_PREDICATE_NODE:
                 return this.builder.buildInPredicate(JJTEXPRESSION_IN_LIST_NODE);
 

--- a/modules/library/cql2-text/src/main/java/org/geootols/filter/text/cql_2/CQL2Compiler.java
+++ b/modules/library/cql2-text/src/main/java/org/geootols/filter/text/cql_2/CQL2Compiler.java
@@ -177,9 +177,9 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
 
         switch (n.getType()) {
 
-                // ----------------------------------------
-                // (+|-) Integer and Float
-                // ----------------------------------------
+            // ----------------------------------------
+            // (+|-) Integer and Float
+            // ----------------------------------------
             case JJTINTEGERNODE:
                 return this.builder.buildLiteralInteger(getTokenInPosition(0).toString());
             case JJTFLOATINGNODE:
@@ -187,33 +187,33 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
             case JJTNEGATIVENUMBER_NODE:
                 return this.builder.bulidNegativeNumber();
 
-                // ----------------------------------------
-                // String
-                // ----------------------------------------
+            // ----------------------------------------
+            // String
+            // ----------------------------------------
             case JJTSTRINGNODE:
                 return this.builder.buildLiteralString(getTokenInPosition(0).toString());
 
-                // ----------------------------------------
-                // Identifier
-                // ----------------------------------------
+            // ----------------------------------------
+            // Identifier
+            // ----------------------------------------
             case JJTIDENTIFIER_NODE:
                 return this.builder.buildIdentifier(JJTIDENTIFIER_PART_NODE);
 
             case JJTIDENTIFIER_PART_NODE:
                 return this.builder.buildIdentifierPart(getTokenInPosition(0));
 
-                // ----------------------------------------
-                // attribute
-                // ----------------------------------------
+            // ----------------------------------------
+            // attribute
+            // ----------------------------------------
             case JJTSIMPLE_ATTRIBUTE_NODE:
                 return this.builder.buildSimpleAttribute();
 
             case JJTCOMPOUND_ATTRIBUTE_NODE:
                 return this.builder.buildCompoundAttribute(JJTSIMPLE_ATTRIBUTE_NODE, ATTRIBUTE_PATH_SEPARATOR);
 
-                // ----------------------------------------
-                // function
-                // ----------------------------------------
+            // ----------------------------------------
+            // function
+            // ----------------------------------------
             case JJTFUNCTION_NODE:
                 return this.builder.buildFunction(JJTFUNCTIONNAME_NODE);
 
@@ -223,7 +223,7 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
             case JJTFUNCTIONARG_NODE:
                 return n; // used as mark of args in stack
 
-                // Math Nodes
+            // Math Nodes
             case JJTADDNODE:
             case JJTSUBTRACTNODE:
             case JJTMULNODE:
@@ -235,7 +235,7 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
             case JJTINTDIVNODE:
                 return buildBinaryFunction(n.getType());
 
-                // Boolean expression
+            // Boolean expression
             case JJTBOOLEAN_AND_NODE:
                 return buildLogicFilter(JJTBOOLEAN_AND_NODE);
 
@@ -245,18 +245,18 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
             case JJTBOOLEAN_NOT_NODE:
                 return buildLogicFilter(JJTBOOLEAN_NOT_NODE);
 
-                // ----------------------------------------
-                // between predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // between predicate actions
+            // ----------------------------------------
             case JJTBETWEEN_NODE:
                 return this.builder.buildBetween();
 
             case JJTNOT_BETWEEN_NODE:
                 return this.builder.buildNotBetween();
 
-                // ----------------------------------------
-                // Compare predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // Compare predicate actions
+            // ----------------------------------------
             case JJTCOMPARISONPREDICATE_EQ_NODE:
             case JJTCOMPARISONPREDICATE_GT_NODE:
             case JJTCOMPARISONPREDICATE_LT_NODE:
@@ -270,27 +270,27 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
 
                 return notFilter;
 
-                // ----------------------------------------
-                // Text predicate (Like)
-                // ----------------------------------------
+            // ----------------------------------------
+            // Text predicate (Like)
+            // ----------------------------------------
             case JJTLIKE_NODE:
                 return this.builder.buildLikeFilter(true);
 
             case JJTNOT_LIKE_NODE:
                 return this.builder.buildNotLikeFilter(true);
 
-                // ----------------------------------------
-                // Null predicate
-                // ----------------------------------------
+            // ----------------------------------------
+            // Null predicate
+            // ----------------------------------------
             case JJTNULLPREDICATENODE:
                 return this.builder.buildPropertyIsNull();
 
             case JJTNOTNULLPREDICATENODE:
                 return this.builder.buildPorpertyNotIsNull();
 
-                // ----------------------------------------
-                // temporal predicate actions
-                // ----------------------------------------
+            // ----------------------------------------
+            // temporal predicate actions
+            // ----------------------------------------
             case JJTDATE_NODE:
                 return this.builder.buildDateExpression(getTokenInPosition(0));
 
@@ -314,9 +314,9 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
             case JJTTPDURING_PERIOD_NODE:
                 return buildDuring();
 
-                // ----------------------------------------
-                // routine invocation Geo Operation
-                // ----------------------------------------
+            // ----------------------------------------
+            // routine invocation Geo Operation
+            // ----------------------------------------
             case JJTROUTINEINVOCATION_GEOOP_EQUAL_NODE:
             case JJTROUTINEINVOCATION_GEOOP_DISJOINT_NODE:
             case JJTROUTINEINVOCATION_GEOOP_INTERSECT_NODE:
@@ -327,9 +327,9 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
             case JJTROUTINEINVOCATION_GEOOP_OVERLAP_NODE:
                 return buildBinarySpatialOperator(n.getType());
 
-                // ----------------------------------------
-                // Geometries:
-                // ----------------------------------------
+            // ----------------------------------------
+            // Geometries:
+            // ----------------------------------------
             case JJTPOINT_NODE:
                 return this.builder.buildCoordinate();
 
@@ -369,9 +369,9 @@ public class CQL2Compiler extends CQL2Parser implements org.geotools.filter.text
             case JJTFALSENODE:
                 return this.builder.buildFalseLiteral();
 
-                // ----------------------------------------
-                //  IN Predicate
-                // ----------------------------------------
+            // ----------------------------------------
+            //  IN Predicate
+            // ----------------------------------------
             case JJTIN_PREDICATE_NODE:
                 return this.builder.buildInPredicate(JJTEXPRESSION_IN_LIST_NODE);
 

--- a/modules/library/main/src/main/java/org/geotools/geometry/jts/JTS.java
+++ b/modules/library/main/src/main/java/org/geotools/geometry/jts/JTS.java
@@ -706,10 +706,10 @@ public final class JTS {
 
         while (!iterator.isDone()) {
             switch (iterator.currentSegment(buffer)) {
-                    /*
-                     * Close the polygon: the last point is equal to the first point, and a LinearRing is
-                     * created.
-                     */
+                /*
+                 * Close the polygon: the last point is equal to the first point, and a LinearRing is
+                 * created.
+                 */
                 case PathIterator.SEG_CLOSE: {
                     if (!coords.isEmpty()) {
                         coords.add(coords.get(0));
@@ -719,10 +719,10 @@ public final class JTS {
                     break;
                 }
 
-                    /*
-                     * General case: A LineString is created from previous points, and a new LineString
-                     * begin for next points.
-                     */
+                /*
+                 * General case: A LineString is created from previous points, and a new LineString
+                 * begin for next points.
+                 */
                 case PathIterator.SEG_MOVETO: {
                     if (!coords.isEmpty()) {
                         lines.add(factory.createLineString(coords.toArray(new Coordinate[coords.size()])));

--- a/modules/library/metadata/src/main/java/org/geotools/measure/AngleFormat.java
+++ b/modules/library/metadata/src/main/java/org/geotools/measure/AngleFormat.java
@@ -372,7 +372,7 @@ public class AngleFormat extends Format {
                     rounded = Math.round(scaledValue);
                     return rounded / scale;
 
-                    // Include impossible case to allow detection of new entries in RoundingMethod.
+                // Include impossible case to allow detection of new entries in RoundingMethod.
                 case ROUND_HALF_EVEN:
                     throw new AssertionError(rm);
             }
@@ -1001,48 +1001,48 @@ public class AngleFormat extends Format {
             boolean swapDM = true;
             BigBoss:
             switch (skipSuffix(source, pos, DEGREES_FIELD)) {
-                    /* ----------------------------------------------
-                     * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
-                     * ----------------------------------------------
-                     * Les degrés étaient suivit du préfix d'un autre angle. Le préfix sera donc
-                     * retourné dans le buffer pour un éventuel traitement par le prochain appel
-                     * à la méthode 'parse' et on n'ira pas plus loin dans l'analyse de la chaîne.
-                     */
+                /* ----------------------------------------------
+                 * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
+                 * ----------------------------------------------
+                 * Les degrés étaient suivit du préfix d'un autre angle. Le préfix sera donc
+                 * retourné dans le buffer pour un éventuel traitement par le prochain appel
+                 * à la méthode 'parse' et on n'ira pas plus loin dans l'analyse de la chaîne.
+                 */
                 case PREFIX_FIELD: {
                     pos.setIndex(indexEndField);
                     break BigBoss;
                 }
-                    /* ----------------------------------------------
-                     * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
-                     * ----------------------------------------------
-                     * On a trouvé le symbole des secondes au lieu de celui des degrés. On fait
-                     * la correction dans les variables 'degrés' et 'secondes' et on considère
-                     * que la lecture est terminée.
-                     */
+                /* ----------------------------------------------
+                 * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
+                 * ----------------------------------------------
+                 * On a trouvé le symbole des secondes au lieu de celui des degrés. On fait
+                 * la correction dans les variables 'degrés' et 'secondes' et on considère
+                 * que la lecture est terminée.
+                 */
                 case SECONDS_FIELD: {
                     secondes = degrees;
                     degrees = Double.NaN;
                     break BigBoss;
                 }
-                    /* ----------------------------------------------
-                     * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
-                     * ----------------------------------------------
-                     * Aucun symbole ne suit les degrés. Des minutes sont-elles attendues?
-                     * Si oui, on fera comme si le symbole des degrés avait été là. Sinon,
-                     * on considèrera que la lecture est terminée.
-                     */
+                /* ----------------------------------------------
+                 * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
+                 * ----------------------------------------------
+                 * Aucun symbole ne suit les degrés. Des minutes sont-elles attendues?
+                 * Si oui, on fera comme si le symbole des degrés avait été là. Sinon,
+                 * on considèrera que la lecture est terminée.
+                 */
                 default: {
                     if (width1 == 0) break BigBoss;
                     if (!spaceAsSeparator) break BigBoss;
                     // fall through
                 }
-                    /* ----------------------------------------------
-                     * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
-                     * ----------------------------------------------
-                     * Un symbole des degrés a été explicitement trouvé. Les degrés sont peut-être
-                     * suivit des minutes. On procèdera donc à la lecture du prochain nombre, puis
-                     * à l'analyse du symbole qui le suit.
-                     */
+                /* ----------------------------------------------
+                 * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
+                 * ----------------------------------------------
+                 * Un symbole des degrés a été explicitement trouvé. Les degrés sont peut-être
+                 * suivit des minutes. On procèdera donc à la lecture du prochain nombre, puis
+                 * à l'analyse du symbole qui le suit.
+                 */
                 case DEGREES_FIELD: {
                     final int indexStartField = index = pos.getIndex();
                     while (index < length && Character.isSpaceChar(source.charAt(index))) {
@@ -1060,57 +1060,57 @@ public class AngleFormat extends Format {
                     indexEndField = pos.getIndex();
                     minutes = fieldObject.doubleValue();
                     switch (skipSuffix(source, pos, width1 != 0 ? MINUTES_FIELD : PREFIX_FIELD)) {
-                            /* ------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
-                             * ------------------------------------------------
-                             * Le symbole trouvé est bel et bien celui des minutes.
-                             * On continuera le bloc pour tenter de lire les secondes.
-                             */
+                        /* ------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
+                         * ------------------------------------------------
+                         * Le symbole trouvé est bel et bien celui des minutes.
+                         * On continuera le bloc pour tenter de lire les secondes.
+                         */
                         case MINUTES_FIELD: {
                             break; // continue outer switch
                         }
-                            /* ------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
-                             * ------------------------------------------------
-                             * Un symbole des secondes a été trouvé au lieu du symbole des minutes
-                             * attendu. On fera la modification dans les variables 'secondes' et
-                             * 'minutes' et on considèrera la lecture terminée.
-                             */
+                        /* ------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
+                         * ------------------------------------------------
+                         * Un symbole des secondes a été trouvé au lieu du symbole des minutes
+                         * attendu. On fera la modification dans les variables 'secondes' et
+                         * 'minutes' et on considèrera la lecture terminée.
+                         */
                         case SECONDS_FIELD: {
                             secondes = minutes;
                             minutes = Double.NaN;
                             break BigBoss;
                         }
-                            /* ------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
-                             * ------------------------------------------------
-                             * Aucun symbole n'a été trouvé. Les minutes étaient-elles attendues?
-                             * Si oui, on les acceptera et on tentera de lire les secondes. Si non,
-                             * on retourne le texte lu dans le buffer et on termine la lecture.
-                             */
+                        /* ------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
+                         * ------------------------------------------------
+                         * Aucun symbole n'a été trouvé. Les minutes étaient-elles attendues?
+                         * Si oui, on les acceptera et on tentera de lire les secondes. Si non,
+                         * on retourne le texte lu dans le buffer et on termine la lecture.
+                         */
                         default: {
                             if (width1 != 0) break; // Continue outer switch
                             // fall through
                         }
-                            /* ------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
-                             * ------------------------------------------------
-                             * Au lieu des minutes, le symbole lu est celui des degrés. On considère
-                             * qu'il appartient au prochain angle. On retournera donc le texte lu dans
-                             * le buffer et on terminera la lecture.
-                             */
+                        /* ------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
+                         * ------------------------------------------------
+                         * Au lieu des minutes, le symbole lu est celui des degrés. On considère
+                         * qu'il appartient au prochain angle. On retournera donc le texte lu dans
+                         * le buffer et on terminera la lecture.
+                         */
                         case DEGREES_FIELD: {
                             pos.setIndex(indexStartField);
                             minutes = Double.NaN;
                             break BigBoss;
                         }
-                            /* ------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
-                             * ------------------------------------------------
-                             * Après les minutes (qu'on accepte), on a trouvé le préfix du prochain
-                             * angle à lire. On retourne ce préfix dans le buffer et on considère la
-                             * lecture terminée.
-                             */
+                        /* ------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES MINUTES
+                         * ------------------------------------------------
+                         * Après les minutes (qu'on accepte), on a trouvé le préfix du prochain
+                         * angle à lire. On retourne ce préfix dans le buffer et on considère la
+                         * lecture terminée.
+                         */
                         case PREFIX_FIELD: {
                             pos.setIndex(indexEndField);
                             break BigBoss;
@@ -1119,14 +1119,14 @@ public class AngleFormat extends Format {
                     swapDM = false;
                     // fall through
                 }
-                    /* ----------------------------------------------
-                     * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
-                     * ----------------------------------------------
-                     * Un symbole des minutes a été trouvé au lieu du symbole des degrés attendu.
-                     * On fera donc la modification dans les variables 'degrés' et 'minutes'. Ces
-                     * minutes sont peut-être suivies des secondes. On tentera donc de lire le
-                     * prochain nombre.
-                     */
+                /* ----------------------------------------------
+                 * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉS DEGRÉS
+                 * ----------------------------------------------
+                 * Un symbole des minutes a été trouvé au lieu du symbole des degrés attendu.
+                 * On fera donc la modification dans les variables 'degrés' et 'minutes'. Ces
+                 * minutes sont peut-être suivies des secondes. On tentera donc de lire le
+                 * prochain nombre.
+                 */
                 case MINUTES_FIELD: {
                     if (swapDM) {
                         minutes = degrees;
@@ -1148,44 +1148,44 @@ public class AngleFormat extends Format {
                     indexEndField = pos.getIndex();
                     secondes = fieldObject.doubleValue();
                     switch (skipSuffix(source, pos, width2 != 0 ? MINUTES_FIELD : PREFIX_FIELD)) {
-                            /* -------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES SECONDES
-                             * -------------------------------------------------
-                             * Un symbole des secondes explicite a été trouvée.
-                             * La lecture est donc terminée.
-                             */
+                        /* -------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES SECONDES
+                         * -------------------------------------------------
+                         * Un symbole des secondes explicite a été trouvée.
+                         * La lecture est donc terminée.
+                         */
                         case SECONDS_FIELD: {
                             break;
                         }
-                            /* -------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES SECONDES
-                             * -------------------------------------------------
-                             * Aucun symbole n'a été trouvée. Attendait-on des secondes? Si oui, les
-                             * secondes seront acceptées. Sinon, elles seront retournées au buffer.
-                             */
+                        /* -------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES SECONDES
+                         * -------------------------------------------------
+                         * Aucun symbole n'a été trouvée. Attendait-on des secondes? Si oui, les
+                         * secondes seront acceptées. Sinon, elles seront retournées au buffer.
+                         */
                         default: {
                             if (width2 != 0) break;
                             // fall through
                         }
-                            /* -------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES SECONDES
-                             * -------------------------------------------------
-                             * Au lieu des degrés, on a trouvé un symbole des minutes ou des
-                             * secondes. On renvoie donc le nombre et son symbole dans le buffer.
-                             */
+                        /* -------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES SECONDES
+                         * -------------------------------------------------
+                         * Au lieu des degrés, on a trouvé un symbole des minutes ou des
+                         * secondes. On renvoie donc le nombre et son symbole dans le buffer.
+                         */
                         case MINUTES_FIELD:
                         case DEGREES_FIELD: {
                             pos.setIndex(indexStartField);
                             secondes = Double.NaN;
                             break;
                         }
-                            /* -------------------------------------------------
-                             * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES SECONDES
-                             * -------------------------------------------------
-                             * Après les secondes (qu'on accepte), on a trouvé le préfix du prochain
-                             * angle à lire. On retourne ce préfix dans le buffer et on considère la
-                             * lecture terminée.
-                             */
+                        /* -------------------------------------------------
+                         * ANALYSE DU SYMBOLE SUIVANT LES PRÉSUMÉES SECONDES
+                         * -------------------------------------------------
+                         * Après les secondes (qu'on accepte), on a trouvé le préfix du prochain
+                         * angle à lire. On retourne ce préfix dans le buffer et on considère la
+                         * lecture terminée.
+                         */
                         case PREFIX_FIELD: {
                             pos.setIndex(indexEndField);
                             break BigBoss;

--- a/modules/library/metadata/src/main/java/org/geotools/util/DateTimeParser.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/DateTimeParser.java
@@ -560,7 +560,7 @@ public class DateTimeParser {
                     case 'W':
                         factor = 7 * MILLIS_IN_DAY;
                         break;
-                        // TODO: handle months in a better way than just taking the average length.
+                    // TODO: handle months in a better way than just taking the average length.
                     case 'M':
                         factor = 30 * MILLIS_IN_DAY;
                         break;

--- a/modules/library/metadata/src/main/java/org/geotools/util/IndexedResourceCompiler.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/IndexedResourceCompiler.java
@@ -275,12 +275,12 @@ public final class IndexedResourceCompiler implements Comparator<Object> {
         search:
         for (int i = 0; i < buffer.length(); i++) { // Length of 'buffer' will vary.
             switch (buffer.charAt(i)) {
-                    /*
-                     * Left and right braces take us up or down a level.  Quotes will only be doubled
-                     * if we are at level 0.  If the brace is between quotes it will not be taken into
-                     * account as it will have been skipped over during the previous pass through the
-                     * loop.
-                     */
+                /*
+                 * Left and right braces take us up or down a level.  Quotes will only be doubled
+                 * if we are at level 0.  If the brace is between quotes it will not be taken into
+                 * account as it will have been skipped over during the previous pass through the
+                 * loop.
+                 */
                 case '{':
                     level++;
                     last = i;

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/FactoryRegistry.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/FactoryRegistry.java
@@ -741,7 +741,7 @@ public class FactoryRegistry {
                     case 3:
                         loader = ClassLoader.getSystemClassLoader();
                         break;
-                        // Add any supplementary class loaders here, if needed.
+                    // Add any supplementary class loaders here, if needed.
                     default:
                         throw new AssertionError(i); // Should never happen.
                 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/AbstractIdentifiedObject.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/AbstractIdentifiedObject.java
@@ -341,8 +341,8 @@ public class AbstractIdentifiedObject extends Formattable implements IdentifiedO
              *       so it should not change across implementations.
              */
             switch (key.hashCode()) {
-                    // Fix case for common keywords. They are not used
-                    // by this class, but are used by some subclasses.
+                // Fix case for common keywords. They are not used
+                // by this class, but are used by some subclasses.
                 case -1528693765:
                     if (key.equalsIgnoreCase("anchorPoint")) key = "anchorPoint";
                     break;
@@ -368,9 +368,9 @@ public class AbstractIdentifiedObject extends Formattable implements IdentifiedO
                     if (key.equalsIgnoreCase("validArea")) key = "validArea";
                     break;
 
-                    // -------------------------------------
-                    // "name": String or ReferenceIdentifier
-                    // -------------------------------------
+                // -------------------------------------
+                // "name": String or ReferenceIdentifier
+                // -------------------------------------
                 case 3373707: {
                     if (key.equals(NAME_KEY)) {
                         if (value instanceof String) {
@@ -387,9 +387,9 @@ public class AbstractIdentifiedObject extends Formattable implements IdentifiedO
                     }
                     break;
                 }
-                    // -------------------------------------------------------
-                    // "alias": String, String[], GenericName or GenericName[]
-                    // -------------------------------------------------------
+                // -------------------------------------------------------
+                // "alias": String, String[], GenericName or GenericName[]
+                // -------------------------------------------------------
                 case 92902992: {
                     if (key.equals(ALIAS_KEY)) {
                         alias = NameFactory.toArray(value);
@@ -397,9 +397,9 @@ public class AbstractIdentifiedObject extends Formattable implements IdentifiedO
                     }
                     break;
                 }
-                    // -----------------------------------------------------------
-                    // "identifiers": ReferenceIdentifier or ReferenceIdentifier[]
-                    // -----------------------------------------------------------
+                // -----------------------------------------------------------
+                // "identifiers": ReferenceIdentifier or ReferenceIdentifier[]
+                // -----------------------------------------------------------
                 case 1368189162: {
                     if (key.equals(IDENTIFIERS_KEY)) {
                         if (value != null) {
@@ -413,9 +413,9 @@ public class AbstractIdentifiedObject extends Formattable implements IdentifiedO
                     }
                     break;
                 }
-                    // ----------------------------------------
-                    // "remarks": String or InternationalString
-                    // ----------------------------------------
+                // ----------------------------------------
+                // "remarks": String or InternationalString
+                // ----------------------------------------
                 case 1091415283: {
                     if (key.equals(REMARKS_KEY)) {
                         if (value instanceof InternationalString) {

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/AbstractEpsgFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/AbstractEpsgFactory.java
@@ -2952,7 +2952,7 @@ public abstract class AbstractEpsgFactory extends AbstractCachedAuthorityFactory
                 return MICRORADIAN;
             case 9110:
                 return SEXAGESIMAL_DMS;
-                // TODO case 9111: return NonSI.SEXAGESIMAL_DM;
+            // TODO case 9111: return NonSI.SEXAGESIMAL_DM;
             case 9203: // Fall through
             case 9201:
                 return ONE;

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/DirectEpsgFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/DirectEpsgFactory.java
@@ -259,8 +259,8 @@ public abstract class DirectEpsgFactory extends DirectAuthorityFactory
                 return NonSI.SECOND_ANGLE;
             case 9105:
                 return USCustomary.GRADE;
-                // DMS is a way to format information but not a real unit, decode towards DEGREE
-                // instead
+            // DMS is a way to format information but not a real unit, decode towards DEGREE
+            // instead
             case 9107:
                 return NonSI.DEGREE_ANGLE; // return Units.DEGREE_MINUTE_SECOND;
             case 9108:
@@ -269,7 +269,7 @@ public abstract class DirectEpsgFactory extends DirectAuthorityFactory
                 return MetricPrefix.MICRO(SI.RADIAN);
             case 9110:
                 return Units.SEXAGESIMAL_DMS;
-                // TODO case 9111: return NonSI.SEXAGESIMAL_DM;
+            // TODO case 9111: return NonSI.SEXAGESIMAL_DM;
             case 9203: // Fall through
             case 9201:
                 return AbstractUnit.ONE;

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StyledShapePainter.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StyledShapePainter.java
@@ -543,7 +543,7 @@ public class StyledShapePainter {
                                 + coords[1]);
                     }
 
-                    // no break here - fall through to next section
+                // no break here - fall through to next section
                 case PathIterator.SEG_LINETO:
 
                     // draw from previous to coords

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/RasterSymbolizerHelper.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/RasterSymbolizerHelper.java
@@ -112,8 +112,8 @@ public class RasterSymbolizerHelper extends SubchainStyleVisitorCoverageProcessi
         // TODO should we go to component color model also?
         // TODO use ImageN TOOLS statistics and ignore no data properly.
         switch (dataType) {
-                // in case the original image has a USHORT pixel type without being associated
-                // with an index color model I would still go to 8 bits
+            // in case the original image has a USHORT pixel type without being associated
+            // with an index color model I would still go to 8 bits
             case DataBuffer.TYPE_USHORT:
                 if (outputImage.getColorModel() instanceof IndexColorModel) {
                     break;

--- a/modules/library/xml/src/main/java/org/geotools/xml/DocumentWriter.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/DocumentWriter.java
@@ -1122,13 +1122,13 @@ public class DocumentWriter {
         // Simplecontent to match
         if (egs != null) {
             switch (egs.getGrouping()) {
-                    // TODO determine if this will work
-                    //                    	case ElementGrouping.COMPLEXCONTENT:
-                    //                    	    writeAny((ComplexContent)egs,schema,ph,hints);
-                    //                    	    break;
-                    //                    	case ElementGrouping.SIMPLECONTENT:
-                    //                    	    writeAny((SimpleContent)egs,schema,ph,hints);
-                    //                    	    break;
+                // TODO determine if this will work
+                //                    	case ElementGrouping.COMPLEXCONTENT:
+                //                    	    writeAny((ComplexContent)egs,schema,ph,hints);
+                //                    	    break;
+                //                    	case ElementGrouping.SIMPLECONTENT:
+                //                    	    writeAny((SimpleContent)egs,schema,ph,hints);
+                //                    	    break;
                 case ElementGrouping.ALL:
                     writeAll((All) egs, schema, ph, hints);
 

--- a/modules/library/xml/src/main/java/org/geotools/xml/filter/FilterOpsComplexTypes.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/filter/FilterOpsComplexTypes.java
@@ -146,7 +146,7 @@ public class FilterOpsComplexTypes {
         int i = 0;
 
         switch (Filters.getExpressionType(expr)) {
-                /* Types implemented by ExpressionLiteral */
+            /* Types implemented by ExpressionLiteral */
             case org.geotools.filter.ExpressionType.LITERAL_DOUBLE:
             case org.geotools.filter.ExpressionType.LITERAL_INTEGER:
             case org.geotools.filter.ExpressionType.LITERAL_STRING:
@@ -156,7 +156,7 @@ public class FilterOpsComplexTypes {
 
                 break;
 
-                /* Types implemented by ExpressionMath. */
+            /* Types implemented by ExpressionMath. */
             case org.geotools.filter.ExpressionType.MATH_ADD:
                 i = 29;
 
@@ -177,9 +177,9 @@ public class FilterOpsComplexTypes {
 
                 break;
 
-                /* Types implemented by ExpressionAttribute. */
+            /* Types implemented by ExpressionAttribute. */
 
-                /** Defines an attribute expression with a declared double type. */
+            /** Defines an attribute expression with a declared double type. */
             case org.geotools.filter.ExpressionType.ATTRIBUTE_DOUBLE:
             case org.geotools.filter.ExpressionType.ATTRIBUTE_INTEGER:
             case org.geotools.filter.ExpressionType.ATTRIBUTE_STRING:

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/dbf/DbaseFileReader.java
@@ -466,7 +466,7 @@ public class DbaseFileReader implements FileReader, Closeable {
         Object object = null;
         if (fieldLen > 0) {
             switch (type) {
-                    // (L)logical (T,t,F,f,Y,y,N,n)
+                // (L)logical (T,t,F,f,Y,y,N,n)
                 case 'l':
                 case 'L':
                     final char c = (char) bytes[fieldOffset];
@@ -489,7 +489,7 @@ public class DbaseFileReader implements FileReader, Closeable {
                             object = null;
                     }
                     break;
-                    // (C)character (String)
+                // (C)character (String)
                 case 'c':
                 case 'C':
                     // if the string begins with a null terminator, the value is null
@@ -502,7 +502,7 @@ public class DbaseFileReader implements FileReader, Closeable {
                         }
                     }
                     break;
-                    // (D)date (Date)
+                // (D)date (Date)
                 case 'd':
                 case 'D':
                     // If the first 8 characters are '0', this is a null date
@@ -527,7 +527,7 @@ public class DbaseFileReader implements FileReader, Closeable {
                         }
                     }
                     break;
-                    // (@) Timestamp (Date)
+                // (@) Timestamp (Date)
                 case '@':
                     try {
                         // TODO: Find a smarter way to do this.
@@ -554,7 +554,7 @@ public class DbaseFileReader implements FileReader, Closeable {
                         // todo: use progresslistener, this isn't a grave error.
                     }
                     break;
-                    // (N)umeric (Integer, Long or Fallthrough to Double)
+                // (N)umeric (Integer, Long or Fallthrough to Double)
                 case 'n':
                 case 'N':
                     // numbers that begin with '*' are considered null
@@ -582,9 +582,9 @@ public class DbaseFileReader implements FileReader, Closeable {
                             }
                         }
                     }
-                    // do not break, fall through to the 'f' case
+                // do not break, fall through to the 'f' case
 
-                    // (F)loating point number
+                // (F)loating point number
                 case 'f':
                 case 'F':
                     if (bytes[fieldOffset] != '*') {

--- a/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/FeatureConversions.java
+++ b/modules/unsupported/flatgeobuf/src/main/java/org/geotools/data/flatgeobuf/FeatureConversions.java
@@ -205,8 +205,9 @@ public class FeatureConversions {
                 }
 
                 case ColumnType.String -> writeString(target, (String) value);
-                default -> throw new RuntimeException(
-                        "Cannot handle type " + value.getClass().getName());
+                default ->
+                    throw new RuntimeException(
+                            "Cannot handle type " + value.getClass().getName());
             }
         }
     }

--- a/modules/unsupported/ogr/ogr-jni/src/main/java/org/geotools/data/ogr/jni/JniOGR.java
+++ b/modules/unsupported/ogr/ogr-jni/src/main/java/org/geotools/data/ogr/jni/JniOGR.java
@@ -165,8 +165,8 @@ public class JniOGR implements OGR {
                 throw new IOException("OGR reported a currupt data error: " + error);
             case OGRERR_FAILURE:
                 throw new IOException("OGR reported a generic failure: " + error);
-                // case OGRERR_INVALID_HANDLE:
-                //    throw new IOException("OGR reported an invalid handle error: " + error);
+            // case OGRERR_INVALID_HANDLE:
+            //    throw new IOException("OGR reported an invalid handle error: " + error);
             case OGRERR_NOT_ENOUGH_DATA:
                 throw new IOException("OGR reported not enough data was provided in the last call: " + error);
             case OGRERR_NOT_ENOUGH_MEMORY:

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
@@ -619,8 +619,9 @@ public class VectorTilesFeatureSource extends ContentFeatureSource {
             case "String" -> String.class;
             case "Boolean" -> Boolean.class;
             case "Number" -> Double.class;
-            default -> throw new UnsupportedOperationException(
-                    "Unable to map field type %s to a Class binding".formatted(fieldType));
+            default ->
+                throw new UnsupportedOperationException(
+                        "Unable to map field type %s to a Class binding".formatted(fieldType));
         };
     }
 

--- a/modules/unsupported/vpf/src/main/java/org/geotools/data/vpf/VPFColumn.java
+++ b/modules/unsupported/vpf/src/main/java/org/geotools/data/vpf/VPFColumn.java
@@ -155,10 +155,10 @@ public class VPFColumn {
 
                 break;
 
-                // Short integers are usually coded values
+            // Short integers are usually coded values
             case DATA_SHORT_INTEGER:
                 attemptLookup = true;
-                // Fall through
+            // Fall through
             case DATA_TEXT:
             case DATA_NULL_FIELD:
             case DATA_LEVEL1_TEXT:

--- a/modules/unsupported/vpf/src/main/java/org/geotools/data/vpf/util/DataUtils.java
+++ b/modules/unsupported/vpf/src/main/java/org/geotools/data/vpf/util/DataUtils.java
@@ -104,104 +104,104 @@ public class DataUtils implements DataTypesDefinition {
                 break;
 
             case DATA_2_COORD_F:
-                //        {
-                //            // I doubt this is being used
-                //          float[][] coords = new float[bytes.length / DATA_2_COORD_F_LEN][2];
-                //          byte[] floatData = new byte[DATA_SHORT_FLOAT_LEN];
-                //
-                //          for (int i = 0; i < coords.length; i++) {
-                //              copyArrays(floatData, bytes, i * DATA_2_COORD_F_LEN);
-                //              coords[i][0] = decodeFloat(floatData);
-                //              copyArrays(floatData, bytes, i * (DATA_2_COORD_F_LEN + 1));
-                //              coords[i][1] = decodeFloat(floatData);
-                //          }
-                //          DirectPosition[] coords = new DirectPosition2D[bytes.length /
-                // DATA_2_COORD_F_LEN];
-                //          double xval, yval;
-                //          byte[] floatData = new byte[DATA_SHORT_FLOAT_LEN];
-                //
-                //          for (int i = 0; i < coords.length; i++) {
-                //              copyArrays(floatData, bytes, i * DATA_2_COORD_F_LEN);
-                //              xval = decodeFloat(floatData);
-                //              copyArrays(floatData, bytes, i * (DATA_2_COORD_F_LEN + 1));
-                //              yval = decodeFloat(floatData);
-                //              coords[i] = new DirectPosition2D(xval, yval);
-                //          }
+            //        {
+            //            // I doubt this is being used
+            //          float[][] coords = new float[bytes.length / DATA_2_COORD_F_LEN][2];
+            //          byte[] floatData = new byte[DATA_SHORT_FLOAT_LEN];
+            //
+            //          for (int i = 0; i < coords.length; i++) {
+            //              copyArrays(floatData, bytes, i * DATA_2_COORD_F_LEN);
+            //              coords[i][0] = decodeFloat(floatData);
+            //              copyArrays(floatData, bytes, i * (DATA_2_COORD_F_LEN + 1));
+            //              coords[i][1] = decodeFloat(floatData);
+            //          }
+            //          DirectPosition[] coords = new DirectPosition2D[bytes.length /
+            // DATA_2_COORD_F_LEN];
+            //          double xval, yval;
+            //          byte[] floatData = new byte[DATA_SHORT_FLOAT_LEN];
+            //
+            //          for (int i = 0; i < coords.length; i++) {
+            //              copyArrays(floatData, bytes, i * DATA_2_COORD_F_LEN);
+            //              xval = decodeFloat(floatData);
+            //              copyArrays(floatData, bytes, i * (DATA_2_COORD_F_LEN + 1));
+            //              yval = decodeFloat(floatData);
+            //              coords[i] = new DirectPosition2D(xval, yval);
+            //          }
 
-                //          result = coords;
-                //            result = new Coordinate2DFloat(coords);
-                //        }
-                //
-                //        break;
+            //          result = coords;
+            //            result = new Coordinate2DFloat(coords);
+            //        }
+            //
+            //        break;
 
             case DATA_2_COORD_R:
-                //        {
-                // I doubt this is being used
-                //            DirectPosition[] coords = new DirectPosition2D[bytes.length /
-                // DATA_2_COORD_R_LEN];
-                //            double xval, yval;
-                //            byte[] doubleData = new byte[DATA_LONG_FLOAT_LEN];
-                //
-                //            for (int i = 0; i < coords.length; i++) {
-                //                copyArrays(doubleData, bytes, i * DATA_2_COORD_R_LEN);
-                //                xval = decodeDouble(doubleData);
-                //                copyArrays(doubleData, bytes, i * (DATA_2_COORD_R_LEN + 1));
-                //                yval = decodeDouble(doubleData);
-                //                coords[i] = new DirectPosition2D(xval, yval);
-                //            }
-                //
-                //            result = coords;
-                //            double[][] coords = new double[bytes.length / DATA_2_COORD_R_LEN][2];
-                //            byte[] doubleData = new byte[DATA_LONG_FLOAT_LEN];
-                //
-                //            for (int i = 0; i < coords.length; i++) {
-                //                copyArrays(doubleData, bytes, i * DATA_2_COORD_R_LEN);
-                //                coords[i][0] = decodeDouble(doubleData);
-                //                copyArrays(doubleData, bytes, i * (DATA_2_COORD_R_LEN + 1));
-                //                coords[i][1] = decodeDouble(doubleData);
-                //            }
-                //
-                //            result = new Coordinate2DDouble(coords);
-                //        }
-                //
-                //        break;
-                //
+            //        {
+            // I doubt this is being used
+            //            DirectPosition[] coords = new DirectPosition2D[bytes.length /
+            // DATA_2_COORD_R_LEN];
+            //            double xval, yval;
+            //            byte[] doubleData = new byte[DATA_LONG_FLOAT_LEN];
+            //
+            //            for (int i = 0; i < coords.length; i++) {
+            //                copyArrays(doubleData, bytes, i * DATA_2_COORD_R_LEN);
+            //                xval = decodeDouble(doubleData);
+            //                copyArrays(doubleData, bytes, i * (DATA_2_COORD_R_LEN + 1));
+            //                yval = decodeDouble(doubleData);
+            //                coords[i] = new DirectPosition2D(xval, yval);
+            //            }
+            //
+            //            result = coords;
+            //            double[][] coords = new double[bytes.length / DATA_2_COORD_R_LEN][2];
+            //            byte[] doubleData = new byte[DATA_LONG_FLOAT_LEN];
+            //
+            //            for (int i = 0; i < coords.length; i++) {
+            //                copyArrays(doubleData, bytes, i * DATA_2_COORD_R_LEN);
+            //                coords[i][0] = decodeDouble(doubleData);
+            //                copyArrays(doubleData, bytes, i * (DATA_2_COORD_R_LEN + 1));
+            //                coords[i][1] = decodeDouble(doubleData);
+            //            }
+            //
+            //            result = new Coordinate2DDouble(coords);
+            //        }
+            //
+            //        break;
+            //
             case DATA_3_COORD_F:
-                //        {
-                // I doubt this is being used
-                //            DirectPosition[] coords = new DirectPosition2D[bytes.length /
-                // DATA_2_COORD_R_LEN];
-                //            double xval, yval, zval;
-                //            byte[] floatData = new byte[DATA_SHORT_FLOAT_LEN];
-                //
-                //            for (int i = 0; i < coords.length; i++) {
-                //                copyArrays(floatData, bytes, i * DATA_3_COORD_F_LEN);
-                //                xval = decodeFloat(floatData);
-                //                copyArrays(floatData, bytes, i * (DATA_3_COORD_F_LEN + 1));
-                //                yval = decodeFloat(floatData);
-                //                copyArrays(floatData, bytes, i * (DATA_3_COORD_F_LEN + 2));
-                //                zval = decodeFloat(floatData);
-                //                coords[i] = new GeneralDirectPosition(xval, yval, zval);
-                //            }
-                //
-                //            result = coords;
-                //            float[][] coords = new float[bytes.length / DATA_3_COORD_F_LEN][3];
-                //            byte[] floatData = new byte[DATA_SHORT_FLOAT_LEN];
-                //
-                //            for (int i = 0; i < coords.length; i++) {
-                //                copyArrays(floatData, bytes, i * DATA_3_COORD_F_LEN);
-                //                coords[i][0] = decodeFloat(floatData);
-                //                copyArrays(floatData, bytes, i * (DATA_3_COORD_F_LEN + 1));
-                //                coords[i][1] = decodeFloat(floatData);
-                //                copyArrays(floatData, bytes, i * (DATA_3_COORD_F_LEN + 2));
-                //                coords[i][2] = decodeFloat(floatData);
-                //            }
-                //
-                //            result = new Coordinate3DFloat(coords);
-                //        }
-                //
-                //        break;
-                //
+            //        {
+            // I doubt this is being used
+            //            DirectPosition[] coords = new DirectPosition2D[bytes.length /
+            // DATA_2_COORD_R_LEN];
+            //            double xval, yval, zval;
+            //            byte[] floatData = new byte[DATA_SHORT_FLOAT_LEN];
+            //
+            //            for (int i = 0; i < coords.length; i++) {
+            //                copyArrays(floatData, bytes, i * DATA_3_COORD_F_LEN);
+            //                xval = decodeFloat(floatData);
+            //                copyArrays(floatData, bytes, i * (DATA_3_COORD_F_LEN + 1));
+            //                yval = decodeFloat(floatData);
+            //                copyArrays(floatData, bytes, i * (DATA_3_COORD_F_LEN + 2));
+            //                zval = decodeFloat(floatData);
+            //                coords[i] = new GeneralDirectPosition(xval, yval, zval);
+            //            }
+            //
+            //            result = coords;
+            //            float[][] coords = new float[bytes.length / DATA_3_COORD_F_LEN][3];
+            //            byte[] floatData = new byte[DATA_SHORT_FLOAT_LEN];
+            //
+            //            for (int i = 0; i < coords.length; i++) {
+            //                copyArrays(floatData, bytes, i * DATA_3_COORD_F_LEN);
+            //                coords[i][0] = decodeFloat(floatData);
+            //                copyArrays(floatData, bytes, i * (DATA_3_COORD_F_LEN + 1));
+            //                coords[i][1] = decodeFloat(floatData);
+            //                copyArrays(floatData, bytes, i * (DATA_3_COORD_F_LEN + 2));
+            //                coords[i][2] = decodeFloat(floatData);
+            //            }
+            //
+            //            result = new Coordinate3DFloat(coords);
+            //        }
+            //
+            //        break;
+            //
             case DATA_3_COORD_R:
             //        {
             // I doubt this is being used

--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
     <series>latest</series>
     <!-- test dependency management. For compile dependency management look at platform-dependencies/pom.xml -->
     <hamcrest.version>3.0</hamcrest.version>
-    <mockito.version>5.15.2</mockito.version>
+    <mockito.version>5.20.0</mockito.version>
     <!-- javadoc configuration -->
     <javadoc.maxHeapSize>1536M</javadoc.maxHeapSize>
     <!-- surefire configuration -->
@@ -566,7 +566,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>5.5.0</version>
+        <version>5.6.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -808,7 +808,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.43.0</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -1312,7 +1312,7 @@
         <configuration>
           <java>
             <palantirJavaFormat>
-              <version>2.50.0</version>
+              <version>2.74.0</version>
               <formatJavadoc>true</formatJavadoc>
             </palantirJavaFormat>
           </java>


### PR DESCRIPTION
Adds java 25 to the list of builds, updates some libraries to support java 25 (build tools bytecode manipulation)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->