### PR TITLE
[GEOT-7931] Partial Revert of GEOT-7415: Revert MultiSurface Schema binding class to MultiPolygon

### DIFF
--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/GMLSchema.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/GMLSchema.java
@@ -35,10 +35,10 @@ import org.geotools.feature.type.ProfileImpl;
 import org.geotools.feature.type.SchemaImpl;
 import org.geotools.geometry.jts.CurvedGeometry;
 import org.geotools.geometry.jts.MultiCurvedGeometry;
-import org.geotools.geometry.jts.MultiSurface;
 import org.geotools.gml3.smil.SMIL20LANGSchema;
 import org.geotools.xlink.XLINKSchema;
 import org.geotools.xs.XSSchema;
+import org.locationtech.jts.geom.MultiPolygon;
 
 public class GMLSchema extends SchemaImpl {
 
@@ -8312,7 +8312,7 @@ public class GMLSchema extends SchemaImpl {
     private static AttributeType build_MULTISURFACETYPE_TYPE() {
         AttributeType builtType = new AttributeTypeImpl(
                 new NameImpl("http://www.opengis.net/gml", "MultiSurfaceType"),
-                MultiSurface.class,
+                MultiPolygon.class,
                 false,
                 false,
                 Collections.emptyList(),
@@ -9550,7 +9550,7 @@ public class GMLSchema extends SchemaImpl {
     private static AttributeType build_MULTISURFACEPROPERTYTYPE_TYPE() {
         AttributeType builtType = new AttributeTypeImpl(
                 new NameImpl("http://www.opengis.net/gml", "MultiSurfacePropertyType"),
-                MultiSurface.class,
+                MultiPolygon.class,
                 false,
                 false,
                 Collections.emptyList(),

--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/MultiSurfaceTypeBinding.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/MultiSurfaceTypeBinding.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.geotools.geometry.jts.CurvedGeometryFactory;
-import org.geotools.geometry.jts.MultiSurface;
 import org.geotools.gml3.ArcParameters;
 import org.geotools.gml3.GML;
 import org.geotools.xsd.AbstractComplexBinding;
@@ -93,7 +92,7 @@ public class MultiSurfaceTypeBinding extends AbstractComplexBinding {
      */
     @Override
     public Class getType() {
-        return MultiSurface.class;
+        return MultiPolygon.class;
     }
 
     @Override

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiSurfaceTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiSurfaceTypeBindingTest.java
@@ -67,7 +67,7 @@ public class MultiSurfaceTypeBindingTest extends GML3TestSupport {
     }
 
     @Test
-    public void testIsMultiPologynType() {
+    public void testIsMultiPolygonType() {
         Assert.assertEquals(MultiPolygon.class, GMLSchema.MULTISURFACETYPE_TYPE.getBinding());
     }
 }

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiSurfaceTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/MultiSurfaceTypeBindingTest.java
@@ -25,6 +25,7 @@ import org.geotools.gml3.GMLSchema;
 import org.junit.Assert;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.MultiPolygon;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
@@ -63,5 +64,10 @@ public class MultiSurfaceTypeBindingTest extends GML3TestSupport {
     @Test
     public void testMultiSurfaceTypeAssignable() {
         Assert.assertTrue(GMLSchema.MULTISURFACETYPE_TYPE.getBinding().isAssignableFrom(MultiSurface.class));
+    }
+
+    @Test
+    public void testIsMultiPologynType() {
+        Assert.assertEquals(MultiPolygon.class, GMLSchema.MULTISURFACETYPE_TYPE.getBinding());
     }
 }


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-11373

As part of the fix of [GEOT-7415: Error on WFS Transaction with Multisurface featuresResolved](https://osgeo-org.atlassian.net/browse/GEOT-7415)
, the binding classes of MultiSurfaceType and MultiSurfacePropertyType were changed MultiPolygon.class to MultiSurface.class.

This change was both unnecessary as well as regressive. It caused a bug in WFS 1.1 where there was an inconsistency in the schema’s returned by GetFeature and DescribeFeatureType for MultiSurface geometries, causing blocking problems for several clients.

Since MultiPolygon is a superclass of MultiSurface, this does not pose any actual contradictions if we parse and encode MultiPolygons as MultiSurfaces. The XSD machinery resolves by isAssignableFrom, not exact class, and the declared binding only drives DescribeFeatureType naming via FeatureTypeSchemaBuilder.findTypeName. So the GMLProfile in WFS 1.1. is still able to find the name and the type of MultSurface.class since it actually actively checks for superclasses. 

The actual fix of [GEOT-7415: Error on WFS Transaction with Multisurface featuresResolved](https://osgeo-org.atlassian.net/browse/GEOT-7415)
 still works, the tests still pass. The write-path fix is left in place, so the WFS-T transaction fix is preserved and not regressed.

The original geoserver ticket:
[![GEOS-11373](https://badgen.net/badge/JIRA/GEOS-11373/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11373) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

See the ticket for explanation.

Tests are in
https://github.com/geoserver/geoserver/pull/9137
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 