### PR TITLE
[GEOT-7895] Avoid not needed casts for JSON in jdbc-postgis plugin

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
@@ -708,7 +708,6 @@ class FilterToSqlHelper {
 
             if (needCast) out.write('(');
             json.accept(delegate, null);
-            out.write(" ::json ");
             String strPointer = literal.getValue().toString();
             List<String> pointerEl =
                     Stream.of(strPointer.split("/")).filter(p -> !p.equals("")).collect(Collectors.toList());

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisFilterToSQLTest.java
@@ -260,7 +260,7 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
 
         filterToSql.encode(pointer);
         String sql = writer.toString().toLowerCase().trim();
-        assertEquals("testjson ::json  -> 'arr' ->> 0", sql);
+        assertEquals("testjson -> 'arr' ->> 0", sql);
     }
 
     @Test
@@ -270,7 +270,7 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         Filter startsWith = ff.equals(pointer, ff.literal("value"));
         filterToSql.encode(startsWith);
         String sql = writer.toString().toLowerCase().trim();
-        assertEquals("where testjson ::json  ->> '1407' = 'value'", sql);
+        assertEquals("where testjson ->> '1407' = 'value'", sql);
     }
 
     @Test
@@ -280,7 +280,7 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         Filter startsWith = ff.equals(pointer, ff.literal("escaped_apostrophe"));
         filterToSql.encode(startsWith);
         String sql = writer.toString().toLowerCase().trim();
-        assertEquals("where testjson ::json  ->> '''' = 'escaped_apostrophe'", sql);
+        assertEquals("where testjson ->> '''' = 'escaped_apostrophe'", sql);
     }
 
     @Test
@@ -290,7 +290,7 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         Filter startsWith = ff.equals(pointer, ff.literal("escaped_literal"));
         filterToSql.encode(startsWith);
         String sql = writer.toString().toLowerCase().trim();
-        assertEquals("where testjson ::json  ->> '''2202' = 'escaped_literal'", sql);
+        assertEquals("where testjson ->> '''2202' = 'escaped_literal'", sql);
     }
 
     @Test
@@ -301,8 +301,7 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         Filter startsWith = ff.equals(pointer, ff.literal("complex_pointer"));
         filterToSql.encode(startsWith);
         String sql = writer.toString().toLowerCase().trim();
-        assertEquals(
-                "where testjson ::json  -> 'numeric_key' -> '0714' -> 'array_index' ->> 1407 = 'complex_pointer'", sql);
+        assertEquals("where testjson -> 'numeric_key' -> '0714' -> 'array_index' ->> 1407 = 'complex_pointer'", sql);
     }
 
     @Test
@@ -313,7 +312,7 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         Filter less = ff.less(pointer, literal);
         filterToSql.encode(less);
         String sql = writer.toString().toLowerCase().trim();
-        assertEquals("where (testjson ::json  -> 'arr' ->> 0)::integer < 3", sql);
+        assertEquals("where (testjson -> 'arr' ->> 0)::integer < 3", sql);
     }
 
     @Test
@@ -325,7 +324,7 @@ public class PostgisFilterToSQLTest extends SQLFilterTestSupport {
         Filter like = ff.like(pointer, "a_literal", "%", "-", "\\", true);
         filterToSql.encode(like);
         String sql = writer.toString().toLowerCase().trim();
-        assertEquals("where testjson ::json  -> 'arr' ->> 0 like 'a_literal'", sql);
+        assertEquals("where testjson -> 'arr' ->> 0 like 'a_literal'", sql);
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7895](https://badgen.net/badge/JIRA/GEOT-7895/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7895) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->
This pull request addresses [issue 7895](https://osgeo-org.atlassian.net/browse/GEOT-7895):
Avoid not needed casts for JSON in jdbc-postgis plugin to improve performance.

Using the function `jsonPointer` in CQL expressions always results in casting JSONB columns to JSON, what is not needed and has a negative impact on the performance.
This contribution aims to remove not necessary casts and improve query performance.

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 