### PR TITLE
Update shapefile invalid shapefile HTTP URL

### DIFF
--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShpFilesStreamTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShpFilesStreamTest.java
@@ -47,6 +47,10 @@ import org.junit.Test;
 
 public class ShpFilesStreamTest implements org.geotools.data.shapefile.files.FileWriter {
 
+    // The URL used to test the invalid URL handling. The old fake domain is not fake any longer,
+    // this is a replacement that minimizes the chances of a server actually being present (high edge of
+    // the ephemeral port range).
+    private static final String INVALID_URI = "http://127.0.0.1:65534/blah.shp";
     private String typeName;
     private Map<ShpFileType, File> map;
     private ShpFiles files;
@@ -93,7 +97,7 @@ public class ShpFilesStreamTest implements org.geotools.data.shapefile.files.Fil
 
     @Test
     public void testExceptionGetInputStream() throws Exception {
-        ShpFiles shpFiles = new ShpFiles(new URL("http://blah/blah.shp"));
+        ShpFiles shpFiles = new ShpFiles(new URL(INVALID_URI));
         try {
             shpFiles.getInputStream(SHP, this);
             fail("maybe test is bad?  We want an exception here");
@@ -104,7 +108,7 @@ public class ShpFilesStreamTest implements org.geotools.data.shapefile.files.Fil
 
     @Test
     public void testExceptionGetOutputStream() throws Exception {
-        ShpFiles shpFiles = new ShpFiles(new URL("http://blah/blah.shp"));
+        ShpFiles shpFiles = new ShpFiles(new URL(INVALID_URI));
         try {
             shpFiles.getOutputStream(SHP, this);
             fail("maybe test is bad?  We want an exception here");
@@ -115,7 +119,7 @@ public class ShpFilesStreamTest implements org.geotools.data.shapefile.files.Fil
 
     @Test
     public void testExceptionGetWriteChannel() throws Exception {
-        ShpFiles shpFiles = new ShpFiles(new URL("http://blah/blah.shp"));
+        ShpFiles shpFiles = new ShpFiles(new URL(INVALID_URI));
         try {
             shpFiles.getWriteChannel(SHP, this);
             fail("maybe test is bad?  We want an exception here");
@@ -126,7 +130,7 @@ public class ShpFilesStreamTest implements org.geotools.data.shapefile.files.Fil
 
     @Test
     public void testExceptionGetReadChannel() throws Exception {
-        ShpFiles shpFiles = new ShpFiles(new URL("http://blah/blah.shp"));
+        ShpFiles shpFiles = new ShpFiles(new URL(INVALID_URI));
         try {
             shpFiles.getReadChannel(SHP, this);
             fail("maybe test is bad?  We want an exception here");


### PR DESCRIPTION
The "blah" host started replying on my network, breaking the test assumption. Switching to a differen URL that should be more under our control and very unlike to have something running on it.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->