### PR TITLE
[QA] Replace UselessOperationOnImmutable rule with UselessPureMethodCall

### DIFF
--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -81,7 +81,7 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
   <rule ref="category/java/errorprone.xml/UnconditionalIfStatement"/>
   <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary"/>
   <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals"/>
-  <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
+  <rule ref="category/java/errorprone.xml/UselessPureMethodCall"/>
   <rule ref="category/java/errorprone.xml/CloseResource">
     <properties>
       <!-- When calling the store to close, PMD wants the full prefix before the call to the method to match, so let's try to use common var names for store ... -->

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Mosaic.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Mosaic.java
@@ -805,6 +805,7 @@ public class Mosaic extends OperationJAI {
 
     /** We override this one to get some extra behavior that ImageWorker has (ROI, paletted images management) */
     @Override
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     protected RenderedImage createRenderedImage(final ParameterBlockImageN parameters, RenderingHints hints) {
         parameters.getSources();
         RenderedImage[] images = parameters

--- a/modules/library/main/src/test/java/org/geotools/feature/FeatureFlatTest.java
+++ b/modules/library/main/src/test/java/org/geotools/feature/FeatureFlatTest.java
@@ -132,7 +132,7 @@ public class FeatureFlatTest {
     }
 
     @Test
-    @SuppressWarnings("ReturnValueIgnored")
+    @SuppressWarnings({"ReturnValueIgnored", "PMD.UselessPureMethodCall"})
     public void testToStringWontThrow() throws IllegalAttributeException {
         SimpleFeature f = SampleFeatureFixtures.createFeature();
         f.setAttributes(new Object[f.getAttributeCount()]);

--- a/modules/library/main/src/test/java/org/geotools/filter/FunctionExpressionImplTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/FunctionExpressionImplTest.java
@@ -172,7 +172,7 @@ public class FunctionExpressionImplTest {
         return sb.toString();
     }
 
-    @SuppressWarnings("ReturnValueIgnored")
+    @SuppressWarnings({"ReturnValueIgnored", "PMD.UselessPureMethodCall"})
     private void testFunction(Function function, List<String> errors)
             throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         final String functionClass = function.getClass().getName();

--- a/modules/library/metadata/src/test/java/org/geotools/util/PartiallyOrderedSetTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/PartiallyOrderedSetTest.java
@@ -154,7 +154,7 @@ public class PartiallyOrderedSetTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    @SuppressWarnings("ReturnValueIgnored")
+    @SuppressWarnings({"ReturnValueIgnored", "PMD.UselessPureMethodCall"})
     public void testLoop() {
         PartiallyOrderedSet<String> poset = new PartiallyOrderedSet<>();
         poset.add("a");

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/wkt/Element.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/wkt/Element.java
@@ -245,6 +245,7 @@ public final class Element {
      * @param position The position in the string.
      * @return An exception with a formatted error message.
      */
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     private ParseException unparsableString(final String text, final ParsePosition position) {
         final int errorIndex = position.getErrorIndex();
         position.getIndex();

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/Compositing.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/Compositing.java
@@ -65,6 +65,7 @@ class Compositing {
     }
 
     /** Compose this {@link Compositing} element with the source GridCoverage. */
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     public GridCoverage2D composeGridCoverage(GridCoverage2D source, GridCoverageFactory factory) {
         if (compositingImage != null) {
             // Make sure to transform the compositingImage to RGB

--- a/modules/plugin/arcgrid/src/test/java/org/geotools/gce/arcgrid/ArcGridReadWriteTest.java
+++ b/modules/plugin/arcgrid/src/test/java/org/geotools/gce/arcgrid/ArcGridReadWriteTest.java
@@ -130,14 +130,15 @@ public class ArcGridReadWriteTest extends ArcGridBaseTestCase {
     }
 
     /** A Simple Test Method which read an arcGrid and write it as a GRASS Ascii Grid */
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     public void writeGrassUnCompressed(File rf, File wf) throws Exception {
 
         final Hints hints = new Hints(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, DefaultGeographicCRS.WGS84);
-        /** Step 1: Reading the coverage */
+        /* Step 1: Reading the coverage */
         GridCoverageReader reader = new ArcGridReader(rf, hints);
         final GridCoverage2D gc1 = (GridCoverage2D) reader.read();
 
-        /** Step 2: Write grid coverage out to temp file */
+        /* Step 2: Write grid coverage out to temp file */
         final GridCoverageWriter writer = new ArcGridWriter(wf);
 
         // setting write parameters
@@ -155,14 +156,14 @@ public class ArcGridReadWriteTest extends ArcGridBaseTestCase {
         writer.write(gc1, gpv);
         writer.dispose();
 
-        /** Step 3: Read the just written coverage */
+        /* Step 3: Read the just written coverage */
         GridCoverageReader reader2 = new ArcGridReader(wf, hints);
         final GridCoverage2D gc2 = (GridCoverage2D) reader2.read();
 
-        /** Step 4: Check if the 2 coverage are equals */
+        /* Step 4: Check if the 2 coverage are equals */
         compare(gc1, gc2);
 
-        /** Step 5: Show the new coverage */
+        /* Step 5: Show the new coverage */
         if (TestData.isInteractiveTest()) {
             gc1.show();
             gc2.show();
@@ -173,6 +174,7 @@ public class ArcGridReadWriteTest extends ArcGridBaseTestCase {
     }
 
     /** A Simple Test Method which read an arcGrid and write it as an ArcGrid */
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     public void writeEsriUnCompressed(File rf, File wf) throws Exception {
 
         final Hints hints = new Hints(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, DefaultGeographicCRS.WGS84);

--- a/modules/plugin/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java
+++ b/modules/plugin/csv/src/main/java/org/geotools/data/csv/CSVDataStoreFactory.java
@@ -179,7 +179,7 @@ public class CSVDataStoreFactory implements FileDataStoreFactorySpi {
     }
 
     @Override
-    @SuppressWarnings("ReturnValueIgnored")
+    @SuppressWarnings({"ReturnValueIgnored", "PMD.UselessPureMethodCall"})
     public boolean isAvailable() {
         try {
             CSVDataStore.class.getName();

--- a/modules/plugin/image/src/test/java/org/geotools/gce/image/WorldImageReaderTest.java
+++ b/modules/plugin/image/src/test/java/org/geotools/gce/image/WorldImageReaderTest.java
@@ -302,6 +302,7 @@ public class WorldImageReaderTest extends WorldImageBaseTestCase {
      *
      * @param source Object
      */
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     private void read(Object source) throws FileNotFoundException, IOException, IllegalArgumentException {
 
         // can we read it?

--- a/modules/plugin/image/src/test/java/org/geotools/gce/image/WorldImageWriterTest.java
+++ b/modules/plugin/image/src/test/java/org/geotools/gce/image/WorldImageWriterTest.java
@@ -94,6 +94,7 @@ public class WorldImageWriterTest extends WorldImageBaseTestCase {
      *
      * @param source Object The object on disk representing the coverage to test.
      */
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     private File write(Object source, String format)
             throws IOException, IllegalArgumentException, FactoryException, TransformException, ParseException {
         // instantiating a reader

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/egr/Tile.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/egr/Tile.java
@@ -196,6 +196,7 @@ class Tile {
      * @return true if count changed.
      * @throws IllegalStateException if raster has not been initialized
      */
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     public boolean refreshCoverageCount() throws IllegalStateException {
         if (raster == null) {
             throw new IllegalStateException("Raster not initialized");

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/JiffleProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/JiffleProcessTest.java
@@ -436,6 +436,7 @@ public class JiffleProcessTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     public void testMultibandBandIndexExpressionsInvalidBandCount() {
         GridCoverage2D c1 = buildCoverage(ONE_DIAGONAL);
         GridCoverage2D c2 = buildCoverage(TWO_SOLID);

--- a/modules/unsupported/vsi/src/test/java/org/geotools/vsi/VSIUtilsTest.java
+++ b/modules/unsupported/vsi/src/test/java/org/geotools/vsi/VSIUtilsTest.java
@@ -133,6 +133,7 @@ public final class VSIUtilsTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     public void testDatasetToVRT() throws IOException {
         final String path = "/tmp/mydataset.vrt";
         final Driver driver = mock(Driver.class);
@@ -168,6 +169,7 @@ public final class VSIUtilsTest {
         verify(band, times(1)).SetMetadataItem(eq("source_0"), eq("<SourceBand>mask"), eq("new_vrt_sources"));
     }
 
+    @SuppressWarnings("PMD.UselessPureMethodCall")
     @Test(expected = IOException.class)
     public void testDatasetToVRTInvalid() throws IOException {
         final String path = "/tmp/mydataset.vrt";


### PR DESCRIPTION
As UselessOperationOnImmutable is deprecated and generating a ton of warnings in the build log.

see https://pmd.github.io/pmd/pmd_rules_java_errorprone.html#uselessoperationonimmutable

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->