### PR TITLE
GEOT-7891: Close the opened HTTP connection if the initialization of the WFSFeatureReader fails

### DIFF
--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
@@ -290,7 +290,7 @@ class WFSFeatureSource extends ContentFeatureSource {
         FeatureReader<SimpleFeatureType, SimpleFeature> reader;
 
         // dispose the opened connection if the WFSFeatureReader initialization throws an exception
-        try{
+        try {
             reader = new WFSFeatureReader(features, response);
         } catch (IOException | RuntimeException e) {
             response.dispose();

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/WFSFeatureSource.java
@@ -287,7 +287,15 @@ class WFSFeatureSource extends ContentFeatureSource {
         GeometryFactory geometryFactory = findGeometryFactory(localQuery.getHints());
         GetParser<SimpleFeature> features = response.getSimpleFeatures(geometryFactory);
 
-        FeatureReader<SimpleFeatureType, SimpleFeature> reader = new WFSFeatureReader(features, response);
+        FeatureReader<SimpleFeatureType, SimpleFeature> reader;
+
+        // dispose the opened connection if the WFSFeatureReader initialization throws an exception
+        try{
+            reader = new WFSFeatureReader(features, response);
+        } catch (IOException | RuntimeException e) {
+            response.dispose();
+            throw e;
+        }
 
         Filter unsupportedFilter = request.getUnsupportedFilter();
         if (unsupportedFilter != null && unsupportedFilter != Filter.INCLUDE) {


### PR DESCRIPTION
[![GEOT-7891](https://badgen.net/badge/JIRA/GEOT-7891/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7891) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Fix resource leak in WFSFeatureSource when reader initialization fails

<!--Include a few sentences describing the overall goals for this Pull Request-->
  ### Description
This PR fixes a resource leak where `GetFeatureResponse` remains undisposed if the `WFSFeatureReader` constructor throws an exception (e.g., during initial feature parsing).

### Related JIRA
https://osgeo-org.atlassian.net/browse/GEOT-7891

### Root Cause
If `WFSFeatureReader` fails to initialize, the calling code in `WFSFeatureSource` never receives a reference to the reader, making it impossible to call `reader.close()`. This leaves the underlying HTTP connection open, leading to connection pool exhaustion.

### Solution
Wrapped the reader instantiation in a try-catch block to ensure `response.dispose()` is called explicitly if initialization fails.
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 