### PR TITLE
PMTiles: Upgrade Tileverse to 1.4.0

### DIFF
--- a/modules/unsupported/pmtiles/pom.xml
+++ b/modules/unsupported/pmtiles/pom.xml
@@ -49,7 +49,7 @@
   </developers>
 
   <properties>
-    <tileverse.version>1.3.5</tileverse.version>
+    <tileverse.version>1.4.0</tileverse.version>
   </properties>
   <!-- =========================================================== -->
   <!--     Dependency Mangement                                    -->

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/PMTilesDataStoreFactory.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/PMTilesDataStoreFactory.java
@@ -319,6 +319,7 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
 
     @Override
     public boolean canProcess(java.util.Map<String, ?> params) {
+        params = RangeReaderConfig.normalizeKeys(params);
         boolean canProcess = DataStoreFactorySpi.super.canProcess(params);
         URI toURI;
         try {

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/tileverse/rangereader/RangeReaderParams.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/tileverse/rangereader/RangeReaderParams.java
@@ -225,14 +225,19 @@ public class RangeReaderParams {
      *   <li>Any other provider-specific parameters
      * </ul>
      *
+     * <p>Forward-compatible {@code storage.*} keys (canonical in tileverse 2.x) are translated to the canonical
+     * {@code io.tileverse.rangereader.*} form via {@link RangeReaderConfig#normalizeKeys(Map)} before lookup, so
+     * DataStoreInfo entries persisted by a future tileverse 2.x consumer (e.g. GeoServer 3.1+) are read correctly here.
+     *
      * @param connectionParams the DataStore connection parameters (from
      *     {@link PMTilesDataStoreFactory#createDataStore})
      * @return properties object suitable for {@link RangeReaderFactory#create}
      */
     public static Properties toProperties(Map<String, ?> connectionParams) {
+        Map<String, Object> normalized = RangeReaderConfig.normalizeKeys(connectionParams);
         Properties configOpts = new Properties();
-        addProperty(RANGEREADER_PROVIDER_ID, connectionParams, configOpts);
-        PROVIDER_PARAMS.forEach(param -> addProperty(param, connectionParams, configOpts));
+        addProperty(RANGEREADER_PROVIDER_ID, normalized, configOpts);
+        PROVIDER_PARAMS.forEach(param -> addProperty(param, normalized, configOpts));
         return configOpts;
     }
 

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/pmtiles/store/PMTilesDataStoreFactoryTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/pmtiles/store/PMTilesDataStoreFactoryTest.java
@@ -253,6 +253,46 @@ public class PMTilesDataStoreFactoryTest {
         }
     }
 
+    /**
+     * Forward compatibility check: {@link PMTilesDataStoreFactory#canProcess(Map)} must accept connection parameters
+     * that use the {@code storage.*} prefix (canonical in tileverse 2.x). Required-param validation in
+     * {@code DataStoreFactorySpi.canProcess} is keyed off the factory's canonical {@code io.tileverse.rangereader.*}
+     * {@link Param}s, so input keys must be normalized first.
+     */
+    @Test
+    public void testCanProcessWithFutureStorageKeys() {
+        PMTilesDataStoreFactory factory = new PMTilesDataStoreFactory();
+        Map<String, Object> params =
+                Map.of(URIP.key, andorra, "storage.provider", "file", "storage.caching.enabled", Boolean.TRUE);
+        assertTrue(factory.canProcess(params));
+    }
+
+    /**
+     * Forward compatibility check: a DataStoreInfo persisted by a future tileverse 2.x consumer (GeoServer 3.1+)
+     * carries connection parameters with the {@code storage.*} prefix. Tileverse 1.4 must still be able to create the
+     * store -- {@link RangeReaderParams#toProperties(Map)} translates the future prefix back to the canonical
+     * {@code io.tileverse.rangereader.*} form before lookup.
+     */
+    @Test
+    public void testCreateDataStoreWithFutureStorageKeys() throws IOException {
+        PMTilesDataStoreFactory factory = new PMTilesDataStoreFactory();
+        Map<String, Object> params = Map.of(
+                URIP.key,
+                andorra,
+                "storage.provider",
+                "file",
+                "storage.caching.enabled",
+                Boolean.TRUE,
+                "storage.caching.blocksize",
+                65536);
+        PMTilesDataStore store = factory.createDataStore(params);
+        try {
+            assertNotNull(store);
+        } finally {
+            if (store != null) store.dispose();
+        }
+    }
+
     @Test
     public void testDataStoreFactories() throws IOException {
         PMTilesDataStoreFactory factory = new PMTilesDataStoreFactory();

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/tileverse/rangereader/RangeReaderParamsTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/tileverse/rangereader/RangeReaderParamsTest.java
@@ -1,0 +1,65 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ *
+ */
+package org.geotools.tileverse.rangereader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link RangeReaderParams#toProperties(Map)} accepts forward-compatible {@code storage.*} parameter keys
+ * (canonical in tileverse 2.x) by translating them to the canonical {@code io.tileverse.rangereader.*} form tileverse
+ * 1.4 understands.
+ */
+public class RangeReaderParamsTest {
+
+    @Test
+    public void toPropertiesNormalizesFutureKeys() {
+        Map<String, Object> connectionParams = new HashMap<>();
+        connectionParams.put("pmtiles", "file:///tmp/sample.pmtiles");
+        connectionParams.put("storage.provider", "file");
+        connectionParams.put("storage.caching.enabled", Boolean.TRUE);
+        connectionParams.put("storage.s3.region", "us-west-2");
+
+        Properties props = RangeReaderParams.toProperties(connectionParams);
+
+        assertEquals("file", props.getProperty("io.tileverse.rangereader.provider"));
+        assertEquals("true", props.getProperty("io.tileverse.rangereader.caching.enabled"));
+        assertEquals("us-west-2", props.getProperty("io.tileverse.rangereader.s3.region"));
+        assertFalse(
+                "no storage.* keys should remain in the output",
+                props.stringPropertyNames().stream().anyMatch(k -> k.startsWith("storage.")));
+    }
+
+    @Test
+    public void toPropertiesPassesCanonicalKeys() {
+        Map<String, Object> connectionParams = new HashMap<>();
+        connectionParams.put("pmtiles", "file:///tmp/sample.pmtiles");
+        connectionParams.put("io.tileverse.rangereader.provider", "file");
+        connectionParams.put("io.tileverse.rangereader.caching.enabled", Boolean.TRUE);
+
+        Properties props = RangeReaderParams.toProperties(connectionParams);
+
+        assertEquals("file", props.getProperty("io.tileverse.rangereader.provider"));
+        assertEquals("true", props.getProperty("io.tileverse.rangereader.caching.enabled"));
+    }
+}


### PR DESCRIPTION
Tileverse `1.4` keeps the canonical `io.tileverse.rangereader.*` parameter prefix and adds forward compatibility for the `storage.*` prefix that will become canonical in Tileverse 2.x.

This way `DataStoreInfo` entries persisted by a future tileverse 2.x consumer (GeoServer 3.1+) -- whose connectionParameters will use the `storage.*` prefix -- still reach the `canonical io.tileverse.rangereader.*` keys, so that a data dir created on gs:3.1/gt:35.1 and rolled back to 3.0/gt:35.0 keeps working without manual migration.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->