### PR TITLE
[GEOT-4962]: Fix Coordinate Frame Rotation transforms [WIP]

### DIFF
--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/AbstractEpsgFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/AbstractEpsgFactory.java
@@ -1271,7 +1271,7 @@ public abstract class AbstractEpsgFactory extends AbstractCachedAuthorityFactory
                 // except for the sign of rotation parameters.
                 parameters.ex = -parameters.ex;
                 parameters.ey = -parameters.ey;
-                parameters.ey = -parameters.ey;
+                parameters.ez = -parameters.ez;
             }
             bwInfos.set(i, parameters);
         }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/DirectEpsgFactory.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/factory/epsg/DirectEpsgFactory.java
@@ -1580,7 +1580,7 @@ public abstract class DirectEpsgFactory extends DirectAuthorityFactory
                 // except for the sign of rotation parameters.
                 parameters.ex = -parameters.ex;
                 parameters.ey = -parameters.ey;
-                parameters.ey = -parameters.ey;
+                parameters.ez = -parameters.ez;
             }
             bwInfos.set(i, parameters);
         }


### PR DESCRIPTION
[![GEOT-4962](https://badgen.net/badge/JIRA/GEOT-4962/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-4962) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This PR is a fix for Coordinate Frame Rotation transforms used when projecting e.g. EPSG:4326 to EPSG:31254 (+ other Austrian CRSs) or EPSG:5018 (Lisbon/Portugal), as mentioned in https://discourse.osgeo.org/t/wms-austria-crs-reprojection-issues/152519. This seems to be the underlying cause of issues [GEOT-4962](https://osgeo-org.atlassian.net/browse/GEOT-4962), [GEOT-7417](https://osgeo-org.atlassian.net/browse/GEOT-7417) and possibly others. 

Summary of the downstream issue, as seen in GeoServer:

<img width="1917" height="805" alt="image" src="https://github.com/user-attachments/assets/6d2c1a0a-15f2-4c95-817e-3786cf98acb9" />


The problem seems to be a copy/paste error made in a couple of places. `GeocentricTranslation.java` seems right:
```java
if (info.method == ROTATION_FRAME_CODE) {
    // Coordinate frame rotation (9607): same as 9606,
    // except for the sign of rotation parameters.
    parameters.ex = -parameters.ex;
    parameters.ey = -parameters.ey;
    parameters.ez = -parameters.ez;
}
```
Whereas the classes changed in this PR were:
```java
if (info.method == ROTATION_FRAME_CODE) {
    // Coordinate frame rotation (9607): same as 9606,
    // except for the sign of rotation parameters.
    parameters.ex = -parameters.ex;
    parameters.ey = -parameters.ey;
   parameters.ey = -parameters.ey;
}
```
(see the repeated `ey` line, negating it again, effectively a NOOP)

WIP: This is currently untested.
Open question: In the downstream example above, ex is flipped, whereas ey and ez are fine - does this mean there's some additional flipping to counter this that would need to be rolled back?
 
Credit: @mattyfromtheblock did pretty much all the work to figure this out.
  
# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 